### PR TITLE
Treat CBOR instants as milliseconds since the linux epoch, not seconds.

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/runtime/transform/SimpleTypeCborUnmarshallers.java
+++ b/core/src/main/java/software/amazon/awssdk/runtime/transform/SimpleTypeCborUnmarshallers.java
@@ -24,7 +24,6 @@ import java.time.Instant;
 import java.util.Date;
 import software.amazon.awssdk.SdkClientException;
 import software.amazon.awssdk.annotation.SdkInternalApi;
-import software.amazon.awssdk.util.DateUtils;
 
 @SdkInternalApi
 public class SimpleTypeCborUnmarshallers {
@@ -218,8 +217,7 @@ public class SimpleTypeCborUnmarshallers {
         }
 
         public Instant unmarshall(JsonUnmarshallerContext unmarshallerContext) throws Exception {
-            return DateUtils.parseServiceSpecificInstant(unmarshallerContext
-                    .readText());
+            return Instant.ofEpochMilli(unmarshallerContext.getJsonParser().getLongValue());
         }
     }
 

--- a/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
+++ b/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.services.kinesis;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -44,6 +46,7 @@ import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 import software.amazon.awssdk.services.kinesis.model.SplitShardRequest;
 import software.amazon.awssdk.services.kinesis.model.StreamDescription;
 import software.amazon.awssdk.services.kinesis.model.StreamStatus;
+import software.amazon.awssdk.utils.BinaryUtils;
 
 public class KinesisIntegrationTests extends AbstractTestCase {
 
@@ -225,10 +228,13 @@ public class KinesisIntegrationTests extends AbstractTestCase {
         Assert.assertNotNull(record.sequenceNumber());
         new BigInteger(record.sequenceNumber());
 
-        String value = new String(record.data().array());
+        String value = new String(BinaryUtils.copyBytesFrom(record.data()));
         Assert.assertEquals(data, value);
 
         Assert.assertNotNull(record.partitionKey());
+
+        // The timestamp should be relatively recent
+        Assert.assertTrue(Duration.between(record.approximateArrivalTimestamp(), Instant.now()).toMinutes() < 5);
     }
 
     private void testPuts(final String streamName, final Shard shard)


### PR DESCRIPTION
Fixes #184 