### PR TITLE
Added alias for SdkHttpUtils.firstMatchingHeader utility method to the HTTP request/response objects and builders.

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/auth/Aws4Signer.java
+++ b/core/src/main/java/software/amazon/awssdk/core/auth/Aws4Signer.java
@@ -197,9 +197,9 @@ public class Aws4Signer extends AbstractAwsSigner
         mutableRequest.header(SignerConstants.X_AMZ_DATE, signerParams.getFormattedSigningDateTime());
 
         String contentSha256 = calculateContentHash(signerParams, mutableRequest);
-        SdkHttpUtils.firstMatchingHeader(mutableRequest.headers(), SignerConstants.X_AMZ_CONTENT_SHA256)
-                    .filter(h -> h.equals("required"))
-                    .ifPresent(h -> mutableRequest.header(SignerConstants.X_AMZ_CONTENT_SHA256, contentSha256));
+        mutableRequest.firstMatchingHeader(SignerConstants.X_AMZ_CONTENT_SHA256)
+                      .filter(h -> h.equals("required"))
+                      .ifPresent(h -> mutableRequest.header(SignerConstants.X_AMZ_CONTENT_SHA256, contentSha256));
 
         final String canonicalRequest = createCanonicalRequest(mutableRequest, contentSha256);
 

--- a/core/src/main/java/software/amazon/awssdk/core/http/DefaultErrorResponseHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/http/DefaultErrorResponseHandler.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 import software.amazon.awssdk.core.util.StringUtils;
 import software.amazon.awssdk.core.util.XpathUtils;
 import software.amazon.awssdk.utils.IoUtils;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Implementation of HttpResponseHandler that handles only error responses from Amazon Web Services.
