### PR TITLE
Stopped throwing checked exceptions from close() methods.

### DIFF
--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
@@ -402,6 +402,14 @@
           <property name="ignoreComments" value="true"/>
         </module>
 
+        <!-- Checks that we don't implement AutoCloseable/Closeable -->
+        <module name="Regexp">
+            <property name="format" value="(class|interface).*(implements|extends).*[^\w](Closeable|AutoCloseable)[^\w]"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="message" value="Use SdkAutoCloseable instead of Closeable/AutoCloseable"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
         <!-- Checks for redundant public modifier on interfaces and other redundant modifiers -->
         <module name="RedundantModifier" />
     </module>

--- a/cloudwatchmetrics/src/test/java/software/amazon/awssdk/metrics/internal/cloudwatch/CloudWatchTestClient.java
+++ b/cloudwatchmetrics/src/test/java/software/amazon/awssdk/metrics/internal/cloudwatch/CloudWatchTestClient.java
@@ -53,7 +53,7 @@ public class CloudWatchTestClient implements CloudWatchClient {
     }
 
     @Override
-    public void close() throws Exception {
-        close();
+    public void close() {
+        
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/CodeEmitter.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/CodeEmitter.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.codegen.emitters;
 
+import software.amazon.awssdk.utils.FunctionalUtils;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
 /**
  * Submits generator tasks to executor.
  */
-public class CodeEmitter implements AutoCloseable {
-
+public class CodeEmitter implements SdkAutoCloseable {
     private final Iterable<GeneratorTask> generatorTasks;
     private final GeneratorTaskExecutor taskExecutor;
 
@@ -37,8 +39,8 @@ public class CodeEmitter implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
-        taskExecutor.waitForCompletion();
+    public void close() {
+        FunctionalUtils.invokeSafely(taskExecutor::waitForCompletion);
         taskExecutor.shutdown();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -99,7 +99,6 @@ public final class AsyncClientClass extends AsyncClientInterface {
     private MethodSpec closeMethod() {
         return MethodSpec.methodBuilder("close")
                          .addAnnotation(Override.class)
-                         .addException(Exception.class)
                          .addModifiers(Modifier.PUBLIC)
                          .addStatement("$N.close()", "clientHandler")
                          .build();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 public class AsyncClientInterface implements ClassSpec {
 
@@ -55,7 +56,7 @@ public class AsyncClientInterface implements ClassSpec {
     @Override
     public TypeSpec poetSpec() {
         return PoetUtils.createInterfaceBuilder(className)
-                        .addSuperinterface(AutoCloseable.class)
+                        .addSuperinterface(SdkAutoCloseable.class)
                         .addJavadoc(getJavadoc())
                         .addMethod(create())
                         .addMethod(builder())

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -207,7 +207,6 @@ public class SyncClientClass implements ClassSpec {
                          .addAnnotation(Override.class)
                          .addStatement("clientHandler.close()")
                          .addModifiers(Modifier.PUBLIC)
-                         .addException(Exception.class)
                          .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.sync.RequestBody;
 import software.amazon.awssdk.sync.StreamingResponseHandler;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 public final class SyncClientInterface implements ClassSpec {
 
@@ -57,7 +58,7 @@ public final class SyncClientInterface implements ClassSpec {
     @Override
     public TypeSpec poetSpec() {
         Builder classBuilder = PoetUtils.createInterfaceBuilder(className)
-                                        .addSuperinterface(AutoCloseable.class)
+                                        .addSuperinterface(SdkAutoCloseable.class)
                                         .addJavadoc(getJavadoc())
                                         .addField(FieldSpec.builder(String.class, "SERVICE_NAME")
                                                            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -259,7 +259,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         clientHandler.close();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -291,7 +291,7 @@ final class DefaultJsonClient implements JsonClient {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         clientHandler.close();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -142,7 +142,7 @@ final class DefaultQueryClient implements QueryClient {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         clientHandler.close();
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/auth/AwsCredentialsProviderChain.java
+++ b/core/src/main/java/software/amazon/awssdk/auth/AwsCredentialsProviderChain.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.SdkClientException;
 import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -42,7 +43,7 @@ import software.amazon.awssdk.utils.Validate;
  * <p>This chain implements {@link AutoCloseable}. When closed, it will call the {@link AutoCloseable#close()} on any credential
  * providers in the chain that need to be closed.</p>
  */
-public final class AwsCredentialsProviderChain implements AwsCredentialsProvider, AutoCloseable {
+public final class AwsCredentialsProviderChain implements AwsCredentialsProvider, SdkAutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(AwsCredentialsProviderChain.class);
 
     private final List<AwsCredentialsProvider> credentialsProviders;

--- a/core/src/main/java/software/amazon/awssdk/auth/DefaultCredentialsProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/auth/DefaultCredentialsProvider.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.auth;
 
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
 /**
  * AWS credentials provider chain that looks for credentials in this order:
  * <ol>
@@ -32,7 +34,7 @@ package software.amazon.awssdk.auth;
  * @see ElasticContainerCredentialsProvider
  * @see InstanceProfileCredentialsProvider
  */
-public class DefaultCredentialsProvider implements AwsCredentialsProvider, AutoCloseable {
+public class DefaultCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
     /**
      * As a minor optimization, we reuse the same underlying provider chain for all calls to
      * {@link #DefaultCredentialsProvider()}. This is done because we reuse this chain in every client by default, and reusing

--- a/core/src/main/java/software/amazon/awssdk/auth/EC2CredentialsProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/auth/EC2CredentialsProvider.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.internal.EC2CredentialsUtils;
 import software.amazon.awssdk.util.ComparableUtils;
 import software.amazon.awssdk.util.DateUtils;
 import software.amazon.awssdk.util.json.Jackson;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.cache.CachedSupplier;
 import software.amazon.awssdk.utils.cache.NonBlocking;
@@ -39,7 +40,7 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
  * an EC2 instance.
  */
 @SdkInternalApi
-class EC2CredentialsProvider implements AwsCredentialsProvider, AutoCloseable {
+class EC2CredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
     private final CredentialsEndpointProvider credentialsEndpointProvider;
     private final CachedSupplier<AwsCredentials> credentialsCache;
 

--- a/core/src/main/java/software/amazon/awssdk/auth/ElasticContainerCredentialsProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/auth/ElasticContainerCredentialsProvider.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.SdkClientException;
 import software.amazon.awssdk.annotation.SdkTestInternalApi;
 import software.amazon.awssdk.internal.CredentialsEndpointProvider;
 import software.amazon.awssdk.retry.internal.CredentialsEndpointRetryPolicy;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
  * {@link AwsCredentialsProvider} implementation that loads credentials from the Amazon Elastic Container Service.
@@ -31,7 +32,7 @@ import software.amazon.awssdk.retry.internal.CredentialsEndpointRetryPolicy;
  * <p>The URI path is retrieved from the environment variable "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" in the container's
  * environment. If the environment variable is not set, this credentials provider will always return null.</p>
  */
-public class ElasticContainerCredentialsProvider implements AwsCredentialsProvider, AutoCloseable {
+public class ElasticContainerCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(ElasticContainerCredentialsProvider.class);
 
     /**

--- a/core/src/main/java/software/amazon/awssdk/auth/InstanceProfileCredentialsProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/auth/InstanceProfileCredentialsProvider.java
@@ -23,11 +23,12 @@ import software.amazon.awssdk.annotation.ReviewBeforeRelease;
 import software.amazon.awssdk.internal.CredentialsEndpointProvider;
 import software.amazon.awssdk.internal.EC2CredentialsUtils;
 import software.amazon.awssdk.util.EC2MetadataUtils;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
  * Credentials provider implementation that loads credentials from the Amazon EC2 Instance Metadata Service.
  */
-public class InstanceProfileCredentialsProvider implements AwsCredentialsProvider, AutoCloseable {
+public class InstanceProfileCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
     /**
      * The client to use to fetch the Amazon ECS credentials.
      */

--- a/core/src/main/java/software/amazon/awssdk/client/AsyncClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/client/AsyncClientHandler.java
@@ -20,12 +20,13 @@ import software.amazon.awssdk.SdkRequest;
 import software.amazon.awssdk.ServiceAdvancedConfiguration;
 import software.amazon.awssdk.annotation.SdkProtectedApi;
 import software.amazon.awssdk.config.ClientConfiguration;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
  * Client interface to invoke an API.
  */
 @SdkProtectedApi
-public abstract class AsyncClientHandler extends BaseClientHandler implements AutoCloseable {
+public abstract class AsyncClientHandler extends BaseClientHandler implements SdkAutoCloseable {
 
     AsyncClientHandler(ClientConfiguration clientConfiguration,
                        ServiceAdvancedConfiguration serviceAdvancedConfiguration) {

--- a/core/src/main/java/software/amazon/awssdk/client/AsyncClientHandlerImpl.java
+++ b/core/src/main/java/software/amazon/awssdk/client/AsyncClientHandlerImpl.java
@@ -133,7 +133,7 @@ public class AsyncClientHandlerImpl extends AsyncClientHandler {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         client.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/client/ClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/client/ClientHandler.java
@@ -19,12 +19,13 @@ import software.amazon.awssdk.SdkRequest;
 import software.amazon.awssdk.ServiceAdvancedConfiguration;
 import software.amazon.awssdk.annotation.SdkProtectedApi;
 import software.amazon.awssdk.config.ClientConfiguration;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
  * Client interface to invoke an API.
  */
 @SdkProtectedApi
-public abstract class ClientHandler extends BaseClientHandler implements AutoCloseable {
+public abstract class ClientHandler extends BaseClientHandler implements SdkAutoCloseable {
 
     public ClientHandler(ClientConfiguration clientConfiguration,
                   ServiceAdvancedConfiguration serviceAdvancedConfiguration) {

--- a/core/src/main/java/software/amazon/awssdk/client/SdkAsyncClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/client/SdkAsyncClientHandler.java
@@ -53,7 +53,7 @@ public class SdkAsyncClientHandler extends AsyncClientHandler {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         delegateHandler.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/client/SdkClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/client/SdkClientHandler.java
@@ -52,7 +52,7 @@ public class SdkClientHandler extends ClientHandler {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         delegateHandler.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/client/SyncClientHandlerImpl.java
+++ b/core/src/main/java/software/amazon/awssdk/client/SyncClientHandlerImpl.java
@@ -100,7 +100,7 @@ public class SyncClientHandlerImpl extends ClientHandler {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         client.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/client/builder/DefaultClientBuilder.java
+++ b/core/src/main/java/software/amazon/awssdk/client/builder/DefaultClientBuilder.java
@@ -389,7 +389,7 @@ public abstract class DefaultClientBuilder<B extends ClientBuilder<B, C>, C>
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             // Do nothing, this client is managed by the customer.
         }
     }
@@ -419,7 +419,7 @@ public abstract class DefaultClientBuilder<B extends ClientBuilder<B, C>, C>
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             // Do nothing, this client is managed by the customer.
         }
     }

--- a/core/src/main/java/software/amazon/awssdk/http/AmazonAsyncHttpClient.java
+++ b/core/src/main/java/software/amazon/awssdk/http/AmazonAsyncHttpClient.java
@@ -49,10 +49,11 @@ import software.amazon.awssdk.internal.http.timers.client.ClientExecutionTimer;
 import software.amazon.awssdk.metrics.AwsSdkMetrics;
 import software.amazon.awssdk.metrics.RequestMetricCollector;
 import software.amazon.awssdk.util.CapacityManager;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 @ThreadSafe
 @SdkProtectedApi
-public class AmazonAsyncHttpClient implements AutoCloseable {
+public class AmazonAsyncHttpClient implements SdkAutoCloseable {
 
     /**
      * A request metric collector used specifically for this httpClientSettings client; or null if
@@ -91,7 +92,7 @@ public class AmazonAsyncHttpClient implements AutoCloseable {
      * make more requests.
      */
     @Override
-    public void close() throws Exception {
+    public void close() {
         httpClientDependencies.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/http/AmazonHttpClient.java
+++ b/core/src/main/java/software/amazon/awssdk/http/AmazonHttpClient.java
@@ -65,10 +65,11 @@ import software.amazon.awssdk.internal.http.timers.client.ClientExecutionTimer;
 import software.amazon.awssdk.metrics.AwsSdkMetrics;
 import software.amazon.awssdk.metrics.RequestMetricCollector;
 import software.amazon.awssdk.util.CapacityManager;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 @ThreadSafe
 @SdkProtectedApi
-public class AmazonHttpClient implements AutoCloseable {
+public class AmazonHttpClient implements SdkAutoCloseable {
 
     public static final String HEADER_USER_AGENT = "User-Agent";
 
@@ -149,7 +150,7 @@ public class AmazonHttpClient implements AutoCloseable {
      * make more requests.
      */
     @Override
-    public void close() throws Exception {
+    public void close() {
         httpClientDependencies.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/http/HttpAsyncClientDependencies.java
+++ b/core/src/main/java/software/amazon/awssdk/http/HttpAsyncClientDependencies.java
@@ -38,7 +38,7 @@ public class HttpAsyncClientDependencies extends HttpClientDependencies {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         super.close();
         IoUtils.closeQuietly(asyncClientConfiguration.asyncHttpClient(), null);
         asyncClientConfiguration.asyncExecutorService().shutdown();

--- a/core/src/main/java/software/amazon/awssdk/http/HttpClientDependencies.java
+++ b/core/src/main/java/software/amazon/awssdk/http/HttpClientDependencies.java
@@ -21,13 +21,14 @@ import software.amazon.awssdk.SdkGlobalTime;
 import software.amazon.awssdk.config.ClientConfiguration;
 import software.amazon.awssdk.internal.http.timers.client.ClientExecutionTimer;
 import software.amazon.awssdk.util.CapacityManager;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
  * Client scoped dependencies of {@link AmazonHttpClient}. May be injected into constructors of {@link
  * software.amazon.awssdk.http.pipeline.RequestPipeline} implementations by
  * {@link software.amazon.awssdk.http.pipeline.RequestPipelineBuilder}.
  */
-public abstract class HttpClientDependencies implements AutoCloseable {
+public abstract class HttpClientDependencies implements SdkAutoCloseable {
     private final ClientConfiguration clientConfiguration;
     private final CapacityManager capacityManager;
     private final ClientExecutionTimer clientExecutionTimer;
@@ -79,7 +80,7 @@ public abstract class HttpClientDependencies implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.clientExecutionTimer.close();
     }
 

--- a/core/src/main/java/software/amazon/awssdk/http/HttpSyncClientDependencies.java
+++ b/core/src/main/java/software/amazon/awssdk/http/HttpSyncClientDependencies.java
@@ -39,7 +39,7 @@ public class HttpSyncClientDependencies extends HttpClientDependencies {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         super.close();
         IoUtils.closeQuietly(syncClientConfiguration.httpClient(), null);
     }

--- a/core/src/main/java/software/amazon/awssdk/internal/http/timers/client/ClientExecutionTimer.java
+++ b/core/src/main/java/software/amazon/awssdk/internal/http/timers/client/ClientExecutionTimer.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotation.SdkTestInternalApi;
 import software.amazon.awssdk.annotation.ThreadSafe;
 import software.amazon.awssdk.http.AmazonHttpClient;
 import software.amazon.awssdk.internal.http.timers.TimeoutThreadPoolBuilder;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
  * Represents a timer to enforce a timeout on the total client execution time. That is the time
@@ -34,7 +35,7 @@ import software.amazon.awssdk.internal.http.timers.TimeoutThreadPoolBuilder;
 // order and even concurrently, we need to rely on AmazonHttpClient to call our shutdown() method.
 @SdkInternalApi
 @ThreadSafe
-public class ClientExecutionTimer implements AutoCloseable {
+public class ClientExecutionTimer implements SdkAutoCloseable {
 
     private static final String THREAD_NAME_PREFIX = "AwsSdkClientExecutionTimerThread";
 
@@ -83,7 +84,7 @@ public class ClientExecutionTimer implements AutoCloseable {
      * {@link AmazonHttpClient} is shutdown
      */
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (executor != null) {
             executor.shutdown();
         }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
@@ -15,13 +15,15 @@
 
 package software.amazon.awssdk.http;
 
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
 /**
  * Generic interface to take a representation of an HTTP request, make the HTTP call, and return a representation of an
  * HTTP response.
  *
  * <p>Implementations MUST be thread safe.</p>
  */
-public interface SdkHttpClient extends AutoCloseable, ConfigurationProvider {
+public interface SdkHttpClient extends SdkAutoCloseable, ConfigurationProvider {
 
     /**
      * Create a {@link AbortableCallable} that can be used to execute the HTTP request.

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
@@ -19,8 +19,9 @@ import software.amazon.awssdk.annotation.ReviewBeforeRelease;
 import software.amazon.awssdk.http.ConfigurationProvider;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkRequestContext;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
-public interface SdkAsyncHttpClient extends AutoCloseable, ConfigurationProvider {
+public interface SdkAsyncHttpClient extends SdkAutoCloseable, ConfigurationProvider {
 
     /**
      * Create an {@link AbortableRunnable} that can be used to execute the HTTP request.

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -62,7 +62,7 @@ final class UrlConnectionHttpClient implements SdkHttpClient {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
 
     }
 

--- a/opensdk-runtime/src/main/java/software/amazon/awssdk/opensdk/protect/client/SdkClientHandler.java
+++ b/opensdk-runtime/src/main/java/software/amazon/awssdk/opensdk/protect/client/SdkClientHandler.java
@@ -47,7 +47,7 @@ public class SdkClientHandler extends ClientHandler {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         delegateHandler.close();
     }
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/buffered/SqsBufferedAsyncClient.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/buffered/SqsBufferedAsyncClient.java
@@ -222,7 +222,7 @@ public class SqsBufferedAsyncClient implements SQSAsyncClient {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         realSqs.close();
     }
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.auth.AwsCredentials;
 import software.amazon.awssdk.auth.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.STSClient;
 import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.cache.CachedSupplier;
 import software.amazon.awssdk.utils.cache.NonBlocking;
@@ -38,7 +39,7 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
  */
 @ThreadSafe
 @SdkInternalApi
-abstract class StsCredentialsProvider implements AwsCredentialsProvider, AutoCloseable {
+abstract class StsCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
     /**
      * The STS client that should be used for periodically updating the session credentials in the background.
      */

--- a/utils/src/main/java/software/amazon/awssdk/utils/SdkAutoCloseable.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/SdkAutoCloseable.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import software.amazon.awssdk.annotation.SdkProtectedApi;
+
+/**
+ * An implementation of {@link AutoCloseable} that does not throw any checked exceptions. The SDK does not throw checked
+ * exceptions in its close() methods, so users of the SDK should not need to handle them.
+ */
+@SdkProtectedApi
+// CHECKSTYLE:OFF - This is the only place we're allowed to use AutoCloseable
+public interface SdkAutoCloseable extends AutoCloseable {
+    // CHECKSTYLE:ON
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void close();
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/CachedSupplier.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/CachedSupplier.java
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotation.ReviewBeforeRelease;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -34,7 +35,7 @@ import software.amazon.awssdk.utils.Validate;
  *
  * This should be created using {@link #builder(Supplier)}.
  */
-public final class CachedSupplier<T> implements Supplier<T>, AutoCloseable {
+public final class CachedSupplier<T> implements Supplier<T>, SdkAutoCloseable {
     /**
      * Maximum time to wait for a blocking refresh lock before calling refresh again. This is to rate limit how many times we call
      * refresh. In the ideal case, refresh always occurs in a timely fashion and only one thread actually does the refresh.
@@ -191,7 +192,7 @@ public final class CachedSupplier<T> implements Supplier<T>, AutoCloseable {
      * @see NonBlocking
      */
     @FunctionalInterface
-    public interface PrefetchStrategy extends AutoCloseable {
+    public interface PrefetchStrategy extends SdkAutoCloseable {
         /**
          * Execute the provided value updater to update the cache. The specific implementation defines how this is invoked.
          */


### PR DESCRIPTION
Switched out AutoCloseable use for SdkAutoCloseable, an implementation of AutoCloseable that throws no exceptions. Banned use of AutoCloseable/Closeable in extends/implements statements.