### PR TITLE
Adding a try-catch around the getenv call for safety.

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/DefaultEventLoopGroupFactory.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/DefaultEventLoopGroupFactory.java
@@ -69,9 +69,14 @@ public final class DefaultEventLoopGroupFactory
 
     @ReviewBeforeRelease("We should work with Lambda to get Epoll opened up")
     private boolean isNotAwsLambda() {
-        // CHECKSTYLE:OFF - This is temporary (hopefully!)
-        return isBlank(System.getenv("AWS_LAMBDA_FUNCTION_NAME"));
-        // CHECKSTYLE:ON
+        try {
+            // CHECKSTYLE:OFF - This is temporary (hopefully!)
+            return isBlank(System.getenv("AWS_LAMBDA_FUNCTION_NAME"));
+            // CHECKSTYLE:ON
+        } catch (RuntimeException e) {
+            //Couldn't determine if we're on lambda or not, assume we're not.
+            return true;
+        }
     }
 
     private ThreadFactory resolveThreadFactory() {


### PR DESCRIPTION
Realised that getenv could throw a security exception and I don't really want to blow-up because we couldn't determine we're on lambda. Adding a try-catch so that we assume we're not on Lambda if we get an exception.

Follow-up to https://github.com/aws/aws-sdk-java-v2/pull/208