### PR TITLE
Add cross-module test coverage to sonar.

### DIFF
--- a/http-clients/pom.xml
+++ b/http-clients/pom.xml
@@ -14,6 +14,10 @@
     <name>AWS Java SDK :: HTTP Clients</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <modules>
         <module>apache-client</module>
         <module>netty-nio-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
         <!-- These properties are used by S3 for its test dependencies -->
         <bouncycastle.version>1.56</bouncycastle.version>
 
+        <!-- Sonar -->
+        <root.offset>..</root.offset>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.jacoco.reportPath>${basedir}/${root.offset}/target/jacoco.exec</sonar.jacoco.reportPath>
+
         <skip.unit.tests>${skipTests}</skip.unit.tests>
     </properties>
 
@@ -455,6 +460,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.8</version>
+                <configuration>
+                    <destFile>${sonar.jacoco.reportPath}</destFile>
+                    <append>true</append>
+                </configuration>
                 <executions>
                     <execution>
                         <id>jacoco-initialize</id>
@@ -476,6 +485,7 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
             </plugin>
+
         </plugins>
     </build>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,6 +27,10 @@
     <name>AWS Java SDK :: Services</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <modules>
         <module>acm</module>
         <module>api-gateway</module>

--- a/test/dynamodbdocument-v1/pom.xml
+++ b/test/dynamodbdocument-v1/pom.xml
@@ -29,6 +29,10 @@
     <description>DynamoDB Document API largely unchanged from v1. The v1 API is kept for testing purposes only. All classes are in the test directories to prevent use in application code.</description>
     <url>https://aws.amazon.com/sdkforjava</url>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/test/dynamodbmapper-v1/pom.xml
+++ b/test/dynamodbmapper-v1/pom.xml
@@ -29,6 +29,10 @@
     <description>DynamoDB Mapper largely unchanged from v1. The v1 Mapper is kept for testing purposes only. All classes are in the test directories to prevent use in application code.</description>
     <url>https://aws.amazon.com/sdkforjava</url>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/test/protocol-tests-core/pom.xml
+++ b/test/protocol-tests-core/pom.xml
@@ -29,6 +29,10 @@
     <name>AWS Java SDK :: Test :: Protocol Tests Core</name>
     <description>Contains test drivers and assertions for protocol tests.</description>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.unitils</groupId>

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -29,6 +29,10 @@
     <name>AWS Java SDK :: Test :: Protocol Tests</name>
     <description>Contains functional tests for all supported protocols.</description>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <dependencies>
         <!--Normal Dependencies-->
         <dependency>

--- a/test/service-test-utils/pom.xml
+++ b/test/service-test-utils/pom.xml
@@ -30,6 +30,10 @@
     </description>
     <url>https://aws.amazon.com/sdkforjava</url>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <!-- The dependencies section in pom.xml is auto generated. No manual changes are allowed -->
     <dependencies>
         <dependency>

--- a/test/test-utils/pom.xml
+++ b/test/test-utils/pom.xml
@@ -30,6 +30,10 @@
     </description>
     <url>https://aws.amazon.com/sdkforjava</url>
 
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
     <!-- The dependencies section in pom.xml is auto generated. No manual changes are allowed -->
     <dependencies>
         <dependency>


### PR DESCRIPTION
A "root.offset" system property had to be added to force all tests to
write to the same jacoco output file. There's no easy way in maven to
get the root module directory.