### PR TITLE
Remove special handling of services that have result wrappers. We nee…

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -46,7 +46,6 @@ import software.amazon.awssdk.codegen.model.service.Operation;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.naming.DefaultNamingStrategy;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
-import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * Builds an intermediate model to be used by the templates from the service model and
@@ -161,23 +160,17 @@ public class IntermediateModelBuilder {
 
     private void linkOperationsToInputOutputShapes(IntermediateModel model) {
         for (Map.Entry<String, OperationModel> entry : model.getOperations().entrySet()) {
+
             Operation operation = service.getOperations().get(entry.getKey());
+
             if (entry.getValue().getInput() != null) {
                 entry.getValue().setInputShape(model.getShapes().get(entry.getValue().getInput().getSimpleType()));
             }
+
             if (operation.getOutput() != null) {
                 String outputShapeName = operation.getOutput().getShape();
-                // TODO need to figure this out for wrapper outputs.
-                // See [JAVA-1556]
-
-                // Only link when output shape is not a result wrapper. When it is a result wrapper
-                // we only preserve the single member the wrapper has in the intermediate model
-                // so this lookup will fail.
-                if (StringUtils.isBlank(operation.getOutput().getResultWrapper())) {
-                    entry.getValue().setOutputShape(model.getShapeByC2jName(outputShapeName));
-                }
+                entry.getValue().setOutputShape(model.getShapeByC2jName(outputShapeName));
             }
-
         }
     }
 


### PR DESCRIPTION
…d shapemodels for pagination

<!--- Provide a general summary of your changes in the Title above -->

## Description
In v1, we flatten the response shape for some services that have result wrappers.
For example, using DBClusterParameterGroup as return type instead of CopyDBClusterParameterGroupResponse
https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-rds/src/main/java/com/amazonaws/services/rds/AmazonRDSClient.java#L712
Not applicable to v2 anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need output shapemodel during paginator generation.

## Testing
mvn clean install

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
