### PR TITLE
Making it easier to supply async http configuration.

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/client/builder/AsyncClientBuilder.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/builder/AsyncClientBuilder.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.client.builder;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 
 /**
  * This includes required and optional override configuration required by every async client builder. An instance can be acquired
@@ -49,4 +50,20 @@ public interface AsyncClientBuilder<B extends AsyncClientBuilder<B, C>, C>
      * finished with it, the SDK will only close HTTP clients that it creates.
      */
     B asyncHttpConfiguration(ClientAsyncHttpConfiguration asyncHttpConfiguration);
+
+    /**
+     * Configures the HTTP client used by the service client.
+     *
+     * Allows just specifying the builder parameters without having to instantiate a builder and call <code>build</code> on it.
+     * For example
+     *
+     * <pre><code>
+     *     builder().asyncHttpConfiguration(b -> b.httpClient(client));
+     * </code></pre>
+     *
+     * @see #asyncHttpConfiguration(ClientAsyncHttpConfiguration)
+     */
+    default B asyncHttpConfiguration(Consumer<ClientAsyncHttpConfiguration.Builder> asyncHttpConfiguration) {
+        return asyncHttpConfiguration(ClientAsyncHttpConfiguration.builder().apply(asyncHttpConfiguration).build());
+    }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/client/builder/ClientAsyncHttpConfiguration.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/builder/ClientAsyncHttpConfiguration.java
@@ -124,6 +124,7 @@ public final class ClientAsyncHttpConfiguration
          */
         // This intentionally returns SdkBuilder so that only httpClient or httpClientFactory may be supplied.
         SdkBuilder<?, ClientAsyncHttpConfiguration> httpClientFactory(SdkAsyncHttpClientFactory sdkClientFactory);
+
     }
 
     /**

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettySdkHttpClientFactory.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettySdkHttpClientFactory.java
@@ -22,6 +22,7 @@ import static software.amazon.awssdk.http.SdkHttpConfigurationOption.SOCKET_TIME
 import io.netty.channel.EventLoopGroup;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -169,6 +170,16 @@ public final class NettySdkHttpClientFactory
          */
         Builder eventLoopGroupConfiguration(EventLoopGroupConfiguration eventLoopGroupConfiguration);
 
+        /**
+         * Configuration for the Netty {@link EventLoopGroup} which multiplexes IO events.
+         *
+         * @param eventLoopGroupConfiguration consumer that allows a {@link EventLoopGroupConfiguration.Builder} to be mutated.
+         * @return This builder for method chaining.
+         * @see #eventLoopGroupConfiguration(EventLoopGroupConfiguration)
+         */
+        default Builder eventLoopGroupConfiguration(Consumer<EventLoopGroupConfiguration.Builder> eventLoopGroupConfiguration) {
+            return eventLoopGroupConfiguration(EventLoopGroupConfiguration.builder().apply(eventLoopGroupConfiguration).build());
+        }
     }
 
     private static final class DefaultBuilder implements Builder {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of having to do this:

```java
DynamoDBAsyncClient.builder().asyncHttpConfiguration(
    ClientAsyncHttpConfiguration.builder()
                                .httpClientFactory(NettySdkHttpClientFactory.builder()
                                                                            .maxConnectionsPerEndpoint(MAX_CONNECTIONS)
                                                                            .build())
                                .build())
                   .build();
```

we can do :

```java
DynamoDBAsyncClient.builder().asyncHttpConfiguration(
    b -> b.httpClientFactory(NettySdkHttpClientFactory.builder()
                                                      .maxConnectionsPerEndpoint(MAX_CONNECTIONS)))
                           .build();
```
