### PR TITLE
Make test-utils a test scoped dependency in KMS

### DIFF
--- a/services/kms/pom.xml
+++ b/services/kms/pom.xml
@@ -35,6 +35,7 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>test-utils</artifactId>
             <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Description
Make test-utils a test scoped dependency in KMS

## Motivation and Context
Do not want to pull in test dependencies

## Testing
In SDK project:
$ mvn install
In my project:
$ mvn dependency:tree
no longer shows test-util (and other transitive dependencies like junit) in the tree

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
Strictly, this could be a breaking change for users that inappropriately relied on dependencies of test-util e.g. Guice

## Checklist
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
