### PR TITLE
Move check for epoll group outside of loop

### DIFF
--- a/http-clients/netty-nio-client/src/it/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientIntegrationTest.java
+++ b/http-clients/netty-nio-client/src/it/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientIntegrationTest.java
@@ -56,6 +56,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+
+import io.netty.channel.nio.NioEventLoopGroup;
 import org.assertj.core.api.Condition;
 import org.junit.AfterClass;
 import org.junit.Rule;
@@ -155,10 +157,10 @@ public class NettyNioAsyncHttpClientIntegrationTest {
     public void customEventLoopGroup_NotClosedWhenClientIsClosed() throws Exception {
 
         ThreadFactory threadFactory = spy(new CustomThreadFactory());
-        EventLoopGroup eventLoopGroup = spy(DefaultEventLoopGroupFactory.builder()
-                                                                        .threadFactory(threadFactory)
-                                                                        .build()
-                                                                        .create());
+        // Cannot use DefaultEventLoopGroupFactory because the concrete
+        // implementation it creates is platform-dependent and could be a final
+        // (i.e. non-spyable) class.
+        EventLoopGroup eventLoopGroup = spy(new NioEventLoopGroup(0, threadFactory));
         EventLoopGroupConfiguration eventLoopGroupConfiguration =
                 EventLoopGroupConfiguration.builder()
                                            .eventLoopGroup(eventLoopGroup)

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -128,11 +128,11 @@ final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         // Keep unwrapping until it's not a DelegatingEventLoopGroup
         while (unwrapped instanceof DelegatingEventLoopGroup) {
             unwrapped = ((DelegatingEventLoopGroup) unwrapped).getDelegate();
-            if (unwrapped instanceof EpollEventLoopGroup) {
-                return EpollSocketChannel.class;
-            }
         }
-        // None of the wrapped event loop groups were Epoll so assume Nio.
+
+        if (unwrapped instanceof EpollEventLoopGroup) {
+            return EpollSocketChannel.class;
+        }
         return NioSocketChannel.class;
     }
 


### PR DESCRIPTION
If the configured EventLoopGroup is not an instance of
DelegatingEventLoopGroup, then resolveSocketChannelClass always returns
NioSocketChannel which is incorrect.