### PR TITLE
Allow interceptors to define their own priority.

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/client/BaseClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/client/BaseClientHandler.java
@@ -62,7 +62,7 @@ abstract class BaseClientHandler {
                                          .putAttribute(AwsExecutionAttributes.REQUEST_CONFIG, requestConfig);
 
         return ExecutionContext.builder()
-                               .interceptorChain(new ExecutionInterceptorChain(overrideConfiguration.lastExecutionInterceptors()))
+                               .interceptorChain(new ExecutionInterceptorChain(overrideConfiguration.executionInterceptors()))
                                .interceptorContext(InterceptorContext.builder()
                                                                      .request(requestConfig.getOriginalRequest())
                                                                      .build())

--- a/core/src/main/java/software/amazon/awssdk/config/ClientOverrideConfiguration.java
+++ b/core/src/main/java/software/amazon/awssdk/config/ClientOverrideConfiguration.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.metrics.RequestMetricCollector;
 import software.amazon.awssdk.retry.v2.RetryPolicy;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -43,7 +44,7 @@ public class ClientOverrideConfiguration
     private final Boolean gzipEnabled;
     private final RequestMetricCollector requestMetricCollector;
     private final RetryPolicy retryPolicy;
-    private final List<ExecutionInterceptor> lastExecutionInterceptors;
+    private final List<ExecutionInterceptor> executionInterceptors;
     private final AttributeMap advancedOptions;
 
     /**
@@ -56,7 +57,7 @@ public class ClientOverrideConfiguration
         this.gzipEnabled = builder.gzipEnabled;
         this.requestMetricCollector = builder.requestMetricCollector;
         this.retryPolicy = builder.retryPolicy;
-        this.lastExecutionInterceptors = Collections.unmodifiableList(new ArrayList<>(builder.lastExecutionInterceptors));
+        this.executionInterceptors = Collections.unmodifiableList(new ArrayList<>(builder.executionInterceptors));
         this.advancedOptions = builder.advancedOptions.build();
     }
 
@@ -69,7 +70,7 @@ public class ClientOverrideConfiguration
                                                               .gzipEnabled(gzipEnabled)
                                                               .requestMetricCollector(requestMetricCollector)
                                                               .retryPolicy(retryPolicy)
-                                                              .lastExecutionInterceptors(lastExecutionInterceptors);
+                                                              .executionInterceptors(executionInterceptors);
     }
 
     /**
@@ -169,13 +170,14 @@ public class ClientOverrideConfiguration
     }
 
     /**
-     * An immutable collection of {@link ExecutionInterceptor}s that should be hooked into the execution of each request, in the
-     * order that they should be applied.
+     * An immutable collection of {@link ExecutionInterceptor}s that should be hooked into the execution of each request.
      *
-     * @see Builder#lastExecutionInterceptors(List)
+     * Any interceptors with the same {@link Priority} should be executed in the order returned by this method.
+     *
+     * @see Builder#executionInterceptors(List)
      */
-    public List<ExecutionInterceptor> lastExecutionInterceptors() {
-        return lastExecutionInterceptors;
+    public List<ExecutionInterceptor> executionInterceptors() {
+        return executionInterceptors;
     }
 
     /**
@@ -267,28 +269,27 @@ public class ClientOverrideConfiguration
         Builder retryPolicy(RetryPolicy retryPolicy);
 
         /**
-         * Configure a list of execution interceptors that will have access to read and modify the request and response objcets as
+         * Configure a list of execution interceptors that will have access to read and modify the request and response objects as
          * they are processed by the SDK. These will replace any interceptors configured previously with this method or
-         * {@link #addLastExecutionInterceptor(ExecutionInterceptor)}.
+         * {@link #addExecutionInterceptor(ExecutionInterceptor)}.
          *
-         * The provided interceptors are executed in the order they are configured and are always later in the order than the ones
-         * automatically added by the SDK. See {@link ExecutionInterceptor} for a more detailed explanation of interceptor order.
+         * Any {@link ExecutionInterceptor}s given to this method with the same {@link Priority} will be executed in the order
+         * they are given.
          *
-         * @see ClientOverrideConfiguration#lastExecutionInterceptors()
+         * @see ClientOverrideConfiguration#executionInterceptors()
          */
-        Builder lastExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors);
+        Builder executionInterceptors(List<ExecutionInterceptor> executionInterceptors);
 
         /**
          * Add an execution interceptor that will have access to read and modify the request and response objects as they are
          * processed by the SDK.
          *
-         * Interceptors added using this method are executed in the order they are configured and are always later in the order
-         * than the ones automatically added by the SDK. See {@link ExecutionInterceptor} for a more detailed explanation of
-         * interceptor order.
+         * Any {@link ExecutionInterceptor}s added via this method with the same {@link Priority} will be executed in the order
+         * they were added.
          *
-         * @see ClientOverrideConfiguration#lastExecutionInterceptors()
+         * @see ClientOverrideConfiguration#executionInterceptors()
          */
-        Builder addLastExecutionInterceptor(ExecutionInterceptor executionInterceptor);
+        Builder addExecutionInterceptor(ExecutionInterceptor executionInterceptor);
 
         /**
          * Configure an advanced override option. These values are used very rarely, and the majority of SDK customers can ignore
@@ -317,7 +318,7 @@ public class ClientOverrideConfiguration
         private Boolean gzipEnabled;
         private RequestMetricCollector requestMetricCollector;
         private RetryPolicy retryPolicy;
-        private List<ExecutionInterceptor> lastExecutionInterceptors = new ArrayList<>();
+        private List<ExecutionInterceptor> executionInterceptors = new ArrayList<>();
         private AttributeMap.Builder advancedOptions = AttributeMap.builder();
 
         @Override
@@ -388,20 +389,20 @@ public class ClientOverrideConfiguration
         }
 
         @Override
-        public Builder lastExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
-            this.lastExecutionInterceptors.clear();
-            this.lastExecutionInterceptors.addAll(executionInterceptors);
+        public Builder executionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
+            this.executionInterceptors.clear();
+            this.executionInterceptors.addAll(executionInterceptors);
             return this;
         }
 
         @Override
-        public Builder addLastExecutionInterceptor(ExecutionInterceptor executionInterceptors) {
-            this.lastExecutionInterceptors.add(executionInterceptors);
+        public Builder addExecutionInterceptor(ExecutionInterceptor executionInterceptors) {
+            this.executionInterceptors.add(executionInterceptors);
             return this;
         }
 
-        public void setLastExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
-            lastExecutionInterceptors(executionInterceptors);
+        public void setExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
+            executionInterceptors(executionInterceptors);
         }
 
         @Override

--- a/core/src/main/java/software/amazon/awssdk/config/defaults/GlobalClientConfigurationDefaults.java
+++ b/core/src/main/java/software/amazon/awssdk/config/defaults/GlobalClientConfigurationDefaults.java
@@ -18,9 +18,7 @@ package software.amazon.awssdk.config.defaults;
 import static software.amazon.awssdk.config.AdvancedClientOption.USER_AGENT_PREFIX;
 import static software.amazon.awssdk.config.AdvancedClientOption.USER_AGENT_SUFFIX;
 import static software.amazon.awssdk.config.InternalAdvancedClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED;
-import static software.amazon.awssdk.utils.CollectionUtils.mergeLists;
 
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotation.ReviewBeforeRelease;
@@ -28,7 +26,6 @@ import software.amazon.awssdk.annotation.SdkInternalApi;
 import software.amazon.awssdk.config.ClientConfiguration;
 import software.amazon.awssdk.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.handlers.ClasspathInterceptorChainFactory;
-import software.amazon.awssdk.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.metrics.RequestMetricCollector;
 import software.amazon.awssdk.retry.PredefinedRetryPolicies;
 import software.amazon.awssdk.retry.RetryPolicyAdapter;
@@ -60,9 +57,7 @@ public final class GlobalClientConfigurationDefaults extends ClientConfiguration
         builder.retryPolicy(applyDefault(configuration.retryPolicy(), () ->
                 new RetryPolicyAdapter(PredefinedRetryPolicies.DEFAULT)));
 
-        // Put global interceptors before the ones currently configured.
-        List<ExecutionInterceptor> globalInterceptors = new ClasspathInterceptorChainFactory().getGlobalInterceptors();
-        builder.lastExecutionInterceptors(mergeLists(globalInterceptors, configuration.lastExecutionInterceptors()));
+        new ClasspathInterceptorChainFactory().getGlobalInterceptors().forEach(builder::addExecutionInterceptor);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/awssdk/config/defaults/ServiceBuilderConfigurationDefaults.java
+++ b/core/src/main/java/software/amazon/awssdk/config/defaults/ServiceBuilderConfigurationDefaults.java
@@ -25,7 +25,6 @@ import java.util.function.Supplier;
 import software.amazon.awssdk.annotation.SdkProtectedApi;
 import software.amazon.awssdk.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.handlers.ClasspathInterceptorChainFactory;
-import software.amazon.awssdk.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.runtime.auth.SignerProvider;
 
 /**
@@ -66,12 +65,9 @@ public class ServiceBuilderConfigurationDefaults extends ClientConfigurationDefa
         }
 
         ClasspathInterceptorChainFactory chainFactory = new ClasspathInterceptorChainFactory();
-
-        // Add service interceptors before the ones currently configured.
-        List<ExecutionInterceptor> serviceInterceptors = new ArrayList<>();
-        requestHandlerPaths.forEach(p -> serviceInterceptors.addAll(chainFactory.getInterceptors(p)));
-        serviceInterceptors.addAll(config.lastExecutionInterceptors());
-        builder.lastExecutionInterceptors(serviceInterceptors);
+        requestHandlerPaths.stream()
+                           .flatMap(p -> chainFactory.getInterceptors(p).stream())
+                           .forEach(builder::addExecutionInterceptor);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/awssdk/interceptor/Priority.java
+++ b/core/src/main/java/software/amazon/awssdk/interceptor/Priority.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.interceptor;
+
+import software.amazon.awssdk.handlers.ClasspathInterceptorChainFactory;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Defines the priority in which {@link ExecutionInterceptor}s should be executed. Interceptors are sorted by their priorities in
+ * ascending order.
+ *
+ * <p>Most interceptors that aren't defined by special libraries or the service itself should use the {@link #USER} priority, or a
+ * function of the {@link #USER} priority (eg. {@code new Priority(Priority.USER.value() - 1)}).</p>
+ *
+ * @see ExecutionInterceptor
+ */
+public class Priority implements Comparable<Priority> {
+    /**
+     * The default priority for an interceptor that is written for a specific service, without which the request will fail.
+     *
+     * <p>These interceptors are usually defined by the service that will be receiving the request in order to augment the request
+     * with additional information or to modify the request because its JSON definition is insufficient. These are usually loaded
+     * automatically using service-specific interceptors paths via
+     * {@link ClasspathInterceptorChainFactory#getInterceptors(String)}.</p>
+     */
+    public static final Priority SERVICE = new Priority(1000);
+
+    /**
+     * The default priority for an interceptor that is written to be used across services.
+     *
+     * <p>These interceptors are usually defined by a library that will be reading the request for logging, metrics or auditing
+     * purposes. These interceptors are usually defined by libraries that are automatically loaded from the classpath via
+     * {@link ClasspathInterceptorChainFactory#getGlobalInterceptors()}.</p>
+     */
+    public static final Priority GLOBAL = new Priority(2000);
+
+    /**
+     * The default priority for an interceptor that is written by a consumer of the SDK.
+     *
+     * <p>These interceptors are usually registered directly into a specific client via
+     * {@link software.amazon.awssdk.config.ClientOverrideConfiguration.Builder#addExecutionInterceptor(ExecutionInterceptor)}.
+     * </p>
+     */
+    public static final Priority USER = new Priority(3000);
+
+    private Integer value;
+
+    /**
+     * Create a priority with the provided value. This should usually not be used except in relation to another static priorities
+     * (like {@link Priority#USER}).
+     *
+     * <p>
+     * For example:
+     * <ol>
+     *     <li>{@code Priority.USER} should be used instead of {@code new Priority(3000)}</li>
+     *     <li>{@code new Priority(Priority.USER.value() - 1)} should be used to specify an interceptor that happens before other
+     *     {@code Priority.USER} interceptors</li>
+     *     <li>{@code new Priority(Priority.USER.value() + 1)} should be used to specify an interceptor that happens after other
+     *     {@code Priority.USER} interceptors</li>
+     * </ol>
+     * </p>
+     */
+    public Priority(Integer value) {
+        this.value = Validate.paramNotNull(value, "value");
+        Validate.isTrue(value >= 0, "Priority must be positive.");
+    }
+
+    @Override
+    public int compareTo(Priority o) {
+        return value.compareTo(o.value);
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/config/ImmutableClientConfigurationTest.java
+++ b/core/src/test/java/software/amazon/awssdk/config/ImmutableClientConfigurationTest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.auth.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.internal.auth.NoOpSignerProvider;
 import software.amazon.awssdk.metrics.RequestMetricCollector;
 import software.amazon.awssdk.retry.v2.RetryPolicy;
@@ -97,7 +98,7 @@ public class ImmutableClientConfigurationTest {
                                           .advancedOption(AdvancedClientOption.SIGNER_PROVIDER, SIGNER_PROVIDER)
                                           .advancedOption(AdvancedClientOption.ENABLE_DEFAULT_REGION_DETECTION, false)
                                           .retryPolicy(RETRY_POLICY)
-                                          .addLastExecutionInterceptor(EXECUTION_INTERCEPTOR)
+                                          .addExecutionInterceptor(EXECUTION_INTERCEPTOR)
                                           .build();
     }
 }

--- a/core/src/test/java/software/amazon/awssdk/interceptor/ExecutionInterceptorChainTest.java
+++ b/core/src/test/java/software/amazon/awssdk/interceptor/ExecutionInterceptorChainTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.interceptor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.SdkRequest;
+import software.amazon.awssdk.SdkResponse;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+
+/**
+ * Verify the functionality of the {@link ExecutionInterceptorChain}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExecutionInterceptorChainTest {
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private NoOpInterceptor first;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private NoOpInterceptor second;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private NoOpInterceptor third;
+
+    private ExecutionInterceptorChain chain;
+
+    @Before
+    public void sortInterceptors() {
+        when(first.priority()).thenReturn(new Priority(1));
+        when(second.priority()).thenReturn(new Priority(2));
+        when(third.priority()).thenReturn(new Priority(2));
+
+        // Intentionally create the chain in a different order to make sure:
+        // FIRST gets moved to the front, SECOND and THIRD stay in the provided order
+        chain = new ExecutionInterceptorChain(Arrays.asList(second, first, third));
+    }
+
+    @Test
+    public void methodOrderIsCorrect() {
+        InterceptorContext context = InterceptorContext.builder()
+                                                       .request(new SdkRequest() {})
+                                                       .httpRequest(SdkHttpFullRequest.builder().build())
+                                                       .httpResponse(SdkHttpFullResponse.builder().build())
+                                                       .response(new SdkResponse() {})
+                                                       .build();
+
+        chain.beforeExecution(context, null);
+        chain.modifyRequest(context, null);
+        chain.beforeMarshalling(context, null);
+        chain.afterMarshalling(context, null);
+        chain.modifyHttpRequest(context, null);
+        chain.beforeTransmission(context, null);
+        chain.afterTransmission(context, null);
+        chain.modifyHttpResponse(context, null);
+        chain.beforeUnmarshalling(context, null);
+        chain.afterUnmarshalling(context, null);
+        chain.modifyResponse(context, null);
+        chain.afterExecution(context, null);
+
+        verifyInOrder(i -> i.beforeExecution(any(), any()));
+        verifyInOrder(i -> i.modifyRequest(any(), any()));
+        verifyInOrder(i -> i.beforeMarshalling(any(), any()));
+        verifyInOrder(i -> i.afterMarshalling(any(), any()));
+        verifyInOrder(i -> i.modifyHttpRequest(any(), any()));
+        verifyInOrder(i -> i.beforeTransmission(any(), any()));
+        verifyReverseOrder(i -> i.afterTransmission(any(), any()));
+        verifyReverseOrder(i -> i.modifyHttpResponse(any(), any()));
+        verifyReverseOrder(i -> i.beforeUnmarshalling(any(), any()));
+        verifyReverseOrder(i -> i.afterUnmarshalling(any(), any()));
+        verifyReverseOrder(i -> i.modifyResponse(any(), any()));
+        verifyReverseOrder(i -> i.afterExecution(any(), any()));
+    }
+
+    public void verifyInOrder(Consumer<ExecutionInterceptor> methodCall) {
+        InOrder inOrder = Mockito.inOrder(first, second, third);
+        methodCall.accept(inOrder.verify(first));
+        methodCall.accept(inOrder.verify(second));
+        methodCall.accept(inOrder.verify(third));
+    }
+
+    public void verifyReverseOrder(Consumer<ExecutionInterceptor> methodCall) {
+        InOrder inOrder = Mockito.inOrder(first, second, third);
+        methodCall.accept(inOrder.verify(third));
+        methodCall.accept(inOrder.verify(second));
+        methodCall.accept(inOrder.verify(first));
+    }
+
+    public static class NoOpInterceptor implements ExecutionInterceptor {
+        @Override
+        public Priority priority() {
+            return Priority.USER;
+        }
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/internal/http/request/SlowExecutionInterceptor.java
+++ b/core/src/test/java/software/amazon/awssdk/internal/http/request/SlowExecutionInterceptor.java
@@ -18,11 +18,16 @@ package software.amazon.awssdk.internal.http.request;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 /**
  * Implementation of {@link ExecutionInterceptor} with configurable wait times
  */
 public class SlowExecutionInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.USER;
+    }
 
     private int beforeTransmissionWait;
     private int afterTransmissionWait;

--- a/services/api-gateway/src/main/java/software/amazon/awssdk/services/apigateway/internal/AcceptJsonInterceptor.java
+++ b/services/api-gateway/src/main/java/software/amazon/awssdk/services/apigateway/internal/AcceptJsonInterceptor.java
@@ -19,8 +19,14 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
+
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         return context.httpRequest()

--- a/services/cloudsearch/src/main/java/software/amazon/awssdk/services/cloudsearchdomain/SwitchToPostInterceptor.java
+++ b/services/cloudsearch/src/main/java/software/amazon/awssdk/services/cloudsearchdomain/SwitchToPostInterceptor.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.cloudsearchdomain.model.SearchRequest;
 import software.amazon.awssdk.util.SdkHttpUtils;
 
@@ -28,6 +29,11 @@ import software.amazon.awssdk.util.SdkHttpUtils;
  * Ensures that all SearchRequests use <code>POST</code> instead of <code>GET</code>.
  */
 public class SwitchToPostInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
+
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         SdkHttpFullRequest request = context.httpRequest();

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/global/handlers/TestGlobalExecutionInterceptor.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/global/handlers/TestGlobalExecutionInterceptor.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.global.handlers;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 public class TestGlobalExecutionInterceptor implements ExecutionInterceptor {
 
@@ -29,6 +30,11 @@ public class TestGlobalExecutionInterceptor implements ExecutionInterceptor {
 
     public static boolean wasCalled() {
         return wasCalled;
+    }
+
+    @Override
+    public Priority priority() {
+        return Priority.USER;
     }
 
     @Override

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/EC2Interceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/EC2Interceptor.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.DescribeSpotInstanceRequestsResponse;
 import software.amazon.awssdk.services.ec2.model.GroupIdentifier;
@@ -42,6 +43,11 @@ import software.amazon.awssdk.services.ec2.model.SpotInstanceRequest;
 import software.amazon.awssdk.utils.Base64Utils;
 
 public class EC2Interceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
+
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         SdkHttpFullRequest request = context.httpRequest();

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/GeneratePreSignUrlInterceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/GeneratePreSignUrlInterceptor.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.interceptor.InterceptorContext;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.EC2Client;
 import software.amazon.awssdk.services.ec2.model.CopySnapshotRequest;
@@ -39,6 +40,10 @@ import software.amazon.awssdk.util.SdkHttpUtils;
  * TODO: Is this actually right? What if a different interceptor modifies the message? Should this be treated as a signer?
  */
 public class GeneratePreSignUrlInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/TimestampFormatInterceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/TimestampFormatInterceptor.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.ec2.model.DescribeSpotFleetRequestHistoryRequest;
 import software.amazon.awssdk.services.ec2.model.RequestSpotFleetRequest;
 
@@ -39,6 +40,11 @@ public final class TimestampFormatInterceptor implements ExecutionInterceptor {
     private static final String START_TIME = "StartTime";
     private static final String VALID_FROM = "SpotFleetRequestConfig.ValidFrom";
     private static final String VALID_UNTIL = "SpotFleetRequestConfig.ValidUntil";
+
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
+++ b/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.glacier.model.ListVaultsRequest;
 import software.amazon.awssdk.test.AwsIntegrationTestBase;
 
@@ -40,7 +41,7 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
                               .credentialsProvider(getCredentialsProvider())
                               .overrideConfiguration(ClientOverrideConfiguration
                                                              .builder()
-                                                             .addLastExecutionInterceptor(capturingExecutionInterceptor)
+                                                             .addExecutionInterceptor(capturingExecutionInterceptor)
                                                              .build())
                               .build();
     }
@@ -62,6 +63,11 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
     public static class CapturingExecutionInterceptor implements ExecutionInterceptor {
 
         private SdkHttpFullRequest beforeTransmission;
+
+        @Override
+        public Priority priority() {
+            return Priority.USER;
+        }
 
         @Override
         public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/AcceptJsonInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/AcceptJsonInterceptor.java
@@ -19,8 +19,14 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
+
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         return context.httpRequest()

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
@@ -19,11 +19,16 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.glacier.model.DescribeJobRequest;
 import software.amazon.awssdk.services.glacier.model.GetJobOutputRequest;
 import software.amazon.awssdk.services.glacier.model.UploadMultipartPartRequest;
 
 public class GlacierExecutionInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/logs/src/main/java/software/amazon/awssdk/services/logs/internal/AcceptJsonInterceptor.java
+++ b/services/logs/src/main/java/software/amazon/awssdk/services/logs/internal/AcceptJsonInterceptor.java
@@ -20,9 +20,15 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 @ReviewBeforeRelease("It's unclear if we need this, service seems to work fine without it.")
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
+
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         return context.httpRequest()

--- a/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/PredictEndpointInterceptor.java
+++ b/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/PredictEndpointInterceptor.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.machinelearning.model.PredictRequest;
 
 /**
@@ -30,6 +31,10 @@ import software.amazon.awssdk.services.machinelearning.model.PredictRequest;
  * the endpoint to send the request to.
  */
 public class PredictEndpointInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/RandomIdInterceptor.java
+++ b/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/RandomIdInterceptor.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.annotation.ReviewBeforeRelease;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.machinelearning.model.CreateBatchPredictionRequest;
 import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromRDSRequest;
 import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromRedshiftRequest;
@@ -34,6 +35,10 @@ import software.amazon.awssdk.services.machinelearning.model.CreateMLModelReques
  */
 @ReviewBeforeRelease("They should be using the idempotency trait")
 public class RandomIdInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/RdsPresignInterceptor.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.interceptor.InterceptorContext;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.runtime.endpoint.DefaultServiceEndpointBuilder;
 import software.amazon.awssdk.util.AwsHostNameUtils;
@@ -42,6 +43,7 @@ import software.amazon.awssdk.utils.StringUtils;
  */
 abstract class RdsPresignInterceptor<T extends AmazonWebServiceRequest> implements ExecutionInterceptor {
     private static final String SERVICE_NAME = "rds";
+
     private static final String PARAM_SOURCE_REGION = "SourceRegion";
     private static final String PARAM_DESTINATION_REGION = "DestinationRegion";
     private static final String PARAM_PRESIGNED_URL = "PreSignedUrl";
@@ -69,6 +71,11 @@ abstract class RdsPresignInterceptor<T extends AmazonWebServiceRequest> implemen
         } else {
             this.signingOverrideDate = null;
         }
+    }
+
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
     }
 
     @Override

--- a/services/route53/src/main/java/software/amazon/awssdk/services/route53/internal/Route53IdInterceptor.java
+++ b/services/route53/src/main/java/software/amazon/awssdk/services/route53/internal/Route53IdInterceptor.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.SdkResponse;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.route53.model.AliasTarget;
 import software.amazon.awssdk.services.route53.model.ChangeInfo;
 import software.amazon.awssdk.services.route53.model.ChangeResourceRecordSetsResponse;
@@ -47,6 +48,11 @@ import software.amazon.awssdk.services.route53.model.ResourceRecordSet;
  * partial resource path elements from IDs returned by Route 53.
  */
 public class Route53IdInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
+
     @Override
     public SdkResponse modifyResponse(Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
         SdkResponse response = context.response();

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.http.async.SimpleSubscriber;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -115,7 +116,7 @@ public class GetObjectAsyncIntegrationTest extends S3IntegrationTestBase {
     private S3AsyncClient createClientWithInterceptor(ExecutionInterceptor assertingInterceptor) {
         return s3AsyncClientBuilder()
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
-                                                                  .addLastExecutionInterceptor(assertingInterceptor)
+                                                                  .addExecutionInterceptor(assertingInterceptor)
                                                                   .build())
                 .build();
     }
@@ -127,6 +128,11 @@ public class GetObjectAsyncIntegrationTest extends S3IntegrationTestBase {
      * async.
      */
     public static class AssertingExecutionInterceptor implements ExecutionInterceptor {
+        @Override
+        public Priority priority() {
+            return Priority.USER;
+        }
+
         @Override
         public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
             // The response object should be the pojo. Not the result type of the AsyncResponseHandler

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
@@ -105,7 +105,7 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
 
     private S3Client createClientWithInterceptor(ExecutionInterceptor interceptor) {
         return s3ClientBuilder().overrideConfiguration(ClientOverrideConfiguration.builder()
-                                                                                  .addLastExecutionInterceptor(interceptor)
+                                                                                  .addExecutionInterceptor(interceptor)
                                                                                   .build())
                                 .build();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptor.java
@@ -20,10 +20,15 @@ import software.amazon.awssdk.annotation.ReviewBeforeRelease;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.s3.BucketUtils;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 public class CreateBucketInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     @ReviewBeforeRelease("Automatically set location constraint to the bucket region if not provided. Also" +

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/DecodeUrlEncodedResponseInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/DecodeUrlEncodedResponseInterceptor.java
@@ -23,12 +23,17 @@ package software.amazon.awssdk.services.s3.handlers;
 
 import software.amazon.awssdk.annotation.ReviewBeforeRelease;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 //import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 //import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 //import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 
 @ReviewBeforeRelease("Finish this and hook it up")
 public class DecodeUrlEncodedResponseInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     //    @Override
     //    public void afterResponse(Request<?> request, Response<?> response) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.s3.BucketUtils;
 import software.amazon.awssdk.services.s3.S3AdvancedConfiguration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
@@ -34,9 +35,13 @@ import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
 
 public class EndpointAddressInterceptor implements ExecutionInterceptor {
-
     private static List<Class<?>> ACCELERATE_DISABLED_OPERATIONS = Arrays.asList(
             ListBucketsRequest.class, CreateBucketRequest.class, DeleteBucketRequest.class);
+
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/SingleStringExecutionInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/SingleStringExecutionInterceptor.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
 import software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest;
 import software.amazon.awssdk.utils.IoUtils;
@@ -48,6 +49,10 @@ import software.amazon.awssdk.utils.IoUtils;
  * responses of these operations to include the required XML wrappers.
  */
 public final class SingleStringExecutionInterceptor implements ExecutionInterceptor {
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     @ReviewBeforeRelease("Change to use instanceof on request object after request handlers refactor")

--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/MessageAttributesIntegrationTest.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/MessageAttributesIntegrationTest.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
@@ -73,7 +74,7 @@ public class MessageAttributesIntegrationTest extends IntegrationTestBase {
                                                   .credentialsProvider(getCredentialsProvider())
                                                   .overrideConfiguration(ClientOverrideConfiguration
                                                                                  .builder()
-                                                                                 .addLastExecutionInterceptor(
+                                                                                 .addExecutionInterceptor(
                                                                                          new TamperingInterceptor())
                                                                                  .build())
                                                   .build()) {
@@ -90,6 +91,10 @@ public class MessageAttributesIntegrationTest extends IntegrationTestBase {
     }
 
     public static class TamperingInterceptor implements ExecutionInterceptor {
+        @Override
+        public Priority priority() {
+            return Priority.USER;
+        }
 
         @Override
         public SdkResponse modifyResponse(Context.ModifyResponse context, ExecutionAttributes executionAttributes) {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptor.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.AmazonClientException;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -50,7 +51,6 @@ import software.amazon.awssdk.utils.BinaryUtils;
  * comparing the returned MD5 with the calculation according to the original request.
  */
 public class MessageMD5ChecksumInterceptor implements ExecutionInterceptor {
-
     private static final int INTEGER_SIZE_IN_BYTES = 4;
     private static final byte STRING_TYPE_FIELD_INDEX = 1;
     private static final byte BINARY_TYPE_FIELD_INDEX = 2;
@@ -70,6 +70,11 @@ public class MessageMD5ChecksumInterceptor implements ExecutionInterceptor {
     private static final String MESSAGE_ATTRIBUTES = "message attributes";
 
     private static final Logger log = LoggerFactory.getLogger(MessageMD5ChecksumInterceptor.class);
+
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public void afterExecution(Context.AfterExecution context, ExecutionAttributes executionAttributes) {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/QueueUrlInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/QueueUrlInterceptor.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 /**
  * Custom request handler for SQS that processes the request before it gets routed to the client
@@ -37,6 +38,11 @@ import software.amazon.awssdk.interceptor.ExecutionInterceptor;
 @ReviewBeforeRelease("Do we still want to do this?")
 public class QueueUrlInterceptor implements ExecutionInterceptor {
     private static final String QUEUE_URL_PARAMETER = "QueueUrl";
+    
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
+    }
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/SqsExecutionInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/SqsExecutionInterceptor.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 
 public class SqsExecutionInterceptor implements ExecutionInterceptor {
 
@@ -37,6 +38,11 @@ public class SqsExecutionInterceptor implements ExecutionInterceptor {
         NONSTANDARD_ENDPOINT_MAP.put("sa-east-1.queue.amazonaws.com", "sqs.sa-east-1.amazonaws.com");
         NONSTANDARD_ENDPOINT_MAP.put("us-gov-west-1.queue.amazonaws.com", "sqs.us-gov-west-1.amazonaws.com");
         NONSTANDARD_ENDPOINT_MAP.put("ap-southeast-2.queue.amazonaws.com", "sqs.ap-southeast-2.amazonaws.com");
+    }
+
+    @Override
+    public Priority priority() {
+        return Priority.SERVICE;
     }
 
     @Override

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
@@ -61,6 +61,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.interceptor.Context;
 import software.amazon.awssdk.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.interceptor.Priority;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
@@ -466,12 +467,17 @@ public class ExecutionInterceptorTest {
                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                       .credentialsProvider(new StaticCredentialsProvider(new AwsCredentials("akid", "skid")))
                       .overrideConfiguration(ClientOverrideConfiguration.builder()
-                                                                        .addLastExecutionInterceptor(interceptor)
+                                                                        .addExecutionInterceptor(interceptor)
                                                                         .build())
                       .build();
     }
 
     private static class MessageUpdatingInterceptor implements ExecutionInterceptor {
+        @Override
+        public Priority priority() {
+            return Priority.USER;
+        }
+
         @Override
         public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
             MembersInHeadersRequest request = (MembersInHeadersRequest) context.request();
@@ -500,7 +506,10 @@ public class ExecutionInterceptorTest {
     }
 
     private static class NoOpInterceptor implements ExecutionInterceptor {
-
+        @Override
+        public Priority priority() {
+            return Priority.USER;
+        }
     }
 
     private static class NoOpRequestProvider implements AsyncRequestProvider {


### PR DESCRIPTION
SDK users usually don't know what order interceptors should be executed. The only time it actually matters is if there's an implicit dependency between two interceptors. In this case, the interceptors should be able to resolve that ordering themselves and not require the user to know what order the interceptors need to be defined in.