### PR TITLE
Adding a helper that exposes an async string request provider

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/async/AsyncRequestProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/async/AsyncRequestProvider.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.async;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -60,6 +62,29 @@ public interface AsyncRequestProvider extends Publisher<ByteBuffer> {
      */
     static AsyncRequestProvider fromFile(Path path) {
         return FileAsyncRequestProvider.builder().path(path).build();
+    }
+
+    /**
+     * Creates an {@link AsyncRequestProvider} that uses a single string as data.
+     *
+     * @param string The string to provide.
+     * @param cs The {@link Charset} to use.
+     * @return Implementation of {@link AsyncRequestProvider} that uses the specified string.
+     * @see SingleByteArrayAsyncRequestProvider
+     */
+    static AsyncRequestProvider fromString(String string, Charset cs) {
+        return new SingleByteArrayAsyncRequestProvider(string.getBytes(cs));
+    }
+
+    /**
+     * Creates an {@link AsyncRequestProvider} that uses a single string as data with UTF_8 encoding.
+     *
+     * @param string The string to provider.
+     * @return Implementation of {@link AsyncRequestProvider} that uses the specified string.
+     * @see #fromString(String, Charset)
+     */
+    static AsyncRequestProvider fromString(String string) {
+        return fromString(string, StandardCharsets.UTF_8);
     }
 
 }

--- a/core/src/main/java/software/amazon/awssdk/async/SingleByteArrayAsyncRequestProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/async/SingleByteArrayAsyncRequestProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.async;
+
+import java.nio.ByteBuffer;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+class SingleByteArrayAsyncRequestProvider implements AsyncRequestProvider {
+
+    private final byte[] bytes;
+
+    SingleByteArrayAsyncRequestProvider(byte[] bytes) {
+        this.bytes = bytes.clone();
+    }
+
+    @Override
+    public long contentLength() {
+        return bytes.length;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        subscriber.onSubscribe(
+            new Subscription() {
+                @Override
+                public void request(long n) {
+                    if (n > 0) {
+                        subscriber.onNext(ByteBuffer.wrap(bytes));
+                        subscriber.onComplete();
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                }
+            }
+        );
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/async/AsyncRequestProviderTest.java
+++ b/core/src/test/java/software/amazon/awssdk/async/AsyncRequestProviderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
+
+public class AsyncRequestProviderTest {
+
+    @Test
+    public void canCreateAStringProvider() {
+        AsyncRequestProvider provider = AsyncRequestProvider.fromString("Hello!");
+        StringBuilder sb = new StringBuilder();
+        boolean done = false;
+
+        Subscriber<ByteBuffer> subscriber = spy(new SimpleSubscriber(buffer -> {
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                sb.append(new String(bytes, StandardCharsets.UTF_8));
+            }));
+
+        provider.subscribe(subscriber);
+
+        assertThat(sb.toString()).isEqualTo("Hello!");
+        assertThat(provider.contentLength()).isEqualTo(6);
+        verify(subscriber).onComplete();
+        verify(subscriber, times(0)).onError(any(Throwable.class));
+    }
+}


### PR DESCRIPTION
Can be used (for example) for uploading to s3:

```java
S3AsyncClient s3 = ...;
s3.putObject(PutObjectRequest.builder().bucket("bucket-name").key("some-key.txt").build(),
             AsyncRequestProvider.fromString("hello world!!!"));
```