### PR TITLE
Correcting S3 unmarshalling for a couple of operations

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/SingleStringResponseOperationsIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/SingleStringResponseOperationsIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.services.s3.model.BucketLocationConstraint.UsWest2;
+
+import java.util.Date;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.auth.policy.Action;
+import software.amazon.awssdk.auth.policy.Policy;
+import software.amazon.awssdk.auth.policy.Principal;
+import software.amazon.awssdk.auth.policy.Resource;
+import software.amazon.awssdk.auth.policy.Statement;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketRequestPaymentRequest;
+import software.amazon.awssdk.services.s3.model.PutBucketPolicyRequest;
+
+public final class SingleStringResponseOperationsIntegrationTest extends S3IntegrationTestBase {
+
+    /**
+     * The name of the bucket created, used, and deleted by these tests.
+     */
+    private static String bucketName = "single-string-integ-test-" + new Date().getTime();
+
+    @BeforeClass
+    public static void setupSuite() {
+        s3.createBucket(CreateBucketRequest.builder()
+                                           .bucket(bucketName)
+                                           .createBucketConfiguration(CreateBucketConfiguration.builder()
+                                                                                               .locationConstraint(UsWest2)
+                                                                                               .build())
+                                           .build());
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build());
+    }
+
+
+    @Test
+    public void getBucketLocationReturnsAResult() {
+        GetBucketLocationRequest request = GetBucketLocationRequest.builder().bucket(bucketName).build();
+        assertThat(s3.getBucketLocation(request).locationConstraint()).isEqualTo(Region.US_WEST_2.value());
+    }
+
+
+    @Test
+    public void getBucketPolicyReturnsAResult() {
+        String policy = createPolicy();
+        s3.putBucketPolicy(PutBucketPolicyRequest.builder().bucket(bucketName).policy(policy).build());
+
+        GetBucketPolicyRequest request = GetBucketPolicyRequest.builder().bucket(bucketName).build();
+        assertThat(s3.getBucketPolicy(request).policy()).contains("arn:aws:s3:::" + bucketName);
+    }
+
+    @Test
+    public void getRequestPayerReturnsAResult() {
+        GetBucketRequestPaymentRequest request = GetBucketRequestPaymentRequest.builder().bucket(bucketName).build();
+        assertThat(s3.getBucketRequestPayment(request).payer()).isEqualTo("BucketOwner");
+    }
+
+    private String createPolicy() {
+        return new Policy().withStatements(
+            new Statement(Statement.Effect.Allow)
+                .withPrincipals(new Principal("*"))
+                .withResources(new Resource("arn:aws:s3:::" + bucketName))
+                .withActions((Action) () -> "*"))
+                           .toJson();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/SingleStringResponseHandler.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/SingleStringResponseHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.handlers;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotation.ReviewBeforeRelease;
+import software.amazon.awssdk.handlers.RequestHandler;
+import software.amazon.awssdk.http.HttpResponse;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Enables S3 single-string responses to be correctly unmarshalled.
+ *
+ * Most S3 operations return a structure wrapped in an outer XML element with two exceptions
+ *
+ * <ul>
+ *  <li>GetBucketLocation which returns {@code <LocationConstraint>region</LocationConstraint> } </li>
+ *  <li>GetBucketPolicy which returns a raw JSON document representing the policy</li>
+ * </ul>
+ * The Sax unmarshaller used for S3 is expecting this outer wrapper. This response handler modifies the
+ * responses of these operations to include the required XML wrappers.
+ */
+public final class SingleStringResponseHandler extends RequestHandler {
+
+    @Override
+    @ReviewBeforeRelease("Change to use instanceof on request object after request handlers refactor")
+    public HttpResponse beforeUnmarshalling(SdkHttpFullRequest request, HttpResponse httpResponse) {
+        //TODO: This should use instanceof on the request type once get the actual SDK request in here after the handlers refactor
+        if (request.getHttpMethod().equals(SdkHttpMethod.GET) && httpResponse.getContent() != null) {
+            if (request.getParameters().containsKey("policy")) {
+                addPolicyXmlTags(httpResponse);
+            } else if (request.getParameters().containsKey("location")) {
+                wrapLocationConstraintResponseToExpectedDepth(httpResponse);
+            }
+        }
+        return httpResponse;
+    }
+
+    private void addPolicyXmlTags(HttpResponse httpResponse) {
+        List<InputStream> streams = Arrays.asList(
+            new ByteArrayInputStream("<Policy>".getBytes(StandardCharsets.UTF_8)),
+            httpResponse.getContent(),
+            new ByteArrayInputStream("</Policy>".getBytes(StandardCharsets.UTF_8))
+        );
+
+        httpResponse.setContent(new SequenceInputStream(Collections.enumeration(streams)));
+    }
+
+    private void wrapLocationConstraintResponseToExpectedDepth(HttpResponse httpResponse) {
+        String contents = invokeSafely(() -> IoUtils.toString(httpResponse.getContent()));
+        String newContents = contents.replace("<LocationConstraint", "<Wrap><LocationConstraint")
+                                     .replace("</LocationConstraint>", "</LocationConstraint></Wrap>");
+        httpResponse.setContent(new ByteArrayInputStream(newContents.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/services/s3/src/main/resources/software/amazon/awssdk/services/s3/request.handler2s
+++ b/services/s3/src/main/resources/software/amazon/awssdk/services/s3/request.handler2s
@@ -1,2 +1,3 @@
 software.amazon.awssdk.services.s3.handlers.EndpointAddressRequestHandler
 software.amazon.awssdk.services.s3.handlers.CreateBucketRequestHandler
+software.amazon.awssdk.services.s3.handlers.SingleStringResponseHandler


### PR DESCRIPTION
Most S3 operations return a structure wrapped in an outer XML element with two exceptions
- GetBucketLocation which returns `<LocationConstraint>region</LocationConstraint>`
- GetBucketPolicy which returns a raw JSON document representing the policy

The Sax unmarshaller used for S3 is expecting this outer wrapper. This response handler modifies the responses of these operations to include the required XML wrappers.

