### PR TITLE
update to jackson 2.9.1

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/protocol/json/JsonContent.java
+++ b/core/src/main/java/software/amazon/awssdk/protocol/json/JsonContent.java
@@ -67,7 +67,11 @@ public class JsonContent {
     }
 
     private static JsonNode parseJsonContent(byte[] rawJsonContent, ObjectMapper mapper) {
-        if (rawJsonContent == null) {
+        if (rawJsonContent == null || rawJsonContent.length == 0) {
+            // Note: behavior of mapper.readTree changed in 2.9 so we need to explicitly
+            // check for an empty input and return an empty object or else the return
+            // value will be null:
+            // https://github.com/FasterXML/jackson-databind/issues/1406
             return mapper.createObjectNode();
         }
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     </scm>
     <properties>
         <awsjavasdk.version>${project.version}</awsjavasdk.version>
-        <jackson.version>2.8.8</jackson.version>
+        <jackson.version>2.9.1</jackson.version>
         <ion.java.version>1.0.2</ion.java.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.4</easymock.version>
@@ -92,7 +92,7 @@
         <netty.version>4.1.13.Final</netty.version>
         <unitils.version>3.3</unitils.version>
         <xmlunit.version>1.3</xmlunit.version>
-        <jacksonjr.version>2.9.0.pr4</jacksonjr.version>
+        <jacksonjr.version>2.9.1</jacksonjr.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- These properties are used by SWF for its dependencies -->


### PR DESCRIPTION
Prior to 2.9.1 `jackson-jr-objects` has backticks in the
jar manifest which hits a bug in jdk9. For more details
see FasterXML/jackson-jr#55.

This change also ensure that the jackson versions are
the all the same:

**Before**

```
$ mvn --projects core dependency:tree -Dincludes=*:jackson-*::*
...
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ core ---
[INFO] software.amazon.awssdk:core:jar:2.0.0-preview-3-SNAPSHOT
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.8.8:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.8.8:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.8.8:compile
[INFO] +- com.fasterxml.jackson.jr:jackson-jr-objects:jar:2.9.0.pr4:compile
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.8.8:compile
[INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.8.8:compile
[INFO] \- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.8.8:compile
```

**After**

```
$ mvn --projects core dependency:tree -Dincludes=*:jackson-*::*
...
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ core ---
[INFO] software.amazon.awssdk:core:jar:2.0.0-preview-3-SNAPSHOT
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.1:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.1:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.9.1:compile
[INFO] +- com.fasterxml.jackson.jr:jackson-jr-objects:jar:2.9.1:compile
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.9.1:compile
[INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.9.1:compile
[INFO] \- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.9.1:compile
```