### PR TITLE
Created http-client-tests package.

### DIFF
--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -33,6 +33,12 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-tests</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/SdkTlsSocketFactory.java
@@ -103,6 +103,7 @@ public class SdkTlsSocketFactory extends SSLConnectionSocketFactory {
         return false;
     }
 
+    @Override
     public Socket connectSocket(
             final int connectTimeout,
             final Socket socket,

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientWireMockTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientWireMockTest.java
@@ -1,0 +1,11 @@
+package software.amazon.awssdk.http.apache;
+
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpClientTestSuite;
+
+public class ApacheHttpClientWireMockTest extends SdkHttpClientTestSuite {
+    @Override
+    protected SdkHttpClient createSdkHttpClient(SdkHttpClientOptions options) {
+        return ApacheSdkHttpClientFactory.builder().build().createHttpClient();
+    }
+}

--- a/http-clients/url-connection-client/pom.xml
+++ b/http-clients/url-connection-client/pom.xml
@@ -18,25 +18,16 @@
             <artifactId>http-client-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-tests</artifactId>
+            <version>${awsjavasdk.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
@@ -14,95 +14,12 @@
  */
 package software.amazon.awssdk.http.urlconnection;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
-import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkRequestContext;
-import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.http.SdkHttpClientTestSuite;
 
-@RunWith(MockitoJUnitRunner.class)
-public final class UrlConnectionHttpClientWireMockTest {
-
-    @Rule
-    public WireMockRule mockServer = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
-
-    private static SdkHttpClient client = UrlConnectionSdkHttpClientFactory.builder()
-                                                                           .build()
-                                                                           .createHttpClient();
-
-    @Mock
-    private SdkRequestContext requestContext;
-
-    @Test
-    public void canMakeBasicRequests() throws Exception {
-
-        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withHeader("Some-Header", "With Value").withBody("hello")));
-
-        URI uri = URI.create("http://localhost:" + mockServer.port());
-        SdkHttpFullRequest request = mockSdkRequest(uri);
-
-        SdkHttpFullResponse response = client.prepareRequest(request, requestContext).call();
-
-        verify(1, getRequestedFor(urlMatching("/"))
-            .withHeader("Host", containing("localhost"))
-            .withHeader("User-Agent", containing("hello")));
-        assertThat(IoUtils.toString(response.content().orElse(null))).isEqualTo("hello");
-        assertThat(response.firstMatchingHeader("Some-Header")).contains("With Value");
-        assertThat(response.firstMatchingHeader("Some-Header")).contains("With Value");
-    }
-
-    @Test
-    public void canGetResponsesForAllResponseCodes() throws Exception {
-        testForResponseCode(HttpURLConnection.HTTP_OK);
-        testForResponseCode(HttpURLConnection.HTTP_ACCEPTED);
-        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN);
-        testForResponseCode(HttpURLConnection.HTTP_MOVED_PERM);
-        testForResponseCode(HttpURLConnection.HTTP_MOVED_TEMP);
-        testForResponseCode(HttpURLConnection.HTTP_INTERNAL_ERROR);
-    }
-
-    private void testForResponseCode(int returnCode) throws Exception {
-        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withStatus(returnCode).withBody("response")));
-
-        URI uri = URI.create("http://localhost:" + mockServer.port());
-        SdkHttpFullRequest request = mockSdkRequest(uri);
-
-        SdkHttpFullResponse response = client.prepareRequest(request, requestContext).call();
-
-        verify(1, getRequestedFor(urlMatching("/")).withHeader("Host", containing("localhost")));
-        assertThat(IoUtils.toString(response.content().orElse(null))).isEqualTo("response");
-        assertThat(response.statusCode()).isEqualTo(returnCode);
-        mockServer.resetMappings();
-    }
-
-    private SdkHttpFullRequest mockSdkRequest(URI uri) {
-        return SdkHttpFullRequest.builder()
-                                 .host(uri.getHost())
-                                 .protocol(uri.getScheme())
-                                 .port(uri.getPort())
-                                 .method(SdkHttpMethod.GET)
-                                 .header("Host", uri.getHost())
-                                 .header("User-Agent", "hello-world!")
-                                 .build();
+public final class UrlConnectionHttpClientWireMockTest extends SdkHttpClientTestSuite {
+    @Override
+    protected SdkHttpClient createSdkHttpClient(SdkHttpClientOptions options) {
+        return UrlConnectionSdkHttpClientFactory.builder().build().createHttpClient();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,13 @@
         <module>codegen-maven-plugin</module>
         <module>bundle</module>
         <module>build-tools</module>
-        <module>test/dynamodbmapper-v1</module>
         <module>test/dynamodbdocument-v1</module>
+        <module>test/dynamodbmapper-v1</module>
+        <module>test/http-client-tests</module>
         <module>test/protocol-tests</module>
         <module>test/protocol-tests-core</module>
-        <module>test/test-utils</module>
         <module>test/service-test-utils</module>
+        <module>test/test-utils</module>
         <module>annotations</module>
         <module>utils</module>
     </modules>

--- a/test/http-client-tests/pom.xml
+++ b/test/http-client-tests/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.0.0-preview-5-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>http-client-tests</artifactId>
+    <name>AWS Java SDK :: Test :: HTTP Client Tests</name>
+    <description>A set of acceptance tests that can be extended by an SDK HTTP plugin implementation to help ensure it behaves in
+        manner consistent with what is expected by the SDK.</description>
+    <url>https://aws.amazon.com/sdkforjava</url>
+
+    <properties>
+        <root.offset>../..</root.offset>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>junit</artifactId>
+            <groupId>junit</groupId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import javax.net.ssl.SSLHandshakeException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * A set of tests validating that the functionality implemented by a {@link SdkHttpClient}.
+ *
+ * This is used by an HTTP plugin implementation by extending this class and implementing the abstract methods to provide this
+ * suite with a testable HTTP client implementation.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public abstract class SdkHttpClientTestSuite {
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+
+    @Mock
+    private SdkRequestContext requestContext;
+
+    @Test
+    public void supportsAllResponseCodes() throws Exception {
+        SdkHttpClient client = createSdkHttpClient();
+        testForResponseCode(client, HttpURLConnection.HTTP_OK);
+        testForResponseCode(client, HttpURLConnection.HTTP_ACCEPTED);
+        testForResponseCode(client, HttpURLConnection.HTTP_FORBIDDEN);
+        testForResponseCode(client, HttpURLConnection.HTTP_MOVED_PERM);
+        testForResponseCode(client, HttpURLConnection.HTTP_MOVED_TEMP);
+        testForResponseCode(client, HttpURLConnection.HTTP_INTERNAL_ERROR);
+    }
+
+    @Test
+    public void validatesHttpsCertificateIssuer() throws Exception {
+        SdkHttpClient client = createSdkHttpClient();
+
+        SdkHttpFullRequest request = mockSdkRequest("https://localhost:" + mockServer.httpsPort());
+
+        assertThatThrownBy(client.prepareRequest(request, requestContext)::call)
+                .isInstanceOf(SSLHandshakeException.class);
+    }
+
+    private void testForResponseCode(SdkHttpClient client, int returnCode) throws Exception {
+        stubForMockRequest(returnCode);
+
+        SdkHttpFullRequest request = mockSdkRequest("http://localhost:" + mockServer.port());
+        SdkHttpFullResponse response = client.prepareRequest(request, requestContext).call();
+
+        validateResponse(response, returnCode);
+    }
+
+    private void stubForMockRequest(int returnCode) {
+        stubFor(any(urlPathEqualTo("/")).willReturn(
+                aResponse().withStatus(returnCode).withHeader("Some-Header", "With Value").withBody("hello")));
+    }
+
+    private void validateResponse(SdkHttpFullResponse response, int returnCode) throws IOException {
+        verify(1, postRequestedFor(urlMatching("/"))
+                .withHeader("Host", containing("localhost"))
+                .withHeader("User-Agent", equalTo("hello-world!"))
+                .withRequestBody(equalTo("Body")));
+
+        assertThat(IoUtils.toString(response.content().orElse(null))).isEqualTo("hello");
+        assertThat(response.firstMatchingHeader("Some-Header")).contains("With Value");
+        assertThat(response.statusCode()).isEqualTo(returnCode);
+        mockServer.resetMappings();
+    }
+
+    private SdkHttpFullRequest mockSdkRequest(String uriString) {
+        URI uri = URI.create(uriString);
+        return SdkHttpFullRequest.builder()
+                                 .host(uri.getHost())
+                                 .protocol(uri.getScheme())
+                                 .port(uri.getPort())
+                                 .method(SdkHttpMethod.POST)
+                                 .header("Host", uri.getHost())
+                                 .header("User-Agent", "hello-world!")
+                                 .content(new ByteArrayInputStream("Body".getBytes(StandardCharsets.UTF_8)))
+                                 .build();
+    }
+
+    /**
+     * {@link #createSdkHttpClient(SdkHttpClientOptions)} with default options.
+     */
+    protected final SdkHttpClient createSdkHttpClient() {
+        return createSdkHttpClient(new SdkHttpClientOptions());
+    }
+
+    /**
+     * Implemented by a child class to create an HTTP client to validate based on the provided options.
+     */
+    protected abstract SdkHttpClient createSdkHttpClient(SdkHttpClientOptions options);
+
+    /**
+     * The options that should be considered when creating the client via {@link #createSdkHttpClient(SdkHttpClientOptions)}.
+     */
+    protected static final class SdkHttpClientOptions {
+        // TODO: Add option for disabling certificate validation. This should probably be supported by all HTTP implementations
+        // because it is necessary for testing that HTTPS functions correctly.
+    }
+}


### PR DESCRIPTION
This package includes a suite of tests to validate the functionality of all HTTP client implementations.

Initially this has only been populated with the tests that were already in the URL connection implementation plus one additional test to validate that untrusted certificate issuers fail the request.

In the future, we could add:
1. Tests for HTTPS endpoints (requires implementations to support disabling SSL validation)
2. Tests for async clients
3. Integration tests that call badssl.com for validating a multitude of invalid server certificates
4. More comprehensive testing scenarios (the ones currently in place are very limited "happy case" tests)