### PR TITLE
Return enums from model getters and make enums follow the standard java naming scheme.

### DIFF
--- a/build-tools/src/main/resources/software/amazon/awssdk/findbugs-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/findbugs-suppressions.xml
@@ -65,6 +65,8 @@
         </Or>
         <!-- URF_UNREAD_FIELD, DLS_DEAD_LOCAL_STORE: Sometimes we have unread variables and fields because they're only
         conditionally used. It's cleaner to just always generate them, even if we may not actually be using them. -->
-        <Bug pattern="URF_UNREAD_FIELD,DLS_DEAD_LOCAL_STORE" />
+        <!-- REC_CATCH_EXCEPTION: Sometimes we want to convert runtime exceptions into sdk exceptions, so we catch it and
+        wrap it in an sdk-specific exception. -->
+        <Bug pattern="URF_UNREAD_FIELD,DLS_DEAD_LOCAL_STORE, REC_CATCH_EXCEPTION" />
     </Match>
 </FindBugsFilter>

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Utils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Utils.java
@@ -23,9 +23,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeMarshaller;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
@@ -63,6 +65,22 @@ public class Utils {
 
     public static boolean isExceptionShape(Shape shape) {
         return shape.isException() || shape.isFault();
+    }
+
+    public static boolean isOrContainsEnumShape(Shape shape, Map<String, Shape> allShapes) {
+        boolean isEnum = isEnumShape(shape);
+        boolean isMapWithEnumMember = isMapShape(shape) && (isEnumShape(allShapes.get(shape.getMapKeyType().getShape())) ||
+                                                            isEnumShape(allShapes.get(shape.getMapValueType().getShape())));
+        boolean isListWithEnumMember = isListShape(shape) && isEnumShape(allShapes.get(shape.getListMember().getShape()));
+        return isEnum || isMapWithEnumMember || isListWithEnumMember;
+    }
+
+    public static boolean isOrContainsEnum(MemberModel member) {
+        boolean isEnum = member.getEnumType() != null;
+        boolean isMapWithEnumMember = member.isMap() && (member.getMapModel().getKeyModel().getEnumType() != null ||
+                                                         member.getMapModel().getValueModel().getEnumType() != null);
+        boolean isListWithEnumMember = member.isList() && member.getListModel().getListMemberModel().getEnumType() != null;
+        return isEnum || isMapWithEnumMember || isListWithEnumMember;
     }
 
     public static String getServiceName(ServiceMetadata metadata, CustomizationConfig customizationConfig) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MapModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MapModel.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.codegen.model.intermediate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import software.amazon.awssdk.codegen.internal.TypeUtils;
 
 public class MapModel {
 
@@ -24,13 +23,9 @@ public class MapModel {
 
     private final String interfaceType;
 
-    private final String keyType;
-
     private final String keyLocationName;
 
     private final MemberModel keyModel;
-
-    private final String valueType;
 
     private final String valueLocationName;
 
@@ -39,19 +34,15 @@ public class MapModel {
     public MapModel(
             @JsonProperty("implType") String implType,
             @JsonProperty("interfaceType") String interfaceType,
-            @JsonProperty("keyType") String mapKeyType,
             @JsonProperty("keyLocationName") String keyLocationName,
             @JsonProperty("keyModel") MemberModel keyModel,
-            @JsonProperty("valueType") String mapValueType,
             @JsonProperty("valueLocationName") String valueLocationName,
             @JsonProperty("valueModel") MemberModel valueModel) {
 
         this.implType = implType;
         this.interfaceType = interfaceType;
-        this.keyType = mapKeyType;
         this.keyLocationName = keyLocationName;
         this.keyModel = keyModel;
-        this.valueType = mapValueType;
         this.valueLocationName = valueLocationName;
         this.valueModel = valueModel;
     }
@@ -64,20 +55,12 @@ public class MapModel {
         return interfaceType;
     }
 
-    public String getKeyType() {
-        return keyType;
-    }
-
     public String getKeyLocationName() {
         return keyLocationName;
     }
 
     public MemberModel getKeyModel() {
         return keyModel;
-    }
-
-    public String getValueType() {
-        return valueType;
     }
 
     public String getValueLocationName() {
@@ -88,28 +71,13 @@ public class MapModel {
         return valueModel;
     }
 
-    public boolean isKeySimple() {
-        return TypeUtils.isSimple(keyType);
-    }
-
-    public boolean isValueSimple() {
-        return TypeUtils.isSimple(valueType);
-    }
-
-    public boolean isValueList() {
-        return valueType.startsWith(TypeUtils
-                                            .getDataTypeMapping(TypeUtils.LIST_INTERFACE));
-    }
-
     public String getTemplateType() {
-        return interfaceType + "<" + keyType + "," + valueType + ">";
-    }
-
-    public String getTemplateImplType() {
-        return implType + "<" + keyType + "," + valueType + ">";
+        return interfaceType +
+               "<" + keyModel.getVariable().getVariableType() + "," + valueModel.getVariable().getVariableType() + ">";
     }
 
     public String getEntryType() {
-        return String.format("Map.Entry<%s, %s>", keyType, valueType);
+        return String.format("Map.Entry<%s, %s>",
+                             keyModel.getVariable().getVariableType(), valueModel.getVariable().getVariableType());
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
@@ -64,6 +64,8 @@ public class MemberModel extends DocumentationModel {
 
     private String fluentGetterMethodName;
 
+    private String fluentEnumGetterMethodName;
+
     private String fluentSetterMethodName;
 
     private String beanStyleGetterName;
@@ -145,6 +147,19 @@ public class MemberModel extends DocumentationModel {
 
     public MemberModel withFluentGetterMethodName(String getterMethodName) {
         setFluentGetterMethodName(getterMethodName);
+        return this;
+    }
+
+    public String getFluentEnumGetterMethodName() {
+        return fluentEnumGetterMethodName;
+    }
+
+    public void setFluentEnumGetterMethodName(String fluentEnumGetterMethodName) {
+        this.fluentEnumGetterMethodName = fluentEnumGetterMethodName;
+    }
+
+    public MemberModel withFluentEnumGetterMethodName(String fluentEnumGetterMethodName) {
+        setFluentEnumGetterMethodName(fluentEnumGetterMethodName);
         return this;
     }
 
@@ -252,13 +267,13 @@ public class MemberModel extends DocumentationModel {
         this.listModel = listModel;
     }
 
-    public MapModel getMapModel() {
-        return mapModel;
-    }
-
     public MemberModel withListModel(ListModel list) {
         setListModel(list);
         return this;
+    }
+
+    public MapModel getMapModel() {
+        return mapModel;
     }
 
     public void setMapModel(MapModel map) {
@@ -301,7 +316,7 @@ public class MemberModel extends DocumentationModel {
 
         docBuilder.append(StringUtils.isNotBlank(documentation) ? documentation : DEFAULT_SETTER.replace("%s", name) + "\n");
 
-        if (ByteBuffer.class.getName().equals(this.getGetterModel().getReturnType())) {
+        if (returnTypeIs(ByteBuffer.class)) {
             appendParagraph(docBuilder, "To preserve immutability, the remaining bytes in the provided buffer will be copied "
                                         + "into a new buffer when set.");
         }
@@ -313,20 +328,37 @@ public class MemberModel extends DocumentationModel {
     }
 
     public String getGetterDocumentation() {
-        String returnType = this.getGetterModel().getReturnType();
         StringBuilder docBuilder = new StringBuilder();
         docBuilder.append(StringUtils.isNotBlank(documentation) ? documentation : DEFAULT_GETTER.replace("%s", name))
                 .append(LF);
 
-        if (returnType != null) {
-            if (returnType.equals(ByteBuffer.class.getName())) {
-                appendParagraph(docBuilder,
-                                "This method will return a new read-only {@code ByteBuffer} each time it is invoked.");
-            }
+        if (returnTypeIs(ByteBuffer.class)) {
+            appendParagraph(docBuilder,
+                            "This method will return a new read-only {@code ByteBuffer} each time it is invoked.");
+        } else if (returnTypeIs(List.class) || returnTypeIs(Map.class)) {
+            appendParagraph(docBuilder, "Attempts to modify the collection returned by this method will result in an "
+                                        + "UnsupportedOperationException.");
+        }
 
-            if (returnType.startsWith(List.class.getName()) || returnType.startsWith(Map.class.getName())) {
-                appendParagraph(docBuilder, "Attempts to modify the collection returned by this method will result in an "
-                                            + "UnsupportedOperationException.");
+        if (enumType != null) {
+            if (returnTypeIs(List.class)) {
+                appendParagraph(docBuilder,
+                                "If the list returned by the service includes enum values that are not available in the "
+                                + "current SDK version, {@link #%s} will use {@link %s#UNKNOWN_TO_SDK_VERSION} in place of those "
+                                + "values in the list. The raw values returned by the service are available from {@link #%s}.",
+                                getFluentEnumGetterMethodName(), getEnumType(), getFluentGetterMethodName());
+            } else if (returnTypeIs(Map.class)) {
+                appendParagraph(docBuilder,
+                                "If the map returned by the service includes enum values that are not available in the "
+                                + "current SDK version, {@link #%s} will not include those keys in the map. {@link #%s} "
+                                + "will include all data from the service.",
+                                getFluentEnumGetterMethodName(), getEnumType(), getFluentGetterMethodName());
+            } else {
+                appendParagraph(docBuilder,
+                                "If the service returns an enum value that is not available in the current SDK version, "
+                                + "{@link #%s} will return {@link %s#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the "
+                                + "service is available from {@link #%s}.",
+                                getFluentEnumGetterMethodName(), getEnumType(), getFluentGetterMethodName());
             }
         }
 
@@ -337,6 +369,11 @@ public class MemberModel extends DocumentationModel {
                   .append(getEnumDoc());
 
         return docBuilder.toString();
+    }
+
+    private boolean returnTypeIs(Class<?> clazz) {
+        String returnType = this.getGetterModel().getReturnType();
+        return returnType != null && returnType.startsWith(clazz.getName()); // Use startsWith in case it's parametrized
     }
 
     public String getFluentSetterDocumentation() {
@@ -474,10 +511,10 @@ public class MemberModel extends DocumentationModel {
         return c2jName;
     }
 
-    private void appendParagraph(StringBuilder builder, String content) {
+    private void appendParagraph(StringBuilder builder, String content, Object... contentArgs) {
         builder.append("<p>")
                .append(LF)
-               .append(content)
+               .append(String.format(content, contentArgs))
                .append(LF)
                .append("</p>")
                .append(LF);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -32,6 +32,8 @@ import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.service.Output;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
+import software.amazon.awssdk.codegen.model.service.Shape;
+import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.StringUtils;
 
 /**
@@ -39,6 +41,8 @@ import software.amazon.awssdk.utils.StringUtils;
  * CustomizationConfig}.
  */
 public class DefaultNamingStrategy implements NamingStrategy {
+
+    private static Logger log = Logger.loggerFor(DefaultNamingStrategy.class);
 
     private static final Set<String> RESERVED_KEYWORDS = new HashSet<String>() {
         {
@@ -125,21 +129,41 @@ public class DefaultNamingStrategy implements NamingStrategy {
 
     @Override
     public String getEnumValueName(String enumValue) {
-        StringBuilder builder = new StringBuilder();
+        String result = enumValue;
 
-        String sanitizedEnumValue = enumValue.replace("::", ":").replace("/", "").replace("(", "")
-                                             .replace(")", "");
+        // Special cases
+        result = result.replaceAll("textORcsv", "TEXT_OR_CSV");
 
-        for (String part : sanitizedEnumValue.split("[ -.:]")) {
-            if (part.length() > 1) {
-                builder.append(StringUtils.upperCase(part.substring(0, 1)))
-                       .append(part.substring(1));
-            } else {
-                builder.append(StringUtils.upperCase(part));
-            }
+        // Convert non-underscore word boundaries into underscore word boundaries
+        result = result.replaceAll("[:/()-. ]+", "_"); // acm-success -> acm_success
+
+        // If the number had a standalone v in front of it, separate it out (version).
+        result = result.replaceAll("([^a-z]{2,})v([0-9]+)", "$1_v$2_") // TESTv4 -> TEST_v4_
+                       .replaceAll("([^A-Z]{2,})V([0-9]+)", "$1_V$2_"); // TestV4 -> Test_V4_
+
+        // Add an underscore between camelCased words
+        result = result.replaceAll("([a-z])([A-Z][a-zA-Z])", "$1_$2"); // AcmSuccess -> Acm_Success
+
+        // Add an underscore after acronyms
+        result = result.replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2"); // ACMSuccess -> ACM_Success
+
+        // Add an underscore after a number in the middle of a word
+        result = result.replaceAll("([0-9])([a-zA-Z])", "$1_$2"); // s3ec2 -> s3_ec2
+
+        // Remove extra underscores - multiple consecutive ones or those and the beginning/end of words
+        result = result.replaceAll("_+", "_") // Foo__Bar -> Foo_Bar
+                       .replaceAll("^_*([^_].*[^_])_*$", "$1"); // _Foo_ -> Foo
+
+        // Convert all lower-case words
+        result = StringUtils.upperCase(result);
+
+        if (!result.matches("^[A-Z][A-Z0-9_]*$")) {
+            String attempt = result;
+            log.warn(() -> "Invalid enum member generated for input '" + enumValue + "'. Best attempt: '" + attempt + "' If this "
+                           + "enum is not customized out, the build will fail.");
         }
 
-        return builder.toString();
+        return result;
     }
 
     @Override
@@ -157,14 +181,32 @@ public class DefaultNamingStrategy implements NamingStrategy {
     }
 
     @Override
-    public String getFluentGetterMethodName(String memberName) {
+    public String getFluentGetterMethodName(String memberName, Shape shape) {
+        String getterMethodName = Utils.unCapitialize(memberName);
+
+        if (Utils.isOrContainsEnumShape(shape, serviceModel.getShapes())) {
+            getterMethodName += "String";
+
+            if (Utils.isListShape(shape) || Utils.isMapShape(shape)) {
+                getterMethodName += "s";
+            }
+        }
+
+        return getterMethodName;
+    }
+
+    @Override
+    public String getFluentEnumGetterMethodName(String memberName, Shape shape) {
+        if (!Utils.isOrContainsEnumShape(shape, serviceModel.getShapes())) {
+            return null;
+        }
+
         return Utils.unCapitialize(memberName);
     }
 
     @Override
     public String getBeanStyleGetterMethodName(String memberName) {
         return String.format("get%s", Utils.capitialize(memberName));
-
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/NamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/NamingStrategy.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.codegen.naming;
 
+import software.amazon.awssdk.codegen.model.service.Shape;
+
 /**
  * Strategy to name various Java constructs based on the naming in the model and potentially customizations.
  */
@@ -65,9 +67,17 @@ public interface NamingStrategy {
 
     /**
      * @param memberName Member name to name getter for.
+     * @param shape The shape associated with the member.
      * @return Name of the getter method for a model class member.
      */
-    String getFluentGetterMethodName(String memberName);
+    String getFluentGetterMethodName(String memberName, Shape shape);
+
+    /**
+     * @param memberName The full member to get the name for.
+     * @param shape The shape associated with the member.
+     * @return Name of the getter method for an enum model class member.
+     */
+    String getFluentEnumGetterMethodName(String memberName, Shape shape);
 
     /**
      * @param memberName Member name to name getter for.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AbstractMemberSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AbstractMemberSetters.java
@@ -115,7 +115,8 @@ abstract class AbstractMemberSetters implements MemberSetters {
             return ParameterSpec.builder(listType, fieldName()).build();
         }
         if (memberModel.isMap() && hasBuilder(memberModel.getMapModel().getValueModel())) {
-            TypeName keyType = typeProvider.getTypeNameForSimpleType(memberModel.getMapModel().getKeyType());
+            TypeName keyType = typeProvider.getTypeNameForSimpleType(memberModel.getMapModel().getKeyModel()
+                                                                                .getVariable().getVariableType());
             TypeName valueType = poetExtensions.getModelClass(memberModel.getMapModel().getValueModel().getC2jShape())
                                                .nestedClass("BuilderImpl");
             TypeName mapType = ParameterizedTypeName.get(ClassName.get(Map.class), keyType, valueType);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/BeanGetterHelper.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/BeanGetterHelper.java
@@ -61,7 +61,8 @@ public final class BeanGetterHelper {
     }
 
     private MethodSpec mapOfBuildersGetter(MemberModel memberModel) {
-        TypeName keyType = typeProvider.getTypeNameForSimpleType(memberModel.getMapModel().getKeyType());
+        TypeName keyType = typeProvider.getTypeNameForSimpleType(memberModel.getMapModel().getKeyModel()
+                                                                            .getVariable().getVariableType());
         ClassName valueType = poetExtensions.getModelClass(memberModel.getMapModel().getValueModel().getC2jShape());
         TypeName returnType = ParameterizedTypeName.get(ClassName.get(Map.class), keyType, valueType.nestedClass("Builder"));
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MemberCopierSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MemberCopierSpec.java
@@ -108,7 +108,8 @@ class MemberCopierSpec implements ClassSpec {
     }
 
     private MethodSpec builderCopyMethodForList() {
-        TypeName keyType = typeProvider.getTypeNameForSimpleType(memberModel.getMapModel().getKeyType());
+        TypeName keyType = typeProvider.getTypeNameForSimpleType(memberModel.getMapModel().getKeyModel()
+                                                                            .getVariable().getVariableType());
         ClassName valueParameter = poetExtensions.getModelClass(memberModel.getMapModel().getValueModel().getC2jShape());
         ClassName builderForParameter = valueParameter.nestedClass("Builder");
         TypeName parameterType =

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceModelCopiers.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceModelCopiers.java
@@ -113,7 +113,7 @@ public class ServiceModelCopiers {
         } else if (memberModel.isMap()) {
             MapModel mapModel = memberModel.getMapModel();
             // NOTE: keys are always simple, so don't bother checking
-            if (!mapModel.isValueSimple()) {
+            if (!mapModel.getValueModel().isSimple()) {
                 MemberModel valueMember = mapModel.getValueModel();
                 allMembers.put(valueMember.getC2jShape(), valueMember);
                 putMembersOfMember(valueMember, allMembers);

--- a/codegen/src/main/resources/macros/common/MethodDefinitionMacro.ftl
+++ b/codegen/src/main/resources/macros/common/MethodDefinitionMacro.ftl
@@ -81,8 +81,8 @@
 
 <#elseif member.map>
     <#local mapModel = member.mapModel/>
-    <#local mapKeyType = mapModel.keyType/>
-    <#local mapValueType = mapModel.valueType/>
+    <#local mapKeyType = mapModel.keyModel.variable.variableType/>
+    <#local mapValueType = mapModel.valueModel.variable.variableType/>
     <#local keyVariableName = "key">
     <#local valueVariableName = "value"/>
 

--- a/codegen/src/main/resources/macros/marshaller/query/MemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/query/MemberMarshallerMacro.ftl
@@ -94,18 +94,18 @@
 
     if (${variable.variableName} != null) {
         int ${listIndex} = 1;
-        for (Map.Entry<${mapModel.keyType},${mapModel.valueType}> entry : ${variable.variableName}.entrySet()) {
+        for (Map.Entry<${mapModel.keyModel.variable.variableType},${mapModel.valueModel.variable.variableType}> entry : ${variable.variableName}.entrySet()) {
             if (entry.getKey() != null) {
-                request.addParameter("${parameterPath}." + ${listIndex} + ".${mapModel.keyLocationName}", StringUtils.from${mapModel.keyType}(entry.getKey()));
+                request.addParameter("${parameterPath}." + ${listIndex} + ".${mapModel.keyLocationName}", StringUtils.from${mapModel.keyModel.variable.variableType}(entry.getKey()));
             }
-            <#if mapModel.valueSimple>
+            <#if mapModel.valueModel.simple>
             if (entry.getValue() != null) {
                 request.addParameter("${parameterPath}." + ${listIndex} + ".${mapModel.valueLocationName}", StringUtils.from${mapModel.valueModel.variable.simpleType}(entry.getValue()));
             }
             <#else>
             if (entry.getValue() != null) {
                 <#local path = parameterPath + ".\" + " + listIndex + " + \"" + ".${mapModel.valueLocationName}"/>
-                <@MemberMarshallerMacro.content customConfig mapModel.valueType "entry.getValue()" shapes path/>
+                <@MemberMarshallerMacro.content customConfig mapModel.valueModel.variable.variableType "entry.getValue()" shapes path/>
             }
             </#if>
             ${listIndex} ++;

--- a/codegen/src/main/resources/macros/marshaller/rest-json/RequestMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/rest-json/RequestMarshallerMacro.ftl
@@ -99,7 +99,7 @@ public class ${shapeName}Marshaller implements Marshaller<Request<${shapeName}>,
                    <#elseif member.isMap()>
                       <#local loopVariable = member.variable.variableName + "Entry"/>
                       jsonGenerator.writeStartObject();
-                      for(Map.Entry<${member.mapModel.keyType},${member.mapModel.valueType}> ${loopVariable} : ${member.variable.variableName}.entrySet()) {
+                      for(Map.Entry<${member.mapModel.keyModel.variable.variableType},${member.mapModel.valueModel.variable.variableType}> ${loopVariable} : ${member.variable.variableName}.entrySet()) {
                           if (${loopVariable}.getValue() != null) {
                               jsonGenerator.writeFieldName(${loopVariable}.getKey());
 

--- a/codegen/src/main/resources/macros/marshaller/rest-xml/MemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/rest-xml/MemberMarshallerMacro.ftl
@@ -67,10 +67,10 @@
             xmlWriter.value(${loopVariable}.getKey());
             xmlWriter.endElement();
             xmlWriter.startElement("${mapModel.valueLocationName}");
-            <#if mapModel.valueSimple>
+            <#if mapModel.valueModel.simple>
                 xmlWriter.value(${loopVariable}.getValue());
             <#else>
-                <@MemberMarshallerMacro.content customConfig mapModel.valueType loopVariable shapes/>
+                <@MemberMarshallerMacro.content customConfig mapModel.valueModel.variable.variableType loopVariable shapes/>
             </#if>
             xmlWriter.endElement();
             xmlWriter.endElement();

--- a/codegen/src/main/resources/macros/marshaller/rest/QueryStringMemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/rest/QueryStringMemberMarshallerMacro.ftl
@@ -10,12 +10,12 @@
 
             ${mapModel.templateType} ${variable.variableName} = ${getMember}();
             if(${variable.variableName} != null) {
-                for (Map.Entry<${mapModel.keyType},${mapModel.valueType}> entry : ${variable.variableName}.entrySet()) {
+                for (Map.Entry<${mapModel.keyModel.variable.variableType},${mapModel.valueModel.variable.variableType}> entry : ${variable.variableName}.entrySet()) {
                     if (entry.getValue() != null) {
                         <#if mapModel.valueModel.list>
-                            request.addParameters(StringUtils.from${mapModel.keyType}(entry.getKey()), entry.getValue());
+                            request.addParameters(StringUtils.from${mapModel.keyModel.variable.variableType}(entry.getKey()), entry.getValue());
                         <#else>
-                            request.addParameter(StringUtils.from${mapModel.keyType}(entry.getKey()), StringUtils.from${mapModel.valueType}(entry.getValue()));
+                            request.addParameter(StringUtils.from${mapModel.keyModel.variable.variableType}(entry.getKey()), StringUtils.from${mapModel.valueModel.variable.variableType}(entry.getValue()));
                         </#if>
                     }
                 }

--- a/codegen/src/main/resources/macros/unmarshaller/awsquery/MapEntryUnmarshaller.ftl
+++ b/codegen/src/main/resources/macros/unmarshaller/awsquery/MapEntryUnmarshaller.ftl
@@ -1,14 +1,14 @@
 <#macro content memberModel >
     private static class ${memberModel.name}MapEntryUnmarshaller
-           implements Unmarshaller<Map.Entry<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}>, StaxUnmarshallerContext> {
+           implements Unmarshaller<Map.Entry<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}>, StaxUnmarshallerContext> {
 
         @Override
-        public Entry<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}> unmarshall(StaxUnmarshallerContext context) throws Exception {
+        public Entry<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}> unmarshall(StaxUnmarshallerContext context) throws Exception {
             int originalDepth = context.getCurrentDepth();
             int targetDepth = originalDepth + 1;
 
-            MapEntry<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}> entry
-                = new MapEntry<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}>();
+            MapEntry<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}> entry
+                = new MapEntry<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}>();
 
             while (true) {
                 XMLEvent xmlEvent = context.nextEvent();
@@ -16,7 +16,7 @@
 
                 if (xmlEvent.isAttribute() || xmlEvent.isStartElement()) {
                     if (context.testExpression("${memberModel.mapModel.keyLocationName}", targetDepth)) {
-                        entry.setKey(${memberModel.mapModel.keyType}Unmarshaller.getInstance().unmarshall(context));
+                        entry.setKey(${memberModel.mapModel.keyModel.variable.variableType}Unmarshaller.getInstance().unmarshall(context));
                         continue;
                     }
                     if (context.testExpression("${memberModel.mapModel.valueLocationName}", targetDepth)) {

--- a/codegen/src/main/resources/macros/unmarshaller/awsquery/MemberUnmarshallerInvocation.ftl
+++ b/codegen/src/main/resources/macros/unmarshaller/awsquery/MemberUnmarshallerInvocation.ftl
@@ -43,7 +43,7 @@
                     if (${memberModel.variable.variableName} == null) {
                         ${memberModel.variable.variableName} = new java.util.HashMap<>();
                     }
-                    Entry<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}> entry = ${memberModel.name}MapEntryUnmarshaller.getInstance().unmarshall(context);
+                    Entry<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}> entry = ${memberModel.name}MapEntryUnmarshaller.getInstance().unmarshall(context);
                     // ${shapeVarName}.add${memberModel.name}Entry(entry.getKey(), entry.getValue());
 
                     ${memberModel.variable.variableName}.put(entry.getKey(), entry.getValue());

--- a/codegen/src/main/resources/macros/unmarshaller/json/MemberUnmarshallerDeclaration.ftl
+++ b/codegen/src/main/resources/macros/unmarshaller/json/MemberUnmarshallerDeclaration.ftl
@@ -12,7 +12,7 @@
         </#if>
         new ListUnmarshaller<${memberModel.listModel.memberType}>(${memberUnmarshaller})
     <#elseif memberModel.map >
-        <#local keyUnmarshaller = "context.getUnmarshaller(${memberModel.mapModel.keyType}.class)" />
+        <#local keyUnmarshaller = "context.getUnmarshaller(${memberModel.mapModel.keyModel.variable.variableType}.class)" />
         <#if memberModel.mapModel.valueModel?has_content >
             <#local valueUnmarshaller >
                 <#-- recursion -->
@@ -20,9 +20,9 @@
             </#local>
         <#else>
             <#local valueUnmarshaller = "context.getUnmarshaller
-                 (${memberModel.mapModel.valueType}.class)" />
+                 (${memberModel.mapModel.valueModel.variable.variableType}.class)" />
         </#if>
-        new MapUnmarshaller<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}>(${keyUnmarshaller}, ${valueUnmarshaller})
+        new MapUnmarshaller<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}>(${keyUnmarshaller}, ${valueUnmarshaller})
     <#else>
         ${memberModel.variable.simpleType}Unmarshaller.getInstance()
     </#if>

--- a/codegen/src/main/resources/templates/query/ModelStaxUnmarshaller.ftl
+++ b/codegen/src/main/resources/templates/query/ModelStaxUnmarshaller.ftl
@@ -91,7 +91,7 @@ public class ${shape.shapeName}Unmarshaller implements Unmarshaller<${shape.shap
 
         <#if !memberModel.http.location?? || memberModel.http.location != "headers">
             <#if memberModel.map>
-                java.util.Map<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}> ${memberModel.variable.variableName} = null;
+                java.util.Map<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}> ${memberModel.variable.variableName} = null;
             </#if>
             <#if memberModel.list>
                 java.util.List<${memberModel.listModel.memberType}> ${memberModel.variable.variableName} = null;
@@ -102,7 +102,7 @@ public class ${shape.shapeName}Unmarshaller implements Unmarshaller<${shape.shap
 
 <#list shape.members as memberModel>
     <#if memberModel.map && memberModel.http.location?? && memberModel.http.location == "headers">
-    Map<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}> ${memberModel.variable.variableName} = new HashMap<>();
+    Map<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}> ${memberModel.variable.variableName} = new HashMap<>();
     context.getHeaders().entrySet().stream().filter(e -> e.getKey().startsWith("${memberModel.http.unmarshallLocationName}")).forEach(e -> {
         ${memberModel.variable.variableName}.put(e.getKey().replace("${memberModel.http.unmarshallLocationName}", ""), e.getValue());
     });
@@ -115,7 +115,7 @@ public class ${shape.shapeName}Unmarshaller implements Unmarshaller<${shape.shap
 <#list shape.members as memberModel>
     <#if !memberModel.http.location?? || memberModel.http.location != "headers">
         <#if memberModel.map>
-            java.util.Map<${memberModel.mapModel.keyType}, ${memberModel.mapModel.valueType}> ${memberModel.variable.variableName} = null;
+            java.util.Map<${memberModel.mapModel.keyModel.variable.variableType}, ${memberModel.mapModel.valueModel.variable.variableType}> ${memberModel.variable.variableName} = null;
         </#if>
         <#if memberModel.list>
             java.util.List<${memberModel.listModel.memberType}> ${memberModel.variable.variableName} = null;

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
@@ -16,25 +16,79 @@
 
 package software.amazon.awssdk.codegen.naming;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
 public class DefaultNamingStrategyTest {
 
+    private DefaultNamingStrategy strat = new DefaultNamingStrategy(null, null);
+
     @Test
     public void canConvertStringsWithNonAlphasToClassNames() {
-        NamingStrategy sut = new DefaultNamingStrategy(null, null);
         String anInvalidClassName = "a phrase-With_other.delimiters";
-        assertThat(sut.getJavaClassName(anInvalidClassName), equalTo("APhraseWithOtherDelimiters"));
+        assertThat(strat.getJavaClassName(anInvalidClassName)).isEqualTo("APhraseWithOtherDelimiters");
     }
 
     @Test
     public void canConvertAuthorizerStartingWithNumber() {
-        NamingStrategy sut = new DefaultNamingStrategy(null, null);
         String anInvalidClassName = "35-authorizer-implementation";
-        assertThat(sut.getAuthorizerClassName(anInvalidClassName), equalTo("I35AuthorizerImplementation"));
+        assertThat(strat.getAuthorizerClassName(anInvalidClassName)).isEqualTo("I35AuthorizerImplementation");
     }
 
+    @Test
+    public void enumNamesConvertCorrectly() {
+        validateConversion("Twilio-Sms", "TWILIO_SMS");
+        validateConversion("t2.micro", "T2_MICRO");
+        validateConversion("GreaterThanThreshold", "GREATER_THAN_THRESHOLD");
+        validateConversion("INITIALIZED", "INITIALIZED");
+        validateConversion("GENERIC_EVENT", "GENERIC_EVENT");
+        validateConversion("WINDOWS_2012", "WINDOWS_2012");
+        validateConversion("ec2:spot-fleet-request:TargetCapacity", "EC2_SPOT_FLEET_REQUEST_TARGET_CAPACITY");
+        validateConversion("elasticmapreduce:instancegroup:InstanceCount", "ELASTICMAPREDUCE_INSTANCEGROUP_INSTANCE_COUNT");
+        validateConversion("application/vnd.amazonaws.card.generic", "APPLICATION_VND_AMAZONAWS_CARD_GENERIC");
+        validateConversion("IPV4", "IPV4");
+        validateConversion("ipv4", "IPV4");
+        validateConversion("IPv4", "IP_V4");
+        validateConversion("ipV4", "IP_V4");
+        validateConversion("IPMatch", "IP_MATCH");
+        validateConversion("S3", "S3");
+        validateConversion("EC2Instance", "EC2_INSTANCE");
+        validateConversion("aws.config", "AWS_CONFIG");
+        validateConversion("AWS::EC2::CustomerGateway", "AWS_EC2_CUSTOMER_GATEWAY");
+        validateConversion("application/pdf", "APPLICATION_PDF");
+        validateConversion("ADConnector", "AD_CONNECTOR");
+        validateConversion("MS-CHAPv1", "MS_CHAP_V1");
+        validateConversion("One-Way: Outgoing", "ONE_WAY_OUTGOING");
+        validateConversion("scram_sha_1", "SCRAM_SHA_1");
+        validateConversion("EC_prime256v1", "EC_PRIME256_V1");
+        validateConversion("EC_PRIME256V1", "EC_PRIME256_V1");
+        validateConversion("EC2v11.4", "EC2_V11_4");
+        validateConversion("nodejs4.3-edge", "NODEJS4_3_EDGE");
+        validateConversion("BUILD_GENERAL1_SMALL", "BUILD_GENERAL1_SMALL");
+        validateConversion("SSE_S3", "SSE_S3");
+        validateConversion("http1.1", "HTTP1_1");
+        validateConversion("T100", "T100");
+        validateConversion("s3:ObjectCreated:*", "S3_OBJECT_CREATED");
+        validateConversion("s3:ObjectCreated:Put", "S3_OBJECT_CREATED_PUT");
+        validateConversion("TLSv1", "TLS_V1");
+        validateConversion("TLSv1.2", "TLS_V1_2");
+        validateConversion("us-east-1", "US_EAST_1");
+        validateConversion("io1", "IO1");
+        validateConversion("testNESTEDAcronym", "TEST_NESTED_ACRONYM");
+        validateConversion("IoT", "IOT");
+        validateConversion("textORcsv", "TEXT_OR_CSV");
+        validateConversion("__foo___", "FOO");
+        validateConversion("TEST__FOO", "TEST_FOO");
+        validateConversion("IFrame", "I_FRAME");
+        validateConversion("TPain", "T_PAIN");
+        validateConversion("S3EC2", "S3_EC2");
+        validateConversion("S3Ec2", "S3_EC2");
+        validateConversion("s3Ec2", "S3_EC2");
+        validateConversion("s3ec2", "S3_EC2");
+    }
+
+    private void validateConversion(String input, String expectedOutput) {
+        assertThat(strat.getEnumValueName(input)).isEqualTo(expectedOutput);
+    }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/PoetMatchers.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/PoetMatchers.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static software.amazon.awssdk.codegen.poet.PoetUtils.buildJavaFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -27,6 +28,7 @@ import org.junit.ComparisonFailure;
 import software.amazon.awssdk.codegen.emitters.CodeTransformer;
 import software.amazon.awssdk.codegen.emitters.JavaCodeFormatter;
 import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.Validate;
 
 public final class PoetMatchers {
 
@@ -58,7 +60,9 @@ public final class PoetMatchers {
 
     private static String getExpectedClass(ClassSpec spec, String testFile) {
         try {
-            return processor.apply(IoUtils.toString(spec.getClass().getResourceAsStream(testFile)));
+            InputStream resource = spec.getClass().getResourceAsStream(testFile);
+            Validate.notNull(resource, "Failed to load test file: " + testFile);
+            return processor.apply(IoUtils.toString(resource));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/common/EnumClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/common/EnumClassTest.java
@@ -33,7 +33,7 @@ public class EnumClassTest {
         ShapeModel m = new ShapeModel("TestEnumClass");
         m.setType(ShapeType.Enum);
         m.setShapeName("TestEnumClass");
-        m.setEnums(asList(new EnumModel("Available", "available"), new EnumModel("PermanentFailure", "permanent-failure")));
+        m.setEnums(asList(new EnumModel("AVAILABLE", "available"), new EnumModel("PERMANENT_FAILURE", "permanent-failure")));
         m.setDocumentation("Some comment on the class itself");
 
         EnumClass sut = new EnumClass("software.amazon.awssdk.codegen.poet.common.model", m);

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/AwsModelSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/AwsModelSpecTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.concurrent.Executors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,7 +39,6 @@ import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
 
 @RunWith(Parameterized.class)
 public class AwsModelSpecTest {
-    private static File serviceModelFile;
     private static IntermediateModel intermediateModel;
     private final ShapeModel shapeModel;
 
@@ -61,8 +61,8 @@ public class AwsModelSpecTest {
         return shapeModel.getShapeName().toLowerCase(Locale.ENGLISH) + ".java";
     }
 
-    private static void setUp() throws URISyntaxException, IOException {
-        serviceModelFile = new File(AwsModelSpecTest.class.getResource("service-2.json").getFile());
+    private static void setUp() throws IOException {
+        File serviceModelFile = new File(AwsModelSpecTest.class.getResource("service-2.json").getFile());
         File customizationConfigFile = new File(AwsModelSpecTest.class
                                                     .getResource("customization.config")
                                                     .getFile());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-enum-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-enum-class.java
@@ -1,21 +1,4 @@
-/*
- * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
 package software.amazon.awssdk.codegen.poet.common.model;
-
-import static software.amazon.awssdk.utils.StringUtils.isBlank;
 
 import java.util.stream.Stream;
 import javax.annotation.Generated;
@@ -25,9 +8,11 @@ import javax.annotation.Generated;
  */
 @Generated("software.amazon.awssdk:codegen")
 public enum TestEnumClass {
-    Available("available"),
+    AVAILABLE("available"),
 
-    PermanentFailure("permanent-failure");
+    PERMANENT_FAILURE("permanent-failure"),
+
+    UNKNOWN_TO_SDK_VERSION(null);
 
     private final String value;
 
@@ -37,21 +22,20 @@ public enum TestEnumClass {
 
     @Override
     public String toString() {
-        return value;
+        return String.valueOf(value);
     }
 
     /**
-     * Use this in place of valueOf.
+     * Use this in place of valueOf to convert the raw string returned by the service into the enum value.
      *
      * @param value
      *        real value
      * @return TestEnumClass corresponding to the value
      */
     public static TestEnumClass fromValue(String value) {
-        if (isBlank(value)) {
-            throw new IllegalArgumentException("Value cannot be null or empty!");
+        if (value == null) {
+            return null;
         }
-        return Stream.of(TestEnumClass.values()).filter(e -> e.toString().equals(value)).findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Cannot create enum from " + value + " value!"));
+        return Stream.of(TestEnumClass.values()).filter(e -> e.toString().equals(value)).findFirst().orElse(UNKNOWN_TO_SDK_VERSION);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -6,11 +6,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 import software.amazon.awssdk.core.AmazonWebServiceRequest;
 import software.amazon.awssdk.core.runtime.StandardMemberCopier;
+import software.amazon.awssdk.core.runtime.TypeConverter;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -19,7 +22,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public class AllTypesRequest extends AmazonWebServiceRequest implements
-        ToCopyableBuilder<AllTypesRequest.Builder, AllTypesRequest> {
+                                                             ToCopyableBuilder<AllTypesRequest.Builder, AllTypesRequest> {
     private final String stringMember;
 
     private final Integer integerMember;
@@ -34,6 +37,8 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
     private final List<String> simpleList;
 
+    private final List<String> listOfEnums;
+
     private final List<Map<String, String>> listOfMaps;
 
     private final List<SimpleStruct> listOfStructs;
@@ -42,7 +47,15 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
     private final Map<String, String> mapOfStringToString;
 
-    private final Map<String, SimpleStruct> mapOfStringToStruct;
+    private final Map<String, SimpleStruct> mapOfStringToSimpleStruct;
+
+    private final Map<String, String> mapOfEnumToEnum;
+
+    private final Map<String, String> mapOfEnumToString;
+
+    private final Map<String, String> mapOfStringToEnum;
+
+    private final Map<String, SimpleStruct> mapOfEnumToSimpleStruct;
 
     private final Instant timestampMember;
 
@@ -72,11 +85,16 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         this.doubleMember = builder.doubleMember;
         this.longMember = builder.longMember;
         this.simpleList = builder.simpleList;
+        this.listOfEnums = builder.listOfEnums;
         this.listOfMaps = builder.listOfMaps;
         this.listOfStructs = builder.listOfStructs;
         this.mapOfStringToIntegerList = builder.mapOfStringToIntegerList;
         this.mapOfStringToString = builder.mapOfStringToString;
-        this.mapOfStringToStruct = builder.mapOfStringToStruct;
+        this.mapOfStringToSimpleStruct = builder.mapOfStringToSimpleStruct;
+        this.mapOfEnumToEnum = builder.mapOfEnumToEnum;
+        this.mapOfEnumToString = builder.mapOfEnumToString;
+        this.mapOfStringToEnum = builder.mapOfStringToEnum;
+        this.mapOfEnumToSimpleStruct = builder.mapOfEnumToSimpleStruct;
         this.timestampMember = builder.timestampMember;
         this.structWithNestedTimestampMember = builder.structWithNestedTimestampMember;
         this.blobArg = builder.blobArg;
@@ -156,6 +174,30 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
     }
 
     /**
+     * Returns the value of the ListOfEnums property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the ListOfEnums property for this object.
+     */
+    public List<EnumType> listOfEnums() {
+        return TypeConverter.convert(listOfEnums, EnumType::fromValue);
+    }
+
+    /**
+     * Returns the value of the ListOfEnums property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the ListOfEnums property for this object.
+     */
+    public List<String> listOfEnumsStrings() {
+        return listOfEnums;
+    }
+
+    /**
      * Returns the value of the ListOfMaps property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
@@ -204,15 +246,114 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
     }
 
     /**
-     * Returns the value of the MapOfStringToStruct property for this object.
+     * Returns the value of the MapOfStringToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
      *
-     * @return The value of the MapOfStringToStruct property for this object.
+     * @return The value of the MapOfStringToSimpleStruct property for this object.
      */
-    public Map<String, SimpleStruct> mapOfStringToStruct() {
-        return mapOfStringToStruct;
+    public Map<String, SimpleStruct> mapOfStringToSimpleStruct() {
+        return mapOfStringToSimpleStruct;
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToEnum property for this object.
+     */
+    public Map<EnumType, EnumType> mapOfEnumToEnum() {
+        return TypeConverter.convert(mapOfEnumToEnum, EnumType::fromValue, EnumType::fromValue,
+                                     (k, v) -> !Objects.equals(k, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToEnum property for this object.
+     */
+    public Map<String, String> mapOfEnumToEnumStrings() {
+        return mapOfEnumToEnum;
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToString property for this object.
+     */
+    public Map<EnumType, String> mapOfEnumToString() {
+        return TypeConverter.convert(mapOfEnumToString, EnumType::fromValue, Function.identity(),
+                                     (k, v) -> !Objects.equals(k, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToString property for this object.
+     */
+    public Map<String, String> mapOfEnumToStringStrings() {
+        return mapOfEnumToString;
+    }
+
+    /**
+     * Returns the value of the MapOfStringToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfStringToEnum property for this object.
+     */
+    public Map<String, EnumType> mapOfStringToEnum() {
+        return TypeConverter.convert(mapOfStringToEnum, Function.identity(), EnumType::fromValue, (k, v) -> true);
+    }
+
+    /**
+     * Returns the value of the MapOfStringToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfStringToEnum property for this object.
+     */
+    public Map<String, String> mapOfStringToEnumStrings() {
+        return mapOfStringToEnum;
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToSimpleStruct property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToSimpleStruct property for this object.
+     */
+    public Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct() {
+        return TypeConverter.convert(mapOfEnumToSimpleStruct, EnumType::fromValue, Function.identity(),
+                                     (k, v) -> !Objects.equals(k, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToSimpleStruct property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToSimpleStruct property for this object.
+     */
+    public Map<String, SimpleStruct> mapOfEnumToSimpleStructStrings() {
+        return mapOfEnumToSimpleStruct;
     }
 
     /**
@@ -307,11 +448,29 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
     /**
      * Returns the value of the EnumType property for this object.
+     * <p>
+     * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * </p>
      *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
-    public String enumType() {
+    public EnumType enumType() {
+        return EnumType.fromValue(enumType);
+    }
+
+    /**
+     * Returns the value of the EnumType property for this object.
+     * <p>
+     * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * </p>
+     *
+     * @return The value of the EnumType property for this object.
+     * @see EnumType
+     */
+    public String enumTypeString() {
         return enumType;
     }
 
@@ -338,14 +497,19 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         hashCode = 31 * hashCode + ((doubleMember() == null) ? 0 : doubleMember().hashCode());
         hashCode = 31 * hashCode + ((longMember() == null) ? 0 : longMember().hashCode());
         hashCode = 31 * hashCode + ((simpleList() == null) ? 0 : simpleList().hashCode());
+        hashCode = 31 * hashCode + ((listOfEnumsStrings() == null) ? 0 : listOfEnumsStrings().hashCode());
         hashCode = 31 * hashCode + ((listOfMaps() == null) ? 0 : listOfMaps().hashCode());
         hashCode = 31 * hashCode + ((listOfStructs() == null) ? 0 : listOfStructs().hashCode());
         hashCode = 31 * hashCode + ((mapOfStringToIntegerList() == null) ? 0 : mapOfStringToIntegerList().hashCode());
         hashCode = 31 * hashCode + ((mapOfStringToString() == null) ? 0 : mapOfStringToString().hashCode());
-        hashCode = 31 * hashCode + ((mapOfStringToStruct() == null) ? 0 : mapOfStringToStruct().hashCode());
+        hashCode = 31 * hashCode + ((mapOfStringToSimpleStruct() == null) ? 0 : mapOfStringToSimpleStruct().hashCode());
+        hashCode = 31 * hashCode + ((mapOfEnumToEnumStrings() == null) ? 0 : mapOfEnumToEnumStrings().hashCode());
+        hashCode = 31 * hashCode + ((mapOfEnumToStringStrings() == null) ? 0 : mapOfEnumToStringStrings().hashCode());
+        hashCode = 31 * hashCode + ((mapOfStringToEnumStrings() == null) ? 0 : mapOfStringToEnumStrings().hashCode());
+        hashCode = 31 * hashCode + ((mapOfEnumToSimpleStructStrings() == null) ? 0 : mapOfEnumToSimpleStructStrings().hashCode());
         hashCode = 31 * hashCode + ((timestampMember() == null) ? 0 : timestampMember().hashCode());
         hashCode = 31 * hashCode
-                + ((structWithNestedTimestampMember() == null) ? 0 : structWithNestedTimestampMember().hashCode());
+                   + ((structWithNestedTimestampMember() == null) ? 0 : structWithNestedTimestampMember().hashCode());
         hashCode = 31 * hashCode + ((blobArg() == null) ? 0 : blobArg().hashCode());
         hashCode = 31 * hashCode + ((structWithNestedBlob() == null) ? 0 : structWithNestedBlob().hashCode());
         hashCode = 31 * hashCode + ((blobMap() == null) ? 0 : blobMap().hashCode());
@@ -353,7 +517,7 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         hashCode = 31 * hashCode + ((recursiveStruct() == null) ? 0 : recursiveStruct().hashCode());
         hashCode = 31 * hashCode + ((polymorphicTypeWithSubTypes() == null) ? 0 : polymorphicTypeWithSubTypes().hashCode());
         hashCode = 31 * hashCode + ((polymorphicTypeWithoutSubTypes() == null) ? 0 : polymorphicTypeWithoutSubTypes().hashCode());
-        hashCode = 31 * hashCode + ((enumType() == null) ? 0 : enumType().hashCode());
+        hashCode = 31 * hashCode + ((enumTypeString() == null) ? 0 : enumTypeString().hashCode());
         return hashCode;
     }
 
@@ -411,6 +575,12 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         if (other.simpleList() != null && !other.simpleList().equals(this.simpleList())) {
             return false;
         }
+        if (other.listOfEnumsStrings() == null ^ this.listOfEnumsStrings() == null) {
+            return false;
+        }
+        if (other.listOfEnumsStrings() != null && !other.listOfEnumsStrings().equals(this.listOfEnumsStrings())) {
+            return false;
+        }
         if (other.listOfMaps() == null ^ this.listOfMaps() == null) {
             return false;
         }
@@ -435,10 +605,36 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         if (other.mapOfStringToString() != null && !other.mapOfStringToString().equals(this.mapOfStringToString())) {
             return false;
         }
-        if (other.mapOfStringToStruct() == null ^ this.mapOfStringToStruct() == null) {
+        if (other.mapOfStringToSimpleStruct() == null ^ this.mapOfStringToSimpleStruct() == null) {
             return false;
         }
-        if (other.mapOfStringToStruct() != null && !other.mapOfStringToStruct().equals(this.mapOfStringToStruct())) {
+        if (other.mapOfStringToSimpleStruct() != null
+            && !other.mapOfStringToSimpleStruct().equals(this.mapOfStringToSimpleStruct())) {
+            return false;
+        }
+        if (other.mapOfEnumToEnumStrings() == null ^ this.mapOfEnumToEnumStrings() == null) {
+            return false;
+        }
+        if (other.mapOfEnumToEnumStrings() != null && !other.mapOfEnumToEnumStrings().equals(this.mapOfEnumToEnumStrings())) {
+            return false;
+        }
+        if (other.mapOfEnumToStringStrings() == null ^ this.mapOfEnumToStringStrings() == null) {
+            return false;
+        }
+        if (other.mapOfEnumToStringStrings() != null && !other.mapOfEnumToStringStrings().equals(this.mapOfEnumToStringStrings())) {
+            return false;
+        }
+        if (other.mapOfStringToEnumStrings() == null ^ this.mapOfStringToEnumStrings() == null) {
+            return false;
+        }
+        if (other.mapOfStringToEnumStrings() != null && !other.mapOfStringToEnumStrings().equals(this.mapOfStringToEnumStrings())) {
+            return false;
+        }
+        if (other.mapOfEnumToSimpleStructStrings() == null ^ this.mapOfEnumToSimpleStructStrings() == null) {
+            return false;
+        }
+        if (other.mapOfEnumToSimpleStructStrings() != null
+            && !other.mapOfEnumToSimpleStructStrings().equals(this.mapOfEnumToSimpleStructStrings())) {
             return false;
         }
         if (other.timestampMember() == null ^ this.timestampMember() == null) {
@@ -451,7 +647,7 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
             return false;
         }
         if (other.structWithNestedTimestampMember() != null
-                && !other.structWithNestedTimestampMember().equals(this.structWithNestedTimestampMember())) {
+            && !other.structWithNestedTimestampMember().equals(this.structWithNestedTimestampMember())) {
             return false;
         }
         if (other.blobArg() == null ^ this.blobArg() == null) {
@@ -488,20 +684,20 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
             return false;
         }
         if (other.polymorphicTypeWithSubTypes() != null
-                && !other.polymorphicTypeWithSubTypes().equals(this.polymorphicTypeWithSubTypes())) {
+            && !other.polymorphicTypeWithSubTypes().equals(this.polymorphicTypeWithSubTypes())) {
             return false;
         }
         if (other.polymorphicTypeWithoutSubTypes() == null ^ this.polymorphicTypeWithoutSubTypes() == null) {
             return false;
         }
         if (other.polymorphicTypeWithoutSubTypes() != null
-                && !other.polymorphicTypeWithoutSubTypes().equals(this.polymorphicTypeWithoutSubTypes())) {
+            && !other.polymorphicTypeWithoutSubTypes().equals(this.polymorphicTypeWithoutSubTypes())) {
             return false;
         }
-        if (other.enumType() == null ^ this.enumType() == null) {
+        if (other.enumTypeString() == null ^ this.enumTypeString() == null) {
             return false;
         }
-        if (other.enumType() != null && !other.enumType().equals(this.enumType())) {
+        if (other.enumTypeString() != null && !other.enumTypeString().equals(this.enumTypeString())) {
             return false;
         }
         return true;
@@ -531,6 +727,9 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         if (simpleList() != null) {
             sb.append("SimpleList: ").append(simpleList()).append(",");
         }
+        if (listOfEnumsStrings() != null) {
+            sb.append("ListOfEnums: ").append(listOfEnumsStrings()).append(",");
+        }
         if (listOfMaps() != null) {
             sb.append("ListOfMaps: ").append(listOfMaps()).append(",");
         }
@@ -543,8 +742,20 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         if (mapOfStringToString() != null) {
             sb.append("MapOfStringToString: ").append(mapOfStringToString()).append(",");
         }
-        if (mapOfStringToStruct() != null) {
-            sb.append("MapOfStringToStruct: ").append(mapOfStringToStruct()).append(",");
+        if (mapOfStringToSimpleStruct() != null) {
+            sb.append("MapOfStringToSimpleStruct: ").append(mapOfStringToSimpleStruct()).append(",");
+        }
+        if (mapOfEnumToEnumStrings() != null) {
+            sb.append("MapOfEnumToEnum: ").append(mapOfEnumToEnumStrings()).append(",");
+        }
+        if (mapOfEnumToStringStrings() != null) {
+            sb.append("MapOfEnumToString: ").append(mapOfEnumToStringStrings()).append(",");
+        }
+        if (mapOfStringToEnumStrings() != null) {
+            sb.append("MapOfStringToEnum: ").append(mapOfStringToEnumStrings()).append(",");
+        }
+        if (mapOfEnumToSimpleStructStrings() != null) {
+            sb.append("MapOfEnumToSimpleStruct: ").append(mapOfEnumToSimpleStructStrings()).append(",");
         }
         if (timestampMember() != null) {
             sb.append("TimestampMember: ").append(timestampMember()).append(",");
@@ -573,8 +784,8 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         if (polymorphicTypeWithoutSubTypes() != null) {
             sb.append("PolymorphicTypeWithoutSubTypes: ").append(polymorphicTypeWithoutSubTypes()).append(",");
         }
-        if (enumType() != null) {
-            sb.append("EnumType: ").append(enumType()).append(",");
+        if (enumTypeString() != null) {
+            sb.append("EnumType: ").append(enumTypeString()).append(",");
         }
         if (sb.length() > 1) {
             sb.setLength(sb.length() - 1);
@@ -585,52 +796,62 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "StringMember":
-            return Optional.of(clazz.cast(stringMember()));
-        case "IntegerMember":
-            return Optional.of(clazz.cast(integerMember()));
-        case "BooleanMember":
-            return Optional.of(clazz.cast(booleanMember()));
-        case "FloatMember":
-            return Optional.of(clazz.cast(floatMember()));
-        case "DoubleMember":
-            return Optional.of(clazz.cast(doubleMember()));
-        case "LongMember":
-            return Optional.of(clazz.cast(longMember()));
-        case "SimpleList":
-            return Optional.of(clazz.cast(simpleList()));
-        case "ListOfMaps":
-            return Optional.of(clazz.cast(listOfMaps()));
-        case "ListOfStructs":
-            return Optional.of(clazz.cast(listOfStructs()));
-        case "MapOfStringToIntegerList":
-            return Optional.of(clazz.cast(mapOfStringToIntegerList()));
-        case "MapOfStringToString":
-            return Optional.of(clazz.cast(mapOfStringToString()));
-        case "MapOfStringToStruct":
-            return Optional.of(clazz.cast(mapOfStringToStruct()));
-        case "TimestampMember":
-            return Optional.of(clazz.cast(timestampMember()));
-        case "StructWithNestedTimestampMember":
-            return Optional.of(clazz.cast(structWithNestedTimestampMember()));
-        case "BlobArg":
-            return Optional.of(clazz.cast(blobArg()));
-        case "StructWithNestedBlob":
-            return Optional.of(clazz.cast(structWithNestedBlob()));
-        case "BlobMap":
-            return Optional.of(clazz.cast(blobMap()));
-        case "ListOfBlobs":
-            return Optional.of(clazz.cast(listOfBlobs()));
-        case "RecursiveStruct":
-            return Optional.of(clazz.cast(recursiveStruct()));
-        case "PolymorphicTypeWithSubTypes":
-            return Optional.of(clazz.cast(polymorphicTypeWithSubTypes()));
-        case "PolymorphicTypeWithoutSubTypes":
-            return Optional.of(clazz.cast(polymorphicTypeWithoutSubTypes()));
-        case "EnumType":
-            return Optional.of(clazz.cast(enumType()));
-        default:
-            return Optional.empty();
+            case "StringMember":
+                return Optional.of(clazz.cast(stringMember()));
+            case "IntegerMember":
+                return Optional.of(clazz.cast(integerMember()));
+            case "BooleanMember":
+                return Optional.of(clazz.cast(booleanMember()));
+            case "FloatMember":
+                return Optional.of(clazz.cast(floatMember()));
+            case "DoubleMember":
+                return Optional.of(clazz.cast(doubleMember()));
+            case "LongMember":
+                return Optional.of(clazz.cast(longMember()));
+            case "SimpleList":
+                return Optional.of(clazz.cast(simpleList()));
+            case "ListOfEnums":
+                return Optional.of(clazz.cast(listOfEnumsStrings()));
+            case "ListOfMaps":
+                return Optional.of(clazz.cast(listOfMaps()));
+            case "ListOfStructs":
+                return Optional.of(clazz.cast(listOfStructs()));
+            case "MapOfStringToIntegerList":
+                return Optional.of(clazz.cast(mapOfStringToIntegerList()));
+            case "MapOfStringToString":
+                return Optional.of(clazz.cast(mapOfStringToString()));
+            case "MapOfStringToSimpleStruct":
+                return Optional.of(clazz.cast(mapOfStringToSimpleStruct()));
+            case "MapOfEnumToEnum":
+                return Optional.of(clazz.cast(mapOfEnumToEnumStrings()));
+            case "MapOfEnumToString":
+                return Optional.of(clazz.cast(mapOfEnumToStringStrings()));
+            case "MapOfStringToEnum":
+                return Optional.of(clazz.cast(mapOfStringToEnumStrings()));
+            case "MapOfEnumToSimpleStruct":
+                return Optional.of(clazz.cast(mapOfEnumToSimpleStructStrings()));
+            case "TimestampMember":
+                return Optional.of(clazz.cast(timestampMember()));
+            case "StructWithNestedTimestampMember":
+                return Optional.of(clazz.cast(structWithNestedTimestampMember()));
+            case "BlobArg":
+                return Optional.of(clazz.cast(blobArg()));
+            case "StructWithNestedBlob":
+                return Optional.of(clazz.cast(structWithNestedBlob()));
+            case "BlobMap":
+                return Optional.of(clazz.cast(blobMap()));
+            case "ListOfBlobs":
+                return Optional.of(clazz.cast(listOfBlobs()));
+            case "RecursiveStruct":
+                return Optional.of(clazz.cast(recursiveStruct()));
+            case "PolymorphicTypeWithSubTypes":
+                return Optional.of(clazz.cast(polymorphicTypeWithSubTypes()));
+            case "PolymorphicTypeWithoutSubTypes":
+                return Optional.of(clazz.cast(polymorphicTypeWithoutSubTypes()));
+            case "EnumType":
+                return Optional.of(clazz.cast(enumTypeString()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -708,6 +929,24 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         Builder simpleList(String... simpleList);
 
         /**
+         * Sets the value of the ListOfEnums property for this object.
+         *
+         * @param listOfEnums
+         *        The new value for the ListOfEnums property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder listOfEnums(Collection<String> listOfEnums);
+
+        /**
+         * Sets the value of the ListOfEnums property for this object.
+         *
+         * @param listOfEnums
+         *        The new value for the ListOfEnums property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder listOfEnums(String... listOfEnums);
+
+        /**
          * Sets the value of the ListOfMaps property for this object.
          *
          * @param listOfMaps
@@ -762,13 +1001,49 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         Builder mapOfStringToString(Map<String, String> mapOfStringToString);
 
         /**
-         * Sets the value of the MapOfStringToStruct property for this object.
+         * Sets the value of the MapOfStringToSimpleStruct property for this object.
          *
-         * @param mapOfStringToStruct
-         *        The new value for the MapOfStringToStruct property for this object.
+         * @param mapOfStringToSimpleStruct
+         *        The new value for the MapOfStringToSimpleStruct property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder mapOfStringToStruct(Map<String, SimpleStruct> mapOfStringToStruct);
+        Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct);
+
+        /**
+         * Sets the value of the MapOfEnumToEnum property for this object.
+         *
+         * @param mapOfEnumToEnum
+         *        The new value for the MapOfEnumToEnum property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfEnumToEnum(Map<String, String> mapOfEnumToEnum);
+
+        /**
+         * Sets the value of the MapOfEnumToString property for this object.
+         *
+         * @param mapOfEnumToString
+         *        The new value for the MapOfEnumToString property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfEnumToString(Map<String, String> mapOfEnumToString);
+
+        /**
+         * Sets the value of the MapOfStringToEnum property for this object.
+         *
+         * @param mapOfStringToEnum
+         *        The new value for the MapOfStringToEnum property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfStringToEnum(Map<String, String> mapOfStringToEnum);
+
+        /**
+         * Sets the value of the MapOfEnumToSimpleStruct property for this object.
+         *
+         * @param mapOfEnumToSimpleStruct
+         *        The new value for the MapOfEnumToSimpleStruct property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfEnumToSimpleStruct(Map<String, SimpleStruct> mapOfEnumToSimpleStruct);
 
         /**
          * Sets the value of the TimestampMember property for this object.
@@ -902,6 +1177,8 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
         private List<String> simpleList;
 
+        private List<String> listOfEnums;
+
         private List<Map<String, String>> listOfMaps;
 
         private List<SimpleStruct> listOfStructs;
@@ -910,7 +1187,15 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
         private Map<String, String> mapOfStringToString;
 
-        private Map<String, SimpleStruct> mapOfStringToStruct;
+        private Map<String, SimpleStruct> mapOfStringToSimpleStruct;
+
+        private Map<String, String> mapOfEnumToEnum;
+
+        private Map<String, String> mapOfEnumToString;
+
+        private Map<String, String> mapOfStringToEnum;
+
+        private Map<String, SimpleStruct> mapOfEnumToSimpleStruct;
 
         private Instant timestampMember;
 
@@ -943,11 +1228,16 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
             doubleMember(model.doubleMember);
             longMember(model.longMember);
             simpleList(model.simpleList);
+            listOfEnums(model.listOfEnums);
             listOfMaps(model.listOfMaps);
             listOfStructs(model.listOfStructs);
             mapOfStringToIntegerList(model.mapOfStringToIntegerList);
             mapOfStringToString(model.mapOfStringToString);
-            mapOfStringToStruct(model.mapOfStringToStruct);
+            mapOfStringToSimpleStruct(model.mapOfStringToSimpleStruct);
+            mapOfEnumToEnum(model.mapOfEnumToEnum);
+            mapOfEnumToString(model.mapOfEnumToString);
+            mapOfStringToEnum(model.mapOfStringToEnum);
+            mapOfEnumToSimpleStruct(model.mapOfEnumToSimpleStruct);
             timestampMember(model.timestampMember);
             structWithNestedTimestampMember(model.structWithNestedTimestampMember);
             blobArg(model.blobArg);
@@ -1065,6 +1355,27 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
             this.simpleList = ListOfStringsCopier.copy(simpleList);
         }
 
+        public final Collection<String> getListOfEnums() {
+            return listOfEnums;
+        }
+
+        @Override
+        public final Builder listOfEnums(Collection<String> listOfEnums) {
+            this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder listOfEnums(String... listOfEnums) {
+            listOfEnums(Arrays.asList(listOfEnums));
+            return this;
+        }
+
+        public final void setListOfEnums(Collection<String> listOfEnums) {
+            this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
+        }
+
         public final Collection<Map<String, String>> getListOfMaps() {
             return listOfMaps;
         }
@@ -1136,18 +1447,76 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
             this.mapOfStringToString = MapOfStringToStringCopier.copy(mapOfStringToString);
         }
 
-        public final Map<String, SimpleStruct.Builder> getMapOfStringToStruct() {
-            return mapOfStringToStruct != null ? CollectionUtils.mapValues(mapOfStringToStruct, SimpleStruct::toBuilder) : null;
+        public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
+            return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
+                                                                                 SimpleStruct::toBuilder) : null;
         }
 
         @Override
-        public final Builder mapOfStringToStruct(Map<String, SimpleStruct> mapOfStringToStruct) {
-            this.mapOfStringToStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToStruct);
+        public final Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct) {
+            this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToSimpleStruct);
             return this;
         }
 
-        public final void setMapOfStringToStruct(Map<String, SimpleStruct.BuilderImpl> mapOfStringToStruct) {
-            this.mapOfStringToStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToStruct);
+        public final void setMapOfStringToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfStringToSimpleStruct) {
+            this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToSimpleStruct);
+        }
+
+        public final Map<String, String> getMapOfEnumToEnum() {
+            return mapOfEnumToEnum;
+        }
+
+        @Override
+        public final Builder mapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
+            this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
+            return this;
+        }
+
+        public final void setMapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
+            this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
+        }
+
+        public final Map<String, String> getMapOfEnumToString() {
+            return mapOfEnumToString;
+        }
+
+        @Override
+        public final Builder mapOfEnumToString(Map<String, String> mapOfEnumToString) {
+            this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
+            return this;
+        }
+
+        public final void setMapOfEnumToString(Map<String, String> mapOfEnumToString) {
+            this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
+        }
+
+        public final Map<String, String> getMapOfStringToEnum() {
+            return mapOfStringToEnum;
+        }
+
+        @Override
+        public final Builder mapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
+            this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
+            return this;
+        }
+
+        public final void setMapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
+            this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
+        }
+
+        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
+            return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
+                                                   : null;
+        }
+
+        @Override
+        public final Builder mapOfEnumToSimpleStruct(Map<String, SimpleStruct> mapOfEnumToSimpleStruct) {
+            this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copy(mapOfEnumToSimpleStruct);
+            return this;
+        }
+
+        public final void setMapOfEnumToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
+            this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyFromBuilder(mapOfEnumToSimpleStruct);
         }
 
         public final Instant getTimestampMember() {
@@ -1176,7 +1545,7 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                .build() : null;
+                    .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -6,12 +6,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 import software.amazon.awssdk.core.AmazonWebServiceResult;
 import software.amazon.awssdk.core.ResponseMetadata;
 import software.amazon.awssdk.core.runtime.StandardMemberCopier;
+import software.amazon.awssdk.core.runtime.TypeConverter;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -35,6 +38,8 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
     private final List<String> simpleList;
 
+    private final List<String> listOfEnums;
+
     private final List<Map<String, String>> listOfMaps;
 
     private final List<SimpleStruct> listOfStructs;
@@ -43,7 +48,15 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
     private final Map<String, String> mapOfStringToString;
 
-    private final Map<String, SimpleStruct> mapOfStringToStruct;
+    private final Map<String, SimpleStruct> mapOfStringToSimpleStruct;
+
+    private final Map<String, String> mapOfEnumToEnum;
+
+    private final Map<String, String> mapOfEnumToString;
+
+    private final Map<String, String> mapOfStringToEnum;
+
+    private final Map<String, SimpleStruct> mapOfEnumToSimpleStruct;
 
     private final Instant timestampMember;
 
@@ -73,11 +86,16 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         this.doubleMember = builder.doubleMember;
         this.longMember = builder.longMember;
         this.simpleList = builder.simpleList;
+        this.listOfEnums = builder.listOfEnums;
         this.listOfMaps = builder.listOfMaps;
         this.listOfStructs = builder.listOfStructs;
         this.mapOfStringToIntegerList = builder.mapOfStringToIntegerList;
         this.mapOfStringToString = builder.mapOfStringToString;
-        this.mapOfStringToStruct = builder.mapOfStringToStruct;
+        this.mapOfStringToSimpleStruct = builder.mapOfStringToSimpleStruct;
+        this.mapOfEnumToEnum = builder.mapOfEnumToEnum;
+        this.mapOfEnumToString = builder.mapOfEnumToString;
+        this.mapOfStringToEnum = builder.mapOfStringToEnum;
+        this.mapOfEnumToSimpleStruct = builder.mapOfEnumToSimpleStruct;
         this.timestampMember = builder.timestampMember;
         this.structWithNestedTimestampMember = builder.structWithNestedTimestampMember;
         this.blobArg = builder.blobArg;
@@ -157,6 +175,30 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
     }
 
     /**
+     * Returns the value of the ListOfEnums property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the ListOfEnums property for this object.
+     */
+    public List<EnumType> listOfEnums() {
+        return TypeConverter.convert(listOfEnums, EnumType::fromValue);
+    }
+
+    /**
+     * Returns the value of the ListOfEnums property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the ListOfEnums property for this object.
+     */
+    public List<String> listOfEnumsStrings() {
+        return listOfEnums;
+    }
+
+    /**
      * Returns the value of the ListOfMaps property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
@@ -205,15 +247,114 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
     }
 
     /**
-     * Returns the value of the MapOfStringToStruct property for this object.
+     * Returns the value of the MapOfStringToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
      *
-     * @return The value of the MapOfStringToStruct property for this object.
+     * @return The value of the MapOfStringToSimpleStruct property for this object.
      */
-    public Map<String, SimpleStruct> mapOfStringToStruct() {
-        return mapOfStringToStruct;
+    public Map<String, SimpleStruct> mapOfStringToSimpleStruct() {
+        return mapOfStringToSimpleStruct;
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToEnum property for this object.
+     */
+    public Map<EnumType, EnumType> mapOfEnumToEnum() {
+        return TypeConverter.convert(mapOfEnumToEnum, EnumType::fromValue, EnumType::fromValue,
+                                     (k, v) -> !Objects.equals(k, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToEnum property for this object.
+     */
+    public Map<String, String> mapOfEnumToEnumStrings() {
+        return mapOfEnumToEnum;
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToString property for this object.
+     */
+    public Map<EnumType, String> mapOfEnumToString() {
+        return TypeConverter.convert(mapOfEnumToString, EnumType::fromValue, Function.identity(),
+                                     (k, v) -> !Objects.equals(k, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToString property for this object.
+     */
+    public Map<String, String> mapOfEnumToStringStrings() {
+        return mapOfEnumToString;
+    }
+
+    /**
+     * Returns the value of the MapOfStringToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfStringToEnum property for this object.
+     */
+    public Map<String, EnumType> mapOfStringToEnum() {
+        return TypeConverter.convert(mapOfStringToEnum, Function.identity(), EnumType::fromValue, (k, v) -> true);
+    }
+
+    /**
+     * Returns the value of the MapOfStringToEnum property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfStringToEnum property for this object.
+     */
+    public Map<String, String> mapOfStringToEnumStrings() {
+        return mapOfStringToEnum;
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToSimpleStruct property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToSimpleStruct property for this object.
+     */
+    public Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct() {
+        return TypeConverter.convert(mapOfEnumToSimpleStruct, EnumType::fromValue, Function.identity(),
+                                     (k, v) -> !Objects.equals(k, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    /**
+     * Returns the value of the MapOfEnumToSimpleStruct property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     *
+     * @return The value of the MapOfEnumToSimpleStruct property for this object.
+     */
+    public Map<String, SimpleStruct> mapOfEnumToSimpleStructStrings() {
+        return mapOfEnumToSimpleStruct;
     }
 
     /**
@@ -308,11 +449,29 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
     /**
      * Returns the value of the EnumType property for this object.
+     * <p>
+     * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * </p>
      *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
-    public String enumType() {
+    public EnumType enumType() {
+        return EnumType.fromValue(enumType);
+    }
+
+    /**
+     * Returns the value of the EnumType property for this object.
+     * <p>
+     * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * </p>
+     *
+     * @return The value of the EnumType property for this object.
+     * @see EnumType
+     */
+    public String enumTypeString() {
         return enumType;
     }
 
@@ -339,11 +498,16 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         hashCode = 31 * hashCode + ((doubleMember() == null) ? 0 : doubleMember().hashCode());
         hashCode = 31 * hashCode + ((longMember() == null) ? 0 : longMember().hashCode());
         hashCode = 31 * hashCode + ((simpleList() == null) ? 0 : simpleList().hashCode());
+        hashCode = 31 * hashCode + ((listOfEnumsStrings() == null) ? 0 : listOfEnumsStrings().hashCode());
         hashCode = 31 * hashCode + ((listOfMaps() == null) ? 0 : listOfMaps().hashCode());
         hashCode = 31 * hashCode + ((listOfStructs() == null) ? 0 : listOfStructs().hashCode());
         hashCode = 31 * hashCode + ((mapOfStringToIntegerList() == null) ? 0 : mapOfStringToIntegerList().hashCode());
         hashCode = 31 * hashCode + ((mapOfStringToString() == null) ? 0 : mapOfStringToString().hashCode());
-        hashCode = 31 * hashCode + ((mapOfStringToStruct() == null) ? 0 : mapOfStringToStruct().hashCode());
+        hashCode = 31 * hashCode + ((mapOfStringToSimpleStruct() == null) ? 0 : mapOfStringToSimpleStruct().hashCode());
+        hashCode = 31 * hashCode + ((mapOfEnumToEnumStrings() == null) ? 0 : mapOfEnumToEnumStrings().hashCode());
+        hashCode = 31 * hashCode + ((mapOfEnumToStringStrings() == null) ? 0 : mapOfEnumToStringStrings().hashCode());
+        hashCode = 31 * hashCode + ((mapOfStringToEnumStrings() == null) ? 0 : mapOfStringToEnumStrings().hashCode());
+        hashCode = 31 * hashCode + ((mapOfEnumToSimpleStructStrings() == null) ? 0 : mapOfEnumToSimpleStructStrings().hashCode());
         hashCode = 31 * hashCode + ((timestampMember() == null) ? 0 : timestampMember().hashCode());
         hashCode = 31 * hashCode
                    + ((structWithNestedTimestampMember() == null) ? 0 : structWithNestedTimestampMember().hashCode());
@@ -354,7 +518,7 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         hashCode = 31 * hashCode + ((recursiveStruct() == null) ? 0 : recursiveStruct().hashCode());
         hashCode = 31 * hashCode + ((polymorphicTypeWithSubTypes() == null) ? 0 : polymorphicTypeWithSubTypes().hashCode());
         hashCode = 31 * hashCode + ((polymorphicTypeWithoutSubTypes() == null) ? 0 : polymorphicTypeWithoutSubTypes().hashCode());
-        hashCode = 31 * hashCode + ((enumType() == null) ? 0 : enumType().hashCode());
+        hashCode = 31 * hashCode + ((enumTypeString() == null) ? 0 : enumTypeString().hashCode());
         return hashCode;
     }
 
@@ -412,6 +576,12 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         if (other.simpleList() != null && !other.simpleList().equals(this.simpleList())) {
             return false;
         }
+        if (other.listOfEnumsStrings() == null ^ this.listOfEnumsStrings() == null) {
+            return false;
+        }
+        if (other.listOfEnumsStrings() != null && !other.listOfEnumsStrings().equals(this.listOfEnumsStrings())) {
+            return false;
+        }
         if (other.listOfMaps() == null ^ this.listOfMaps() == null) {
             return false;
         }
@@ -436,10 +606,36 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         if (other.mapOfStringToString() != null && !other.mapOfStringToString().equals(this.mapOfStringToString())) {
             return false;
         }
-        if (other.mapOfStringToStruct() == null ^ this.mapOfStringToStruct() == null) {
+        if (other.mapOfStringToSimpleStruct() == null ^ this.mapOfStringToSimpleStruct() == null) {
             return false;
         }
-        if (other.mapOfStringToStruct() != null && !other.mapOfStringToStruct().equals(this.mapOfStringToStruct())) {
+        if (other.mapOfStringToSimpleStruct() != null
+            && !other.mapOfStringToSimpleStruct().equals(this.mapOfStringToSimpleStruct())) {
+            return false;
+        }
+        if (other.mapOfEnumToEnumStrings() == null ^ this.mapOfEnumToEnumStrings() == null) {
+            return false;
+        }
+        if (other.mapOfEnumToEnumStrings() != null && !other.mapOfEnumToEnumStrings().equals(this.mapOfEnumToEnumStrings())) {
+            return false;
+        }
+        if (other.mapOfEnumToStringStrings() == null ^ this.mapOfEnumToStringStrings() == null) {
+            return false;
+        }
+        if (other.mapOfEnumToStringStrings() != null && !other.mapOfEnumToStringStrings().equals(this.mapOfEnumToStringStrings())) {
+            return false;
+        }
+        if (other.mapOfStringToEnumStrings() == null ^ this.mapOfStringToEnumStrings() == null) {
+            return false;
+        }
+        if (other.mapOfStringToEnumStrings() != null && !other.mapOfStringToEnumStrings().equals(this.mapOfStringToEnumStrings())) {
+            return false;
+        }
+        if (other.mapOfEnumToSimpleStructStrings() == null ^ this.mapOfEnumToSimpleStructStrings() == null) {
+            return false;
+        }
+        if (other.mapOfEnumToSimpleStructStrings() != null
+            && !other.mapOfEnumToSimpleStructStrings().equals(this.mapOfEnumToSimpleStructStrings())) {
             return false;
         }
         if (other.timestampMember() == null ^ this.timestampMember() == null) {
@@ -499,10 +695,10 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
             && !other.polymorphicTypeWithoutSubTypes().equals(this.polymorphicTypeWithoutSubTypes())) {
             return false;
         }
-        if (other.enumType() == null ^ this.enumType() == null) {
+        if (other.enumTypeString() == null ^ this.enumTypeString() == null) {
             return false;
         }
-        if (other.enumType() != null && !other.enumType().equals(this.enumType())) {
+        if (other.enumTypeString() != null && !other.enumTypeString().equals(this.enumTypeString())) {
             return false;
         }
         return true;
@@ -532,6 +728,9 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         if (simpleList() != null) {
             sb.append("SimpleList: ").append(simpleList()).append(",");
         }
+        if (listOfEnumsStrings() != null) {
+            sb.append("ListOfEnums: ").append(listOfEnumsStrings()).append(",");
+        }
         if (listOfMaps() != null) {
             sb.append("ListOfMaps: ").append(listOfMaps()).append(",");
         }
@@ -544,8 +743,20 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         if (mapOfStringToString() != null) {
             sb.append("MapOfStringToString: ").append(mapOfStringToString()).append(",");
         }
-        if (mapOfStringToStruct() != null) {
-            sb.append("MapOfStringToStruct: ").append(mapOfStringToStruct()).append(",");
+        if (mapOfStringToSimpleStruct() != null) {
+            sb.append("MapOfStringToSimpleStruct: ").append(mapOfStringToSimpleStruct()).append(",");
+        }
+        if (mapOfEnumToEnumStrings() != null) {
+            sb.append("MapOfEnumToEnum: ").append(mapOfEnumToEnumStrings()).append(",");
+        }
+        if (mapOfEnumToStringStrings() != null) {
+            sb.append("MapOfEnumToString: ").append(mapOfEnumToStringStrings()).append(",");
+        }
+        if (mapOfStringToEnumStrings() != null) {
+            sb.append("MapOfStringToEnum: ").append(mapOfStringToEnumStrings()).append(",");
+        }
+        if (mapOfEnumToSimpleStructStrings() != null) {
+            sb.append("MapOfEnumToSimpleStruct: ").append(mapOfEnumToSimpleStructStrings()).append(",");
         }
         if (timestampMember() != null) {
             sb.append("TimestampMember: ").append(timestampMember()).append(",");
@@ -574,8 +785,8 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         if (polymorphicTypeWithoutSubTypes() != null) {
             sb.append("PolymorphicTypeWithoutSubTypes: ").append(polymorphicTypeWithoutSubTypes()).append(",");
         }
-        if (enumType() != null) {
-            sb.append("EnumType: ").append(enumType()).append(",");
+        if (enumTypeString() != null) {
+            sb.append("EnumType: ").append(enumTypeString()).append(",");
         }
         if (sb.length() > 1) {
             sb.setLength(sb.length() - 1);
@@ -586,52 +797,62 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "StringMember":
-            return Optional.of(clazz.cast(stringMember()));
-        case "IntegerMember":
-            return Optional.of(clazz.cast(integerMember()));
-        case "BooleanMember":
-            return Optional.of(clazz.cast(booleanMember()));
-        case "FloatMember":
-            return Optional.of(clazz.cast(floatMember()));
-        case "DoubleMember":
-            return Optional.of(clazz.cast(doubleMember()));
-        case "LongMember":
-            return Optional.of(clazz.cast(longMember()));
-        case "SimpleList":
-            return Optional.of(clazz.cast(simpleList()));
-        case "ListOfMaps":
-            return Optional.of(clazz.cast(listOfMaps()));
-        case "ListOfStructs":
-            return Optional.of(clazz.cast(listOfStructs()));
-        case "MapOfStringToIntegerList":
-            return Optional.of(clazz.cast(mapOfStringToIntegerList()));
-        case "MapOfStringToString":
-            return Optional.of(clazz.cast(mapOfStringToString()));
-        case "MapOfStringToStruct":
-            return Optional.of(clazz.cast(mapOfStringToStruct()));
-        case "TimestampMember":
-            return Optional.of(clazz.cast(timestampMember()));
-        case "StructWithNestedTimestampMember":
-            return Optional.of(clazz.cast(structWithNestedTimestampMember()));
-        case "BlobArg":
-            return Optional.of(clazz.cast(blobArg()));
-        case "StructWithNestedBlob":
-            return Optional.of(clazz.cast(structWithNestedBlob()));
-        case "BlobMap":
-            return Optional.of(clazz.cast(blobMap()));
-        case "ListOfBlobs":
-            return Optional.of(clazz.cast(listOfBlobs()));
-        case "RecursiveStruct":
-            return Optional.of(clazz.cast(recursiveStruct()));
-        case "PolymorphicTypeWithSubTypes":
-            return Optional.of(clazz.cast(polymorphicTypeWithSubTypes()));
-        case "PolymorphicTypeWithoutSubTypes":
-            return Optional.of(clazz.cast(polymorphicTypeWithoutSubTypes()));
-        case "EnumType":
-            return Optional.of(clazz.cast(enumType()));
-        default:
-            return Optional.empty();
+            case "StringMember":
+                return Optional.of(clazz.cast(stringMember()));
+            case "IntegerMember":
+                return Optional.of(clazz.cast(integerMember()));
+            case "BooleanMember":
+                return Optional.of(clazz.cast(booleanMember()));
+            case "FloatMember":
+                return Optional.of(clazz.cast(floatMember()));
+            case "DoubleMember":
+                return Optional.of(clazz.cast(doubleMember()));
+            case "LongMember":
+                return Optional.of(clazz.cast(longMember()));
+            case "SimpleList":
+                return Optional.of(clazz.cast(simpleList()));
+            case "ListOfEnums":
+                return Optional.of(clazz.cast(listOfEnumsStrings()));
+            case "ListOfMaps":
+                return Optional.of(clazz.cast(listOfMaps()));
+            case "ListOfStructs":
+                return Optional.of(clazz.cast(listOfStructs()));
+            case "MapOfStringToIntegerList":
+                return Optional.of(clazz.cast(mapOfStringToIntegerList()));
+            case "MapOfStringToString":
+                return Optional.of(clazz.cast(mapOfStringToString()));
+            case "MapOfStringToSimpleStruct":
+                return Optional.of(clazz.cast(mapOfStringToSimpleStruct()));
+            case "MapOfEnumToEnum":
+                return Optional.of(clazz.cast(mapOfEnumToEnumStrings()));
+            case "MapOfEnumToString":
+                return Optional.of(clazz.cast(mapOfEnumToStringStrings()));
+            case "MapOfStringToEnum":
+                return Optional.of(clazz.cast(mapOfStringToEnumStrings()));
+            case "MapOfEnumToSimpleStruct":
+                return Optional.of(clazz.cast(mapOfEnumToSimpleStructStrings()));
+            case "TimestampMember":
+                return Optional.of(clazz.cast(timestampMember()));
+            case "StructWithNestedTimestampMember":
+                return Optional.of(clazz.cast(structWithNestedTimestampMember()));
+            case "BlobArg":
+                return Optional.of(clazz.cast(blobArg()));
+            case "StructWithNestedBlob":
+                return Optional.of(clazz.cast(structWithNestedBlob()));
+            case "BlobMap":
+                return Optional.of(clazz.cast(blobMap()));
+            case "ListOfBlobs":
+                return Optional.of(clazz.cast(listOfBlobs()));
+            case "RecursiveStruct":
+                return Optional.of(clazz.cast(recursiveStruct()));
+            case "PolymorphicTypeWithSubTypes":
+                return Optional.of(clazz.cast(polymorphicTypeWithSubTypes()));
+            case "PolymorphicTypeWithoutSubTypes":
+                return Optional.of(clazz.cast(polymorphicTypeWithoutSubTypes()));
+            case "EnumType":
+                return Optional.of(clazz.cast(enumTypeString()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -709,6 +930,24 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         Builder simpleList(String... simpleList);
 
         /**
+         * Sets the value of the ListOfEnums property for this object.
+         *
+         * @param listOfEnums
+         *        The new value for the ListOfEnums property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder listOfEnums(Collection<String> listOfEnums);
+
+        /**
+         * Sets the value of the ListOfEnums property for this object.
+         *
+         * @param listOfEnums
+         *        The new value for the ListOfEnums property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder listOfEnums(String... listOfEnums);
+
+        /**
          * Sets the value of the ListOfMaps property for this object.
          *
          * @param listOfMaps
@@ -763,13 +1002,49 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         Builder mapOfStringToString(Map<String, String> mapOfStringToString);
 
         /**
-         * Sets the value of the MapOfStringToStruct property for this object.
+         * Sets the value of the MapOfStringToSimpleStruct property for this object.
          *
-         * @param mapOfStringToStruct
-         *        The new value for the MapOfStringToStruct property for this object.
+         * @param mapOfStringToSimpleStruct
+         *        The new value for the MapOfStringToSimpleStruct property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder mapOfStringToStruct(Map<String, SimpleStruct> mapOfStringToStruct);
+        Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct);
+
+        /**
+         * Sets the value of the MapOfEnumToEnum property for this object.
+         *
+         * @param mapOfEnumToEnum
+         *        The new value for the MapOfEnumToEnum property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfEnumToEnum(Map<String, String> mapOfEnumToEnum);
+
+        /**
+         * Sets the value of the MapOfEnumToString property for this object.
+         *
+         * @param mapOfEnumToString
+         *        The new value for the MapOfEnumToString property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfEnumToString(Map<String, String> mapOfEnumToString);
+
+        /**
+         * Sets the value of the MapOfStringToEnum property for this object.
+         *
+         * @param mapOfStringToEnum
+         *        The new value for the MapOfStringToEnum property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfStringToEnum(Map<String, String> mapOfStringToEnum);
+
+        /**
+         * Sets the value of the MapOfEnumToSimpleStruct property for this object.
+         *
+         * @param mapOfEnumToSimpleStruct
+         *        The new value for the MapOfEnumToSimpleStruct property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder mapOfEnumToSimpleStruct(Map<String, SimpleStruct> mapOfEnumToSimpleStruct);
 
         /**
          * Sets the value of the TimestampMember property for this object.
@@ -903,6 +1178,8 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
         private List<String> simpleList;
 
+        private List<String> listOfEnums;
+
         private List<Map<String, String>> listOfMaps;
 
         private List<SimpleStruct> listOfStructs;
@@ -911,7 +1188,15 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
         private Map<String, String> mapOfStringToString;
 
-        private Map<String, SimpleStruct> mapOfStringToStruct;
+        private Map<String, SimpleStruct> mapOfStringToSimpleStruct;
+
+        private Map<String, String> mapOfEnumToEnum;
+
+        private Map<String, String> mapOfEnumToString;
+
+        private Map<String, String> mapOfStringToEnum;
+
+        private Map<String, SimpleStruct> mapOfEnumToSimpleStruct;
 
         private Instant timestampMember;
 
@@ -944,11 +1229,16 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
             doubleMember(model.doubleMember);
             longMember(model.longMember);
             simpleList(model.simpleList);
+            listOfEnums(model.listOfEnums);
             listOfMaps(model.listOfMaps);
             listOfStructs(model.listOfStructs);
             mapOfStringToIntegerList(model.mapOfStringToIntegerList);
             mapOfStringToString(model.mapOfStringToString);
-            mapOfStringToStruct(model.mapOfStringToStruct);
+            mapOfStringToSimpleStruct(model.mapOfStringToSimpleStruct);
+            mapOfEnumToEnum(model.mapOfEnumToEnum);
+            mapOfEnumToString(model.mapOfEnumToString);
+            mapOfStringToEnum(model.mapOfStringToEnum);
+            mapOfEnumToSimpleStruct(model.mapOfEnumToSimpleStruct);
             timestampMember(model.timestampMember);
             structWithNestedTimestampMember(model.structWithNestedTimestampMember);
             blobArg(model.blobArg);
@@ -1066,6 +1356,27 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
             this.simpleList = ListOfStringsCopier.copy(simpleList);
         }
 
+        public final Collection<String> getListOfEnums() {
+            return listOfEnums;
+        }
+
+        @Override
+        public final Builder listOfEnums(Collection<String> listOfEnums) {
+            this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder listOfEnums(String... listOfEnums) {
+            listOfEnums(Arrays.asList(listOfEnums));
+            return this;
+        }
+
+        public final void setListOfEnums(Collection<String> listOfEnums) {
+            this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
+        }
+
         public final Collection<Map<String, String>> getListOfMaps() {
             return listOfMaps;
         }
@@ -1137,18 +1448,76 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
             this.mapOfStringToString = MapOfStringToStringCopier.copy(mapOfStringToString);
         }
 
-        public final Map<String, SimpleStruct.Builder> getMapOfStringToStruct() {
-            return mapOfStringToStruct != null ? CollectionUtils.mapValues(mapOfStringToStruct, SimpleStruct::toBuilder) : null;
+        public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
+            return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
+                                                                                 SimpleStruct::toBuilder) : null;
         }
 
         @Override
-        public final Builder mapOfStringToStruct(Map<String, SimpleStruct> mapOfStringToStruct) {
-            this.mapOfStringToStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToStruct);
+        public final Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct) {
+            this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToSimpleStruct);
             return this;
         }
 
-        public final void setMapOfStringToStruct(Map<String, SimpleStruct.BuilderImpl> mapOfStringToStruct) {
-            this.mapOfStringToStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToStruct);
+        public final void setMapOfStringToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfStringToSimpleStruct) {
+            this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToSimpleStruct);
+        }
+
+        public final Map<String, String> getMapOfEnumToEnum() {
+            return mapOfEnumToEnum;
+        }
+
+        @Override
+        public final Builder mapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
+            this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
+            return this;
+        }
+
+        public final void setMapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
+            this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
+        }
+
+        public final Map<String, String> getMapOfEnumToString() {
+            return mapOfEnumToString;
+        }
+
+        @Override
+        public final Builder mapOfEnumToString(Map<String, String> mapOfEnumToString) {
+            this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
+            return this;
+        }
+
+        public final void setMapOfEnumToString(Map<String, String> mapOfEnumToString) {
+            this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
+        }
+
+        public final Map<String, String> getMapOfStringToEnum() {
+            return mapOfStringToEnum;
+        }
+
+        @Override
+        public final Builder mapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
+            this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
+            return this;
+        }
+
+        public final void setMapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
+            this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
+        }
+
+        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
+            return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
+                                                   : null;
+        }
+
+        @Override
+        public final Builder mapOfEnumToSimpleStruct(Map<String, SimpleStruct> mapOfEnumToSimpleStruct) {
+            this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copy(mapOfEnumToSimpleStruct);
+            return this;
+        }
+
+        public final void setMapOfEnumToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
+            this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyFromBuilder(mapOfEnumToSimpleStruct);
         }
 
         public final Instant getTimestampMember() {
@@ -1177,7 +1546,7 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                .build() : null;
+                    .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
@@ -15,7 +15,7 @@ final class BlobMapTypeCopier {
             return null;
         }
         Map<String, ByteBuffer> blobMapTypeParamCopy = blobMapTypeParam.entrySet().stream()
-                                                                       .collect(toMap(e -> StandardMemberCopier.copy(e.getKey()), e -> StandardMemberCopier.copy(e.getValue())));
+                                                                       .collect(toMap(Map.Entry::getKey, e -> StandardMemberCopier.copy(e.getValue())));
         return Collections.unmodifiableMap(blobMapTypeParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
@@ -1,0 +1,19 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated("software.amazon.awssdk:codegen")
+final class ListOfEnumsCopier {
+    static List<String> copy(Collection<String> listOfEnumsParam) {
+        if (listOfEnumsParam == null) {
+            return null;
+        }
+        List<String> listOfEnumsParamCopy = listOfEnumsParam.stream().collect(toList());
+        return Collections.unmodifiableList(listOfEnumsParamCopy);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
@@ -1,0 +1,19 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("software.amazon.awssdk:codegen")
+final class MapOfEnumToEnumCopier {
+    static Map<String, String> copy(Map<String, String> mapOfEnumToEnumParam) {
+        if (mapOfEnumToEnumParam == null) {
+            return null;
+        }
+        Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
+                                                                           .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
@@ -1,0 +1,26 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("software.amazon.awssdk:codegen")
+final class MapOfEnumToSimpleStructCopier {
+    static Map<String, SimpleStruct> copy(Map<String, SimpleStruct> mapOfEnumToSimpleStructParam) {
+        if (mapOfEnumToSimpleStructParam == null) {
+            return null;
+        }
+        Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
+                                                                                                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
+    }
+
+    static Map<String, SimpleStruct> copyFromBuilder(Map<String, ? extends SimpleStruct.Builder> mapOfEnumToSimpleStructParam) {
+        if (mapOfEnumToSimpleStructParam == null) {
+            return null;
+        }
+        return copy(mapOfEnumToSimpleStructParam.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
@@ -1,0 +1,19 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("software.amazon.awssdk:codegen")
+final class MapOfEnumToStringCopier {
+    static Map<String, String> copy(Map<String, String> mapOfEnumToStringParam) {
+        if (mapOfEnumToStringParam == null) {
+            return null;
+        }
+        Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
+                                                                               .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
@@ -1,0 +1,19 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Generated;
+
+@Generated("software.amazon.awssdk:codegen")
+final class MapOfStringToEnumCopier {
+    static Map<String, String> copy(Map<String, String> mapOfStringToEnumParam) {
+        if (mapOfStringToEnumParam == null) {
+            return null;
+        }
+        Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
+                                                                               .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Generated;
-import software.amazon.awssdk.core.runtime.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToIntegerListCopier {
@@ -16,7 +15,7 @@ final class MapOfStringToIntegerListCopier {
             return null;
         }
         Map<String, List<Integer>> mapOfStringToIntegerListParamCopy = mapOfStringToIntegerListParam.entrySet().stream()
-                                                                                                    .collect(toMap(e -> StandardMemberCopier.copy(e.getKey()), e -> ListOfIntegersCopier.copy(e.getValue())));
+                                                                                                    .collect(toMap(Map.Entry::getKey, e -> ListOfIntegersCopier.copy(e.getValue())));
         return Collections.unmodifiableMap(mapOfStringToIntegerListParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
@@ -7,17 +7,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Generated;
-import software.amazon.awssdk.core.runtime.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToListOfListOfStringsCopier {
-    static Map<String, List<List<String>>> copy(Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
+    static Map<String, List<List<String>>> copy(
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
         if (mapOfStringToListOfListOfStringsParam == null) {
             return null;
         }
         Map<String, List<List<String>>> mapOfStringToListOfListOfStringsParamCopy = mapOfStringToListOfListOfStringsParam
-            .entrySet().stream()
-            .collect(toMap(e -> StandardMemberCopier.copy(e.getKey()), e -> ListOfListOfStringsCopier.copy(e.getValue())));
+                .entrySet().stream().collect(toMap(Map.Entry::getKey, e -> ListOfListOfStringsCopier.copy(e.getValue())));
         return Collections.unmodifiableMap(mapOfStringToListOfListOfStringsParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toMap;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Generated;
-import software.amazon.awssdk.core.runtime.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToSimpleStructCopier {
@@ -14,7 +13,7 @@ final class MapOfStringToSimpleStructCopier {
             return null;
         }
         Map<String, SimpleStruct> mapOfStringToSimpleStructParamCopy = mapOfStringToSimpleStructParam.entrySet().stream()
-                                                                                                     .collect(toMap(e -> StandardMemberCopier.copy(e.getKey()), Map.Entry::getValue));
+                                                                                                     .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
         return Collections.unmodifiableMap(mapOfStringToSimpleStructParamCopy);
     }
 
@@ -22,6 +21,7 @@ final class MapOfStringToSimpleStructCopier {
         if (mapOfStringToSimpleStructParam == null) {
             return null;
         }
-        return copy(mapOfStringToSimpleStructParam.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+        return copy(mapOfStringToSimpleStructParam.entrySet().stream()
+                                                  .collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toMap;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Generated;
-import software.amazon.awssdk.core.runtime.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToStringCopier {
@@ -13,11 +12,8 @@ final class MapOfStringToStringCopier {
         if (mapOfStringToStringParam == null) {
             return null;
         }
-
         Map<String, String> mapOfStringToStringParamCopy = mapOfStringToStringParam.entrySet().stream()
-                                                                                   .collect(toMap(e -> StandardMemberCopier.copy(e.getKey()), Map.Entry::getValue));
-
+                                                                                   .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
         return Collections.unmodifiableMap(mapOfStringToStringParamCopy);
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toMap;
 import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Generated;
-import software.amazon.awssdk.core.runtime.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class RecursiveMapTypeCopier {
@@ -14,12 +13,12 @@ final class RecursiveMapTypeCopier {
             return null;
         }
         Map<String, RecursiveStructType> recursiveMapTypeParamCopy = recursiveMapTypeParam.entrySet().stream()
-                                                                                          .collect(toMap(e -> StandardMemberCopier.copy(e.getKey()), Map.Entry::getValue));
+                                                                                          .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
         return Collections.unmodifiableMap(recursiveMapTypeParamCopy);
     }
 
     static Map<String, RecursiveStructType> copyFromBuilder(
-        Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
+            Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
         if (recursiveMapTypeParam == null) {
             return null;
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/service-2.json
@@ -69,11 +69,16 @@
         "DoubleMember":{"shape":"Double"},
         "LongMember":{"shape":"Long"},
         "SimpleList":{"shape":"ListOfStrings"},
+        "ListOfEnums":{"shape":"ListOfEnums"},
         "ListOfMaps":{"shape":"ListOfMapStringToString"},
         "ListOfStructs":{"shape":"ListOfSimpleStructs"},
         "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
         "MapOfStringToString":{"shape":"MapOfStringToString"},
-        "MapOfStringToStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "MapOfStringToSimpleStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
+        "MapOfEnumToString":{"shape":"MapOfEnumToString"},
+        "MapOfStringToEnum":{"shape":"MapOfStringToEnum"},
+        "MapOfEnumToSimpleStruct":{"shape":"MapOfEnumToSimpleStruct"},
         "TimestampMember":{"shape":"Timestamp"},
         "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
         "BlobArg":{"shape":"BlobType"},
@@ -145,6 +150,10 @@
       "type":"list",
       "member":{"shape":"String"}
     },
+    "ListOfEnums":{
+      "type":"list",
+      "member":{"shape":"EnumType"}
+    },
     "Long":{"type":"long"},
     "MapOfStringToIntegerList":{
       "type":"map",
@@ -165,6 +174,26 @@
       "type":"map",
       "key":{"shape":"String"},
       "value":{"shape":"String"}
+    },
+    "MapOfEnumToEnum":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"EnumType"}
+    },
+    "MapOfEnumToString":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"String"}
+    },
+    "MapOfStringToEnum":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"EnumType"}
+    },
+    "MapOfEnumToSimpleStruct":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"SimpleStruct"}
     },
     "NestedContainersStructure":{
       "type":"structure",

--- a/core/src/main/java/software/amazon/awssdk/core/runtime/TypeConverter.java
+++ b/core/src/main/java/software/amazon/awssdk/core/runtime/TypeConverter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.runtime;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * A utilities class used by generated clients to easily convert between nested types, such as lists and maps.
+ */
+@SdkProtectedApi
+public final class TypeConverter {
+    /**
+     * Null-safely convert between types by applying a function.
+     */
+    public static <T, U> U convert(T toConvert, Function<? super T, ? extends U> converter) {
+        if (toConvert == null) {
+            return null;
+        }
+
+        return converter.apply(toConvert);
+    }
+
+    /**
+     * Null-safely convert between two lists by applying a function to each value.
+     */
+    public static <T, U> List<U> convert(List<T> toConvert, Function<? super T, ? extends U> converter) {
+        if (toConvert == null) {
+            return null;
+        }
+
+        List<U> result = toConvert.stream().map(converter).collect(Collectors.toList());
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * Null-safely convert between two maps by applying a function to each key and value. A predicate is also specified to filter
+     * the results, in case the mapping function were to generate duplicate keys, etc.
+     */
+    public static <T1, T2, U1, U2> Map<U1, U2> convert(Map<T1, T2> toConvert,
+                                                       Function<? super T1, ? extends U1> keyConverter,
+                                                       Function<? super T2, ? extends U2> valueConverter,
+                                                       BiPredicate<U1, U2> resultFilter) {
+        if (toConvert == null) {
+            return null;
+        }
+
+        Map<U1, U2> result = toConvert.entrySet().stream()
+                                      .map(e -> new SimpleImmutableEntry<>(keyConverter.apply(e.getKey()),
+                                                                           valueConverter.apply(e.getValue())))
+                                      .filter(p -> resultFilter.test(p.getKey(), p.getValue()))
+                                      .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        return Collections.unmodifiableMap(result);
+    }
+}

--- a/services/api-gateway/src/it/java/software/amazon/awssdk/services/apigateway/ServiceIntegrationTest.java
+++ b/services/api-gateway/src/it/java/software/amazon/awssdk/services/apigateway/ServiceIntegrationTest.java
@@ -81,7 +81,7 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
 
     @Test
     public void testUpdateRetrieveRestApi() {
-        PatchOperation patch = PatchOperation.builder().op(Op.Replace)
+        PatchOperation patch = PatchOperation.builder().op(Op.REPLACE)
                                                    .path("/description").value("updatedDesc").build();
         apiGateway.updateRestApi(UpdateRestApiRequest.builder().restApiId(restApiId)
                                                            .patchOperations(patch).build());
@@ -117,7 +117,7 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
         Assert.assertEquals(createApiKeyResult.name(), NAME);
         Assert.assertEquals(createApiKeyResult.description(), DESCRIPTION);
 
-        PatchOperation patch = PatchOperation.builder().op(Op.Replace)
+        PatchOperation patch = PatchOperation.builder().op(Op.REPLACE)
                                                    .path("/description").value("updatedDesc").build();
         apiGateway.updateApiKey(UpdateApiKeyRequest.builder().apiKey(apiKeyId)
                                                          .patchOperations(patch).build());
@@ -163,7 +163,7 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
         Assert.assertEquals(createResourceResult.pathPart(), "fooPath");
         Assert.assertEquals(createResourceResult.parentId(), rootResourceId);
 
-        PatchOperation patch = PatchOperation.builder().op(Op.Replace)
+        PatchOperation patch = PatchOperation.builder().op(Op.REPLACE)
                                                    .path("/pathPart").value("updatedPath").build();
         apiGateway.updateResource(UpdateResourceRequest.builder()
                                           .restApiId(restApiId)

--- a/services/applicationautoscaling/src/it/java/software/amazon/awssdk/services/applicationautoscaling/ServiceIntegrationTest.java
+++ b/services/applicationautoscaling/src/it/java/software/amazon/awssdk/services/applicationautoscaling/ServiceIntegrationTest.java
@@ -38,7 +38,7 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
     @Test
     public void testScalingPolicy() {
         DescribeScalingPoliciesResponse res = autoscaling.describeScalingPolicies(DescribeScalingPoliciesRequest.builder()
-                .serviceNamespace(ServiceNamespace.Ecs).build());
+                .serviceNamespace(ServiceNamespace.ECS).build());
         Assert.assertNotNull(res);
         Assert.assertNotNull(res.scalingPolicies());
     }

--- a/services/cloudformation/src/it/java/software/amazon/awssdk/services/cloudformation/StackIntegrationTests.java
+++ b/services/cloudformation/src/it/java/software/amazon/awssdk/services/cloudformation/StackIntegrationTests.java
@@ -280,7 +280,7 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
             assertNotNull(summary);
             assertNotNull(summary.stackStatus());
             assertNotNull(summary.creationTime());
-            if (summary.stackStatus().contains("DELETE")) {
+            if (summary.stackStatusString().contains("DELETE")) {
                 assertNotNull(summary.deletionTime());
             }
             assertNotNull(summary.stackId());
@@ -299,7 +299,7 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
             assertNotNull(summary);
             assertNotNull(summary.stackStatus());
             assertNotNull(summary.creationTime());
-            if (summary.stackStatus().contains("DELETE")) {
+            if (summary.stackStatusString().contains("DELETE")) {
                 assertNotNull(summary.deletionTime());
             }
             assertNotNull(summary.stackId());
@@ -323,7 +323,7 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
             assertTrue(summary.stackStatus().equals("CREATE_COMPLETE")
                        || summary.stackStatus().equals("DELETE_COMPLETE"));
             assertNotNull(summary.creationTime());
-            if (summary.stackStatus().contains("DELETE")) {
+            if (summary.stackStatusString().contains("DELETE")) {
                 assertNotNull(summary.deletionTime());
             }
             assertNotNull(summary.stackId());
@@ -399,7 +399,7 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
                                    .stacks();
             assertEquals(1, stacks.size());
 
-            if (!stacks.get(0).stackStatus().equalsIgnoreCase(oldStatus.toString())) {
+            if (!stacks.get(0).stackStatusString().equalsIgnoreCase(oldStatus.toString())) {
                 return;
             }
 

--- a/services/cloudfront/src/it/java/software/amazon/awssdk/services/cloudfront/PresignedUrlIntegrationTest.java
+++ b/services/cloudfront/src/it/java/software/amazon/awssdk/services/cloudfront/PresignedUrlIntegrationTest.java
@@ -124,12 +124,12 @@ public class PresignedUrlIntegrationTest extends IntegrationTestBase {
         s3.putObjectAcl(PutObjectAclRequest.builder()
                                            .bucket(bucketName)
                                            .key("key")
-                                           .acl(ObjectCannedACL.AuthenticatedRead)
+                                           .acl(ObjectCannedACL.AUTHENTICATED_READ)
                                            .accessControlPolicy(
                                                AccessControlPolicy.builder()
                                                                   .grants(Grant.builder()
                                                                                .grantee(Grantee.builder()
-                                                                                               .type(Type.CanonicalUser)
+                                                                                               .type(Type.CANONICAL_USER)
                                                                                                .id(s3CanonicalUserId)
                                                                                                .build())
                                                                                .permission(Permission.READ)
@@ -142,7 +142,7 @@ public class PresignedUrlIntegrationTest extends IntegrationTestBase {
             CreateDistributionRequest.builder()
                                      .distributionConfig(
                                          DistributionConfig.builder()
-                                                           .priceClass(PriceClass.PriceClass_100)
+                                                           .priceClass(PriceClass.PRICE_CLASS_100)
                                                            .defaultCacheBehavior(
                                                                DefaultCacheBehavior.builder()
                                                                                    .minTTL(100L)
@@ -157,7 +157,7 @@ public class PresignedUrlIntegrationTest extends IntegrationTestBase {
                                                                                    .forwardedValues(
                                                                                        ForwardedValues.builder()
                                                                                                       .cookies(CookiePreference.builder()
-                                                                                                                               .forward(ItemSelection.None)
+                                                                                                                               .forward(ItemSelection.NONE)
                                                                                                                                .build())
                                                                                                       .queryString(true)
                                                                                                       .build())
@@ -192,7 +192,7 @@ public class PresignedUrlIntegrationTest extends IntegrationTestBase {
                                                                                                   ForwardedValues.builder()
                                                                                                                  .cookies(
                                                                                                                      CookiePreference.builder()
-                                                                                                                                     .forward(ItemSelection.None)
+                                                                                                                                     .forward(ItemSelection.NONE)
                                                                                                                                      .build())
                                                                                                                  .queryString(true)
                                                                                                                  .build())

--- a/services/cloudsearch/src/it/java/software/amazon/awssdk/services/cloudsearch/CloudSearchv2IntegrationTest.java
+++ b/services/cloudsearch/src/it/java/software/amazon/awssdk/services/cloudsearch/CloudSearchv2IntegrationTest.java
@@ -178,7 +178,7 @@ public class CloudSearchv2IntegrationTest extends AwsIntegrationTestBase {
     public void testIndexDocuments() {
 
         IndexField indexField = IndexField.builder().indexFieldName(
-                testIndexName).indexFieldType(IndexFieldType.Literal).build();
+                testIndexName).indexFieldType(IndexFieldType.LITERAL).build();
 
         cloudSearch.defineIndexField(DefineIndexFieldRequest.builder()
                                                             .domainName(testDomainName).indexField(indexField).build());
@@ -322,7 +322,7 @@ public class CloudSearchv2IntegrationTest extends AwsIntegrationTestBase {
                                                                                          IndexField.builder()
                                                                                                    .indexFieldName(testIndexName)
                                                                                                    .indexFieldType(
-                                                                                                           IndexFieldType.Text)
+                                                                                                           IndexFieldType.TEXT)
                                                                                                    .textOptions(
                                                                                                            TextOptions.builder()
                                                                                                                       .analysisScheme(
@@ -381,7 +381,7 @@ public class CloudSearchv2IntegrationTest extends AwsIntegrationTestBase {
 
         AnalysisScheme analysisScheme = AnalysisScheme.builder()
                                                       .analysisSchemeName(testAnalysisSchemeName)
-                                                      .analysisSchemeLanguage(AnalysisSchemeLanguage.Ar).build();
+                                                      .analysisSchemeLanguage(AnalysisSchemeLanguage.AR).build();
         cloudSearch.defineAnalysisScheme(DefineAnalysisSchemeRequest.builder()
                                                                     .domainName(testDomainName).analysisScheme(
                         analysisScheme).build());
@@ -393,7 +393,7 @@ public class CloudSearchv2IntegrationTest extends AwsIntegrationTestBase {
                                        .domainName(testDomainName)
                                        .indexField(IndexField.builder()
                                                              .indexFieldName(testIndexName)
-                                                             .indexFieldType(IndexFieldType.Text)
+                                                             .indexFieldType(IndexFieldType.TEXT)
                                                              .textOptions(TextOptions.builder()
                                                                                      .analysisScheme(testAnalysisSchemeName)
                                                                                      .build()).build()).build();
@@ -407,7 +407,7 @@ public class CloudSearchv2IntegrationTest extends AwsIntegrationTestBase {
         assertEquals(schemeStatus.options().analysisSchemeName(),
                      testAnalysisSchemeName);
         assertEquals(schemeStatus.options().analysisSchemeLanguage(),
-                     AnalysisSchemeLanguage.Ar.toString());
+                     AnalysisSchemeLanguage.AR);
 
         DescribeIndexFieldsResponse describeIndexFieldsResult = cloudSearch
                 .describeIndexFields(DescribeIndexFieldsRequest.builder()
@@ -427,7 +427,7 @@ public class CloudSearchv2IntegrationTest extends AwsIntegrationTestBase {
     @Test
     public void testScalingParameters() {
         ScalingParameters scalingParameters = ScalingParameters.builder()
-                                                               .desiredInstanceType(PartitionInstanceType.SearchM1Small)
+                                                               .desiredInstanceType(PartitionInstanceType.SEARCH_M1_SMALL)
                                                                .desiredReplicationCount(5)
                                                                .desiredPartitionCount(5).build();
         cloudSearch.updateScalingParameters(UpdateScalingParametersRequest.builder()

--- a/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
+++ b/services/cloudwatch/src/it/java/software/amazon/awssdk/services/cloudwatch/CloudWatchIntegrationTest.java
@@ -236,7 +236,7 @@ public class CloudWatchIntegrationTest extends AwsIntegrationTestBase {
          * Get the history
          */
         DescribeAlarmHistoryRequest alarmHistoryRequest = DescribeAlarmHistoryRequest.builder()
-                .alarmName(rq1.alarmName()).historyItemType(HistoryItemType.StateUpdate)
+                .alarmName(rq1.alarmName()).historyItemType(HistoryItemType.STATE_UPDATE)
                 .build();
         DescribeAlarmHistoryResponse historyResult = cloudwatch
                 .describeAlarmHistory(alarmHistoryRequest);

--- a/services/codepipeline/src/it/java/software/amazon/awssdk/services/codepipeline/AwsCodePipelineClientIntegrationTest.java
+++ b/services/codepipeline/src/it/java/software/amazon/awssdk/services/codepipeline/AwsCodePipelineClientIntegrationTest.java
@@ -83,10 +83,10 @@ public class AwsCodePipelineClientIntegrationTest extends AwsTestBase {
     @Test
     public void createFindDelete_ActionType() {
         ActionTypeId actionTypeId = ActionTypeId.builder()
-                .category(ActionCategory.Build)
+                .category(ActionCategory.BUILD)
                 .provider("test-provider")
                 .version("1")
-                .owner(ActionOwner.Custom)
+                .owner(ActionOwner.CUSTOM)
                 .build();
         ArtifactDetails artifactDetails = ArtifactDetails.builder()
                 .maximumCount(1)

--- a/services/directory/src/it/java/software/amazon/awssdk/services/directory/ServiceIntegrationTest.java
+++ b/services/directory/src/it/java/software/amazon/awssdk/services/directory/ServiceIntegrationTest.java
@@ -49,7 +49,7 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
         String dsId = dsClient
                 .createDirectory(CreateDirectoryRequest.builder().description("This is my directory!")
                                                              .name("AWS.Java.SDK.Directory").shortName("md").password("My.Awesome.Password.2015")
-                                                             .size(DirectorySize.Small).vpcSettings(
+                                                             .size(DirectorySize.SMALL).vpcSettings(
                                 DirectoryVpcSettings.builder().vpcId(vpcId).subnetIds(subnetId_0, subnetId_1).build()).build())
                 .directoryId();
 

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/TableUtilsIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/TableUtilsIntegrationTest.java
@@ -107,7 +107,7 @@ public class TableUtilsIntegrationTest extends AwsIntegrationTestBase {
      */
     private String tableStatus() {
         try {
-            return ddb.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).table().tableStatus();
+            return ddb.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).table().tableStatusString();
         } catch (ResourceNotFoundException e) {
             return null;
         }

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/Index.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/Index.java
@@ -237,8 +237,7 @@ public class Index implements QueryApi, ScanApi {
             if (list != null) {
                 for (GlobalSecondaryIndexDescription d : list) {
                     if (d.indexName().equals(indexName)) {
-                        final String status = d.indexStatus();
-                        switch (IndexStatus.fromValue(status)) {
+                        switch (d.indexStatus()) {
                             case ACTIVE:
                                 return desc;
                             case CREATING:
@@ -250,7 +249,7 @@ public class Index implements QueryApi, ScanApi {
                                         "Global Secondary Index "
                                         + indexName
                                         + " is not being created or updated (with status="
-                                        + status + ")");
+                                        + d.indexStatusString() + ")");
                         }
                     }
                 }
@@ -285,14 +284,13 @@ public class Index implements QueryApi, ScanApi {
             if (list != null) {
                 for (GlobalSecondaryIndexDescription d : list) {
                     if (d.indexName().equals(indexName)) {
-                        final String status = d.indexStatus();
-                        if (IndexStatus.fromValue(status) == IndexStatus.DELETING) {
+                        if (d.indexStatus() == IndexStatus.DELETING) {
                             Thread.sleep(SLEEP_TIME_MILLIS);
                             continue retry;
                         }
                         throw new IllegalArgumentException(
                                 "Global Secondary Index " + indexName
-                                + " is not being deleted (with status=" + status + ")");
+                                + " is not being deleted (with status=" + d.indexStatusString() + ")");
                     }
                 }
             }
@@ -326,8 +324,7 @@ public class Index implements QueryApi, ScanApi {
             if (list != null) {
                 for (GlobalSecondaryIndexDescription d : desc.globalSecondaryIndexes()) {
                     if (d.indexName().equals(indexName)) {
-                        final String status = d.indexStatus();
-                        if (IndexStatus.fromValue(status) == IndexStatus.ACTIVE) {
+                        if (d.indexStatus() == IndexStatus.ACTIVE) {
                             return desc;
                         }
                         Thread.sleep(SLEEP_TIME_MILLIS);

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/Table.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/Table.java
@@ -507,8 +507,7 @@ public class Table implements PutItemApi, GetItemApi, QueryApi, ScanApi,
         try {
             for (; ; ) {
                 TableDescription desc = describe();
-                final String status = desc.tableStatus();
-                if (TableStatus.fromValue(status) == TableStatus.ACTIVE) {
+                if (desc.tableStatus() == TableStatus.ACTIVE) {
                     return desc;
                 } else {
                     Thread.sleep(SLEEP_TIME_MILLIS);
@@ -541,14 +540,12 @@ public class Table implements PutItemApi, GetItemApi, QueryApi, ScanApi,
             retry:
             for (; ; ) {
                 TableDescription desc = describe();
-                String status = desc.tableStatus();
-                if (TableStatus.fromValue(status) == TableStatus.ACTIVE) {
+                if (desc.tableStatus() == TableStatus.ACTIVE) {
                     List<GlobalSecondaryIndexDescription> descriptions =
                             desc.globalSecondaryIndexes();
                     if (descriptions != null) {
                         for (GlobalSecondaryIndexDescription d : descriptions) {
-                            status = d.indexStatus();
-                            if (IndexStatus.fromValue(status) != IndexStatus.ACTIVE) {
+                            if (d.indexStatus() != IndexStatus.ACTIVE) {
                                 // Some index is not active.  Keep waiting.
                                 Thread.sleep(SLEEP_TIME_MILLIS);
                                 continue retry;

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchGetItemSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchGetItemSpec.java
@@ -63,7 +63,7 @@ public class BatchGetItemSpec extends AbstractSpec<BatchGetItemRequest> {
 
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
 

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchWriteItemSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchWriteItemSpec.java
@@ -64,7 +64,7 @@ public class BatchWriteItemSpec extends AbstractSpec<BatchWriteItemRequest> {
 
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
 

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/DeleteItemSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/DeleteItemSpec.java
@@ -147,7 +147,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperator();
+        return getRequest().conditionalOperatorString();
     }
 
     public DeleteItemSpec withConditionalOperator(ConditionalOperator conditionalOperator) {
@@ -156,7 +156,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
     public DeleteItemSpec withReturnConsumedCapacity(
@@ -166,7 +166,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getReturnItemCollectionMetrics() {
-        return getRequest().returnItemCollectionMetrics();
+        return getRequest().returnItemCollectionMetricsString();
     }
 
     public DeleteItemSpec withReturnItemCollectionMetrics(
@@ -176,7 +176,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getReturnValues() {
-        return getRequest().returnValues();
+        return getRequest().returnValuesString();
     }
 
     public DeleteItemSpec withReturnValues(ReturnValue returnValues) {

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/GetItemSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/GetItemSpec.java
@@ -62,7 +62,7 @@ public class GetItemSpec extends AbstractSpecWithPrimaryKey<GetItemRequest> {
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
     public GetItemSpec withReturnConsumedCapacity(ReturnConsumedCapacity capacity) {

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/PutItemSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/PutItemSpec.java
@@ -130,7 +130,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperator();
+        return getRequest().conditionalOperatorString();
     }
 
     public PutItemSpec withConditionalOperator(
@@ -140,7 +140,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
     public PutItemSpec withReturnConsumedCapacity(
@@ -150,7 +150,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getReturnItemCollectionMetrics() {
-        return getRequest().returnItemCollectionMetrics();
+        return getRequest().returnItemCollectionMetricsString();
     }
 
     public PutItemSpec withReturnItemCollectionMetrics(
@@ -162,7 +162,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getReturnValues() {
-        return getRequest().returnValues();
+        return getRequest().returnValuesString();
     }
 
     public PutItemSpec withReturnValues(ReturnValue returnValues) {

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/QuerySpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/QuerySpec.java
@@ -103,7 +103,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperator();
+        return getRequest().conditionalOperatorString();
     }
 
     public QuerySpec withConsistentRead(boolean consistentRead) {
@@ -203,7 +203,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
     public QuerySpec withReturnConsumedCapacity(
@@ -227,7 +227,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
     }
 
     public String select() {
-        return getRequest().select();
+        return getRequest().selectString();
     }
 
     // Exclusive start key

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/ScanSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/ScanSpec.java
@@ -79,7 +79,7 @@ public class ScanSpec extends AbstractCollectionSpec<ScanRequest> {
      * @see ScanRequest#getConditionalOperator()
      */
     public String getConditionalOperator() {
-        return getRequest().conditionalOperator();
+        return getRequest().conditionalOperatorString();
     }
 
     /**
@@ -194,7 +194,7 @@ public class ScanSpec extends AbstractCollectionSpec<ScanRequest> {
      * @see ScanRequest#getReturnConsumedCapacity()
      */
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
     /**
@@ -212,7 +212,7 @@ public class ScanSpec extends AbstractCollectionSpec<ScanRequest> {
      */
     // ALL_ATTRIBUTES | ALL_PROJECTED_ATTRIBUTES | SPECIFIC_ATTRIBUTES | COUNT
     public String select() {
-        return getRequest().select();
+        return getRequest().selectString();
     }
 
     /**

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/UpdateItemSpec.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/document/spec/UpdateItemSpec.java
@@ -188,11 +188,11 @@ public class UpdateItemSpec extends AbstractSpecWithPrimaryKey<UpdateItemRequest
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperator();
+        return getRequest().conditionalOperatorString();
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacity();
+        return getRequest().returnConsumedCapacityString();
     }
 
     public UpdateItemSpec withReturnConsumedCapacity(
@@ -208,7 +208,7 @@ public class UpdateItemSpec extends AbstractSpecWithPrimaryKey<UpdateItemRequest
     }
 
     public String getReturnItemCollectionMetrics() {
-        return getRequest().returnItemCollectionMetrics();
+        return getRequest().returnItemCollectionMetricsString();
     }
 
     public UpdateItemSpec withReturnItemCollectionMetrics(
@@ -224,7 +224,7 @@ public class UpdateItemSpec extends AbstractSpecWithPrimaryKey<UpdateItemRequest
     }
 
     public String getReturnValues() {
-        return getRequest().returnValues();
+        return getRequest().returnValuesString();
     }
 
     public UpdateItemSpec withReturnValues(ReturnValue returnValues) {

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/document/ExpectedTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/document/ExpectedTest.java
@@ -47,7 +47,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.EQ.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.EQ, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -59,7 +59,7 @@ public class ExpectedTest {
         ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.EQ.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.EQ, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals(true, ddbExpected_value.attributeValueList().get(0).nul());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -74,7 +74,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.NE.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NE, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -89,7 +89,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.NOT_NULL.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NOT_NULL, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(null, ddbExpected_value.attributeValueList());
         Assert.assertEquals(null, ddbExpected_value.value());
         Assert.assertEquals(null, ddbExpected_value.exists());
@@ -103,7 +103,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.NULL.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NULL, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(null, ddbExpected_value.attributeValueList());
         Assert.assertEquals(null, ddbExpected_value.value());
         Assert.assertEquals(null, ddbExpected_value.exists());
@@ -117,7 +117,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.CONTAINS.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.CONTAINS, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -132,7 +132,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.NOT_CONTAINS.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NOT_CONTAINS, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -147,7 +147,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.BEGINS_WITH.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.BEGINS_WITH, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -163,7 +163,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.IN.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.IN, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -180,7 +180,7 @@ public class ExpectedTest {
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals("charlie", ddbExpected_value.attributeValueList().get(1).s());
         Assert.assertEquals(true, ddbExpected_value.attributeValueList().get(2).nul());
-        Assert.assertEquals(ComparisonOperator.IN.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.IN, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(null, ddbExpected_value.value());
         Assert.assertEquals(null, ddbExpected_value.exists());
 
@@ -212,7 +212,7 @@ public class ExpectedTest {
         Assert.assertEquals(2, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("0", ddbExpected_value.attributeValueList().get(0).n());
         Assert.assertEquals("100", ddbExpected_value.attributeValueList().get(1).n());
-        Assert.assertEquals(ComparisonOperator.BETWEEN.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.BETWEEN, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(null, ddbExpected_value.value());
         Assert.assertEquals(null, ddbExpected_value.exists());
     }
@@ -225,7 +225,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.GE.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.GE, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -240,7 +240,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.GT.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.GT, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -255,7 +255,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.LE.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.LE, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());
@@ -270,7 +270,7 @@ public class ExpectedTest {
         ExpectedAttributeValue ddbExpected_value = ddbExpected.getValue();
 
         Assert.assertEquals("foo", ddbExpected_attrName);
-        Assert.assertEquals(ComparisonOperator.LT.toString(), ddbExpected_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.LT, ddbExpected_value.comparisonOperator());
         Assert.assertEquals(1, ddbExpected_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbExpected_value.attributeValueList().get(0).s());
         Assert.assertEquals(null, ddbExpected_value.value());

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/document/FilterConditionTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/document/FilterConditionTest.java
@@ -50,7 +50,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.EQ.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.EQ, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
 
@@ -60,7 +60,7 @@ public class FilterConditionTest {
         ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.EQ.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.EQ, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals(true, ddbscanFilter_value.attributeValueList().get(0).nul());
     }
@@ -73,7 +73,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.NE.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NE, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -86,7 +86,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.NOT_NULL.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NOT_NULL, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(null, ddbscanFilter_value.attributeValueList());
     }
 
@@ -98,7 +98,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.NULL.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NULL, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(null, ddbscanFilter_value.attributeValueList());
     }
 
@@ -110,7 +110,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.CONTAINS.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.CONTAINS, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -123,7 +123,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.NOT_CONTAINS.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.NOT_CONTAINS, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -136,7 +136,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.BEGINS_WITH.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.BEGINS_WITH, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -150,7 +150,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.IN.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.IN, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
 
@@ -165,7 +165,7 @@ public class FilterConditionTest {
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
         Assert.assertEquals("charlie", ddbscanFilter_value.attributeValueList().get(1).s());
         Assert.assertEquals(true, ddbscanFilter_value.attributeValueList().get(2).nul());
-        Assert.assertEquals(ComparisonOperator.IN.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.IN, ddbscanFilter_value.comparisonOperator());
 
         // Null values
         try {
@@ -195,7 +195,7 @@ public class FilterConditionTest {
         Assert.assertEquals(2, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("0", ddbscanFilter_value.attributeValueList().get(0).n());
         Assert.assertEquals("100", ddbscanFilter_value.attributeValueList().get(1).n());
-        Assert.assertEquals(ComparisonOperator.BETWEEN.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.BETWEEN, ddbscanFilter_value.comparisonOperator());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.GE.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.GE, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -219,7 +219,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.GT.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.GT, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -232,7 +232,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.LE.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.LE, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }
@@ -245,7 +245,7 @@ public class FilterConditionTest {
         Condition ddbscanFilter_value = ddbscanFilter.getValue();
 
         Assert.assertEquals("foo", ddbscanFilter_attrName);
-        Assert.assertEquals(ComparisonOperator.LT.toString(), ddbscanFilter_value.comparisonOperator());
+        Assert.assertEquals(ComparisonOperator.LT, ddbscanFilter_value.comparisonOperator());
         Assert.assertEquals(1, ddbscanFilter_value.attributeValueList().size());
         Assert.assertEquals("bar", ddbscanFilter_value.attributeValueList().get(0).s());
     }

--- a/services/dynamodb/src/test/java/utils/test/util/DynamoDBTestBase.java
+++ b/services/dynamodb/src/test/java/utils/test/util/DynamoDBTestBase.java
@@ -78,13 +78,12 @@ public class DynamoDBTestBase extends AwsTestBase {
                 DescribeTableRequest request = DescribeTableRequest.builder().tableName(tableName).build();
                 TableDescription table = dynamo.describeTable(request).table();
 
-                String tableStatus = table.tableStatus();
-                log.info(() -> "  - current state: " + tableStatus);
-                if (tableStatus.equals(TableStatus.DELETING.toString())) {
+                log.info(() -> "  - current state: " + table.tableStatusString());
+                if (table.tableStatus() == TableStatus.DELETING) {
                     continue;
                 }
             } catch (AmazonServiceException ase) {
-                if (ase.getErrorCode().equalsIgnoreCase("ResourceNotFoundException") == true) {
+                if (ase.getErrorCode().equalsIgnoreCase("ResourceNotFoundException")) {
                     log.info(() -> "successfully deleted");
                     return;
                 }

--- a/services/elasticsearch/src/it/java/software/amazon/awssdk/services/elasticsearch/ServiceIntegrationTest.java
+++ b/services/elasticsearch/src/it/java/software/amazon/awssdk/services/elasticsearch/ServiceIntegrationTest.java
@@ -69,7 +69,7 @@ public class ServiceIntegrationTest extends AwsTestBase {
                         .ebsOptions(EBSOptions.builder()
                                               .ebsEnabled(true)
                                               .volumeSize(10)
-                                              .volumeType(VolumeType.Standard)
+                                              .volumeType(VolumeType.STANDARD)
                                               .build())
                         .domainName(DOMAIN_NAME)
                         .build()).domainStatus();

--- a/services/inspector/src/test/java/software/amazon/awssdk/services/inspector/InspectorErrorUnmarshallingTest.java
+++ b/services/inspector/src/test/java/software/amazon/awssdk/services/inspector/InspectorErrorUnmarshallingTest.java
@@ -63,7 +63,7 @@ public class InspectorErrorUnmarshallingTest {
             inspector.listRulesPackages(ListRulesPackagesRequest.builder().build());
         } catch (AccessDeniedException e) {
             assertEquals("AccessDeniedException", e.getErrorCode());
-            assertEquals("ACCESS_DENIED_TO_RULES_PACKAGE", e.inspectorErrorCode());
+            assertEquals("ACCESS_DENIED_TO_RULES_PACKAGE", e.inspectorErrorCodeString());
         }
     }
 

--- a/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
+++ b/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
@@ -463,8 +463,7 @@ public class KinesisIntegrationTests extends AbstractTestCase {
             Assert.assertNotNull(description.streamARN());
             Assert.assertFalse(description.hasMoreShards());
 
-            StreamStatus status =
-                    StreamStatus.valueOf(description.streamStatus());
+            StreamStatus status = description.streamStatus();
             Assert.assertNotNull(status);
 
             if (status == StreamStatus.ACTIVE) {

--- a/services/lambda/src/it/java/software/amazon/awssdk/services/lambda/ServiceIntegrationTest.java
+++ b/services/lambda/src/it/java/software/amazon/awssdk/services/lambda/ServiceIntegrationTest.java
@@ -150,7 +150,7 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
         CreateFunctionResponse result = lambda.createFunction(CreateFunctionRequest.builder()
                 .description("My cloud function").functionName(FUNCTION_NAME)
                 .code(FunctionCode.builder().zipFile(ByteBuffer.wrap(functionBits)).build())
-                .handler("helloworld.handler").memorySize(128).runtime(Runtime.Nodejs43).timeout(10)
+                .handler("helloworld.handler").memorySize(128).runtime(Runtime.NODEJS4_3).timeout(10)
                 .role(lambdaServiceRoleArn).build()).join();
 
         checkValid_CreateFunctionResponse(result);
@@ -182,14 +182,14 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
 
         // Invoke the function
         InvokeResponse invokeResult = lambda.invoke(InvokeRequest.builder().functionName(FUNCTION_NAME)
-                .invocationType(InvocationType.Event).payload(ByteBuffer.wrap("{}".getBytes())).build()).join();
+                .invocationType(InvocationType.EVENT).payload(ByteBuffer.wrap("{}".getBytes())).build()).join();
 
         Assert.assertEquals(202, invokeResult.statusCode().intValue());
         Assert.assertNull(invokeResult.logResult());
         Assert.assertEquals(0, invokeResult.payload().remaining());
 
         invokeResult = lambda.invoke(InvokeRequest.builder().functionName(FUNCTION_NAME)
-                .invocationType(InvocationType.RequestResponse).logType(LogType.Tail)
+                .invocationType(InvocationType.REQUEST_RESPONSE).logType(LogType.TAIL)
                 .payload(ByteBuffer.wrap("{}".getBytes())).build()).join();
 
         Assert.assertEquals(200, invokeResult.statusCode().intValue());

--- a/services/lambda/src/it/java/software/amazon/awssdk/services/lambda/invoke/HelloWorldIntegrationTest.java
+++ b/services/lambda/src/it/java/software/amazon/awssdk/services/lambda/invoke/HelloWorldIntegrationTest.java
@@ -68,7 +68,7 @@ public class HelloWorldIntegrationTest extends IntegrationTestBase {
                 .code(FunctionCode.builder().zipFile(ByteBuffer.wrap(functionBits)).build())
                 .handler("helloworld.handler")
                 .memorySize(128)
-                .runtime(Runtime.Nodejs43)
+                .runtime(Runtime.NODEJS4_3)
                 .timeout(10)
                 .role(lambdaServiceRoleArn)
                 .build())
@@ -137,10 +137,10 @@ public class HelloWorldIntegrationTest extends IntegrationTestBase {
     }
 
     public static interface HelloWorldService {
-        @LambdaFunction(functionName = "helloWorld", invocationType = InvocationType.Event)
+        @LambdaFunction(functionName = "helloWorld", invocationType = InvocationType.EVENT)
         void helloWorldAsync();
 
-        @LambdaFunction(functionName = "helloWorld", invocationType = InvocationType.DryRun)
+        @LambdaFunction(functionName = "helloWorld", invocationType = InvocationType.DRY_RUN)
         void helloWorldDryRun();
 
         @LambdaFunction
@@ -149,7 +149,7 @@ public class HelloWorldIntegrationTest extends IntegrationTestBase {
         @LambdaFunction
         String helloWorld(String input);
 
-        @LambdaFunction(logType = LogType.Tail)
+        @LambdaFunction(logType = LogType.TAIL)
         String helloWorld(ComplexInput input);
 
         @LambdaFunction(functionName = "helloWorld")

--- a/services/lambda/src/main/java/software/amazon/awssdk/services/lambda/invoke/LambdaFunction.java
+++ b/services/lambda/src/main/java/software/amazon/awssdk/services/lambda/invoke/LambdaFunction.java
@@ -59,7 +59,7 @@ public @interface LambdaFunction {
      *                                      </code>
      * @see InvokeRequest#invocationType(InvocationType)
      */
-    InvocationType invocationType() default InvocationType.RequestResponse;
+    InvocationType invocationType() default InvocationType.REQUEST_RESPONSE;
 
     /**
      * The type of log to request from the service. If unspecified, no logs will be requested. If
@@ -71,5 +71,5 @@ public @interface LambdaFunction {
      * @see InvokeRequest#logType(LogType)
      * @see LoggerFactory.getLogger(Class)
      */
-    LogType logType() default LogType.None;
+    LogType logType() default LogType.NONE;
 }

--- a/services/lambda/src/main/java/software/amazon/awssdk/services/lambda/invoke/LambdaInvokerFactory.java
+++ b/services/lambda/src/main/java/software/amazon/awssdk/services/lambda/invoke/LambdaInvokerFactory.java
@@ -227,7 +227,7 @@ public final class LambdaInvokerFactory {
                 throw new LambdaSerializationException("No LambdaFunction annotation for method " + method.getName());
             }
 
-            if (annotation.invocationType() != InvocationType.RequestResponse && annotation.logType() != LogType.None) {
+            if (annotation.invocationType() != InvocationType.REQUEST_RESPONSE && annotation.logType() != LogType.NONE) {
                 throw new LambdaSerializationException("InvocationType must be RequestResponse if LogType " + "is set");
             }
 

--- a/services/lambda/src/test/java/software/amazon/awssdk/services/lambda/invoke/LambdaInvokerFactoryTest.java
+++ b/services/lambda/src/test/java/software/amazon/awssdk/services/lambda/invoke/LambdaInvokerFactoryTest.java
@@ -500,16 +500,16 @@ public class LambdaInvokerFactoryTest {
         @LambdaFunction
         void doIt();
 
-        @LambdaFunction(functionName = "doIt", invocationType = InvocationType.Event)
+        @LambdaFunction(functionName = "doIt", invocationType = InvocationType.EVENT)
         void doItAsynchronously();
 
-        @LambdaFunction(functionName = "doIt", logType = LogType.Tail)
+        @LambdaFunction(functionName = "doIt", logType = LogType.TAIL)
         void doItWithLogs();
 
-        @LambdaFunction(functionName = "doIt", invocationType = InvocationType.Event, logType = LogType.Tail)
+        @LambdaFunction(functionName = "doIt", invocationType = InvocationType.EVENT, logType = LogType.TAIL)
         void doItAsyncLogs();
 
-        @LambdaFunction(functionName = "doIt", invocationType = InvocationType.DryRun, logType = LogType.Tail)
+        @LambdaFunction(functionName = "doIt", invocationType = InvocationType.DRY_RUN, logType = LogType.TAIL)
         void doItDryRunLogs();
 
         @LambdaFunction

--- a/services/machinelearning/src/it/java/software/amazon/awssdk/services/machinelearning/AmazonMachineLearningIntegrationTest.java
+++ b/services/machinelearning/src/it/java/software/amazon/awssdk/services/machinelearning/AmazonMachineLearningIntegrationTest.java
@@ -31,7 +31,6 @@ import software.amazon.awssdk.services.machinelearning.model.CreateRealtimeEndpo
 import software.amazon.awssdk.services.machinelearning.model.DeleteDataSourceRequest;
 import software.amazon.awssdk.services.machinelearning.model.DeleteMLModelRequest;
 import software.amazon.awssdk.services.machinelearning.model.DeleteRealtimeEndpointRequest;
-import software.amazon.awssdk.services.machinelearning.model.EntityStatus;
 import software.amazon.awssdk.services.machinelearning.model.GetDataSourceRequest;
 import software.amazon.awssdk.services.machinelearning.model.GetDataSourceResponse;
 import software.amazon.awssdk.services.machinelearning.model.GetMLModelRequest;
@@ -40,7 +39,6 @@ import software.amazon.awssdk.services.machinelearning.model.MLModelType;
 import software.amazon.awssdk.services.machinelearning.model.PredictRequest;
 import software.amazon.awssdk.services.machinelearning.model.Prediction;
 import software.amazon.awssdk.services.machinelearning.model.RealtimeEndpointInfo;
-import software.amazon.awssdk.services.machinelearning.model.RealtimeEndpointStatus;
 import software.amazon.awssdk.services.machinelearning.model.S3DataSpec;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
@@ -117,7 +115,7 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
         s3.putObject(PutObjectRequest.builder()
                                      .bucket(BUCKET_NAME)
                                      .key(KEY)
-                                     .acl(ObjectCannedACL.PublicRead)
+                                     .acl(ObjectCannedACL.PUBLIC_READ)
                                      .build(),
                      RequestBody.of(DATA.getBytes()));
     }
@@ -232,8 +230,7 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
 
             System.out.println(result);
 
-            String status = result.status();
-            switch (EntityStatus.valueOf(status)) {
+            switch (result.status()) {
                 case PENDING:
                 case INPROGRESS:
                     Thread.sleep(10000);
@@ -242,11 +239,11 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
                 case FAILED:
                 case COMPLETED:
                 case DELETED:
-                    return status;
+                    return result.statusString();
 
                 default:
                     Assert.fail("Unrecognized data source validation status: "
-                                + status);
+                                + result.statusString());
             }
         }
 
@@ -263,8 +260,7 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
 
             System.out.println(result);
 
-            String status = result.status();
-            switch (EntityStatus.valueOf(status)) {
+            switch (result.status()) {
                 case PENDING:
                 case INPROGRESS:
                     Thread.sleep(10000);
@@ -273,11 +269,11 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
                 case FAILED:
                 case COMPLETED:
                 case DELETED:
-                    return status;
+                    return result.statusString();
 
                 default:
                     throw new IllegalStateException("Unrecognized status: "
-                                                    + status);
+                                                    + result.statusString());
             }
         }
 
@@ -300,8 +296,7 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
                 continue;
             }
 
-            String status = info.endpointStatus();
-            switch (RealtimeEndpointStatus.valueOf(status)) {
+            switch (info.endpointStatus()) {
                 case READY:
                     return info.endpointUrl();
 

--- a/services/marketplacecommerceanalytics/src/it/java/software/amazon/awssdk/services/marketplacecommerceanalytics/ServiceIntegrationTest.java
+++ b/services/marketplacecommerceanalytics/src/it/java/software/amazon/awssdk/services/marketplacecommerceanalytics/ServiceIntegrationTest.java
@@ -136,7 +136,7 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
                                                      .roleNameArn(roleArn).destinationS3BucketName(BUCKET_NAME)
                                                      .snsTopicArn(topicArn)
                                                      .destinationS3BucketName(BUCKET_NAME).destinationS3Prefix("some-prefix")
-                                                     .dataSetType(DataSetType.Customer_subscriber_hourly_monthly_subscriptions)
+                                                     .dataSetType(DataSetType.CUSTOMER_SUBSCRIBER_HOURLY_MONTHLY_SUBSCRIPTIONS)
                                                      .build());
     }
 

--- a/services/polly/src/test/java/software/amazon/awssdk/services/polly/presign/SynthesizeSpeechPresignTest.java
+++ b/services/polly/src/test/java/software/amazon/awssdk/services/polly/presign/SynthesizeSpeechPresignTest.java
@@ -107,7 +107,7 @@ public class SynthesizeSpeechPresignTest {
         final URL url = presigners.getPresignedSynthesizeSpeechUrl(
                 new SynthesizeSpeechPresignRequest()
                         .withText("Hello world")
-                        .withOutputFormat(OutputFormat.Pcm)
+                        .withOutputFormat(OutputFormat.PCM)
                         .withLexiconNames("AwsLexicon")
                         .withVoiceId("Salli"));
         assertEquals(
@@ -122,7 +122,7 @@ public class SynthesizeSpeechPresignTest {
                 new SynthesizeSpeechPresignRequest()
                         .withExpirationDate(Date.from(instant))
                         .withText("S3 is an AWS service")
-                        .withOutputFormat(OutputFormat.Mp3)
+                        .withOutputFormat(OutputFormat.MP3)
                         .withLexiconNames("FooLexicon", "AwsLexicon")
                         .withVoiceId("Salli"));
         assertEquals(

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketAccelerateIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketAccelerateIntegrationTest.java
@@ -119,7 +119,7 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
             }
         }, new RetryableParams().withMaxAttempts(30).withDelayInMs(200));
 
-        assertEquals(BucketVersioningStatus.Enabled.name(),
+        assertEquals(BucketVersioningStatus.ENABLED.name(),
                      accelerateClient.getBucketVersioning(GetBucketVersioningRequest.builder()
                                                                                     .bucket(US_BUCKET_NAME)
                                                                                     .build())
@@ -134,21 +134,21 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
         String status = s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
                                                                                                    .bucket(US_BUCKET_NAME)
                                                                                                    .build())
-                          .status();
+                          .statusString();
 
         if (status == null || !status.equals("Enabled")) {
             enableAccelerateOnBucket();
         }
 
         assertEquals(
-                BucketAccelerateStatus.Enabled.toString(),
+                BucketAccelerateStatus.ENABLED.toString(),
                 s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
                                                                                            .bucket(US_BUCKET_NAME)
                                                                                            .build())
                   .status());
 
         disableAccelerateOnBucket();
-        assertEquals(BucketAccelerateStatus.Suspended.toString(),
+        assertEquals(BucketAccelerateStatus.SUSPENDED.toString(),
                      s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
                                                                                                 .bucket(US_BUCKET_NAME)
                                                                                                 .build())
@@ -161,7 +161,7 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
         String status = s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
                                                                                                    .bucket(US_BUCKET_NAME)
                                                                                                    .build())
-                          .status();
+                          .statusString();
 
         if (status == null || !status.equals("Enabled")) {
             enableAccelerateOnBucket();
@@ -181,7 +181,7 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
                 PutBucketAccelerateConfigurationRequest.builder()
                                                        .bucket(US_BUCKET_NAME)
                                                        .accelerateConfiguration(AccelerateConfiguration.builder()
-                                                                                                       .status(BucketAccelerateStatus.Enabled)
+                                                                                                       .status(BucketAccelerateStatus.ENABLED)
                                                                                                        .build())
                                                        .build());
         // Wait a bit for accelerate to kick in
@@ -193,7 +193,7 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
                 PutBucketAccelerateConfigurationRequest.builder()
                                                        .bucket(US_BUCKET_NAME)
                                                        .accelerateConfiguration(AccelerateConfiguration.builder()
-                                                                                                       .status(BucketAccelerateStatus.Suspended)
+                                                                                                       .status(BucketAccelerateStatus.SUSPENDED)
                                                                                                        .build())
                                                        .build());
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketInventoryConfigurationIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketInventoryConfigurationIntegrationTest.java
@@ -92,9 +92,9 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
                                                               .isEnabled(true)
                                                               .id(configId)
                                                               .destination(destination)
-                                                              .includedObjectVersions(InventoryIncludedObjectVersions.All)
+                                                              .includedObjectVersions(InventoryIncludedObjectVersions.ALL)
                                                               .schedule(InventorySchedule.builder()
-                                                                                         .frequency(InventoryFrequency.Daily)
+                                                                                         .frequency(InventoryFrequency.DAILY)
                                                                                          .build())
                                                               .build();
 
@@ -113,8 +113,8 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
 
         assertEquals(configId, config.id());
         assertTrue(config.isEnabled());
-        assertEquals(InventoryIncludedObjectVersions.All.toString(), config.includedObjectVersions());
-        assertEquals(InventoryFrequency.Daily.toString(), config.schedule().frequency());
+        assertEquals(InventoryIncludedObjectVersions.ALL.toString(), config.includedObjectVersions());
+        assertEquals(InventoryFrequency.DAILY.toString(), config.schedule().frequency());
         s3BucketDestination = config.destination().s3BucketDestination();
         assertEquals(BUCKET_ARN, s3BucketDestination.bucket());
         assertEquals(InventoryFormat.CSV.toString(), s3BucketDestination.format());
@@ -142,8 +142,8 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
         String accountId = "test-account";
         List<String> optionalFields = new ArrayList<String>() {
             {
-                add(InventoryOptionalField.ETag.toString());
-                add(InventoryOptionalField.Size.toString());
+                add(InventoryOptionalField.E_TAG.toString());
+                add(InventoryOptionalField.SIZE.toString());
             }
         };
 
@@ -160,9 +160,9 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
                                                               .isEnabled(true)
                                                               .id(configId)
                                                               .destination(destination)
-                                                              .includedObjectVersions(InventoryIncludedObjectVersions.All)
+                                                              .includedObjectVersions(InventoryIncludedObjectVersions.ALL)
                                                               .schedule(InventorySchedule.builder()
-                                                                                         .frequency(InventoryFrequency.Daily)
+                                                                                         .frequency(InventoryFrequency.DAILY)
                                                                                          .build())
                                                               .filter(InventoryFilter.builder().prefix(prefix).build())
                                                               .optionalFields(optionalFields)
@@ -182,8 +182,8 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
 
         assertEquals(configId, config.id());
         assertTrue(config.isEnabled());
-        assertEquals(InventoryIncludedObjectVersions.All.toString(), config.includedObjectVersions());
-        assertEquals(InventoryFrequency.Daily.toString(), config.schedule().frequency());
+        assertEquals(InventoryIncludedObjectVersions.ALL.toString(), config.includedObjectVersions());
+        assertEquals(InventoryFrequency.DAILY.toString(), config.schedule().frequency());
         s3BucketDestination = config.destination().s3BucketDestination();
         assertEquals(BUCKET_ARN, s3BucketDestination.bucket());
         assertEquals(InventoryFormat.CSV.toString(), s3BucketDestination.format());

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/CreateBucketIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/CreateBucketIntegrationTest.java
@@ -37,7 +37,7 @@ public class CreateBucketIntegrationTest extends S3IntegrationTestBase {
         S3Client client = S3Client.builder().region(Region.US_WEST_2).credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).build();
         client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
 
-        String region = client.getBucketLocation(GetBucketLocationRequest.builder().bucket(BUCKET_NAME).build()).locationConstraint();
+        String region = client.getBucketLocation(GetBucketLocationRequest.builder().bucket(BUCKET_NAME).build()).locationConstraintString();
         assertThat(region).isEqualToIgnoringCase("us-west-2");
     }
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ObjectTaggingIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ObjectTaggingIntegrationTest.java
@@ -56,7 +56,7 @@ public class ObjectTaggingIntegrationTest extends S3IntegrationTestBase {
                                                          .bucket(BUCKET)
                                                          .versioningConfiguration(
                                                                  VersioningConfiguration.builder()
-                                                                                        .status(BucketVersioningStatus.Enabled)
+                                                                                        .status(BucketVersioningStatus.ENABLED)
                                                                                         .build())
                                                          .build());
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/OperationsWithNonStandardResponsesIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/OperationsWithNonStandardResponsesIntegrationTest.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.services.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static software.amazon.awssdk.services.s3.model.BucketLocationConstraint.UsWest2;
+import static software.amazon.awssdk.services.s3.model.BucketLocationConstraint.US_WEST_2;
 
 import java.time.Instant;
 import org.junit.AfterClass;
@@ -48,7 +48,7 @@ public final class OperationsWithNonStandardResponsesIntegrationTest extends S3I
         s3.createBucket(CreateBucketRequest.builder()
                                            .bucket(bucketName)
                                            .createBucketConfiguration(CreateBucketConfiguration.builder()
-                                                                                               .locationConstraint(UsWest2)
+                                                                                               .locationConstraint(US_WEST_2)
                                                                                                .build())
                                            .build());
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3IntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3IntegrationTestBase.java
@@ -69,7 +69,7 @@ public class S3IntegrationTestBase extends AwsTestBase {
                                        .bucket(bucketName)
                                        .createBucketConfiguration(
                                                CreateBucketConfiguration.builder()
-                                                                        .locationConstraint(BucketLocationConstraint.UsWest2)
+                                                                        .locationConstraint(BucketLocationConstraint.US_WEST_2)
                                                                         .build())
                                        .build());
         } catch (S3Exception e) {

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3ListObjectsV2IntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3ListObjectsV2IntegrationTest.java
@@ -337,7 +337,7 @@ public class S3ListObjectsV2IntegrationTest extends S3IntegrationTestBase {
             long offset = obj.lastModified().toEpochMilli() - Instant.now().toEpochMilli();
             assertTrue(offset < ONE_HOUR_IN_MILLISECONDS);
 
-            assertTrue(obj.storageClass().length() > 1);
+            assertTrue(obj.storageClassString().length() > 1);
 
             if (shouldIncludeOwner) {
                 assertNotNull(obj.owner());

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptorTest.java
@@ -42,7 +42,7 @@ public class CreateBucketInterceptorTest {
                 .putAttribute(AwsExecutionAttributes.AWS_REGION, Region.US_EAST_1);
 
         SdkRequest modifiedRequest = new CreateBucketInterceptor().modifyRequest(context, attributes);
-        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraint();
+        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintString();
 
         assertThat(locationConstraint).isEqualToIgnoringCase("us-west-2");
     }
@@ -58,7 +58,7 @@ public class CreateBucketInterceptorTest {
                 .putAttribute(AwsExecutionAttributes.AWS_REGION, Region.US_EAST_2);
 
         SdkRequest modifiedRequest = new CreateBucketInterceptor().modifyRequest(context, attributes);
-        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraint();
+        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintString();
 
         assertThat(locationConstraint).isEqualToIgnoringCase("us-east-2");
     }
@@ -76,7 +76,7 @@ public class CreateBucketInterceptorTest {
                 .putAttribute(AwsExecutionAttributes.AWS_REGION, Region.US_WEST_2);
 
         SdkRequest modifiedRequest = new CreateBucketInterceptor().modifyRequest(context, attributes);
-        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraint();
+        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintString();
 
         assertThat(locationConstraint).isEqualToIgnoringCase("us-west-2");
     }

--- a/services/ses/src/it/java/software/amazon/awssdk/services/ses/EmailIntegrationTest.java
+++ b/services/ses/src/it/java/software/amazon/awssdk/services/ses/EmailIntegrationTest.java
@@ -93,7 +93,7 @@ public class EmailIntegrationTest extends IntegrationTestBase {
     @Test
     public void listIdentities_FilteredForDomainIdentities_OnlyHasDomainIdentityInList() {
         List<String> identities = email.listIdentities(
-                ListIdentitiesRequest.builder().identityType(IdentityType.Domain).build()).identities();
+                ListIdentitiesRequest.builder().identityType(IdentityType.DOMAIN).build()).identities();
         assertThat(identities, not(hasItem(EMAIL)));
         assertThat(identities, hasItem(DOMAIN));
     }
@@ -101,7 +101,7 @@ public class EmailIntegrationTest extends IntegrationTestBase {
     @Test
     public void listIdentities_FilteredForEmailIdentities_OnlyHasEmailIdentityInList() {
         List<String> identities = email.listIdentities(
-                ListIdentitiesRequest.builder().identityType(IdentityType.EmailAddress).build()).identities();
+                ListIdentitiesRequest.builder().identityType(IdentityType.EMAIL_ADDRESS).build()).identities();
         assertThat(identities, hasItem(EMAIL));
         assertThat(identities, not(hasItem(DOMAIN)));
     }
@@ -127,7 +127,7 @@ public class EmailIntegrationTest extends IntegrationTestBase {
         GetIdentityVerificationAttributesResponse result = email
                 .getIdentityVerificationAttributes(GetIdentityVerificationAttributesRequest.builder().identities(EMAIL).build());
         IdentityVerificationAttributes identityVerificationAttributes = result.verificationAttributes().get(EMAIL);
-        assertEquals(VerificationStatus.Pending.toString(), identityVerificationAttributes.verificationStatus());
+        assertEquals(VerificationStatus.PENDING, identityVerificationAttributes.verificationStatus());
         // Verificaton token not applicable for email identities
         assertNull(identityVerificationAttributes.verificationToken());
     }
@@ -138,7 +138,7 @@ public class EmailIntegrationTest extends IntegrationTestBase {
                 .getIdentityVerificationAttributes(GetIdentityVerificationAttributesRequest.builder()
                                                            .identities(DOMAIN).build());
         IdentityVerificationAttributes identityVerificationAttributes = result.verificationAttributes().get(DOMAIN);
-        assertEquals(VerificationStatus.Pending.toString(), identityVerificationAttributes.verificationStatus());
+        assertEquals(VerificationStatus.PENDING, identityVerificationAttributes.verificationStatus());
         assertEquals(DOMAIN_VERIFICATION_TOKEN, identityVerificationAttributes.verificationToken());
     }
 
@@ -154,7 +154,7 @@ public class EmailIntegrationTest extends IntegrationTestBase {
             // should be no tokens and no verification
             IdentityDkimAttributes attributes = result.dkimAttributes().get(testDomain);
             assertFalse(attributes.dkimEnabled());
-            assertEquals(VerificationStatus.NotStarted.toString(), attributes.dkimVerificationStatus());
+            assertEquals(VerificationStatus.NOT_STARTED, attributes.dkimVerificationStatus());
 
             VerifyDomainDkimResponse dkim = email.verifyDomainDkim(VerifyDomainDkimRequest.builder().domain(testDomain).build());
             Thread.sleep(5 * 1000);
@@ -164,7 +164,7 @@ public class EmailIntegrationTest extends IntegrationTestBase {
 
             attributes = result.dkimAttributes().get(testDomain);
             assertTrue(attributes.dkimEnabled());
-            assertTrue(attributes.dkimVerificationStatus().equals(VerificationStatus.Pending.toString()));
+            assertTrue(attributes.dkimVerificationStatus().equals(VerificationStatus.PENDING));
             assertTrue(attributes.dkimTokens().size() == dkim.dkimTokens().size());
 
             try {

--- a/services/sns/src/main/java/software/amazon/awssdk/services/sns/util/Topics.java
+++ b/services/sns/src/main/java/software/amazon/awssdk/services/sns/util/Topics.java
@@ -183,17 +183,17 @@ public class Topics {
     public static String subscribeQueue(SNSClient sns, SQSClient sqs, String snsTopicArn, String sqsQueueUrl,
                                         boolean extendPolicy)
             throws AmazonClientException, AmazonServiceException {
-        List<String> sqsAttrNames = Arrays.asList(QueueAttributeName.QueueArn.toString(),
-                                                  QueueAttributeName.Policy.toString());
+        List<String> sqsAttrNames = Arrays.asList(QueueAttributeName.QUEUE_ARN.toString(),
+                                                  QueueAttributeName.POLICY.toString());
         Map<String, String> sqsAttrs =
                 sqs.getQueueAttributes(GetQueueAttributesRequest.builder()
                         .queueUrl(sqsQueueUrl)
                         .attributeNames(sqsAttrNames)
                         .build())
-                        .attributes();
-        String sqsQueueArn = sqsAttrs.get(QueueAttributeName.QueueArn.toString());
+                        .attributesStrings();
+        String sqsQueueArn = sqsAttrs.get(QueueAttributeName.QUEUE_ARN.toString());
 
-        String policyJson = sqsAttrs.get(QueueAttributeName.Policy.toString());
+        String policyJson = sqsAttrs.get(QueueAttributeName.POLICY.toString());
         Policy policy = extendPolicy && policyJson != null && policyJson.length() > 0
                         ? Policy.fromJson(policyJson) : new Policy();
         policy.getStatements().add(new Statement(Effect.Allow)
@@ -204,7 +204,7 @@ public class Topics {
                                            .withConditions(ConditionFactory.newSourceArnCondition(snsTopicArn)));
 
         Map<String, String> newAttrs = new HashMap<String, String>();
-        newAttrs.put(QueueAttributeName.Policy.toString(), policy.toJson());
+        newAttrs.put(QueueAttributeName.POLICY.toString(), policy.toJson());
         sqs.setQueueAttributes(SetQueueAttributesRequest.builder().queueUrl(sqsQueueUrl).attributes(newAttrs).build());
 
         SubscribeResponse subscribeResult = sns.subscribe(SubscribeRequest.builder()

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/buffered/ReceiveQueueBuffer.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/buffered/ReceiveQueueBuffer.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchReq
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
@@ -286,7 +287,7 @@ public class ReceiveQueueBuffer {
                                                                                    .attributeNames("VisibilityTimeout").build();
                 ResultConverter.appendUserAgent(request, SqsBufferedAsyncClient.USER_AGENT);
                 long visibilityTimeoutSeconds = Long.parseLong(sqsClient.getQueueAttributes(request).join().attributes()
-                                                                        .get("VisibilityTimeout"));
+                                                                        .get(QueueAttributeName.VISIBILITY_TIMEOUT));
                 visibilityTimeoutNanos = TimeUnit.NANOSECONDS.convert(visibilityTimeoutSeconds, TimeUnit.SECONDS);
             }
 

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/buffered/ReceiveQueueBufferTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/buffered/ReceiveQueueBufferTest.java
@@ -36,7 +36,7 @@ public class ReceiveQueueBufferTest {
     private static final Map<String, String> QUEUE_ATTRIBUTES = new HashMap<String, String>();
 
     static {
-        QUEUE_ATTRIBUTES.put(QueueAttributeName.VisibilityTimeout.toString(),
+        QUEUE_ATTRIBUTES.put(QueueAttributeName.VISIBILITY_TIMEOUT.toString(),
                 String.valueOf(VISIBILITY_TIMEOUT_SECONDS));
     }
 

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/core/http/TT0035900619IntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/core/http/TT0035900619IntegrationTest.java
@@ -65,8 +65,8 @@ public class TT0035900619IntegrationTest {
             throws InterruptedException {
         DescribeTableResponse result = client.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
         TableDescription desc = result.table();
-        String status = desc.tableStatus();
-        for (;; status = desc.tableStatus()) {
+        String status = desc.tableStatusString();
+        for (;; status = desc.tableStatusString()) {
             if ("ACTIVE".equals(status)) {
                 return desc;
             } else if ("CREATING".equals(status) || "UPDATING".equals(status)) {

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/JsonIntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/JsonIntegrationTest.java
@@ -68,13 +68,13 @@ public class JsonIntegrationTest extends AwsTestBase {
         Thread.sleep(10000);
 
         while (true) {
-            String status = client.describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build())
-                                  .table()
-                                  .tableStatus();
+            TableStatus status = client.describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build())
+                                       .table()
+                                       .tableStatus();
 
-            if (status.equals(TableStatus.ACTIVE.toString())) {
+            if (status == TableStatus.ACTIVE) {
                 break;
-            } else if (!status.equals(TableStatus.CREATING.toString())) {
+            } else if (status != TableStatus.CREATING) {
                 throw new RuntimeException("Table creation failed");
             }
 

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMapper.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMapper.java
@@ -2252,7 +2252,7 @@ public class DynamoDbMapper extends AbstractDynamoDbMapper {
             for (Entry<String, AttributeValueUpdate> entry : putValues.entrySet()) {
                 String attributeName = entry.getKey();
                 AttributeValue attributeValue = entry.getValue().value();
-                String attributeAction = entry.getValue().action();
+                String attributeAction = entry.getValue().actionString();
 
                 /*
                  * AttributeValueUpdate allows nulls for its values, since they are

--- a/test/dynamodbmapper-v1/src/test/java/utils/test/resources/DynamoDBTableResource.java
+++ b/test/dynamodbmapper-v1/src/test/java/utils/test/resources/DynamoDBTableResource.java
@@ -143,9 +143,9 @@ public abstract class DynamoDBTableResource implements TestResource {
             }
         }
 
-        String tableStatus = table.tableStatus();
+        TableStatus tableStatus = table.tableStatus();
 
-        if (tableStatus.equals(TableStatus.ACTIVE.toString())) {
+        if (tableStatus == TableStatus.ACTIVE) {
             // returns AVAILABLE only if table KeySchema + LSIs + GSIs all match.
             if (UnorderedCollectionComparator.equalUnorderedCollections(createRequest.keySchema(), table.keySchema())
                 && equalUnorderedGsiLists(createRequest.globalSecondaryIndexes(), table.globalSecondaryIndexes())
@@ -154,9 +154,9 @@ public abstract class DynamoDBTableResource implements TestResource {
             } else {
                 return ResourceStatus.EXIST_INCOMPATIBLE_RESOURCE;
             }
-        } else if (tableStatus.equals(TableStatus.CREATING.toString())
-                   || tableStatus.equals(TableStatus.UPDATING.toString())
-                   || tableStatus.equals(TableStatus.DELETING.toString())) {
+        } else if (tableStatus == TableStatus.CREATING
+                   || tableStatus == TableStatus.UPDATING
+                   || tableStatus == TableStatus.DELETING) {
             return ResourceStatus.TRANSIENT;
         } else {
             return ResourceStatus.NOT_EXIST;

--- a/test/dynamodbmapper-v1/src/test/java/utils/test/util/DynamoDBTestBase.java
+++ b/test/dynamodbmapper-v1/src/test/java/utils/test/util/DynamoDBTestBase.java
@@ -78,9 +78,8 @@ public class DynamoDBTestBase extends AwsTestBase {
                 DescribeTableRequest request = DescribeTableRequest.builder().tableName(tableName).build();
                 TableDescription table = dynamo.describeTable(request).table();
 
-                String tableStatus = table.tableStatus();
-                log.info(() -> "  - current state: " + tableStatus);
-                if (tableStatus.equals(TableStatus.DELETING.toString())) {
+                log.info(() -> "  - current state: " + table.tableStatusString());
+                if (table.tableStatus() == TableStatus.DELETING) {
                     continue;
                 }
             } catch (AmazonServiceException ase) {

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/json-core-output.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/json-core-output.json
@@ -59,6 +59,141 @@
     }
   },
   {
+    "description": "Enum with known values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"EnumMember\": \"EnumValue1\"}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "EnumMember": "EnumValue1"
+      }
+    }
+  },
+  {
+    "description": "Enum with unknown values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"EnumMember\": \"XXXXX\"}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "EnumMember": "XXXXX"
+      }
+    }
+  },
+  {
+    "description": "Enum list with known values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"ListOfEnums\": [\"EnumValue1\", \"EnumValue2\"]}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "ListOfEnums": ["EnumValue1", "EnumValue2"]
+      }
+    }
+  },
+  {
+    "description": "Enum list with unknown values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"ListOfEnums\": [\"XXXXX\", \"EnumValue2\"]}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "ListOfEnums": ["XXXXX", "EnumValue2"]
+      }
+    }
+  },
+  {
+    "description": "Enum map with known everything unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"MapOfEnumToEnum\": { \"EnumValue1\": \"EnumValue1\", \"EnumValue2\": \"EnumValue2\" }}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "MapOfEnumToEnum": {
+          "EnumValue1": "EnumValue1",
+          "EnumValue2": "EnumValue2"
+        }
+      }
+    }
+  },
+  {
+    "description": "Enum map with unknown keys unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"MapOfEnumToEnum\": { \"XXXXX\": \"EnumValue1\", \"EnumValue2\": \"EnumValue2\" }}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "MapOfEnumToEnum": {
+          "XXXXX": "EnumValue1",
+          "EnumValue2": "EnumValue2"
+        }
+      }
+    }
+  },
+  {
+    "description": "Enum map with unknown values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"MapOfEnumToEnum\": { \"EnumValue1\": \"XXXXX\", \"EnumValue2\": \"EnumValue2\" }}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "MapOfEnumToEnum": {
+          "EnumValue1": "XXXXX",
+          "EnumValue2": "EnumValue2"
+        }
+      }
+    }
+  },
+  {
     "description": "Base64 encoded blob member is unmarshalled correctly",
     "given": {
       "response": {

--- a/test/protocol-tests/src/main/resources/codegen-resources/awsjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/awsjson/service-2.json
@@ -60,12 +60,15 @@
         "FloatMember":{"shape":"Float"},
         "DoubleMember":{"shape":"Double"},
         "LongMember":{"shape":"Long"},
+        "EnumMember":{"shape":"EnumType"},
         "SimpleList":{"shape":"ListOfStrings"},
+        "ListOfEnums":{"shape":"ListOfEnums"},
         "ListOfMaps":{"shape":"ListOfMapStringToString"},
         "ListOfStructs":{"shape":"ListOfSimpleStructs"},
         "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
         "MapOfStringToString":{"shape":"MapOfStringToString"},
         "MapOfStringToStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
         "TimestampMember":{"shape":"Timestamp"},
         "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
         "BlobArg":{"shape":"BlobType"},
@@ -136,6 +139,10 @@
       "type":"list",
       "member":{"shape":"String"}
     },
+    "ListOfEnums":{
+      "type":"list",
+      "member":{"shape":"EnumType"}
+    },
     "Long":{"type":"long"},
     "MapOfStringToIntegerList":{
       "type":"map",
@@ -156,6 +163,11 @@
       "type":"map",
       "key":{"shape":"String"},
       "value":{"shape":"String"}
+    },
+    "MapOfEnumToEnum":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"EnumType"}
     },
     "NestedContainersStructure":{
       "type":"structure",
@@ -208,6 +220,12 @@
         "SubTypeOneMember":{"shape":"String"}
       }
     },
-    "Timestamp":{"type":"timestamp"}
+    "Timestamp":{"type":"timestamp"},
+    "EnumType": {
+      "type":"string",
+      "enum": [
+        "EnumValue1", "EnumValue2"
+      ]
+    }
   }
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -177,12 +177,15 @@
         "FloatMember":{"shape":"Float"},
         "DoubleMember":{"shape":"Double"},
         "LongMember":{"shape":"Long"},
+        "EnumMember":{"shape":"EnumType"},
         "SimpleList":{"shape":"ListOfStrings"},
+        "ListOfEnums":{"shape":"ListOfEnums"},
         "ListOfMaps":{"shape":"ListOfMapStringToString"},
         "ListOfStructs":{"shape":"ListOfSimpleStructs"},
         "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
         "MapOfStringToString":{"shape":"MapOfStringToString"},
         "MapOfStringToStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
         "TimestampMember":{"shape":"Timestamp"},
         "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
         "BlobArg":{"shape":"BlobType"},
@@ -283,6 +286,10 @@
       "type":"list",
       "member":{"shape":"String"}
     },
+    "ListOfEnums":{
+      "type":"list",
+      "member":{"shape":"EnumType"}
+    },
     "Long":{"type":"long"},
     "MapOfStringToIntegerList":{
       "type":"map",
@@ -317,6 +324,11 @@
       "type":"map",
       "key":{"shape":"String"},
       "value":{"shape":"String"}
+    },
+    "MapOfEnumToEnum":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"EnumType"}
     },
     "MembersInHeadersInput":{
       "type":"structure",
@@ -556,6 +568,12 @@
         "SubTypeOneMember":{"shape":"String"}
       }
     },
-    "Timestamp":{"type":"timestamp"}
+    "Timestamp":{"type":"timestamp"},
+    "EnumType": {
+      "type":"string",
+      "enum": [
+        "EnumValue1", "EnumValue2"
+      ]
+    }
   }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/EnumTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/EnumTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+import org.junit.Test;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.EnumType;
+
+/**
+ * Verifies that the behavior when retrieving enums from a model behaves as expected.
+ */
+public class EnumTest {
+    @Test
+    public void knownEnumFieldsBehaveCorrectly() {
+        assertThat(convertToEnumWithBuilder("EnumValue1")).isEqualTo(EnumType.ENUM_VALUE1);
+        assertThat(convertToEnumWithBuilder((String) null)).isEqualTo(null);
+        assertThat(convertToEnumWithBuilder(EnumType.ENUM_VALUE1)).isEqualTo(EnumType.ENUM_VALUE1);
+    }
+
+    @Test
+    public void unknownEnumFieldsBehaveCorrectly() {
+        assertThat(convertToEnumWithBuilder("Foo")).isEqualTo(EnumType.UNKNOWN_TO_SDK_VERSION);
+    }
+
+    @Test
+    public void knownEnumListFieldsBehaveCorrectly() {
+        assertThat(convertToListEnumWithBuilder("EnumValue1", "EnumValue2"))
+                .containsExactly(EnumType.ENUM_VALUE1, EnumType.ENUM_VALUE2);
+        assertThat(convertToListEnumWithBuilder(new String[] {null })).containsExactly(new EnumType[] {null });
+        assertThat(convertToMapEnumWithBuilder()).isEmpty();
+    }
+
+    @Test
+    public void unknownEnumListFieldsBehaveCorrectly() {
+        assertThat(convertToListEnumWithBuilder("Foo", "EnumValue2")).containsExactly(EnumType.UNKNOWN_TO_SDK_VERSION, EnumType.ENUM_VALUE2);
+    }
+
+    @Test
+    public void knownEnumMapFieldsBehaveCorrectly() {
+        assertThat(convertToMapEnumWithBuilder(new SimpleImmutableEntry<>("EnumValue1", "EnumValue2")))
+                .containsExactly(new SimpleImmutableEntry<>(EnumType.ENUM_VALUE1, EnumType.ENUM_VALUE2));
+    }
+
+    @Test
+    public void unknownEnumMapFieldsBehaveCorrectly() {
+        assertThat(convertToMapEnumWithBuilder(new SimpleImmutableEntry<>("Foo", "EnumValue2")))
+                .isEmpty();
+        assertThat(convertToMapEnumWithBuilder(new SimpleImmutableEntry<>("Foo", "Foo")))
+                .isEmpty();
+        assertThat(convertToMapEnumWithBuilder(new SimpleImmutableEntry<>("Foo", "")))
+                .isEmpty();
+        assertThat(convertToMapEnumWithBuilder(new SimpleImmutableEntry<>("EnumValue1", "Foo")))
+                .containsExactly(new SimpleImmutableEntry<>(EnumType.ENUM_VALUE1, EnumType.UNKNOWN_TO_SDK_VERSION));
+        assertThat(convertToMapEnumWithBuilder(new SimpleImmutableEntry<>("EnumValue1", "")))
+                .containsExactly(new SimpleImmutableEntry<>(EnumType.ENUM_VALUE1, EnumType.UNKNOWN_TO_SDK_VERSION));
+    }
+
+    private EnumType convertToEnumWithBuilder(String value) {
+        return AllTypesResponse.builder().enumMember(value).build().enumMember();
+    }
+
+    private EnumType convertToEnumWithBuilder(EnumType value) {
+        return AllTypesResponse.builder().enumMember(value).build().enumMember();
+    }
+
+    private List<EnumType> convertToListEnumWithBuilder(String... values) {
+        return AllTypesResponse.builder().listOfEnums(values).build().listOfEnums();
+    }
+
+    @SafeVarargs
+    private final Map<EnumType, EnumType> convertToMapEnumWithBuilder(Entry<String, String>... values) {
+        Map<String, String> enumMap = Stream.of(values).collect(toMap(Entry::getKey, Entry::getValue));
+        return AllTypesResponse.builder().mapOfEnumToEnum(enumMap).build().mapOfEnumToEnum();
+    }
+}


### PR DESCRIPTION
Where appropriate, enums are now returned from model getters instead of
strings, which have been moved to a separate method that indicates its
value is a string.

Generated enums now follow the SCREAMING_CASE convention instead of the
PascalCase that was previously used.