### PR TITLE
Sync pagination implementation

### DIFF
--- a/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
+++ b/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.config.BasicCodeGenConfig;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.ServiceExamples;
+import software.amazon.awssdk.codegen.model.service.Paginators;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Waiters;
 import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
@@ -50,6 +51,7 @@ public class GenerationMojo extends AbstractMojo {
     private static final String CUSTOMIZATION_CONFIG_FILE = "customization.config";
     private static final String EXAMPLES_FILE = "examples-1.json";
     private static final String WAITERS_FILE = "waiters-2.json";
+    private static final String PAGINATORS_FILE = "paginators.json";
 
     @Parameter(property = "codeGenResources", defaultValue = "${basedir}/src/main/resources/codegen-resources/")
     private File codeGenResources;
@@ -75,6 +77,7 @@ public class GenerationMojo extends AbstractMojo {
                                       .customizationConfig(loadCustomizationConfig(p))
                                       .serviceModel(loadServiceModel(p))
                                       .waitersModel(loadWaiterModel(p))
+                                      .paginatorsModel(loadPaginatorModel(p))
                                       .examplesModel(loadExamplesModel(p))
                                       .build());
             } catch (MojoExecutionException e) {
@@ -132,6 +135,10 @@ public class GenerationMojo extends AbstractMojo {
 
     private Waiters loadWaiterModel(Path root) {
         return loadOptionalModel(Waiters.class, root.resolve(WAITERS_FILE)).orElse(Waiters.NONE);
+    }
+
+    private Paginators loadPaginatorModel(Path root) {
+        return loadOptionalModel(Paginators.class, root.resolve(PAGINATORS_FILE)).orElse(Paginators.NONE);
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
@@ -77,6 +77,7 @@ final class AddMetadata {
                 .withModelPackageName(Utils.getModelPackageName(serviceName, customizationConfig))
                 .withTransformPackageName(Utils.getTransformPackageName(serviceName, customizationConfig))
                 .withRequestTransformPackageName(Utils.getRequestTransformPackageName(serviceName, customizationConfig))
+                .withPaginatorsPackageName(Utils.getPaginatorsPackageName(serviceName, customizationConfig))
                 .withSmokeTestsPackageName(Utils.getSmokeTestPackageName(serviceName, customizationConfig))
                 .withServiceAbbreviation(serviceMetadata.getServiceAbbreviation())
                 .withServiceFullName(serviceMetadata.getServiceFullName())

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.codegen.model.service.Input;
 import software.amazon.awssdk.codegen.model.service.Member;
 import software.amazon.awssdk.codegen.model.service.Operation;
 import software.amazon.awssdk.codegen.model.service.Output;
+import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Shape;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
@@ -41,10 +42,12 @@ final class AddOperations {
 
     private final ServiceModel serviceModel;
     private final NamingStrategy namingStrategy;
+    private final Map<String, PaginatorDefinition> paginators;
 
     AddOperations(IntermediateModelBuilder builder) {
         this.serviceModel = builder.getService();
         this.namingStrategy = builder.getNamingStrategy();
+        this.paginators = builder.getPaginators().getPaginators();
     }
 
     private static boolean isAuthenticated(Operation op) {
@@ -151,6 +154,7 @@ final class AddOperations {
             operationModel.setDeprecated(op.isDeprecated());
             operationModel.setDocumentation(op.getDocumentation());
             operationModel.setIsAuthenticated(isAuthenticated(op));
+            operationModel.setPaginated(isPaginated(op));
 
             final Input input = op.getInput();
             if (input != null) {
@@ -218,5 +222,9 @@ final class AddOperations {
      */
     private Integer getHttpStatusCode(ErrorTrait errorTrait) {
         return errorTrait == null ? null : errorTrait.getHttpStatusCode();
+    }
+
+    private boolean isPaginated(Operation op) {
+        return paginators.keySet().contains(op.getName()) && paginators.get(op.getName()).isValid();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/C2jModels.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/C2jModels.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.codegen;
 import software.amazon.awssdk.codegen.model.config.BasicCodeGenConfig;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.ServiceExamples;
+import software.amazon.awssdk.codegen.model.service.Paginators;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Waiters;
 
@@ -31,14 +32,17 @@ public class C2jModels {
     private final ServiceExamples examplesModel;
     private final BasicCodeGenConfig codeGenConfig;
     private final CustomizationConfig customizationConfig;
+    private final Paginators paginatorsModel;
 
     private C2jModels(ServiceModel serviceModel, Waiters waitersModel, ServiceExamples examplesModel,
-                      BasicCodeGenConfig codeGenConfig, CustomizationConfig customizationConfig) {
+                      BasicCodeGenConfig codeGenConfig, CustomizationConfig customizationConfig,
+                      Paginators paginatorsModel) {
         this.serviceModel = serviceModel;
         this.waitersModel = waitersModel;
         this.examplesModel = examplesModel;
         this.codeGenConfig = codeGenConfig;
         this.customizationConfig = customizationConfig;
+        this.paginatorsModel = paginatorsModel;
     }
 
     public static Builder builder() {
@@ -65,6 +69,10 @@ public class C2jModels {
         return customizationConfig;
     }
 
+    public Paginators paginatorsModel() {
+        return paginatorsModel;
+    }
+
     public static class Builder {
 
         private ServiceModel serviceModel;
@@ -72,6 +80,7 @@ public class C2jModels {
         private ServiceExamples examplesModel;
         private BasicCodeGenConfig codeGenConfig;
         private CustomizationConfig customizationConfig;
+        private Paginators paginatorsModel;
 
         private Builder() {
         }
@@ -101,10 +110,16 @@ public class C2jModels {
             return this;
         }
 
+        public Builder paginatorsModel(Paginators paginatorsModel) {
+            this.paginatorsModel = paginatorsModel;
+            return this;
+        }
+
         public C2jModels build() {
             final Waiters waiters = waitersModel != null ? waitersModel : Waiters.NONE;
+            final Paginators paginators = paginatorsModel != null ? paginatorsModel : Paginators.NONE;
             final ServiceExamples examples = examplesModel != null ? examplesModel : ServiceExamples.NONE;
-            return new C2jModels(serviceModel, waiters, examples, codeGenConfig, customizationConfig);
+            return new C2jModels(serviceModel, waiters, examples, codeGenConfig, customizationConfig, paginators);
         }
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ServiceExamples;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.model.service.Operation;
+import software.amazon.awssdk.codegen.model.service.Paginators;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.naming.DefaultNamingStrategy;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
@@ -61,6 +62,7 @@ public class IntermediateModelBuilder {
     private final NamingStrategy namingStrategy;
     private final TypeUtils typeUtils;
     private final List<IntermediateModelShapeProcessor> shapeProcessors;
+    private final Paginators paginators;
 
     public IntermediateModelBuilder(C2jModels models) {
         this.customConfig = models.customizationConfig();
@@ -70,6 +72,7 @@ public class IntermediateModelBuilder {
         this.namingStrategy = new DefaultNamingStrategy(service, customConfig);
         this.typeUtils = new TypeUtils(namingStrategy);
         this.shapeProcessors = createShapeProcessors();
+        this.paginators = models.paginatorsModel();
     }
 
 
@@ -116,7 +119,7 @@ public class IntermediateModelBuilder {
 
         IntermediateModel fullModel = new IntermediateModel(
             constructMetadata(service, codeGenConfig, customConfig), operations, shapes,
-            customConfig, examples, authorizers);
+            customConfig, examples, authorizers, paginators.getPaginators());
 
         customization.postprocess(fullModel);
 
@@ -131,7 +134,8 @@ public class IntermediateModelBuilder {
                                                                trimmedShapes,
                                                                fullModel.getCustomizationConfig(),
                                                                fullModel.getExamples(),
-                                                               fullModel.getCustomAuthorizers());
+                                                               fullModel.getCustomAuthorizers(),
+                                                               fullModel.getPaginators());
 
         linkMembersToShapes(trimmedModel);
         linkOperationsToInputOutputShapes(trimmedModel);
@@ -249,4 +253,7 @@ public class IntermediateModelBuilder {
         return typeUtils;
     }
 
+    public Paginators getPaginators() {
+        return paginators;
+    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/OperationDocProvider.java
@@ -51,10 +51,12 @@ abstract class OperationDocProvider {
 
     protected final IntermediateModel model;
     protected final OperationModel opModel;
+    protected final PaginationDocs paginationDocs;
 
     OperationDocProvider(IntermediateModel model, OperationModel opModel) {
         this.model = model;
         this.opModel = opModel;
+        this.paginationDocs = new PaginationDocs(model, opModel);
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/PaginationDocs.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/PaginationDocs.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.docs;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.poet.PoetExtensions;
+import software.amazon.awssdk.codegen.utils.PaginatorUtils;
+
+public class PaginationDocs {
+
+    private final OperationModel operationModel;
+    private final PoetExtensions poetExtensions;
+
+    public PaginationDocs(IntermediateModel intermediateModel, OperationModel operationModel) {
+        this.operationModel = operationModel;
+        this.poetExtensions = new PoetExtensions(intermediateModel);
+    }
+
+    /**
+     * Constructs additional documentation on the client operation that is appended to the service documentation.
+     *
+     * TODO Add a link to our developer guide which will have more details and sample code. Write a blog post too.
+     */
+    public String getDocsForSyncOperation() {
+        return CodeBlock.builder()
+                        .add("<p>This is a variant of {@link #$L($T)} operation. "
+                             + "The return type is a custom iterable that can be used to iterate through all the pages. "
+                             + "SDK will internally handle making service calls for you.\n</p>",
+                             operationModel.getMethodName(), requestType())
+                        .add("<p>\nWhen this operation is called, a custom iterable is returned but no service calls are "
+                             + "made yet. So there is no guarantee that the request is valid. As you iterate "
+                             + "through the iterable, SDK will start lazily loading response pages by making service calls until "
+                             + "there are no pages left or your iteration stops. If there are errors in your request, you will "
+                             + "see the failures only after you start iterating through the iterable.\n</p>")
+                        .add(getSyncCodeSnippets())
+                        .build()
+                        .toString();
+    }
+
+    /**
+     * Constructs javadocs for the generated response classes in a paginated operation.
+     * @param clientInterface A java poet {@link ClassName} type of the sync client interface
+     */
+    public String getDocsForSyncResponseClass(ClassName clientInterface) {
+        return CodeBlock.builder()
+                        .add("<p>Represents the output for the {@link $T#$L($T)} operation which is a paginated operation."
+                             + " This class is an iterable of {@link $T} that can be used to iterate through all the "
+                             + "response pages of the operation.</p>",
+                             clientInterface, getSyncPaginatedMethodName(), requestType(), syncResponsePageType())
+                        .add("<p>When the operation is called, an instance of this class is returned.  At this point, "
+                             + "no service calls are made yet and so there is no guarantee that the request is valid. "
+                             + "As you iterate through the iterable, SDK will start lazily loading response pages by making "
+                             + "service calls until there are no pages left or your iteration stops. If there are errors in your "
+                             + "request, you will see the failures only after you start iterating through the iterable.</p>")
+                        .add(getSyncCodeSnippets())
+                        .build()
+                        .toString();
+    }
+
+    private String getSyncCodeSnippets() {
+        CodeBlock callOperationOnClient = CodeBlock.builder()
+                                           .addStatement("$T responses = client.$L(request)", syncPaginatedResponseType(),
+                                                         getSyncPaginatedMethodName())
+                                           .build();
+
+        return CodeBlock.builder()
+                        .add("\n\n<p>The following are few ways to iterate through the response pages:</p>")
+                        .add("1) Using a Stream")
+                        .add(buildCode(CodeBlock.builder()
+                                                .add(callOperationOnClient)
+                                                .addStatement("responses.stream().forEach(....)")
+                                                .build()))
+                        .add("\n\n2) Using For loop")
+                        .add(buildCode(CodeBlock.builder()
+                                                .add(callOperationOnClient)
+                                                .beginControlFlow("for ($T response : responses)", syncResponsePageType())
+                                                .addStatement(" // do something")
+                                                .endControlFlow()
+                                                .build()))
+                        .add("\n\n3) Use iterator directly")
+                        .add(buildCode(CodeBlock.builder()
+                                                .add(callOperationOnClient)
+                                                .addStatement("responses.iterator().forEachRemaining(....)")
+                                                .build()))
+                        .add(noteAboutSyncNonPaginatedMethod())
+                        .build()
+                        .toString();
+    }
+
+    private CodeBlock buildCode(CodeBlock codeSnippet) {
+        return CodeBlock.builder()
+                        .add("<pre>{@code\n")
+                        .add(codeSnippet)
+                        .add("}</pre>")
+                        .build();
+
+    }
+
+    /**
+     * @return Method name for the sync paginated operation
+     */
+    private String getSyncPaginatedMethodName() {
+        return PaginatorUtils.getSyncMethodName(operationModel.getMethodName());
+    }
+
+    /**
+     * @return A Poet {@link ClassName} for the sync operation request type.
+     *
+     * Example: For ListTables operation, it will be "ListTablesRequest" class.
+     */
+    private ClassName requestType() {
+        return poetExtensions.getModelClass(operationModel.getInput().getVariableType());
+    }
+
+    /**
+     * @return A Poet {@link ClassName} for the return type of sync non-paginated operation.
+     *
+     * Example: For ListTables operation, it will be "ListTablesResponse" class.
+     */
+    private ClassName syncResponsePageType() {
+        return poetExtensions.getModelClass(operationModel.getReturnType().getReturnType());
+    }
+
+    /**
+     * @return A Poet {@link ClassName} for the return type of sync paginated operation.
+     */
+    public ClassName syncPaginatedResponseType() {
+        return poetExtensions.getResponseClassForPaginatedSyncOperation(operationModel.getOperationName());
+    }
+
+    private CodeBlock noteAboutSyncNonPaginatedMethod() {
+        return CodeBlock.builder()
+                        .add("\n<p><b>Note: If you prefer to have control on service calls, use the {@link #$L($T)} operation."
+                             + "</b></p>", operationModel.getMethodName(), requestType())
+                        .build();
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/SimpleMethodOverload.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/SimpleMethodOverload.java
@@ -27,9 +27,19 @@ public enum SimpleMethodOverload {
     NORMAL,
 
     /**
+     * The standard paginated method overload that takes in a request object and returns a response object.
+     */
+    PAGINATED,
+
+    /**
      * Simple method that takes no arguments and creates an empty request object that delegates to the {@link #NORMAL} overload.
      */
     NO_ARG,
+
+    /**
+     * Paginated simple method that takes no arguments and creates an empty request object.
+     */
+    NO_ARG_PAGINATED,
 
     /**
      * Simple method for streaming operations (input or output) that takes in the request object and a file to

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/GeneratorPathProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/GeneratorPathProvider.java
@@ -58,6 +58,10 @@ public class GeneratorPathProvider {
         return sourceDirectory + "/" + Utils.packageToDirectory(model.getMetadata().getFullClientPackageName());
     }
 
+    public String getPaginatorsDirectory() {
+        return sourceDirectory + "/" + Utils.packageToDirectory(model.getMetadata().getFullPaginatorsPackageName());
+    }
+
     public String getPolicyEnumDirectory() {
         return sourceDirectory + "/" + Constants.AUTH_POLICY_ENUM_CLASS_DIR;
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/AwsGeneratorTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/AwsGeneratorTasks.java
@@ -33,7 +33,9 @@ public class AwsGeneratorTasks implements Iterable<GeneratorTask> {
     }
 
     private Iterable<GeneratorTask> createAwsTasks(GeneratorTaskParams params) {
-        return new CompositeIterable<>(new AsyncClientGeneratorTasks(params));
+        // TODO Move AsyncClientGeneratorTasks to common generic tasks (mostly CommonGeneratorTasks class)
+        return new CompositeIterable<>(new AsyncClientGeneratorTasks(params),
+                                       new PaginatorsGeneratorTasks(params));
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/PaginatorsGeneratorTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/PaginatorsGeneratorTasks.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.emitters.tasks;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.safeFunction;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.codegen.emitters.GeneratorTask;
+import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
+import software.amazon.awssdk.codegen.emitters.PoetGeneratorTask;
+import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.paginators.PaginatorResponseClassSpec;
+
+public class PaginatorsGeneratorTasks extends BaseGeneratorTasks {
+
+    private final String paginatorsClassDir;
+
+    public PaginatorsGeneratorTasks(GeneratorTaskParams dependencies) {
+        super(dependencies);
+        this.paginatorsClassDir = dependencies.getPathProvider().getPaginatorsDirectory();
+    }
+
+    @Override
+    protected boolean hasTasks() {
+        return model.hasPaginators();
+    }
+
+    @Override
+    protected List<GeneratorTask> createTasks() throws Exception {
+        info("Emitting paginator classes");
+        return model.getPaginators().entrySet().stream()
+                    .filter(entry -> entry.getValue().isValid())
+                    .map(safeFunction(this::createTask))
+                    .collect(Collectors.toList());
+    }
+
+    private GeneratorTask createTask(Map.Entry<String, PaginatorDefinition> entry) throws IOException {
+        ClassSpec classSpec = new PaginatorResponseClassSpec(model, entry.getKey(), entry.getValue());
+
+        return new PoetGeneratorTask(paginatorsClassDir, model.getFileHeader(), classSpec);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Constants.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Constants.java
@@ -48,6 +48,8 @@ public final class Constants {
 
     public static final String PACKAGE_NAME_TRANSFORM_PATTERN = "%s.transform";
 
+    public static final String PACKAGE_NAME_PAGINATORS_PATTERN = "%s.paginators";
+
     public static final String PACKAGE_NAME_SMOKE_TEST_PATTERN = "%s.smoketests";
 
     public static final String PACKAGE_NAME_CUSTOM_AUTH_PATTERN = "%s.auth";

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Jackson.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Jackson.java
@@ -43,6 +43,8 @@ public final class Jackson {
         MAPPER.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         // TODO: Un comment this once we know for sure, we capture everything in C2j model.
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        MAPPER.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
     }
 
     private Jackson() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Utils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Utils.java
@@ -134,6 +134,10 @@ public final class Utils {
                                         Constants.PACKAGE_NAME_TRANSFORM_PATTERN);
     }
 
+    public static String getPaginatorsPackageName(String serviceName, CustomizationConfig customizationConfig) {
+        return getCustomizedPackageName(serviceName, Constants.PACKAGE_NAME_PAGINATORS_PATTERN);
+    }
+
     public static String getSmokeTestPackageName(String serviceName, CustomizationConfig customizationConfig) {
         return getCustomizedPackageName(serviceName,
                                         Constants.PACKAGE_NAME_SMOKE_TEST_PATTERN);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.codegen.model.intermediate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
 import software.amazon.awssdk.core.AmazonWebServiceResult;
 import software.amazon.awssdk.core.ResponseMetadata;
 import software.amazon.awssdk.utils.IoUtils;
@@ -47,6 +49,9 @@ public final class IntermediateModel {
 
     private final Map<String, AuthorizerModel> customAuthorizers;
 
+    @JsonIgnore
+    private final Map<String, PaginatorDefinition> paginators;
+
     @JsonCreator
     public IntermediateModel(
             @JsonProperty("metadata") Metadata metadata,
@@ -55,7 +60,7 @@ public final class IntermediateModel {
             @JsonProperty("customizationConfig") CustomizationConfig customizationConfig,
             @JsonProperty("serviceExamples") ServiceExamples examples) {
 
-        this(metadata, operations, shapes, customizationConfig, examples, Collections.emptyMap());
+        this(metadata, operations, shapes, customizationConfig, examples, Collections.emptyMap(), Collections.emptyMap());
     }
 
     public IntermediateModel(
@@ -64,13 +69,15 @@ public final class IntermediateModel {
             Map<String, ShapeModel> shapes,
             CustomizationConfig customizationConfig,
             ServiceExamples examples,
-            Map<String, AuthorizerModel> customAuthorizers) {
+            Map<String, AuthorizerModel> customAuthorizers,
+            Map<String, PaginatorDefinition> paginators) {
         this.metadata = metadata;
         this.operations = operations;
         this.shapes = shapes;
         this.customizationConfig = customizationConfig;
         this.examples = examples;
         this.customAuthorizers = customAuthorizers;
+        this.paginators = paginators;
     }
 
     public Metadata getMetadata() {
@@ -99,6 +106,10 @@ public final class IntermediateModel {
 
     public ServiceExamples getExamples() {
         return examples;
+    }
+
+    public Map<String, PaginatorDefinition> getPaginators() {
+        return paginators;
     }
 
     /**
@@ -170,8 +181,11 @@ public final class IntermediateModel {
                customizationConfig.getCustomResponseMetadataClassName();
     }
 
-
     public Map<String, AuthorizerModel> getCustomAuthorizers() {
         return customAuthorizers;
+    }
+
+    public boolean hasPaginators() {
+        return paginators.size() > 0;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
@@ -69,6 +69,8 @@ public class Metadata {
 
     private String requestTransformPackageName;
 
+    private String paginatorsPackageName;
+
     private String authPolicyPackageName;
 
     private String smokeTestsPackageName;
@@ -430,6 +432,23 @@ public class Metadata {
 
     public Metadata withRequestTransformPackageName(String requestTransformPackageName) {
         setRequestTransformPackageName(requestTransformPackageName);
+        return this;
+    }
+
+    public String getFullPaginatorsPackageName() {
+        return joinPackageNames(rootPackageName, getPaginatorsPackageName());
+    }
+
+    public String getPaginatorsPackageName() {
+        return paginatorsPackageName;
+    }
+
+    public void setPaginatorsPackageName(String paginatorsPackageName) {
+        this.paginatorsPackageName = paginatorsPackageName;
+    }
+
+    public Metadata withPaginatorsPackageName(String paginatorsPackageName) {
+        setPaginatorsPackageName(paginatorsPackageName);
         return this;
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
@@ -41,6 +41,8 @@ public class OperationModel extends DocumentationModel {
 
     private boolean isAuthenticated = true;
 
+    private boolean isPaginated;
+
     @JsonIgnore
     private ShapeModel inputShape;
 
@@ -169,5 +171,13 @@ public class OperationModel extends DocumentationModel {
     @JsonIgnore
     public boolean isStreaming() {
         return hasStreamingInput() || hasStreamingOutput();
+    }
+
+    public boolean isPaginated() {
+        return isPaginated;
+    }
+
+    public void setPaginated(boolean paginated) {
+        isPaginated = paginated;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/PaginatorDefinition.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/PaginatorDefinition.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Represents the structure for each operation in paginators.json file
+ *
+ * This class is used to generate auto-paginated APIs.
+ */
+public class PaginatorDefinition {
+
+    /**
+     * The members in the request which needs to be set to get the next page.
+     */
+    @JsonProperty("input_token")
+    private List<String> inputToken;
+
+    /**
+     * The members in the response which are used to get the next page.
+     */
+    @JsonProperty("output_token")
+    private List<String> outputToken;
+
+    /**
+     * The paginated list of members in the response
+     */
+    @JsonProperty("result_key")
+    private List<String> resultKey;
+
+    /**
+     * The name of the member in the response that indicates if the response is truncated.
+     * If the value of member is true, there are more results that can be retrieved.
+     * If the value of member is false, then there are no additional results.
+     *
+     * This is an optional field. If this value is missing, use the outputToken instead to check
+     * if more results are available or not.
+     */
+    @JsonProperty("more_results")
+    private String moreResults;
+
+    /**
+     * The member in the request that is used to limit the number of results per page.
+     */
+    @JsonProperty("limit_key")
+    private String limitKey;
+
+    public PaginatorDefinition() {
+    }
+
+    public List<String> getInputToken() {
+        return inputToken;
+    }
+
+    public void setInputToken(List<String> inputToken) {
+        this.inputToken = inputToken;
+    }
+
+    public List<String> getOutputToken() {
+        return outputToken;
+    }
+
+    public void setOutputToken(List<String> outputToken) {
+        this.outputToken = outputToken;
+    }
+
+    public List<String> getResultKey() {
+        return resultKey;
+    }
+
+    public void setResultKey(List<String> resultKey) {
+        this.resultKey = resultKey;
+    }
+
+    public String getMoreResults() {
+        return moreResults;
+    }
+
+    public void setMoreResults(String moreResults) {
+        this.moreResults = moreResults;
+    }
+
+    public String getLimitKey() {
+        return limitKey;
+    }
+
+    public void setLimitKey(String limitKey) {
+        this.limitKey = limitKey;
+    }
+
+    /**
+     * Returns a boolean value indicating if the information present in this object
+     * is sufficient to generate the paginated APIs.
+     *
+     * @return True if all necessary information to generate paginator APIs is present. Otherwise false.
+     *
+     * TODO Either support fields with Jmespath expressions or add them to invalid list
+     */
+    public boolean isValid() {
+        return inputToken != null && !inputToken.isEmpty() &&
+               outputToken != null && !outputToken.isEmpty();
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Paginators.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Paginators.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * POJO class to represent the paginators.json file.
+ */
+public class Paginators {
+
+    public static final Paginators NONE = new Paginators(Collections.emptyMap());
+
+    @JsonProperty("pagination")
+    private final Map<String, PaginatorDefinition> paginators;
+
+    // Needed for JSON deserialization
+    private Paginators() {
+        this(new HashMap<>());
+    }
+
+    private Paginators(Map<String, PaginatorDefinition> paginators) {
+        this.paginators = paginators;
+    }
+
+    /**
+     * Returns a map of operation name to its {@link PaginatorDefinition}.
+     */
+    public Map<String, PaginatorDefinition> getPaginators() {
+        return paginators;
+    }
+
+    public PaginatorDefinition getPaginatorDefinition(String operationName) {
+        return paginators.get(operationName);
+    }
+
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtensions.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetExtensions.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.codegen.poet;
 
 import com.squareup.javapoet.ClassName;
+import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 
 /**
@@ -60,4 +61,17 @@ public class PoetExtensions {
     public ClassName getClientClass(String className) {
         return ClassName.get(model.getMetadata().getFullClientPackageName(), className);
     }
+
+    /**
+     * @param operationName Name of the operation
+     * @return A Poet {@link ClassName} for the response type of a paginated operation in the base service package.
+     *
+     * Example: If operationName is "ListTables", then the response type of the paginated operation
+     * will be "ListTablesPaginator" class in the base service package.
+     */
+    @ReviewBeforeRelease("Naming of response shape for paginated APIs")
+    public ClassName getResponseClassForPaginatedSyncOperation(String operationName) {
+        return ClassName.get(model.getMetadata().getFullPaginatorsPackageName(), operationName + "Paginator");
+    }
+
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/TypeProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/TypeProvider.java
@@ -39,10 +39,10 @@ import software.amazon.awssdk.codegen.poet.PoetExtensions;
 /**
  * Helper class for resolving Poet {@link TypeName}s for use in model classes.
  */
-class TypeProvider {
+public class TypeProvider {
     private final PoetExtensions poetExtensions;
 
-    TypeProvider(IntermediateModel intermediateModel) {
+    public TypeProvider(IntermediateModel intermediateModel) {
         this.poetExtensions = new PoetExtensions(intermediateModel);
     }
 
@@ -127,6 +127,13 @@ class TypeProvider {
         if (mapModel.getValueModel().isList()) {
             valueType = WildcardTypeName.subtypeOf(valueType);
         }
+
+        return ParameterizedTypeName.get(ClassName.get(Map.Entry.class), keyType, valueType);
+    }
+
+    public TypeName mapEntryWithConcreteTypes(MapModel mapModel) {
+        TypeName keyType = fieldType(mapModel.getKeyModel());
+        TypeName valueType = fieldType(mapModel.getValueModel());
 
         return ParameterizedTypeName.get(ClassName.get(Map.Entry.class), keyType, valueType);
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorResponseClassSpec.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.paginators;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.security.InvalidParameterException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.codegen.docs.PaginationDocs;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.PoetExtensions;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.codegen.poet.model.TypeProvider;
+import software.amazon.awssdk.core.pagination.NextPageFetcher;
+import software.amazon.awssdk.core.pagination.PaginatedItemsIterable;
+import software.amazon.awssdk.core.pagination.PaginatedResponsesIterator;
+import software.amazon.awssdk.core.pagination.SdkIterable;
+
+/**
+ * Java poet {@link ClassSpec} to generate the response class for sync paginated operations.
+ */
+public class PaginatorResponseClassSpec implements ClassSpec {
+
+    private static final String CLIENT_MEMBER = "client";
+    private static final String REQUEST_MEMBER = "firstRequest";
+    private static final String NEXT_PAGE_FETCHER_MEMBER = "nextPageFetcher";
+    private static final String HAS_NEXT_PAGE_METHOD = "hasNextPage";
+    private static final String NEXT_PAGE_METHOD = "nextPage";
+    private static final String PREVIOUS_PAGE_METHOD_ARGUMENT = "previousPage";
+
+    private final IntermediateModel model;
+    private final PoetExtensions poetExtensions;
+    private final TypeProvider typeProvider;
+    private final String c2jOperationName;
+    private final PaginatorDefinition paginatorDefinition;
+    private final OperationModel operationModel;
+    private final PaginationDocs paginationDocs;
+
+    public PaginatorResponseClassSpec(IntermediateModel intermediateModel,
+                                      String c2jOperationName,
+                                      PaginatorDefinition paginatorDefinition) {
+        this.model = intermediateModel;
+        this.poetExtensions = new PoetExtensions(intermediateModel);
+        this.typeProvider = new TypeProvider(intermediateModel);
+        this.c2jOperationName = c2jOperationName;
+        this.paginatorDefinition = paginatorDefinition;
+        this.operationModel = model.getOperation(c2jOperationName);
+        this.paginationDocs = new PaginationDocs(intermediateModel, operationModel);
+    }
+
+    @Override
+    public TypeSpec poetSpec() {
+        TypeSpec.Builder specBuilder = TypeSpec.classBuilder(className())
+                                               .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                                               .addAnnotation(PoetUtils.GENERATED)
+                                               .addSuperinterface(getPaginatedResponseInterface())
+                                               .addFields(Stream.of(syncClientInterfaceField(),
+                                                                    requestClassField(),
+                                                                    nextPageSupplierField())
+                                                                .collect(Collectors.toList()))
+                                               .addMethod(constructor())
+                                               .addMethod(iteratorMethod())
+                                               .addMethods(getMethodSpecsForResultKeyList())
+                                               .addJavadoc(paginationDocs.getDocsForSyncResponseClass(
+                                                   getClientInterfaceName()))
+                                               .addType(nextPageFetcherClass());
+
+        return specBuilder.build();
+    }
+
+    @Override
+    public ClassName className() {
+        return poetExtensions.getResponseClassForPaginatedSyncOperation(c2jOperationName);
+    }
+
+    /**
+     * Returns the interface that is implemented by the Paginated Response class.
+     */
+    private TypeName getPaginatedResponseInterface() {
+        return ParameterizedTypeName.get(ClassName.get(SdkIterable.class), responseType());
+    }
+
+    /**
+     * @return A Poet {@link ClassName} for the sync operation request type.
+     *
+     * Example: For ListTables operation, it will be "ListTablesRequest" class.
+     */
+    private ClassName requestType() {
+        return poetExtensions.getModelClass(operationModel.getInput().getVariableType());
+    }
+
+    /**
+     * @return A Poet {@link ClassName} for the sync operation response type.
+     *
+     * Example: For ListTables operation, it will be "ListTablesResponse" class.
+     */
+    private ClassName responseType() {
+        return poetExtensions.getModelClass(operationModel.getReturnType().getReturnType());
+    }
+
+    /**
+     * @return A Poet {@link ClassName} for the sync client interface
+     */
+    private ClassName getClientInterfaceName() {
+        return poetExtensions.getClientClass(model.getMetadata().getSyncInterface());
+    }
+
+    private FieldSpec syncClientInterfaceField() {
+        return FieldSpec.builder(getClientInterfaceName(), CLIENT_MEMBER, Modifier.PRIVATE, Modifier.FINAL).build();
+    }
+
+    private FieldSpec requestClassField() {
+        return FieldSpec.builder(requestType(), REQUEST_MEMBER, Modifier.PRIVATE, Modifier.FINAL).build();
+    }
+
+    private FieldSpec nextPageSupplierField() {
+        return FieldSpec.builder(NextPageFetcher.class, NEXT_PAGE_FETCHER_MEMBER, Modifier.PRIVATE, Modifier.FINAL).build();
+    }
+
+    private String nextPageFetcherClassName() {
+        return operationModel.getReturnType().getReturnType() + "Fetcher";
+    }
+
+    private MethodSpec constructor() {
+        return MethodSpec.constructorBuilder()
+                         .addModifiers(Modifier.PUBLIC)
+                         .addParameter(getClientInterfaceName(), CLIENT_MEMBER, Modifier.FINAL)
+                         .addParameter(requestType(), REQUEST_MEMBER, Modifier.FINAL)
+                         .addStatement("this.$L = $L", CLIENT_MEMBER, CLIENT_MEMBER)
+                         .addStatement("this.$L = $L", REQUEST_MEMBER, REQUEST_MEMBER)
+                         .addStatement("this.$L = new $L()", NEXT_PAGE_FETCHER_MEMBER, nextPageFetcherClassName())
+                .build();
+    }
+
+    /**
+     * A {@link MethodSpec} for the overridden iterator() method which is inherited
+     * from the interface.
+     */
+    private MethodSpec iteratorMethod() {
+        return MethodSpec.methodBuilder("iterator")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Iterator.class), responseType()))
+                .addStatement("return new $T($L)", PaginatedResponsesIterator.class, NEXT_PAGE_FETCHER_MEMBER)
+                .build();
+    }
+
+    /**
+     * Returns iterable of {@link MethodSpec} to generate helper methods for all members
+     * in {@link PaginatorDefinition#getResultKey()}. All the generated methods return an SdkIterable.
+     *
+     * The helper methods to iterate on paginated member will be generated only
+     * if {@link PaginatorDefinition#getResultKey()} is not null and a non-empty list.
+     */
+    private Iterable<MethodSpec> getMethodSpecsForResultKeyList() {
+        if (paginatorDefinition.getResultKey() != null) {
+            return paginatorDefinition.getResultKey().stream()
+                                      .map(this::getMethodsSpecForSingleResultKey)
+                                      .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    /*
+     * Generate a method spec for single element in {@link PaginatorDefinition#getResultKey()} list.
+     *
+     * If the element is "Folders" and its type is "List<FolderMetadata>", generated code looks like:
+     *
+     *  public SdkIterable<FolderMetadata> folders() {
+     *      Function<DescribeFolderContentsResponse, Iterator<FolderMetadata>> getPaginatedMemberIterator =
+     *              response -> response != null ? response.folders().iterator() : null;
+     *
+     *      return new PaginatedItemsIterable(this, getPaginatedMemberIterator);
+     *  }
+     */
+    private MethodSpec getMethodsSpecForSingleResultKey(String resultKey) {
+        TypeName resultKeyType = getTypeForResultKey(resultKey);
+        MemberModel resultKeyModel = memberModelForResponseMember(resultKey);
+
+        return MethodSpec.methodBuilder(resultKeyModel.getFluentGetterMethodName())
+                         .addModifiers(Modifier.PUBLIC)
+                         .returns(ParameterizedTypeName.get(ClassName.get(SdkIterable.class), resultKeyType))
+                         .addCode("$T getIterator = ",
+                                  ParameterizedTypeName.get(ClassName.get(Function.class),
+                                                            responseType(),
+                                                            ParameterizedTypeName.get(ClassName.get(Iterator.class),
+                                                                                      resultKeyType)))
+                         .addCode(getPaginatedMemberIteratorLambdaBlock(resultKey, resultKeyModel))
+                         .addCode("\n")
+                         .addStatement("return new $T(this, getIterator)", PaginatedItemsIterable.class)
+                         .addJavadoc(CodeBlock.builder()
+                                              .add("Returns an iterable to iterate through the paginated {@link $T#$L()} member. "
+                                                   + "The returned iterable is used to iterate through the results across all "
+                                                   + "response pages and not a single page.\n",
+                                                   responseType(), resultKeyModel.getFluentGetterMethodName())
+                                              .add("\n")
+                                              .add("This method is useful if you are interested in iterating over the paginated "
+                                                   + "member in the response pages instead of the top level pages. "
+                                                   + "Similar to iteration over pages, this method internally makes service "
+                                                   + "calls to get the next list of results until the iteration stops or "
+                                                   + "there are no more results.")
+                                              .build())
+                         .build();
+    }
+
+    private CodeBlock getPaginatedMemberIteratorLambdaBlock(String resultKey, MemberModel resultKeyModel) {
+        final String response = "response";
+        final String fluentGetter = fluentGetterMethodForResponseMember(resultKey);
+
+        CodeBlock iteratorBlock = null;
+
+        if (resultKeyModel.isList()) {
+            iteratorBlock = CodeBlock.builder().add("$L.$L.iterator()", response, fluentGetter).build();
+
+        } else if (resultKeyModel.isMap()) {
+            iteratorBlock = CodeBlock.builder().add("$L.$L.entrySet().iterator()", response, fluentGetter).build();
+        }
+
+        return CodeBlock.builder()
+                        .addStatement("$L -> $L != null ? $L : null", response, response, iteratorBlock)
+                        .build();
+    }
+
+    /**
+     * Returns a list of fluent setter method names for members in {@link PaginatorDefinition#getInputToken()} list.
+     * The size of list returned by this method is equal to the size of {@link PaginatorDefinition#getInputToken()} list.
+     */
+    private List<String> fluentSetterMethodNamesForInputToken() {
+        return paginatorDefinition.getInputToken().stream()
+                                  .map(this::fluentSetterNameForSingleInputToken)
+                                  .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the fluent setter method name for a single member in the request.
+     *
+     * The values in {@link PaginatorDefinition#getInputToken()} are not nested unlike
+     * {@link PaginatorDefinition#getOutputToken()}.
+     */
+    private String fluentSetterNameForSingleInputToken(String inputToken) {
+        return operationModel.getInputShape()
+                .findMemberModelByC2jName(inputToken)
+                .getFluentSetterMethodName();
+    }
+
+    /**
+     * Returns a list of fluent getter methods for members in {@link PaginatorDefinition#getOutputToken()} list.
+     * The size of list returned by this method is equal to the size of {@link PaginatorDefinition#getOutputToken()} list.
+     */
+    private List<String> fluentGetterMethodsForOutputToken() {
+        return paginatorDefinition.getOutputToken().stream()
+                                  .map(this::fluentGetterMethodForResponseMember)
+                                  .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the fluent getter method for a single member in the response.
+     * The returned String includes the '()' after each method name.
+     *
+     * The input member can be a nested String. An example would be StreamDescription.LastEvaluatedShardId
+     * which represents LastEvaluatedShardId member in StreamDescription class. The return value for it
+     * would be "streamDescription().lastEvaluatedShardId()"
+     *
+     * @param member A top level or nested member in response of {@link #c2jOperationName}.
+     */
+    private String fluentGetterMethodForResponseMember(String member) {
+        final String[] hierarchy = member.split("\\.");
+
+        if (hierarchy.length < 1) {
+            throw new IllegalArgumentException(String.format("Error when splitting member %s for operation %s",
+                                                             member, c2jOperationName));
+        }
+
+        ShapeModel parentShape = operationModel.getOutputShape();
+        final StringBuilder getterMethod = new StringBuilder();
+
+        for (String str : hierarchy) {
+            getterMethod.append(".")
+                    .append(parentShape.findMemberModelByC2jName(str).getFluentGetterMethodName())
+                    .append("()");
+
+            parentShape =  parentShape.findMemberModelByC2jName(str).getShape();
+        }
+
+        return getterMethod.substring(1);
+    }
+
+    /**
+     * @param input A top level or nested member in response of {@link #c2jOperationName}.
+     *
+     * @return The {@link MemberModel} of the {@link PaginatorDefinition#getResultKey()}. If input value is nested,
+     * then member model of the last child shape is returned.
+     *
+     * For example, if input is StreamDescription.Shards, then the return value is "Shard" which is the member model for
+     * the Shards.
+     */
+    private MemberModel memberModelForResponseMember(String input) {
+        final String[] hierarchy = input.split("\\.");
+
+        if (hierarchy.length < 1) {
+            throw new IllegalArgumentException(String.format("Error when splitting value %s for operation %s",
+                                                             input, c2jOperationName));
+        }
+
+        ShapeModel shape = operationModel.getOutputShape();
+
+        for (int i = 0; i < hierarchy.length - 1; i++) {
+            shape = shape.findMemberModelByC2jName(hierarchy[i]).getShape();
+        }
+
+        return shape.getMemberByC2jName(hierarchy[hierarchy.length - 1]);
+    }
+
+    /*
+     * Returns the {@link TypeName} for a value in the {@link PaginatorDefinition#getResultKey()} list.
+     *
+     * Examples:
+     * If paginated item is represented as List<String>, then member type is String.
+     * If paginated item is represented as List<Foo>, then member type is Foo.
+     * If paginated item is represented as Map<String, List<Foo>>,
+     *              then member type is Map.Entry<String, List<Foo>>.
+     */
+    private TypeName getTypeForResultKey(String singleResultKey) {
+        MemberModel resultKeyModel = memberModelForResponseMember(singleResultKey);
+
+        if (resultKeyModel == null) {
+            throw new InvalidParameterException("MemberModel is not found for result key: " + singleResultKey);
+        }
+
+        if (resultKeyModel.isList()) {
+            return typeProvider.fieldType(resultKeyModel.getListModel().getListMemberModel());
+        } else if (resultKeyModel.isMap()) {
+            return typeProvider.mapEntryWithConcreteTypes(resultKeyModel.getMapModel());
+        } else {
+            throw new IllegalArgumentException(String.format("Key %s in paginated operation %s should be either a list or a map",
+                                                             singleResultKey, c2jOperationName));
+        }
+    }
+
+    /**
+     * Generates a inner class that implements {@link NextPageFetcher}. An instance of this class
+     * is passed to {@link PaginatedResponsesIterator} to be used while iterating through pages.
+     */
+    private TypeSpec nextPageFetcherClass() {
+        return TypeSpec.classBuilder(nextPageFetcherClassName())
+                       .addModifiers(Modifier.PRIVATE)
+                       .addSuperinterface(ParameterizedTypeName.get(ClassName.get(NextPageFetcher.class), responseType()))
+                       .addMethod(MethodSpec.methodBuilder(HAS_NEXT_PAGE_METHOD)
+                                            .addModifiers(Modifier.PUBLIC)
+                                            .addAnnotation(Override.class)
+                                            .addParameter(responseType(), PREVIOUS_PAGE_METHOD_ARGUMENT)
+                                            .returns(boolean.class)
+                                            .addStatement(hasNextPageMethodBody())
+                                            .build())
+                       .addMethod(MethodSpec.methodBuilder(NEXT_PAGE_METHOD)
+                                            .addModifiers(Modifier.PUBLIC)
+                                            .addAnnotation(Override.class)
+                                            .addParameter(responseType(), PREVIOUS_PAGE_METHOD_ARGUMENT)
+                                            .returns(responseType())
+                                            .addCode(nextPageMethodBody())
+                                            .build())
+                       .build();
+    }
+
+    private String hasNextPageMethodBody() {
+        String body;
+
+        if (paginatorDefinition.getMoreResults() != null) {
+            body = String.format("return %s.%s.booleanValue()",
+                                 PREVIOUS_PAGE_METHOD_ARGUMENT,
+                                 fluentGetterMethodForResponseMember(paginatorDefinition.getMoreResults()));
+        } else {
+            // If there is no more_results token, then output_token will be a single value
+            body = String.format("return %s.%s != null",
+                                 PREVIOUS_PAGE_METHOD_ARGUMENT,
+                                 fluentGetterMethodsForOutputToken().get(0));
+        }
+
+        return body;
+    }
+
+    /*
+     * Returns {@link CodeBlock} for the NEXT_PAGE_METHOD.
+     *
+     * A sample from dynamoDB listTables paginator:
+     *
+     *  if (oldPage == null) {
+     *      return client.listTables(firstRequest);
+     *  } else {
+     *      return client.listTables(firstRequest.toBuilder().exclusiveStartTableName(response.lastEvaluatedTableName())
+     *                               .build());
+     *  }
+     */
+    private CodeBlock nextPageMethodBody() {
+        return CodeBlock.builder()
+                        .beginControlFlow("if ($L == null)", PREVIOUS_PAGE_METHOD_ARGUMENT)
+                        .addStatement("return $L.$L($L)", CLIENT_MEMBER, operationModel.getMethodName(), REQUEST_MEMBER)
+                        .endControlFlow()
+                        .addStatement(codeToGetNextPageIfOldResponseIsNotNull())
+                        .build();
+    }
+
+    /**
+     * Generates the code to get next page by using values from old page.
+     *
+     * Sample generated code:
+     * return client.listTables(firstRequest.toBuilder().exclusiveStartTableName(response.lastEvaluatedTableName()).build());
+     */
+    private String codeToGetNextPageIfOldResponseIsNotNull() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(String.format("return %s.%s(%s.toBuilder()", CLIENT_MEMBER, operationModel.getMethodName(), REQUEST_MEMBER));
+
+        List<String> requestSetterNames = fluentSetterMethodNamesForInputToken();
+        List<String> responseGetterMethods = fluentGetterMethodsForOutputToken();
+
+        for (int i = 0; i < paginatorDefinition.getInputToken().size(); i++) {
+            sb.append(String.format(".%s(%s.%s)", requestSetterNames.get(i), PREVIOUS_PAGE_METHOD_ARGUMENT,
+                                    responseGetterMethods.get(i)));
+        }
+
+        sb.append(".build())");
+
+        return sb.toString();
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/utils/PaginatorUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/utils/PaginatorUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.utils;
+
+import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+
+public final class PaginatorUtils {
+
+    private PaginatorUtils() {
+    }
+
+    /**
+     * @param methodName Name of a method in sync client
+     * @return the name of the pagination enabled sync operation
+     */
+    @ReviewBeforeRelease("Naming of paginated APIs")
+    public static String getSyncMethodName(String methodName) {
+        return methodName + "Iterable";
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/model/service/PaginatorDefinitionTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/model/service/PaginatorDefinitionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class PaginatorDefinitionTest {
+
+    @Test
+    public void isValid_ReturnsFalse_WhenInputToken_IsNullOrEmpty() {
+        PaginatorDefinition paginatorDefinition = new PaginatorDefinition();
+
+        assertNull(paginatorDefinition.getInputToken());
+        assertFalse(paginatorDefinition.isValid());
+
+        paginatorDefinition.setInputToken(Collections.emptyList());
+        assertFalse(paginatorDefinition.isValid());
+    }
+
+    @Test
+    public void isValid_ReturnsFalse_WhenOutputToken_IsNullOrEmpty() {
+        PaginatorDefinition paginatorDefinition = new PaginatorDefinition();
+
+        assertNull(paginatorDefinition.getOutputToken());
+        assertFalse(paginatorDefinition.isValid());
+
+        paginatorDefinition.setOutputToken(Collections.emptyList());
+        assertFalse(paginatorDefinition.isValid());
+    }
+
+    @Test
+    public void isValid_ReturnsFalse_WhenInputTokenIsPresent_AndOutputTokenIsMissing() {
+        PaginatorDefinition paginatorDefinition = new PaginatorDefinition();
+        paginatorDefinition.setInputToken(Arrays.asList("input-token"));
+
+        assertFalse(paginatorDefinition.isValid());
+    }
+
+    @Test
+    public void isValid_ReturnsTrue_WhenBothInputTokenAndOutputToken_ArePresent() {
+        PaginatorDefinition paginatorDefinition = new PaginatorDefinition();
+        paginatorDefinition.setInputToken(Arrays.asList("input-token"));
+        paginatorDefinition.setOutputToken(Arrays.asList("token1", "token2"));
+
+        assertTrue(paginatorDefinition.isValid());
+    }
+
+    @Test
+    public void isValid_ReturnsTrue_WhenResultKey_IsNull() {
+        PaginatorDefinition paginatorDefinition = new PaginatorDefinition();
+        paginatorDefinition.setInputToken(Arrays.asList("input-token"));
+        paginatorDefinition.setOutputToken(Arrays.asList("token1", "token2"));
+
+        assertNull(paginatorDefinition.getResultKey());
+        assertTrue(paginatorDefinition.isValid());
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.codegen.C2jModels;
 import software.amazon.awssdk.codegen.IntermediateModelBuilder;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.service.Paginators;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Waiters;
 import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
@@ -35,9 +36,11 @@ public class ClientTestModels {
     public static IntermediateModel jsonServiceModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/json/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/json/customization.config").getFile());
+        File paginatorsModel = new File(ClientTestModels.class.getResource("client/c2j/json/paginators.json").getFile());
         C2jModels models = C2jModels.builder()
                                     .serviceModel(getServiceModel(serviceModel))
                                     .customizationConfig(getCustomizationConfig(customizationModel))
+                                    .paginatorsModel(getPaginatorsModel(paginatorsModel))
                                     .build();
 
         try {
@@ -76,5 +79,9 @@ public class ClientTestModels {
 
     private static Waiters getWaiters(File file) {
         return ModelLoaderUtils.loadModel(Waiters.class, file);
+    }
+
+    private static Paginators getPaginatorsModel(File file) {
+        return ModelLoaderUtils.loadModel(Paginators.class, file);
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/AwsModelSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/AwsModelSpecTest.java
@@ -22,10 +22,8 @@ import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Locale;
-import java.util.concurrent.Executors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorResponseClassSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorResponseClassSpecTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.paginators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.codegen.C2jModels;
+import software.amazon.awssdk.codegen.IntermediateModelBuilder;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.service.Paginators;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
+
+public class PaginatorResponseClassSpecTest {
+
+    private static IntermediateModel intermediateModel;
+    private static Paginators paginators;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        File serviceModelFile = new File(PaginatorResponseClassSpecTest.class.getResource("service-2.json").getFile());
+        File customizationConfigFile = new File(PaginatorResponseClassSpecTest.class.getResource("customization.config")
+                                                                                    .getFile());
+        File paginatorsModel = new File(PaginatorResponseClassSpecTest.class.getResource("paginators.json")
+                                                                            .getFile());
+
+        paginators = getPaginatorsModel(paginatorsModel);
+
+        intermediateModel = new IntermediateModelBuilder(
+            C2jModels.builder()
+                     .serviceModel(ModelLoaderUtils.loadModel(ServiceModel.class, serviceModelFile))
+                     .customizationConfig(ModelLoaderUtils.loadModel(CustomizationConfig.class, customizationConfigFile))
+                     .paginatorsModel(paginators)
+                     .build())
+            .build();
+    }
+
+    private static Paginators getPaginatorsModel(File file) {
+        return ModelLoaderUtils.loadModel(Paginators.class, file);
+    }
+
+    @Test
+    public void testGeneratedResponseClassesForPaginatedOperations() {
+        paginators.getPaginators().entrySet()
+                  .stream()
+                  .filter(entry -> entry.getValue().isValid())
+                  .forEach(entry ->
+                           {
+                               ClassSpec classSpec = new PaginatorResponseClassSpec(intermediateModel,
+                                                                                    entry.getKey(),
+                                                                                    entry.getValue());
+                               assertThat(classSpec, generatesTo(classSpec.className().simpleName() + ".java"));
+                           });
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/paginators.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/paginators.json
@@ -1,0 +1,15 @@
+{
+  "pagination": {
+    "PaginatedOperationWithResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Items"
+    },
+    "PaginatedOperationWithoutResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
@@ -85,6 +85,36 @@
         "shape": "StructureWithStreamingMember"
       },
       "documentation": "Some operation with a streaming output"
+    },
+    "PaginatedOperationWithResultKey": {
+      "name": "PaginatedOperationWithResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithResultKeyResponse",
+        "resultWrapper": "PaginatedOperationWithResultKeyResult"
+      },
+      "documentation": "Some paginated operation with result_key in paginators.json file"
+    },
+    "PaginatedOperationWithoutResultKey": {
+      "name": "PaginatedOperationWithoutResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithoutResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithoutResultKeyResponse",
+        "resultWrapper": "PaginatedOperationWithoutResultKeyResult"
+      },
+      "documentation": "Some paginated operation without result_key in paginators.json file"
     }
   },
   "shapes": {
@@ -204,6 +234,66 @@
         }
       },
       "payload": "StreamingMember"
+    },
+    "PaginatedOperationWithResultKeyRequest": {
+      "type": "structure",
+      "required": [
+        "NextToken"
+      ],
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "subMember",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "Items": {
+          "shape": "ItemsList",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
+    },
+    "ItemsList":{
+      "type":"list",
+      "member":{"shape":"subMember"}
+    },
+    "PaginatedOperationWithoutResultKeyRequest": {
+      "type": "structure",
+      "required": [
+        "NextToken"
+      ],
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "subMember",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithoutResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
     }
   },
   "documentation": "A service that is implemented using the query protocol"

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -23,6 +23,10 @@ import software.amazon.awssdk.services.json.model.APostOperationWithOutputRespon
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
@@ -33,6 +37,10 @@ import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRe
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersResponseUnmarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyResponseUnmarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingInputOperationResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingOutputOperationRequestMarshaller;
@@ -82,14 +90,14 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     public CompletableFuture<APostOperationResponse> aPostOperation(APostOperationRequest aPostOperationRequest) {
 
         HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new APostOperationResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new APostOperationResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
-                                             .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
-                                             .withErrorResponseHandler(errorResponseHandler).withInput(aPostOperationRequest));
+                                         .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
+                                         .withErrorResponseHandler(errorResponseHandler).withInput(aPostOperationRequest));
     }
 
     /**
@@ -117,19 +125,19 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<APostOperationWithOutputResponse> aPostOperationWithOutput(
-            APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
 
         HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new APostOperationWithOutputResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new APostOperationWithOutputResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
-                .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
-                                 .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(aPostOperationWithOutputRequest));
+            .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                         .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(aPostOperationWithOutputRequest));
     }
 
     /**
@@ -157,19 +165,93 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<GetWithoutRequiredMembersResponse> getWithoutRequiredMembers(
-            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
+        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
 
         HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new GetWithoutRequiredMembersResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new GetWithoutRequiredMembersResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
-                .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
-                                 .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(getWithoutRequiredMembersRequest));
+            .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                         .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(getWithoutRequiredMembersRequest));
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return A Java Future containing the result of the PaginatedOperationWithResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkBaseException Base class for all exceptions that can be thrown by the SDK (both service and
+     *         client). Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+
+        HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new PaginatedOperationWithResultKeyResponseUnmarshaller());
+
+        HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
+
+        return clientHandler
+            .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                         .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(paginatedOperationWithResultKeyRequest));
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return A Java Future containing the result of the PaginatedOperationWithoutResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkBaseException Base class for all exceptions that can be thrown by the SDK (both service and
+     *         client). Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+
+        HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new PaginatedOperationWithoutResultKeyResponseUnmarshaller());
+
+        HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
+
+        return clientHandler
+            .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                         .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(paginatedOperationWithoutResultKeyRequest));
     }
 
     /**
@@ -199,18 +281,18 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<StreamingInputOperationResponse> streamingInputOperation(
-            StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestProvider requestProvider) {
+        StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestProvider requestProvider) {
 
         HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new StreamingInputOperationResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new StreamingInputOperationResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
-                                             .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
-                                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                             .withAsyncRequestProvider(requestProvider).withInput(streamingInputOperationRequest));
+                                         .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                                         .withAsyncRequestProvider(requestProvider).withInput(streamingInputOperationRequest));
     }
 
     /**
@@ -239,20 +321,20 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public <ReturnT> CompletableFuture<ReturnT> streamingOutputOperation(
-            StreamingOutputOperationRequest streamingOutputOperationRequest,
-            AsyncResponseHandler<StreamingOutputOperationResponse, ReturnT> asyncResponseHandler) {
+        StreamingOutputOperationRequest streamingOutputOperationRequest,
+        AsyncResponseHandler<StreamingOutputOperationResponse, ReturnT> asyncResponseHandler) {
 
         HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
-                new StreamingOutputOperationResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
+            new StreamingOutputOperationResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(
-                new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
-                        .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
-                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                        .withInput(streamingOutputOperationRequest), asyncResponseHandler);
+            new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
+                .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                .withInput(streamingOutputOperationRequest), asyncResponseHandler);
     }
 
     @Override
@@ -262,13 +344,13 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private software.amazon.awssdk.core.protocol.json.SdkJsonProtocolFactory init() {
         return new SdkJsonProtocolFactory(new JsonClientMetadata()
-                                                  .withProtocolVersion("1.1")
-                                                  .withSupportsCbor(false)
-                                                  .withSupportsIon(false)
-                                                  .withBaseServiceExceptionClass(software.amazon.awssdk.services.json.model.JsonException.class)
-                                                  .withContentTypeOverride("")
-                                                  .addErrorMetadata(
-                                                          new JsonErrorShapeMetadata().withErrorCode("InvalidInput").withModeledClass(InvalidInputException.class)));
+                                              .withProtocolVersion("1.1")
+                                              .withSupportsCbor(false)
+                                              .withSupportsIon(false)
+                                              .withBaseServiceExceptionClass(software.amazon.awssdk.services.json.model.JsonException.class)
+                                              .withContentTypeOverride("")
+                                              .addErrorMetadata(
+                                                  new JsonErrorShapeMetadata().withErrorCode("InvalidInput").withModeledClass(InvalidInputException.class)));
     }
 
     private HttpResponseHandler<AmazonServiceException> createErrorResponseHandler() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -12,6 +12,10 @@ import software.amazon.awssdk.services.json.model.APostOperationWithOutputReques
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputResponse;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
@@ -245,6 +249,114 @@ public interface JsonAsyncClient extends SdkAutoCloseable {
         Consumer<GetWithoutRequiredMembersRequest.Builder> getWithoutRequiredMembersRequest) {
         return getWithoutRequiredMembers(GetWithoutRequiredMembersRequest.builder().apply(getWithoutRequiredMembersRequest)
                                                                          .build());
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return A Java Future containing the result of the PaginatedOperationWithResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkBaseException Base class for all exceptions that can be thrown by the SDK (both service and
+     *         client). Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file<br/>
+     * This is a convenience which creates an instance of the {@link PaginatedOperationWithResultKeyRequest.Builder}
+     * avoiding the need to create one manually via {@link PaginatedOperationWithResultKeyRequest#builder()}
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     *        a {@link Consumer} that will call methods on {@link PaginatedOperationWithResultKeyRequest.Builder}.
+     * @return A Java Future containing the result of the PaginatedOperationWithResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkBaseException Base class for all exceptions that can be thrown by the SDK (both service and
+     *         client). Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
+        Consumer<PaginatedOperationWithResultKeyRequest.Builder> paginatedOperationWithResultKeyRequest) {
+        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder()
+                                                                                     .apply(paginatedOperationWithResultKeyRequest).build());
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return A Java Future containing the result of the PaginatedOperationWithoutResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkBaseException Base class for all exceptions that can be thrown by the SDK (both service and
+     *         client). Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file<br/>
+     * This is a convenience which creates an instance of the {@link PaginatedOperationWithoutResultKeyRequest.Builder}
+     * avoiding the need to create one manually via {@link PaginatedOperationWithoutResultKeyRequest#builder()}
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     *        a {@link Consumer} that will call methods on {@link PaginatedOperationWithoutResultKeyRequest.Builder}.
+     * @return A Java Future containing the result of the PaginatedOperationWithoutResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkBaseException Base class for all exceptions that can be thrown by the SDK (both service and
+     *         client). Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
+        Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest) {
+        return paginatedOperationWithoutResultKey(PaginatedOperationWithoutResultKeyRequest.builder()
+                                                                                           .apply(paginatedOperationWithoutResultKeyRequest).build());
     }
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -30,16 +30,26 @@ import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersReque
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator;
 import software.amazon.awssdk.services.json.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.APostOperationResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersResponseUnmarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyResponseUnmarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingInputOperationResponseUnmarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingOutputOperationRequestMarshaller;
@@ -90,14 +100,14 @@ final class DefaultJsonClient implements JsonClient {
                                                                                                      SdkBaseException, SdkClientException, JsonException {
 
         HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new APostOperationResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new APostOperationResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
-                                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                             .withInput(aPostOperationRequest).withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
+                                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                                         .withInput(aPostOperationRequest).withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -122,20 +132,20 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public APostOperationWithOutputResponse aPostOperationWithOutput(
-            APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkBaseException,
-                                                                                    SdkClientException, JsonException {
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkBaseException,
+                                                                                SdkClientException, JsonException {
 
         HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new APostOperationWithOutputResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new APostOperationWithOutputResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
-                .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(aPostOperationWithOutputRequest)
-                                 .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
+            .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(aPostOperationWithOutputRequest)
+                         .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -160,20 +170,236 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, SdkBaseException,
-                                                                                      SdkClientException, JsonException {
+        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, SdkBaseException,
+                                                                                  SdkClientException, JsonException {
 
         HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new GetWithoutRequiredMembersResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new GetWithoutRequiredMembersResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
-                .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(getWithoutRequiredMembersRequest)
-                                 .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory)));
+            .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(getWithoutRequiredMembersRequest)
+                         .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory)));
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkBaseException,
+                                                                                              SdkClientException, JsonException {
+
+        HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new PaginatedOperationWithResultKeyResponseUnmarshaller());
+
+        HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
+
+        return clientHandler
+            .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(paginatedOperationWithResultKeyRequest)
+                         .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory)));
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator responses = client.paginatedOperationWithResultKeyIterable(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator responses = client
+     *             .paginatedOperationWithResultKeyIterable(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator responses = client.paginatedOperationWithResultKeyIterable(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithResultKeyPaginator paginatedOperationWithResultKeyIterable(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkBaseException,
+                                                                                              SdkClientException, JsonException {
+        return new PaginatedOperationWithResultKeyPaginator(this, paginatedOperationWithResultKeyRequest);
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return Result of the PaginatedOperationWithoutResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkBaseException,
+                                                                                                    SdkClientException, JsonException {
+
+        HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new PaginatedOperationWithoutResultKeyResponseUnmarshaller());
+
+        HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
+
+        return clientHandler
+            .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                         .withInput(paginatedOperationWithoutResultKeyRequest)
+                         .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory)));
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client.paginatedOperationWithoutResultKeyIterable(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client
+     *             .paginatedOperationWithoutResultKeyIterable(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client.paginatedOperationWithoutResultKeyIterable(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return Result of the PaginatedOperationWithoutResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public PaginatedOperationWithoutResultKeyPaginator paginatedOperationWithoutResultKeyIterable(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkBaseException,
+                                                                                                    SdkClientException, JsonException {
+        return new PaginatedOperationWithoutResultKeyPaginator(this, paginatedOperationWithoutResultKeyRequest);
     }
 
     /**
@@ -208,18 +434,18 @@ final class DefaultJsonClient implements JsonClient {
                                                                    RequestBody requestBody) throws SdkBaseException, SdkClientException, JsonException {
 
         HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new StreamingInputOperationResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+            new StreamingInputOperationResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
-                                             .withResponseHandler(responseHandler)
-                                             .withErrorResponseHandler(errorResponseHandler)
-                                             .withInput(streamingInputOperationRequest)
-                                             .withMarshaller(
-                                                     new StreamingRequestMarshaller<StreamingInputOperationRequest>(
-                                                             new StreamingInputOperationRequestMarshaller(protocolFactory), requestBody)));
+                                         .withResponseHandler(responseHandler)
+                                         .withErrorResponseHandler(errorResponseHandler)
+                                         .withInput(streamingInputOperationRequest)
+                                         .withMarshaller(
+                                             new StreamingRequestMarshaller<StreamingInputOperationRequest>(
+                                                 new StreamingInputOperationRequestMarshaller(protocolFactory), requestBody)));
     }
 
     /**
@@ -230,9 +456,9 @@ final class DefaultJsonClient implements JsonClient {
      *        Functional interface for processing the streamed response content. The unmarshalled
      *        StreamingInputOperationRequest and an InputStream to the response content are provided as parameters to
      *        the callback. The callback may return a transformed type which will be the return value of this method.
-     *        See {@link software.amazon.awssdk.core.sync.StreamingResponseHandler} for details on implementing
-     *        this interface and for links to pre-canned implementations for common scenarios like downloading to a
-     *        file. The service documentation for the response content is as follows 'This be a stream'.
+     *        See {@link software.amazon.awssdk.core.sync.StreamingResponseHandler} for details on implementing this
+     *        interface and for links to pre-canned implementations for common scenarios like downloading to a file. The
+     *        service documentation for the response content is as follows 'This be a stream'.
      * @return The transformed result of the StreamingResponseHandler.
      * @throws SdkBaseException
      *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
@@ -248,21 +474,21 @@ final class DefaultJsonClient implements JsonClient {
     @Override
     public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
                                                       StreamingResponseHandler<StreamingOutputOperationResponse, ReturnT> streamingResponseHandler)
-            throws SdkBaseException, SdkClientException, JsonException {
+        throws SdkBaseException, SdkClientException, JsonException {
 
         HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
-                new StreamingOutputOperationResponseUnmarshaller());
+            new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
+            new StreamingOutputOperationResponseUnmarshaller());
 
         HttpResponseHandler<AmazonServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
-                .execute(
-                        new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
-                                .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                .withInput(streamingOutputOperationRequest)
-                                .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)),
-                        streamingResponseHandler);
+            .execute(
+                new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withInput(streamingOutputOperationRequest)
+                    .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)),
+                streamingResponseHandler);
     }
 
     private HttpResponseHandler<AmazonServiceException> createErrorResponseHandler() {
@@ -271,13 +497,13 @@ final class DefaultJsonClient implements JsonClient {
 
     private software.amazon.awssdk.core.protocol.json.SdkJsonProtocolFactory init() {
         return new SdkJsonProtocolFactory(new JsonClientMetadata()
-                                                  .withProtocolVersion("1.1")
-                                                  .withSupportsCbor(false)
-                                                  .withSupportsIon(false)
-                                                  .withBaseServiceExceptionClass(software.amazon.awssdk.services.json.model.JsonException.class)
-                                                  .withContentTypeOverride("")
-                                                  .addErrorMetadata(
-                                                          new JsonErrorShapeMetadata().withErrorCode("InvalidInput").withModeledClass(InvalidInputException.class)));
+                                              .withProtocolVersion("1.1")
+                                              .withSupportsCbor(false)
+                                              .withSupportsIon(false)
+                                              .withBaseServiceExceptionClass(software.amazon.awssdk.services.json.model.JsonException.class)
+                                              .withContentTypeOverride("")
+                                              .addErrorMetadata(
+                                                  new JsonErrorShapeMetadata().withErrorCode("InvalidInput").withModeledClass(InvalidInputException.class)));
     }
 
     public AcmClientPresigners presigners() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -18,10 +18,16 @@ import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersReque
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InvalidInputException;
 import software.amazon.awssdk.services.json.model.JsonException;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
@@ -35,8 +41,8 @@ public interface JsonClient extends SdkAutoCloseable {
 
     /**
      * Create a {@link JsonClient} with the region loaded from the
-     * {@link software.amazon.awssdk.core.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from the
-     * {@link software.amazon.awssdk.core.auth.DefaultCredentialsProvider}.
+     * {@link software.amazon.awssdk.core.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from
+     * the {@link software.amazon.awssdk.core.auth.DefaultCredentialsProvider}.
      */
     static JsonClient create() {
         return builder().build();
@@ -120,8 +126,8 @@ public interface JsonClient extends SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default APostOperationWithOutputResponse aPostOperationWithOutput(
-            APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkBaseException,
-                                                                                    SdkClientException, JsonException {
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkBaseException,
+                                                                                SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -197,8 +203,8 @@ public interface JsonClient extends SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, SdkBaseException,
-                                                                                      SdkClientException, JsonException {
+        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, SdkBaseException,
+                                                                                  SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -230,6 +236,242 @@ public interface JsonClient extends SdkAutoCloseable {
     }
 
     /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkBaseException,
+                                                                                              SdkClientException, JsonException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
+        Consumer<PaginatedOperationWithResultKeyRequest.Builder> paginatedOperationWithResultKeyRequest)
+        throws SdkBaseException, SdkClientException, JsonException {
+        return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder()
+                                                                                     .apply(paginatedOperationWithResultKeyRequest).build());
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator responses = client.paginatedOperationWithResultKeyIterable(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator responses = client
+     *             .paginatedOperationWithResultKeyIterable(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPaginator responses = client.paginatedOperationWithResultKeyIterable(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return Result of the PaginatedOperationWithResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithResultKeyPaginator paginatedOperationWithResultKeyIterable(
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkBaseException,
+                                                                                              SdkClientException, JsonException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return Result of the PaginatedOperationWithoutResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkBaseException,
+                                                                                                    SdkClientException, JsonException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return Result of the PaginatedOperationWithoutResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
+        Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
+        throws SdkBaseException, SdkClientException, JsonException {
+        return paginatedOperationWithoutResultKey(PaginatedOperationWithoutResultKeyRequest.builder()
+                                                                                           .apply(paginatedOperationWithoutResultKeyRequest).build());
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
+     * internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When this operation is called, a custom iterable is returned but no service calls are made yet. So there is no
+     * guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily loading response
+     * pages by making service calls until there are no pages left or your iteration stops. If there are errors in your
+     * request, you will see the failures only after you start iterating through the iterable.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to iterate through the response pages:
+     * </p>
+     * 1) Using a Stream
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client.paginatedOperationWithoutResultKeyIterable(request);
+     * responses.stream().forEach(....);
+     * }
+     * </pre>
+     *
+     * 2) Using For loop
+     *
+     * <pre>
+     * {
+     *     &#064;code
+     *     software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client
+     *             .paginatedOperationWithoutResultKeyIterable(request);
+     *     for (software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
+     *         // do something;
+     *     }
+     * }
+     * </pre>
+     *
+     * 3) Use iterator directly
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client.paginatedOperationWithoutResultKeyIterable(request);
+     * responses.iterator().forEachRemaining(....);
+     * }
+     * </pre>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return Result of the PaginatedOperationWithoutResultKey operation returned by the service.
+     * @throws SdkBaseException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws JsonException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample JsonClient.PaginatedOperationWithoutResultKey
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default PaginatedOperationWithoutResultKeyPaginator paginatedOperationWithoutResultKeyIterable(
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkBaseException,
+                                                                                                    SdkClientException, JsonException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Some operation with a streaming input
      *
      * @param streamingInputOperationRequest
@@ -257,8 +499,8 @@ public interface JsonClient extends SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-            StreamingInputOperationRequest streamingInputOperationRequest, RequestBody requestBody) throws SdkBaseException,
-                                                                                                           SdkClientException, JsonException {
+        StreamingInputOperationRequest streamingInputOperationRequest, RequestBody requestBody) throws SdkBaseException,
+                                                                                                       SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -285,8 +527,8 @@ public interface JsonClient extends SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-            StreamingInputOperationRequest streamingInputOperationRequest, Path filePath) throws SdkBaseException,
-                                                                                                 SdkClientException, JsonException {
+        StreamingInputOperationRequest streamingInputOperationRequest, Path filePath) throws SdkBaseException,
+                                                                                             SdkClientException, JsonException {
         return streamingInputOperation(streamingInputOperationRequest, RequestBody.of(filePath));
     }
 
@@ -298,9 +540,9 @@ public interface JsonClient extends SdkAutoCloseable {
      *        Functional interface for processing the streamed response content. The unmarshalled
      *        StreamingInputOperationRequest and an InputStream to the response content are provided as parameters to
      *        the callback. The callback may return a transformed type which will be the return value of this method.
-     *        See {@link software.amazon.awssdk.core.sync.StreamingResponseHandler} for details on implementing
-     *        this interface and for links to pre-canned implementations for common scenarios like downloading to a
-     *        file. The service documentation for the response content is as follows 'This be a stream'.
+     *        See {@link software.amazon.awssdk.core.sync.StreamingResponseHandler} for details on implementing this
+     *        interface and for links to pre-canned implementations for common scenarios like downloading to a file. The
+     *        service documentation for the response content is as follows 'This be a stream'.
      * @return The transformed result of the StreamingResponseHandler.
      * @throws SdkBaseException
      *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
@@ -315,7 +557,7 @@ public interface JsonClient extends SdkAutoCloseable {
      */
     default <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
                                                        StreamingResponseHandler<StreamingOutputOperationResponse, ReturnT> streamingResponseHandler)
-            throws SdkBaseException, SdkClientException, JsonException {
+        throws SdkBaseException, SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -341,8 +583,8 @@ public interface JsonClient extends SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingOutputOperationResponse streamingOutputOperation(
-            StreamingOutputOperationRequest streamingOutputOperationRequest, Path filePath) throws SdkBaseException,
-                                                                                                   SdkClientException, JsonException {
+        StreamingOutputOperationRequest streamingOutputOperationRequest, Path filePath) throws SdkBaseException,
+                                                                                               SdkClientException, JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, StreamingResponseHandler.toFile(filePath));
     }
 
@@ -369,8 +611,8 @@ public interface JsonClient extends SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-            StreamingOutputOperationRequest streamingOutputOperationRequest) throws SdkBaseException, SdkClientException,
-                                                                                    JsonException {
+        StreamingOutputOperationRequest streamingOutputOperationRequest) throws SdkBaseException, SdkClientException,
+                                                                                JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, StreamingResponseHandler.toInputStream());
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPaginator.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPaginator.java
@@ -1,0 +1,120 @@
+package software.amazon.awssdk.services.jsonprotocoltests.paginators;
+
+import java.util.Iterator;
+import java.util.function.Function;
+import javax.annotation.Generated;
+import software.amazon.awssdk.core.pagination.NextPageFetcher;
+import software.amazon.awssdk.core.pagination.PaginatedItemsIterable;
+import software.amazon.awssdk.core.pagination.PaginatedResponsesIterator;
+import software.amazon.awssdk.core.pagination.SdkIterable;
+import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient;
+import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.jsonprotocoltests.model.SimpleStruct;
+
+/**
+ * <p>
+ * Represents the output for the
+ * {@link software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient#paginatedOperationWithResultKeyIterable(software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest)}
+ * operation which is a paginated operation. This class is an iterable of
+ * {@link software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse} that can be
+ * used to iterate through all the response pages of the operation.
+ * </p>
+ * <p>
+ * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet and
+ * so there is no guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily
+ * loading response pages by making service calls until there are no pages left or your iteration stops. If there are
+ * errors in your request, you will see the failures only after you start iterating through the iterable.
+ * </p>
+ *
+ * <p>
+ * The following are few ways to iterate through the response pages:
+ * </p>
+ * 1) Using a Stream
+ *
+ * <pre>
+ * {@code
+ * software.amazon.awssdk.services.jsonprotocoltests.paginators.PaginatedOperationWithResultKeyPaginator responses = client.paginatedOperationWithResultKeyIterable(request);
+ * responses.stream().forEach(....);
+ * }
+ * </pre>
+ *
+ * 2) Using For loop
+ *
+ * <pre>
+ * {
+ *     &#064;code
+ *     software.amazon.awssdk.services.jsonprotocoltests.paginators.PaginatedOperationWithResultKeyPaginator responses = client
+ *             .paginatedOperationWithResultKeyIterable(request);
+ *     for (software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse response : responses) {
+ *         // do something;
+ *     }
+ * }
+ * </pre>
+ *
+ * 3) Use iterator directly
+ *
+ * <pre>
+ * {@code
+ * software.amazon.awssdk.services.jsonprotocoltests.paginators.PaginatedOperationWithResultKeyPaginator responses = client.paginatedOperationWithResultKeyIterable(request);
+ * responses.iterator().forEachRemaining(....);
+ * }
+ * </pre>
+ * <p>
+ * <b>Note: If you prefer to have control on service calls, use the
+ * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest)}
+ * operation.</b>
+ * </p>
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class PaginatedOperationWithResultKeyPaginator implements SdkIterable<PaginatedOperationWithResultKeyResponse> {
+    private final JsonProtocolTestsClient client;
+
+    private final PaginatedOperationWithResultKeyRequest firstRequest;
+
+    private final NextPageFetcher nextPageFetcher;
+
+    public PaginatedOperationWithResultKeyPaginator(final JsonProtocolTestsClient client,
+                                                    final PaginatedOperationWithResultKeyRequest firstRequest) {
+        this.client = client;
+        this.firstRequest = firstRequest;
+        this.nextPageFetcher = new PaginatedOperationWithResultKeyResponseFetcher();
+    }
+
+    @Override
+    public Iterator<PaginatedOperationWithResultKeyResponse> iterator() {
+        return new PaginatedResponsesIterator(nextPageFetcher);
+    }
+
+    /**
+     * Returns an iterable to iterate through the paginated {@link PaginatedOperationWithResultKeyResponse#items()}
+     * member. The returned iterable is used to iterate through the results across all response pages and not a single
+     * page.
+     *
+     * This method is useful if you are interested in iterating over the paginated member in the response pages instead
+     * of the top level pages. Similar to iteration over pages, this method internally makes service calls to get the
+     * next list of results until the iteration stops or there are no more results.
+     */
+    public SdkIterable<SimpleStruct> items() {
+        Function<PaginatedOperationWithResultKeyResponse, Iterator<SimpleStruct>> getIterator = response -> response != null ? response
+            .items().iterator() : null;
+
+        return new PaginatedItemsIterable(this, getIterator);
+    }
+
+    private class PaginatedOperationWithResultKeyResponseFetcher implements
+                                                                 NextPageFetcher<PaginatedOperationWithResultKeyResponse> {
+        @Override
+        public boolean hasNextPage(PaginatedOperationWithResultKeyResponse previousPage) {
+            return previousPage.nextToken() != null;
+        }
+
+        @Override
+        public PaginatedOperationWithResultKeyResponse nextPage(PaginatedOperationWithResultKeyResponse previousPage) {
+            if (previousPage == null) {
+                return client.paginatedOperationWithResultKey(firstRequest);
+            }
+            return client.paginatedOperationWithResultKey(firstRequest.toBuilder().nextToken(previousPage.nextToken()).build());
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPaginator.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPaginator.java
@@ -1,0 +1,102 @@
+package software.amazon.awssdk.services.jsonprotocoltests.paginators;
+
+import java.util.Iterator;
+import javax.annotation.Generated;
+import software.amazon.awssdk.core.pagination.NextPageFetcher;
+import software.amazon.awssdk.core.pagination.PaginatedResponsesIterator;
+import software.amazon.awssdk.core.pagination.SdkIterable;
+import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient;
+import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest;
+import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse;
+
+/**
+ * <p>
+ * Represents the output for the
+ * {@link software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient#paginatedOperationWithoutResultKeyIterable(software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest)}
+ * operation which is a paginated operation. This class is an iterable of
+ * {@link software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse} that can
+ * be used to iterate through all the response pages of the operation.
+ * </p>
+ * <p>
+ * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet and
+ * so there is no guarantee that the request is valid. As you iterate through the iterable, SDK will start lazily
+ * loading response pages by making service calls until there are no pages left or your iteration stops. If there are
+ * errors in your request, you will see the failures only after you start iterating through the iterable.
+ * </p>
+ *
+ * <p>
+ * The following are few ways to iterate through the response pages:
+ * </p>
+ * 1) Using a Stream
+ *
+ * <pre>
+ * {@code
+ * software.amazon.awssdk.services.jsonprotocoltests.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client.paginatedOperationWithoutResultKeyIterable(request);
+ * responses.stream().forEach(....);
+ * }
+ * </pre>
+ *
+ * 2) Using For loop
+ *
+ * <pre>
+ * {
+ *     &#064;code
+ *     software.amazon.awssdk.services.jsonprotocoltests.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client
+ *             .paginatedOperationWithoutResultKeyIterable(request);
+ *     for (software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse response : responses) {
+ *         // do something;
+ *     }
+ * }
+ * </pre>
+ *
+ * 3) Use iterator directly
+ *
+ * <pre>
+ * {@code
+ * software.amazon.awssdk.services.jsonprotocoltests.paginators.PaginatedOperationWithoutResultKeyPaginator responses = client.paginatedOperationWithoutResultKeyIterable(request);
+ * responses.iterator().forEachRemaining(....);
+ * }
+ * </pre>
+ * <p>
+ * <b>Note: If you prefer to have control on service calls, use the
+ * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest)}
+ * operation.</b>
+ * </p>
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class PaginatedOperationWithoutResultKeyPaginator implements SdkIterable<PaginatedOperationWithoutResultKeyResponse> {
+    private final JsonProtocolTestsClient client;
+
+    private final PaginatedOperationWithoutResultKeyRequest firstRequest;
+
+    private final NextPageFetcher nextPageFetcher;
+
+    public PaginatedOperationWithoutResultKeyPaginator(final JsonProtocolTestsClient client,
+                                                       final PaginatedOperationWithoutResultKeyRequest firstRequest) {
+        this.client = client;
+        this.firstRequest = firstRequest;
+        this.nextPageFetcher = new PaginatedOperationWithoutResultKeyResponseFetcher();
+    }
+
+    @Override
+    public Iterator<PaginatedOperationWithoutResultKeyResponse> iterator() {
+        return new PaginatedResponsesIterator(nextPageFetcher);
+    }
+
+    private class PaginatedOperationWithoutResultKeyResponseFetcher implements
+                                                                    NextPageFetcher<PaginatedOperationWithoutResultKeyResponse> {
+        @Override
+        public boolean hasNextPage(PaginatedOperationWithoutResultKeyResponse previousPage) {
+            return previousPage.nextToken() != null;
+        }
+
+        @Override
+        public PaginatedOperationWithoutResultKeyResponse nextPage(PaginatedOperationWithoutResultKeyResponse previousPage) {
+            if (previousPage == null) {
+                return client.paginatedOperationWithoutResultKey(firstRequest);
+            }
+            return client
+                .paginatedOperationWithoutResultKey(firstRequest.toBuilder().nextToken(previousPage.nextToken()).build());
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/customization.config
@@ -1,0 +1,7 @@
+{
+    "blacklistedSimpleMethods" : [
+        "allTypes",
+        "nestedContainers",
+        "operationWithNoInputOrOutput"
+    ]
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/paginators.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/paginators.json
@@ -1,0 +1,15 @@
+{
+  "pagination": {
+    "PaginatedOperationWithResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Items"
+    },
+    "PaginatedOperationWithoutResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/service-2.json
@@ -1,0 +1,352 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"restjson",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"JsonProtocolTests",
+    "serviceFullName":"AWS DR Tools JSON Protocol Tests",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsJsonRpcService",
+    "timestampFormat":"unixTimestamp",
+    "uid":"restjson-2016-03-11"
+  },
+  "operations":{
+    "AllTypes":{
+      "name":"AllTypes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"AllTypesStructure"},
+      "output":{"shape":"AllTypesStructure"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "NestedContainers":{
+      "name":"NestedContainers",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"NestedContainersStructure"},
+      "output":{"shape":"NestedContainersStructure"}
+    },
+    "OperationWithNoInputOrOutput":{
+      "name":"OperationWithNoInputOrOutput",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      }
+    },
+    "StreamingInputOperation":{
+      "name":"StreamingInputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/streamingInputOperation"
+      },
+      "input":{"shape":"StructureWithStreamingMember"}
+    },
+    "StreamingOutputOperation":{
+      "name":"StreamingOutputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/streamingOutputOperation"
+      },
+      "output":{"shape":"StructureWithStreamingMember"}
+    },
+    "PaginatedOperationWithResultKey": {
+      "name": "PaginatedOperationWithResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithResultKeyResponse"
+      },
+      "documentation": "Some paginated operation with result_key in paginators.json file"
+    },
+    "PaginatedOperationWithoutResultKey": {
+      "name": "PaginatedOperationWithoutResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithoutResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithoutResultKeyResponse"
+      },
+      "documentation": "Some paginated operation without result_key in paginators.json file"
+    }
+  },
+  "shapes":{
+    "AllTypesStructure":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"},
+        "IntegerMember":{"shape":"Integer"},
+        "BooleanMember":{"shape":"Boolean"},
+        "FloatMember":{"shape":"Float"},
+        "DoubleMember":{"shape":"Double"},
+        "LongMember":{"shape":"Long"},
+        "SimpleList":{"shape":"ListOfStrings"},
+        "ListOfEnums":{"shape":"ListOfEnums"},
+        "ListOfMaps":{"shape":"ListOfMapStringToString"},
+        "ListOfStructs":{"shape":"ListOfSimpleStructs"},
+        "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
+        "MapOfStringToString":{"shape":"MapOfStringToString"},
+        "MapOfStringToSimpleStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
+        "MapOfEnumToString":{"shape":"MapOfEnumToString"},
+        "MapOfStringToEnum":{"shape":"MapOfStringToEnum"},
+        "MapOfEnumToSimpleStruct":{"shape":"MapOfEnumToSimpleStruct"},
+        "TimestampMember":{"shape":"Timestamp"},
+        "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
+        "BlobArg":{"shape":"BlobType"},
+        "StructWithNestedBlob":{"shape":"StructWithNestedBlobType"},
+        "BlobMap":{"shape":"BlobMapType"},
+        "ListOfBlobs":{"shape":"ListOfBlobsType"},
+        "RecursiveStruct":{"shape":"RecursiveStructType"},
+        "PolymorphicTypeWithSubTypes":{"shape":"BaseType"},
+        "PolymorphicTypeWithoutSubTypes":{"shape":"SubTypeOne"},
+        "EnumType":{"shape":"EnumType"}
+      }
+    },
+    "BaseType":{
+      "type":"structure",
+      "members":{
+        "BaseMember":{"shape":"String"}
+      }
+    },
+    "BlobMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"BlobType"}
+    },
+    "BlobType":{"type":"blob"},
+    "Boolean":{"type":"boolean"},
+    "Double":{"type":"double"},
+    "EmptyModeledException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
+    "Float":{"type":"float"},
+    "IdempotentOperationStructure":{
+      "type":"structure",
+      "members":{
+        "IdempotencyToken":{
+          "shape":"String",
+          "idempotencyToken":true
+        }
+      }
+    },
+    "Integer":{"type":"integer"},
+    "ListOfBlobsType":{
+      "type":"list",
+      "member":{"shape":"BlobType"}
+    },
+    "ListOfIntegers":{
+      "type":"list",
+      "member":{"shape":"Integer"}
+    },
+    "ListOfListOfListOfStrings":{
+      "type":"list",
+      "member":{"shape":"ListOfListOfStrings"}
+    },
+    "ListOfListOfStrings":{
+      "type":"list",
+      "member":{"shape":"ListOfStrings"}
+    },
+    "ListOfMapStringToString":{
+      "type":"list",
+      "member":{"shape":"MapOfStringToString"}
+    },
+    "ListOfSimpleStructs":{
+      "type":"list",
+      "member":{"shape":"SimpleStruct"}
+    },
+    "ListOfStrings":{
+      "type":"list",
+      "member":{"shape":"String"}
+    },
+    "ListOfEnums":{
+      "type":"list",
+      "member":{"shape":"EnumType"}
+    },
+    "Long":{"type":"long"},
+    "MapOfStringToIntegerList":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfIntegers"}
+    },
+    "MapOfStringToListOfListOfStrings":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfListOfStrings"}
+    },
+    "MapOfStringToSimpleStruct":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"SimpleStruct"}
+    },
+    "MapOfStringToString":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
+    },
+    "MapOfEnumToEnum":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"EnumType"}
+    },
+    "MapOfEnumToString":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"String"}
+    },
+    "MapOfStringToEnum":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"EnumType"}
+    },
+    "MapOfEnumToSimpleStruct":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"SimpleStruct"}
+    },
+    "NestedContainersStructure":{
+      "type":"structure",
+      "members":{
+        "ListOfListOfStrings":{"shape":"ListOfListOfStrings"},
+        "ListOfListOfListOfStrings":{"shape":"ListOfListOfListOfStrings"},
+        "MapOfStringToListOfListOfStrings":{"shape":"MapOfStringToListOfListOfStrings"}
+      }
+    },
+    "RecursiveListType":{
+      "type":"list",
+      "member":{"shape":"RecursiveStructType"}
+    },
+    "RecursiveMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"RecursiveStructType"}
+    },
+    "RecursiveStructType":{
+      "type":"structure",
+      "members":{
+        "NoRecurse":{"shape":"String"},
+        "RecursiveStruct":{"shape":"RecursiveStructType"},
+        "RecursiveList":{"shape":"RecursiveListType"},
+        "RecursiveMap":{"shape":"RecursiveMapType"}
+      }
+    },
+    "SimpleStruct":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "StreamType":{
+      "type":"blob",
+      "streaming":true
+    },
+    "String":{"type":"string"},
+    "StructWithNestedBlobType":{
+      "type":"structure",
+      "members":{
+        "NestedBlob":{"shape":"BlobType"}
+      }
+    },
+    "StructWithTimestamp":{
+      "type":"structure",
+      "members":{
+        "NestedTimestamp":{"shape":"Timestamp"}
+      }
+    },
+    "StructureWithStreamingMember":{
+      "type":"structure",
+      "members":{
+        "StreamingMember":{"shape":"StreamType"}
+      },
+      "payload":"StreamingMember"
+    },
+    "SubTypeOne":{
+      "type":"structure",
+      "members":{
+        "SubTypeOneMember":{"shape":"String"}
+      }
+    },
+    "EnumType": {
+      "type":"string",
+      "enum": [
+        "EnumValue1", "EnumValue2"
+      ]
+    },
+    "Timestamp":{"type":"timestamp"},
+    "PaginatedOperationWithResultKeyRequest": {
+      "type": "structure",
+      "required": [
+        "NextToken"
+      ],
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "String",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "Items": {
+          "shape": "ListOfSimpleStructs",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
+    },
+    "PaginatedOperationWithoutResultKeyRequest": {
+      "type": "structure",
+      "required": [
+        "NextToken"
+      ],
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "String",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithoutResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
+    }
+  }
+}

--- a/core/src/main/java/software/amazon/awssdk/core/pagination/NextPageFetcher.java
+++ b/core/src/main/java/software/amazon/awssdk/core/pagination/NextPageFetcher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.pagination;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public interface NextPageFetcher<ResponseT> {
+
+    /**
+     * Returns a boolean value indicating if a next page is available.
+     *
+     * @param oldPage last page sent by service in a paginated operation
+     * @return True if there is a next page available. Otherwise false.
+     */
+    boolean hasNextPage(ResponseT oldPage);
+
+    /**
+     * Method that uses the information in #oldPage and returns the
+     * next page if available by making a service call.
+     *
+     * @param oldPage last page sent by service in a paginated operation
+     * @return the next page if available. Otherwise returns null.
+     */
+    ResponseT nextPage(ResponseT oldPage);
+}

--- a/core/src/main/java/software/amazon/awssdk/core/pagination/PaginatedItemsIterable.java
+++ b/core/src/main/java/software/amazon/awssdk/core/pagination/PaginatedItemsIterable.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.pagination;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Iterable for the paginated items. This class can be used through iterate through
+ * all the items across multiple pages until there is no more response from the service.
+ *
+ * @param <ResponseT> The type of a single response page
+ * @param <ItemT> The type of paginated member in a response page
+ */
+@SdkProtectedApi
+public class PaginatedItemsIterable<ResponseT, ItemT> implements SdkIterable<ItemT> {
+
+    private final SdkIterable<ResponseT> pagesIterable;
+    private final Function<ResponseT, Iterator<ItemT>> getItemIterator;
+
+    public PaginatedItemsIterable(SdkIterable<ResponseT> pagesIterable,
+                                  Function<ResponseT, Iterator<ItemT>> getItemIterator) {
+        this.pagesIterable = pagesIterable;
+        this.getItemIterator = getItemIterator;
+    }
+
+    @Override
+    public Iterator<ItemT> iterator() {
+        return new ItemsIterator(pagesIterable.iterator());
+    }
+
+    private class ItemsIterator implements Iterator<ItemT> {
+
+        private final Iterator<ResponseT> pagesIterator;
+        private Iterator<ItemT> singlePageItemsIterator;
+
+        ItemsIterator(final Iterator<ResponseT> pagesIterator) {
+            this.pagesIterator = pagesIterator;
+            this.singlePageItemsIterator = getItemIterator.apply(pagesIterator.next());
+        }
+
+        @Override
+        public boolean hasNext() {
+            while ((singlePageItemsIterator == null || !singlePageItemsIterator.hasNext())
+                   && pagesIterator.hasNext()) {
+                singlePageItemsIterator = getItemIterator.apply(pagesIterator.next());
+            }
+
+            if (singlePageItemsIterator != null && singlePageItemsIterator.hasNext()) {
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        public ItemT next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException("No more elements left");
+            }
+
+            return singlePageItemsIterator.next();
+        }
+    }
+
+}

--- a/core/src/main/java/software/amazon/awssdk/core/pagination/PaginatedResponsesIterator.java
+++ b/core/src/main/java/software/amazon/awssdk/core/pagination/PaginatedResponsesIterator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.pagination;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator for all response pages in a paginated operation.
+ *
+ * This class is used to iterate through all the pages of an operation.
+ * SDK makes service calls to retrieve the next page when next() method is called.
+ *
+ * @param <ResponseT> The type of a single response page
+ */
+public class PaginatedResponsesIterator<ResponseT> implements Iterator<ResponseT> {
+
+    private final NextPageFetcher<ResponseT> nextPageFetcher;
+
+    // This is null when the object is created. It gets initialized in next() method
+    // where SDK make service calls.
+    private ResponseT oldResponse;
+
+    public PaginatedResponsesIterator(NextPageFetcher<ResponseT> nextPageFetcher) {
+        this.nextPageFetcher = nextPageFetcher;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return oldResponse == null || nextPageFetcher.hasNextPage(oldResponse);
+    }
+
+    @Override
+    public ResponseT next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more pages left");
+        }
+
+        oldResponse = nextPageFetcher.nextPage(oldResponse);
+
+        return oldResponse;
+    }
+}

--- a/core/src/main/java/software/amazon/awssdk/core/pagination/SdkIterable.java
+++ b/core/src/main/java/software/amazon/awssdk/core/pagination/SdkIterable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.pagination;
+
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A custom iterable used in paginated responses.
+ *
+ * This interface has a default stream() method which creates a stream from
+ * spliterator method.
+ *
+ * @param <T> the type of elements returned by the iterator
+ */
+public interface SdkIterable<T> extends Iterable<T> {
+
+    default Stream<T> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/core/pagination/PaginatedItemsIterableTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/pagination/PaginatedItemsIterableTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.pagination;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaginatedItemsIterableTest {
+
+    @Mock
+    private SdkIterable pagesIterable;
+
+    @Mock
+    private Iterator pagesIterator;
+
+    @Mock
+    private Function getItemIteratorFunction;
+
+    @Mock
+    private Iterator singlePageItemsIterator;
+
+    private PaginatedItemsIterable itemsIterable;
+
+    @Before
+    public void setup() {
+        when(pagesIterable.iterator()).thenReturn(pagesIterator);
+
+        when(getItemIteratorFunction.apply(any())).thenReturn(singlePageItemsIterator);
+
+        itemsIterable = new PaginatedItemsIterable(pagesIterable, getItemIteratorFunction);
+    }
+
+    @Test
+    public void hasNext_ReturnsFalse_WhenItemsAndPagesIteratorHasNoNextElement() {
+        when(singlePageItemsIterator.hasNext()).thenReturn(false);
+        when(pagesIterator.hasNext()).thenReturn(false);
+
+        assertFalse(itemsIterable.iterator().hasNext());
+    }
+
+    @Test
+    public void hasNext_ReturnsTrue_WhenItemsIteratorHasNextElement() {
+        when(singlePageItemsIterator.hasNext()).thenReturn(true);
+        when(pagesIterator.hasNext()).thenReturn(false);
+
+        assertTrue(itemsIterable.iterator().hasNext());
+    }
+
+    @Test
+    public void hasNextMethodDoesNotRetrieveNextPage_WhenItemsIteratorHasAnElement() {
+        when(singlePageItemsIterator.hasNext()).thenReturn(true);
+
+        Iterator itemsIterator = itemsIterable.iterator();
+        itemsIterator.hasNext();
+        itemsIterator.hasNext();
+
+        // pagesIterator.next() is called only once in ItemsIterator constructor
+        // Not called again in ItemsIterator.hasNext() method
+        verify(pagesIterator, times(1)).next();
+    }
+
+    @Test
+    public void hasNextMethodGetsNextPage_WhenCurrentItemsIteratorHasNoElements() {
+        when(pagesIterator.hasNext()).thenReturn(true);
+
+        when(singlePageItemsIterator.hasNext()).thenReturn(false)
+                                               .thenReturn(true);
+
+
+        itemsIterable.iterator().hasNext();
+
+        // pagesIterator.next() is called only once in ItemsIterator constructor
+        // Called second time in hasNext() method
+        verify(pagesIterator, times(2)).next();
+    }
+
+    @Test
+    public void hasNextMethodGetsNextPage_WhenCurrentItemsIteratorIsNull() {
+        when(pagesIterator.hasNext()).thenReturn(true);
+
+        when(getItemIteratorFunction.apply(any())).thenReturn(null, singlePageItemsIterator);
+
+        when(singlePageItemsIterator.hasNext()).thenReturn(true);
+
+        itemsIterable.iterator().hasNext();
+
+        // pagesIterator.next() is called only once in ItemsIterator constructor
+        // Called second time in hasNext() method
+        verify(pagesIterator, times(2)).next();
+    }
+
+    @Test
+    public void testNextMethod_WhenIntermediatePages_HasEmptyCollectionOfItems() {
+        when(pagesIterator.hasNext()).thenReturn(true);
+
+        // first page has empty items iterator
+        Iterator itemsIterator1 = Mockito.mock(Iterator.class);
+        when(itemsIterator1.hasNext()).thenReturn(false);
+
+        // second page has empty items iterator
+        Iterator itemsIterator2 = Mockito.mock(Iterator.class);
+        when(itemsIterator2.hasNext()).thenReturn(false);
+
+        // third page has empty items iterator
+        Iterator itemsIterator3 = Mockito.mock(Iterator.class);
+        when(itemsIterator3.hasNext()).thenReturn(false);
+
+        // fourth page is non empty
+        Iterator itemsIterator4 = Mockito.mock(Iterator.class);
+        when(itemsIterator4.hasNext()).thenReturn(true);
+
+        when(getItemIteratorFunction.apply(any())).thenReturn(itemsIterator1, itemsIterator2, itemsIterator3, itemsIterator4);
+
+        itemsIterable.iterator().next();
+
+        verify(itemsIterator1, times(0)).next();
+        verify(itemsIterator2, times(0)).next();
+        verify(itemsIterator3, times(0)).next();
+        verify(itemsIterator4, times(1)).next();
+
+        verify(getItemIteratorFunction, times(4)).apply(any());
+    }
+}

--- a/services/api-gateway/src/main/resources/codegen-resources/paginators.json
+++ b/services/api-gateway/src/main/resources/codegen-resources/paginators.json
@@ -1,0 +1,70 @@
+{
+  "pagination": {
+    "GetApiKeys": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetBasePathMappings": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetClientCertificates": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetDeployments": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetDomainNames": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetModels": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetResources": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetRestApis": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetUsage": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetUsagePlans": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    },
+    "GetUsagePlanKeys": {
+      "input_token": "position",
+      "output_token": "position",
+      "limit_key": "limit",
+      "result_key": "items"
+    }
+  }
+}

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/ScanPaginatorIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/ScanPaginatorIntegrationTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.pagination.SdkIterable;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.paginators.ScanPaginator;
+import utils.resources.tables.BasicTempTable;
+import utils.test.util.DynamoDBTestBase;
+import utils.test.util.TableUtils;
+
+public class ScanPaginatorIntegrationTest extends DynamoDBTestBase {
+
+    private static final String TABLE_NAME = BasicTempTable.TEMP_TABLE_NAME;
+    private static final String HASH_KEY_NAME = BasicTempTable.HASH_KEY_NAME;
+    private static final String ATTRIBUTE_FOO = "attribute_foo";
+    private static final int ITEM_COUNT = 19;
+
+    @BeforeClass
+    public static void setUpFixture() throws Exception {
+        DynamoDBTestBase.setUpTestBase();
+
+        dynamo.createTable(CreateTableRequest.builder().tableName(TABLE_NAME)
+                                             .keySchema(KeySchemaElement.builder().keyType(KeyType.HASH)
+                                                                        .attributeName(HASH_KEY_NAME)
+                                                                        .build())
+                                             .attributeDefinitions(AttributeDefinition.builder()
+                                                                                      .attributeType(ScalarAttributeType.N)
+                                                                                      .attributeName(HASH_KEY_NAME)
+                                                                                      .build())
+                                             .provisionedThroughput(ProvisionedThroughput.builder()
+                                                                                         .readCapacityUnits(5L)
+                                                                                         .writeCapacityUnits(5L)
+                                                                                         .build())
+                                             .build());
+
+        TableUtils.waitUntilActive(dynamo, TABLE_NAME);
+
+        putTestData();
+    }
+
+    @AfterClass
+    public static void cleanUpFixture() {
+        dynamo.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
+    }
+
+    @Test
+    public void test_MultipleIteration_On_Responses_Iterable() {
+        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(2).build();
+        ScanPaginator scanResponses = dynamo.scanIterable(request);
+
+        int count = 0;
+
+        // Iterate once
+        for (ScanResponse response : scanResponses) {
+            count += response.count();
+        }
+        Assert.assertEquals(ITEM_COUNT, count);
+
+        // Iterate second time
+        count = 0;
+        for (ScanResponse response : scanResponses) {
+            count += response.count();
+        }
+        Assert.assertEquals(ITEM_COUNT, count);
+    }
+
+    @Test
+    public void test_MultipleIteration_On_PaginatedMember_Iterable() {
+        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(2).build();
+        SdkIterable<Map<String, AttributeValue>> items = dynamo.scanIterable(request).items();
+
+        int count = 0;
+
+        // Iterate once
+        for (Map<String, AttributeValue> item : items) {
+            count++;
+        }
+        Assert.assertEquals(ITEM_COUNT, count);
+
+        // Iterate second time
+        count = 0;
+        for (Map<String, AttributeValue> item : items) {
+            count++;
+        }
+        Assert.assertEquals(ITEM_COUNT, count);
+    }
+
+    @Test
+    public void test_MultipleIteration_On_Responses_Stream() {
+        int results_per_page = 2;
+        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(results_per_page).build();
+        ScanPaginator scanResponses = dynamo.scanIterable(request);
+
+        // Iterate once
+        Assert.assertEquals(ITEM_COUNT, scanResponses.stream()
+                                                     .mapToInt(response -> response.count())
+                                                     .sum());
+
+        // Iterate second time
+        Assert.assertEquals(ITEM_COUNT, scanResponses.stream()
+                                                     .mapToInt(response -> response.count())
+                                                     .sum());
+
+        // Number of pages
+        Assert.assertEquals(Math.ceil((double) ITEM_COUNT/results_per_page), scanResponses.stream().count(), 0);
+    }
+
+    @Test
+    public void test_MultipleIteration_On_PaginatedMember_Stream() {
+        int results_per_page = 2;
+        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(results_per_page).build();
+        SdkIterable<Map<String, AttributeValue>> items = dynamo.scanIterable(request).items();
+
+        // Iterate once
+        Assert.assertEquals(ITEM_COUNT, items.stream().distinct().count());
+
+        // Iterate second time
+        Assert.assertEquals(ITEM_COUNT, items.stream().distinct().count());
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void iteration_On_SameStream_ThrowsError() {
+        int results_per_page = 2;
+        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(results_per_page).build();
+        Stream<Map<String, AttributeValue>> itemsStream = dynamo.scanIterable(request).items().stream();
+
+        // Iterate once
+        Assert.assertEquals(ITEM_COUNT, itemsStream.distinct().count());
+
+        // Iterate second time
+        Assert.assertEquals(ITEM_COUNT, itemsStream.distinct().count());
+    }
+
+    @Test
+    public void mix_Iterator_And_Stream_Calls() {
+        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(2).build();
+        ScanPaginator scanResponses = dynamo.scanIterable(request);
+
+        Assert.assertEquals(ITEM_COUNT, scanResponses.stream().flatMap(r -> r.items().stream())
+                                                     .distinct()
+                                                     .count());
+
+
+        Assert.assertEquals(ITEM_COUNT, scanResponses.stream().mapToInt(response -> response.count()).sum());
+
+
+        int count = 0;
+        for (ScanResponse response : scanResponses) {
+            count += response.count();
+        }
+        Assert.assertEquals(ITEM_COUNT, count);
+    }
+
+    private static void putTestData() {
+        Map<String, AttributeValue> item = new HashMap();
+        Random random = new Random();
+
+        for (int hashKeyValue = 0; hashKeyValue < ITEM_COUNT; hashKeyValue++) {
+            item.put(HASH_KEY_NAME, AttributeValue.builder().n(Integer.toString(hashKeyValue)).build());
+            item.put(ATTRIBUTE_FOO, AttributeValue.builder().n(Integer.toString(random.nextInt(ITEM_COUNT))).build());
+
+            dynamo.putItem(PutItemRequest.builder().tableName(TABLE_NAME).item(item).build());
+            item.clear();
+        }
+    }
+
+}

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodb/paginators.json
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodb/paginators.json
@@ -1,0 +1,27 @@
+{
+  "pagination": {
+    "BatchGetItem": {
+      "input_token": "RequestItems",
+      "output_token": "UnprocessedKeys",
+      "result_key": "Responses"
+    },
+    "ListTables": {
+      "input_token": "ExclusiveStartTableName",
+      "limit_key": "Limit",
+      "output_token": "LastEvaluatedTableName",
+      "result_key": "TableNames"
+    },
+    "Query": {
+      "input_token": "ExclusiveStartKey",
+      "limit_key": "Limit",
+      "output_token": "LastEvaluatedKey",
+      "result_key": "Items"
+    },
+    "Scan": {
+      "input_token": "ExclusiveStartKey",
+      "limit_key": "Limit",
+      "output_token": "LastEvaluatedKey",
+      "result_key": "Items"
+    }
+  }
+}

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/paginators.json
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/paginators.json
@@ -1,0 +1,16 @@
+{
+  "pagination": {
+    "DescribeStream": {
+      "input_token": "ExclusiveStartShardId",
+      "limit_key": "Limit",
+      "output_token": "StreamDescription.LastEvaluatedShardId",
+      "result_key": "StreamDescription.Shards"
+    },
+    "ListStreams": {
+      "input_token": "ExclusiveStartStreamArn",
+      "limit_key": "Limit",
+      "output_token": "LastEvaluatedStreamArn",
+      "result_key": "Streams"
+    }
+  }
+}

--- a/services/route53/src/main/resources/codegen-resources/route53/paginators.json
+++ b/services/route53/src/main/resources/codegen-resources/route53/paginators.json
@@ -1,0 +1,33 @@
+{
+  "pagination": {
+    "ListHealthChecks": {
+      "input_token": "Marker",
+      "output_token": "NextMarker",
+      "more_results": "IsTruncated",
+      "limit_key": "MaxItems",
+      "result_key": "HealthChecks"
+    },
+    "ListHostedZones": {
+      "input_token": "Marker",
+      "output_token": "NextMarker",
+      "more_results": "IsTruncated",
+      "limit_key": "MaxItems",
+      "result_key": "HostedZones"
+    },
+    "ListResourceRecordSets": {
+      "more_results": "IsTruncated",
+      "limit_key": "MaxItems",
+      "result_key": "ResourceRecordSets",
+      "input_token": [
+        "StartRecordName",
+        "StartRecordType",
+        "StartRecordIdentifier"
+      ],
+      "output_token": [
+        "NextRecordName",
+        "NextRecordType",
+        "NextRecordIdentifier"
+      ]
+    }
+  }
+}

--- a/services/route53/src/main/resources/codegen-resources/route53domains/paginators.json
+++ b/services/route53/src/main/resources/codegen-resources/route53domains/paginators.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "pagination": {
+    "ListDomains": {
+      "limit_key": "MaxItems",
+      "input_token": "Marker",
+      "output_token": "NextPageMarker",
+      "result_key": "Domains"
+    },
+    "ListOperations": {
+      "limit_key": "MaxItems",
+      "input_token": "Marker",
+      "output_token": "NextPageMarker",
+      "result_key": "Operations"
+    }
+  }
+}

--- a/services/workdocs/src/main/resources/codegen-resources/paginators.json
+++ b/services/workdocs/src/main/resources/codegen-resources/paginators.json
@@ -1,0 +1,22 @@
+{
+  "pagination": {
+    "DescribeUsers": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "Limit",
+      "result_key": "Users"
+    },
+    "DescribeFolderContents": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "Limit",
+      "result_key": ["Folders", "Documents"]
+    },
+    "DescribeDocumentVersions": {
+      "input_token": "Marker",
+      "output_token": "Marker",
+      "limit_key": "Limit",
+      "result_key": []
+    }
+  }
+}


### PR DESCRIPTION
## Description
Implementation for Sync automatic de-pagination. Supports lists, nested shapes in paginators.json file
Tracking Issue: https://github.com/aws/aws-sdk-java-v2/issues/26

For all paginated operations, there will be two APIs - one with automatic depagination and one that returns a single page. Example: For listTables operation in DynamoDB, the following APIs are present in the client:
1) ListTablesResponse listTables(ListTablesRequest listTablesRequest) - Returns only a single page. similar to v1
2) ListTablesPaginator listTablesIterable(ListTablesRequest listTablesRequest)
This is the auto paginated API in which SDK will make service calls for the customer.

As per recent api review discussions and inconsistencies in paginator files, going with this option is safe in terms of backwards compatibility. Coming to discoverability, these APIs are highly discoverable compared to high level utilities as they are in same client.

## Recent changes
Added more unit tests
Added Javadocs for generated classes

## Testing
mvn clean install
Added an integ test class


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