@@ -132,9 +131,9 @@ public class DefaultErrorResponseHandler implements HttpResponseHandler<AmazonSe
     private String idString(HttpResponse errorResponse) {
         StringBuilder idString = new StringBuilder();
         try {
-            SdkHttpUtils.firstMatchingHeader(errorResponse.getRequest().headers(),
-                                             ApplyTransactionIdStage.HEADER_SDK_TRANSACTION_ID)
-                        .ifPresent(h -> idString.append("Invocation Id:").append(h));
+            errorResponse.getRequest()
+                         .firstMatchingHeader(ApplyTransactionIdStage.HEADER_SDK_TRANSACTION_ID)
+                         .ifPresent(h -> idString.append("Invocation Id:").append(h));
             if (errorResponse.getHeaders().containsKey(X_AMZN_REQUEST_ID_HEADER)) {
                 if (idString.length() > 0) {
                     idString.append(", ");

--- a/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -43,7 +43,6 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
 import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
 import software.amazon.awssdk.utils.FunctionalUtils.UnsafeRunnable;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Delegate to the HTTP implementation to make an HTTP request and receive the response.
@@ -112,7 +111,7 @@ public class MakeAsyncHttpRequestStage<OutputT>
 
     private boolean shouldSetContentLength(SdkHttpFullRequest request, SdkHttpRequestProvider requestProvider) {
         return requestProvider != null
-               && !SdkHttpUtils.firstMatchingHeader(request.headers(), "Content-Length").isPresent()
+               && !request.firstMatchingHeader("Content-Length").isPresent()
                // Can cause issues with signing if content length is present for these method
                && request.method() != SdkHttpMethod.GET
                && request.method() != SdkHttpMethod.HEAD;

--- a/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/ReportRequestContentLengthStage.java
+++ b/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/ReportRequestContentLengthStage.java
@@ -24,7 +24,6 @@ import software.amazon.awssdk.core.RequestExecutionContext;
 import software.amazon.awssdk.core.http.StreamManagingStage;
 import software.amazon.awssdk.core.http.pipeline.RequestToRequestPipeline;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Report the Content-Length of the request input stream to the {@link software.amazon.awssdk.core.event.ProgressListener}.
@@ -36,9 +35,9 @@ public class ReportRequestContentLengthStage implements RequestToRequestPipeline
     @Override
     public SdkHttpFullRequest execute(SdkHttpFullRequest request, RequestExecutionContext context) throws Exception {
         try {
-            SdkHttpUtils.firstMatchingHeader(request.headers(), "Content-Length")
-                        .map(Long::parseLong)
-                        .ifPresent(l -> publishRequestContentLength(context.requestConfig().getProgressListener(), l));
+            request.firstMatchingHeader("Content-Length")
+                   .map(Long::parseLong)
+                   .ifPresent(l -> publishRequestContentLength(context.requestConfig().getProgressListener(), l));
         } catch (NumberFormatException e) {
             log.warn("Cannot parse the Content-Length header of the request.");
         }

--- a/core/src/test/java/software/amazon/awssdk/core/auth/Aws4SignerTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/auth/Aws4SignerTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import software.amazon.awssdk.core.auth.internal.Aws4SignerUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Unit tests for the {@link Aws4Signer}.
@@ -64,7 +63,7 @@ public class Aws4SignerTest {
         signer.setServiceName("demo");
 
         SdkHttpFullRequest signed = SignerTestUtils.signRequest(signer, request.build(), credentials);
-        assertThat(SdkHttpUtils.firstMatchingHeader(signed.headers(), "Authorization"))
+        assertThat(signed.firstMatchingHeader("Authorization"))
                 .hasValue(expectedAuthorizationHeaderWithoutSha256Header);
 
 
@@ -73,9 +72,7 @@ public class Aws4SignerTest {
         request.header("x-amz-sha256", "required");
 
         signed = SignerTestUtils.signRequest(signer, request.build(), credentials);
-        assertThat(
-                SdkHttpUtils
-                        .firstMatchingHeader(signed.headers(), "Authorization")).hasValue(expectedAuthorizationHeaderWithSha256Header);
+        assertThat(signed.firstMatchingHeader("Authorization")).hasValue(expectedAuthorizationHeaderWithSha256Header);
     }
 
     @Test
@@ -97,7 +94,7 @@ public class Aws4SignerTest {
         signer.setServiceName("demo");
 
         SdkHttpFullRequest signed = SignerTestUtils.signRequest(signer, request.build(), credentials);
-        assertThat(SdkHttpUtils.firstMatchingHeader(signed.headers(), "Authorization"))
+        assertThat(signed.firstMatchingHeader("Authorization"))
                 .hasValue(expectedAuthorizationHeaderWithoutSha256Header);
     }
 
@@ -163,7 +160,7 @@ public class Aws4SignerTest {
 
         SdkHttpFullRequest actual = SignerTestUtils.signRequest(signer, request.build(), credentials);
 
-        assertThat(SdkHttpUtils.firstMatchingHeader(actual.headers(), "Authorization"))
+        assertThat(actual.firstMatchingHeader("Authorization"))
                 .hasValue("AWS4-HMAC-SHA256 Credential=akid/19810216/us-east-1/demo/aws4_request, " +
                           "SignedHeaders=host;x-amz-archive-description;x-amz-date, " +
                           "Signature=581d0042389009a28d461124138f1fe8eeb8daed87611d2a2b47fd3d68d81d73");

--- a/core/src/test/java/software/amazon/awssdk/core/http/AmazonHttpClientTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/http/AmazonHttpClientTest.java
@@ -140,8 +140,8 @@ public class AmazonHttpClientTest {
         ArgumentCaptor<SdkHttpFullRequest> httpRequestCaptor = ArgumentCaptor.forClass(SdkHttpFullRequest.class);
         verify(sdkHttpClient).prepareRequest(httpRequestCaptor.capture(), any());
 
-        final String userAgent = SdkHttpUtils.firstMatchingHeader(httpRequestCaptor.getValue().headers(), "User-Agent")
-                                             .orElseThrow(() -> new AssertionError("User-Agent header was not found"));
+        final String userAgent = httpRequestCaptor.getValue().firstMatchingHeader("User-Agent")
+                                                  .orElseThrow(() -> new AssertionError("User-Agent header was not found"));
 
         Assert.assertTrue(userAgent.startsWith(prefix));
         Assert.assertTrue(userAgent.endsWith(suffix));

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullRequest.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * An immutable HTTP request with a possible HTTP body.
@@ -165,6 +166,22 @@ public interface SdkHttpFullRequest
          * until the http request is created.
          */
         Builder method(SdkHttpMethod httpMethod);
+
+        /**
+         * Perform a case-insensitive search for a particular header in this request, returning the first matching header, if one
+         * is found.
+         *
+         * <p>This is useful for headers like 'Content-Type' or 'Content-Length' of which there is expected to be only one value
+         * present.</p>
+         *
+         * <p>This is equivalent to invoking {@link SdkHttpUtils#firstMatchingHeader(Map, String)}</p>.
+         *
+         * @param header The header to search for (case insensitively).
+         * @return The first header that matched the requested one, or empty if one was not found.
+         */
+        default Optional<String> firstMatchingHeader(String header) {
+            return SdkHttpUtils.firstMatchingHeader(headers(), header);
+        }
 
         /**
          * The query parameters, exactly as they were configured with {@link #headers(Map)},

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullResponse.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * An immutable HTTP response with a possible HTTP body.
@@ -85,6 +86,22 @@ public interface SdkHttpFullResponse
          * {@link #header(String, String)} and {@link #header(String, List)}.
          */
         Map<String, List<String>> headers();
+
+        /**
+         * Perform a case-insensitive search for a particular header in this request, returning the first matching header, if one
+         * is found.
+         *
+         * <p>This is useful for headers like 'Content-Type' or 'Content-Length' of which there is expected to be only one value
+         * present.</p>
+         *
+         * <p>This is equivalent to invoking {@link SdkHttpUtils#firstMatchingHeader(Map, String)}</p>.
+         *
+         * @param header The header to search for (case insensitively).
+         * @return The first header that matched the requested one, or empty if one was not found.
+         */
+        default Optional<String> firstMatchingHeader(String header) {
+            return SdkHttpUtils.firstMatchingHeader(headers(), header);
+        }
 
         /**
          * Add a single header to be included in the created HTTP response.

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpHeaders.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpHeaders.java
@@ -17,8 +17,10 @@ package software.amazon.awssdk.http;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * An immutable set of HTTP headers. {@link SdkHttpRequest} should be used for requests, and {@link SdkHttpResponse} should be
@@ -35,4 +37,20 @@ public interface SdkHttpHeaders {
      * @return An unmodifiable map of all headers in this message.
      */
     Map<String, List<String>> headers();
+
+    /**
+     * Perform a case-insensitive search for a particular header in this request, returning the first matching header, if one is
+     * found.
+     *
+     * <p>This is useful for headers like 'Content-Type' or 'Content-Length' of which there is expected to be only one value
+     * present.</p>
+     *
+     * <p>This is equivalent to invoking {@link SdkHttpUtils#firstMatchingHeader(Map, String)}</p>.
+     *
+     * @param header The header to search for (case insensitively).
+     * @return The first header that matched the requested one, or empty if one was not found.
+     */
+    default Optional<String> firstMatchingHeader(String header) {
+        return SdkHttpUtils.firstMatchingHeader(headers(), header);
+    }
 }

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/RepeatableInputStreamRequestEntity.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/RepeatableInputStreamRequestEntity.java
@@ -24,7 +24,6 @@ import org.apache.http.entity.InputStreamEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Custom implementation of {@link org.apache.http.HttpEntity} that delegates to an
@@ -79,9 +78,9 @@ public class RepeatableInputStreamRequestEntity extends BasicHttpEntity {
          * buffer the entire stream contents into memory to determine
          * the content length.
          */
-        long contentLength = SdkHttpUtils.firstMatchingHeader(request.headers(), "Content-Length")
-                                         .map(this::parseContentLength)
-                                         .orElse(-1L);
+        long contentLength = request.firstMatchingHeader("Content-Length")
+                                    .map(this::parseContentLength)
+                                    .orElse(-1L);
 
         content = getContent(request);
         // TODO v2 MetricInputStreamEntity
@@ -89,7 +88,7 @@ public class RepeatableInputStreamRequestEntity extends BasicHttpEntity {
         setContent(content);
         setContentLength(contentLength);
 
-        SdkHttpUtils.firstMatchingHeader(request.headers(), "Content-Type").ifPresent(contentType -> {
+        request.firstMatchingHeader("Content-Type").ifPresent(contentType -> {
             inputStreamRequestEntity.setContentType(contentType);
             setContentType(contentType);
         });

--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientIntegrationTest.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientIntegrationTest.java
@@ -23,18 +23,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +39,6 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkRequestContext;
 import software.amazon.awssdk.utils.IoUtils;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class UrlConnectionHttpClientIntegrationTest {
@@ -75,8 +67,8 @@ public final class UrlConnectionHttpClientIntegrationTest {
             .withHeader("Host", containing("localhost"))
             .withHeader("User-Agent", containing("hello")));
         assertThat(IoUtils.toString(response.content().orElse(null))).isEqualTo("hello");
-        assertThat(SdkHttpUtils.firstMatchingHeader(response.headers(), "Some-Header")).contains("With Value");
-        assertThat(SdkHttpUtils.firstMatchingHeader(response.headers(), "Some-Header")).contains("With Value");
+        assertThat(response.firstMatchingHeader("Some-Header")).contains("With Value");
+        assertThat(response.firstMatchingHeader("Some-Header")).contains("With Value");
     }
 
     @Test

--- a/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
+++ b/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
@@ -27,7 +27,6 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.services.glacier.model.ListVaultsRequest;
 import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 public class ServiceIntegrationTest extends AwsIntegrationTestBase {
 
@@ -54,9 +53,9 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
     public void listVaults_SendsApiVersion() {
         client.listVaults(ListVaultsRequest.builder().build());
         assertThat(capturingExecutionInterceptor.beforeTransmission)
-                .is(new Condition<>(r -> SdkHttpUtils.firstMatchingHeader(r.headers(), "x-amz-glacier-version")
-                                                     .orElseThrow(() -> new AssertionError("x-amz-glacier-version header not found"))
-                                                     .equals("2012-06-01"),
+                .is(new Condition<>(r -> r.firstMatchingHeader("x-amz-glacier-version")
+                                          .orElseThrow(() -> new AssertionError("x-amz-glacier-version header not found"))
+                                          .equals("2012-06-01"),
                                     "Glacier API version is present in header"));
     }
 

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.services.glacier.model.DescribeJobRequest;
 import software.amazon.awssdk.services.glacier.model.GetJobOutputRequest;
 import software.amazon.awssdk.services.glacier.model.UploadMultipartPartRequest;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 public class GlacierExecutionInterceptor implements ExecutionInterceptor {
 
@@ -42,9 +41,9 @@ public class GlacierExecutionInterceptor implements ExecutionInterceptor {
         mutableRequest.header("x-amz-content-sha256", "required");
 
         if (originalRequest instanceof UploadMultipartPartRequest) {
-            SdkHttpUtils.firstMatchingHeader(mutableRequest.headers(), "Content-Range")
-                        .ifPresent(range -> mutableRequest.header("Content-Length",
-                                                             Long.toString(parseContentLengthFromRange(range))));
+            mutableRequest.firstMatchingHeader("Content-Range")
+                          .ifPresent(range -> mutableRequest.header("Content-Length",
+                                                                    Long.toString(parseContentLengthFromRange(range))));
 
         } else if (originalRequest instanceof GetJobOutputRequest || originalRequest instanceof DescribeJobRequest) {
             String resourcePath = mutableRequest.encodedPath();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/AwsS3V4Signer.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/AwsS3V4Signer.java
@@ -30,7 +30,6 @@ import software.amazon.awssdk.services.s3.auth.AwsChunkedEncodingInputStream;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * AWS4 signer implementation for AWS S3
@@ -97,8 +96,8 @@ public class AwsS3V4Signer extends Aws4Signer {
 
         if (isPayloadSigningEnabled(requestToSign)) {
             if (useChunkEncoding(signerRequestParams)) {
-                final String contentLength = SdkHttpUtils.firstMatchingHeader(requestToSign.headers(), CONTENT_LENGTH)
-                                                         .orElse(null);
+                final String contentLength = requestToSign.firstMatchingHeader(CONTENT_LENGTH)
+                                                          .orElse(null);
                 final long originalContentLength;
                 if (contentLength != null) {
                     originalContentLength = Long.parseLong(contentLength);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/PutObjectInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/PutObjectInterceptorTest.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -46,7 +45,7 @@ public class PutObjectInterceptorTest {
 
         final SdkHttpFullRequest modifiedRequest = interceptor.modifyHttpRequest(ctx, new ExecutionAttributes());
 
-        assertThat(SdkHttpUtils.firstMatchingHeader(modifiedRequest.headers(), "Expect")).hasValue("100-continue");
+        assertThat(modifiedRequest.firstMatchingHeader("Expect")).hasValue("100-continue");
     }
 
     @Test
@@ -65,7 +64,7 @@ public class PutObjectInterceptorTest {
 
         final SdkHttpFullRequest modifiedRequest = interceptor.modifyHttpRequest(ctx, new ExecutionAttributes());
 
-        assertThat(SdkHttpUtils.firstMatchingHeader(modifiedRequest.headers(), "Expect")).isNotPresent();
+        assertThat(modifiedRequest.firstMatchingHeader("Expect")).isNotPresent();
     }
 
     private SdkHttpFullRequest sdkHttpFullRequest() {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
@@ -70,7 +70,6 @@ import software.amazon.awssdk.services.protocolrestjson.model.MembersInHeadersRe
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
-import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Verify that request handler hooks are behaving as expected.
@@ -404,11 +403,11 @@ public class ExecutionInterceptorTest {
 
         assertThat(failedRequest.stringMember()).isEqualTo("1");
         assertThat(failedExecutionArg.getValue().httpRequest()).hasValueSatisfying(httpRequest -> {
-            assertThat(SdkHttpUtils.firstMatchingHeader(httpRequest.headers(), "x-amz-string")).hasValue("1");
-            assertThat(SdkHttpUtils.firstMatchingHeader(httpRequest.headers(), "x-amz-integer")).hasValue("2");
+            assertThat(httpRequest.firstMatchingHeader("x-amz-string")).hasValue("1");
+            assertThat(httpRequest.firstMatchingHeader("x-amz-integer")).hasValue("2");
         });
         assertThat(failedExecutionArg.getValue().httpResponse()).hasValueSatisfying(httpResponse -> {
-            assertThat(SdkHttpUtils.firstMatchingHeader(httpResponse.headers(), "x-amz-integer")).hasValue("3");
+            assertThat(httpResponse.firstMatchingHeader("x-amz-integer")).hasValue("3");
         });
 
         if (expectResponse) {
@@ -430,18 +429,18 @@ public class ExecutionInterceptorTest {
     private void validateArgs(Context.AfterMarshalling context,
                               String expectedStringMemberValue, String expectedIntegerHeaderValue) {
         validateArgs(context, expectedStringMemberValue);
-        assertThat(SdkHttpUtils.firstMatchingHeader(context.httpRequest().headers(),
-                                                    "x-amz-integer")).isEqualTo(Optional.ofNullable(expectedIntegerHeaderValue));
-        assertThat(SdkHttpUtils.firstMatchingHeader(context.httpRequest().headers(),
-                                                    "x-amz-string")).isEqualTo(Optional.ofNullable(expectedStringMemberValue));
+        assertThat(context.httpRequest().firstMatchingHeader("x-amz-integer"))
+                .isEqualTo(Optional.ofNullable(expectedIntegerHeaderValue));
+        assertThat(context.httpRequest().firstMatchingHeader("x-amz-string"))
+                .isEqualTo(Optional.ofNullable(expectedStringMemberValue));
     }
 
     private void validateArgs(Context.AfterTransmission context,
                               String expectedStringMemberValue, String expectedIntegerHeaderValue,
                               String expectedResponseIntegerHeaderValue) {
         validateArgs(context, expectedStringMemberValue, expectedIntegerHeaderValue);
-        assertThat(SdkHttpUtils.firstMatchingHeader(context.httpResponse().headers(),
-                                                    "x-amz-integer")).isEqualTo(Optional.ofNullable(expectedResponseIntegerHeaderValue));
+        assertThat(context.httpResponse().firstMatchingHeader("x-amz-integer"))
+                .isEqualTo(Optional.ofNullable(expectedResponseIntegerHeaderValue));
     }
 
     private void validateArgs(Context.AfterUnmarshalling context,


### PR DESCRIPTION
This was requested in https://github.com/aws/aws-sdk-java-v2/pull/178