### PR TITLE
Adding knownValues static to enum generation

### DIFF
--- a/codegen/src/main/resources/templates/common/enum-class.ftl
+++ b/codegen/src/main/resources/templates/common/enum-class.ftl
@@ -49,4 +49,8 @@ public enum ${shape.shapeName} {
 
         throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
     }
+
+    public static Set<${shape.shapeName}> knownValues() {
+        return Stream.of(values()).filter(v -> v != UNKNOWN_TO_SDK_VERSION).collect(toSet());
+    }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-enum-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/common/test-enum-class.java
@@ -1,5 +1,8 @@
 package software.amazon.awssdk.codegen.poet.common.model;
 
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Generated;
 
@@ -37,5 +40,15 @@ public enum TestEnumClass {
             return null;
         }
         return Stream.of(TestEnumClass.values()).filter(e -> e.toString().equals(value)).findFirst().orElse(UNKNOWN_TO_SDK_VERSION);
+    }
+
+    /**
+     * Use this in place of {@link #values()} to return a {@link Set} of all values known to the SDK.
+     * This will return all known enum values except {@link #UNKNOWN_TO_SDK_VERSION}.
+     *
+     * @return a {@link Set} of known {@link TestEnumClass}s
+     */
+    public static Set<TestEnumClass> knownValues() {
+        return Stream.of(values()).filter(v -> v != UNKNOWN_TO_SDK_VERSION).collect(toSet());
     }
 }


### PR DESCRIPTION
A common way to get all enum values and do something with them is Enum.values() - but there are probably cases where customers only really care about the 'known' enum values (ie: not the `UNKNOWN_TO_SDK_VERSION` one).

## Description
Add a new static method to each enum called `knownTypes()` returns all enum values except the `UNKNOWN_TO_SDK_VERSION` value.

## Motivation and Context
See above

## Testing
Updated poet unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
