### PR TITLE
Adding logging for SQS tests

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -151,6 +151,16 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.burt</groupId>
             <artifactId>jmespath-jackson</artifactId>
             <version>0.2.0</version>


### PR DESCRIPTION
## Description
The SQS clock skew test is consistently failing in Jenkins CI. Adding wire-logging to assist debugging. (Also fixes NPE bug in the SQS buffered client.

## Testing
mvn clean verify -Pintegration-tests -pl :sqs

