### PR TITLE
Delete old jmespath AST script

### DIFF
--- a/codegen/src/main/resources/jp-to-ast.py
+++ b/codegen/src/main/resources/jp-to-ast.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-import jmespath
-import json
-import sys
-
-expression = sys.argv[1]
-parsed = jmespath.compile(expression)
-print(json.dumps(parsed.parsed, indent=2))


### PR DESCRIPTION
## Description
Remove `jp-to-ast.py`

## Motivation and Context
File is not needed.

## Testing
`mvn install`

## Screenshots (if appropriate)

## Types of changes
Cleanup

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
