### PR TITLE
Attempting to fix class-loader exception raised on gitter.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ClassLoaderHelper.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/ClassLoaderHelper.java
@@ -19,6 +19,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+/**
+ * @deprecated should be replaced with {@link software.amazon.awssdk.core.util.ClassLoaderHelper}
+ */
+@Deprecated
 public enum ClassLoaderHelper {
     ;
 

--- a/core/src/main/java/software/amazon/awssdk/core/interceptor/ClasspathInterceptorChainFactory.java
+++ b/core/src/main/java/software/amazon/awssdk/core/interceptor/ClasspathInterceptorChainFactory.java
@@ -125,7 +125,7 @@ public final class ClasspathInterceptorChainFactory {
 
     @ReviewBeforeRelease("Can we hard-code our required global and service interceptors and just have this log a warning?")
     private ClassLoader classLoader() {
-        return Validate.notNull(Thread.currentThread().getContextClassLoader(),
-                                "Failed to load the classloader for the current thread.");
+        return Validate.notNull(ClassLoaderHelper.classLoader(),
+                                "Failed to load the classloader for the current thread or the system.");
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/util/ClassLoaderHelper.java
+++ b/core/src/main/java/software/amazon/awssdk/core/util/ClassLoaderHelper.java
@@ -90,7 +90,7 @@ public enum ClassLoaderHelper {
     }
 
     private static URL getResourceViaContext(String resource) {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        ClassLoader loader = classLoader();
         return loader == null ? null : loader.getResource(resource);
     }
 
@@ -111,7 +111,7 @@ public enum ClassLoaderHelper {
     }
 
     private static Class<?> loadClassViaContext(String fqcn) {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        ClassLoader loader = classLoader();
         try {
             return loader == null ? null : loader.loadClass(fqcn);
         } catch (ClassNotFoundException e) {
@@ -230,5 +230,17 @@ public enum ClassLoaderHelper {
         } catch (IOException e) {
             return null;
         }
+    }
+
+    /**
+     * Attempt to get the current thread's class loader and fallback to the system classloader if null
+     * @return a {@link ClassLoader} or null if none found
+     */
+    public static ClassLoader classLoader() {
+        ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
+        if (threadClassLoader != null) {
+            return threadClassLoader;
+        }
+        return ClassLoader.getSystemClassLoader();
     }
 }


### PR DESCRIPTION
Running via AWS Lambda on Async causes the following stack trace during construction of FirehoseAsyncClient

```
java.lang.NullPointerException: Failed to load the classloader for the current thread.
at software.amazon.awssdk.utils.Validate.notNull(Validate.java:118)
at software.amazon.awssdk.handlers.ClasspathInterceptorChainFactory.classLoader(ClasspathInterceptorChainFactory.java:129)
at software.amazon.awssdk.handlers.ClasspathInterceptorChainFactory.createExecutionInterceptorsFromClasspath(ClasspathInterceptorChainFactory.java:62)
at software.amazon.awssdk.handlers.ClasspathInterceptorChainFactory.getInterceptors(ClasspathInterceptorChainFactory.java:50)
at software.amazon.awssdk.config.defaults.ServiceBuilderConfigurationDefaults.lambda$applyOverrideDefaults$1(ServiceBuilderConfigurationDefaults.java:72)
at java.util.ArrayList.forEach(ArrayList.java:1249)
at software.amazon.awssdk.config.defaults.ServiceBuilderConfigurationDefaults.applyOverrideDefaults(ServiceBuilderConfigurationDefaults.java:72)
at software.amazon.awssdk.config.defaults.ClientConfigurationDefaults.applyDefaultValues(ClientConfigurationDefaults.java:127)
at software.amazon.awssdk.config.defaults.ClientConfigurationDefaults.applyDefaultValues(ClientConfigurationDefaults.java:71)
at software.amazon.awssdk.config.defaults.ClientConfigurationDefaults.applyAsyncDefaults(ClientConfigurationDefaults.java:61)
at software.amazon.awssdk.client.builder.DefaultClientBuilder.asyncClientConfiguration(DefaultClientBuilder.java:190)
at software.amazon.awssdk.services.firehose.DefaultFirehoseAsyncClientBuilder.buildClient(DefaultFirehoseAsyncClientBuilder.java:28)
at software.amazon.awssdk.services.firehose.DefaultFirehoseAsyncClientBuilder.buildClient(DefaultFirehoseAsyncClientBuilder.java:22)
at software.amazon.awssdk.client.builder.DefaultClientBuilder.build(DefaultClientBuilder.java:111)
```

## Description
This is due to the `Thread.currentThread().getContextClassLoader()` this change attempts to fall back to the System classloader to load the resources : `ClassLoader.getSystemClassLoader()`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
