### PR TITLE
add guava as dependency for test/test-utils

### DIFF
--- a/test/test-utils/pom.xml
+++ b/test/test-utils/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>hamcrest-all</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Maybe I'm missing something, but I could not build successfully without adding guava to the test/test-utils pom.

`TestExecutors` needs access to these classes:
```java
import com.google.common.util.concurrent.ForwardingExecutorService;
import com.google.common.util.concurrent.Futures;
```