### PR TITLE
Adding some helpers for being able to create DyanmoDB AttributeValues.

### DIFF
--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/model/Item.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/model/Item.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb.model;
+
+import static java.util.stream.Collectors.toList;
+import static software.amazon.awssdk.utils.CollectionUtils.toMap;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
+
+/**
+ * Used to build a DynamoDB item map.
+ *
+ * For example to pass to a {@link PutItemRequest.Builder#item(Map)}.
+ */
+@ReviewBeforeRelease("May want to do this a different way")
+public final class Item extends HashMap<String, AttributeValue> {
+
+    private Item(Builder builder) {
+        putAll(builder.item);
+    }
+
+    /**
+     * Create a new instance of the {@link Builder}.
+     *
+     * @return a new instance of the {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder implements SdkBuilder<Builder, Item> {
+        private final Map<String, AttributeValue> item = new HashMap<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Build a {@link Map} representing a DyanmoDB item.
+         *
+         * @return a {@link Map} representing a DyanmoDB item
+         */
+        @Override
+        public Item build() {
+            return new Item(this);
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a String to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().s(stringValue).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param stringValue the string value of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, String stringValue) {
+            item.put(key, AttributeValue.builder().s(stringValue).build());
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a Boolean to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().bool(booleanValue).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param booleanValue the boolean value of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, Boolean booleanValue) {
+            item.put(key, AttributeValue.builder().bool(booleanValue).build());
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a Number to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().n(String.valueOf(numericValue)).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param numericValue the numeric value of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, Number numericValue) {
+            item.put(key, AttributeValue.builder().n(String.valueOf(numericValue)).build());
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing binary data to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().b(ByteBuffer.wrap(binaryValue)).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param binaryValue the binary value of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, byte[] binaryValue) {
+            return attribute(key, ByteBuffer.wrap(binaryValue));
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing binary data to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().b(binaryValue).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param binaryValue the binary value of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, ByteBuffer binaryValue) {
+            item.put(key, AttributeValue.builder().b(binaryValue).build());
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of AttributeValues to the item with the specified key.
+         *
+         * This will attempt to infer the of of the {@link AttributeValue} for each given {@link Object} in the list
+         * based on the type. Supported types are:
+         * <ul>
+         * <li><strong>{@link AttributeValue}</strong> which is unaltered</li>
+         * <li><strong>{@link String}</strong> becomes {@link AttributeValue#s()}</li>
+         * <li><strong>{@link Number}</strong> (and anything that can be automatically boxed to {@link Number} including
+         * int, long, float etc.) becomes {@link AttributeValue#n()}</li>
+         * <li><strong>{@link Boolean}</strong> (and bool) becomes {@link AttributeValue#bool()}</li>
+         * <li><strong>byte[]</strong> becomes {@link AttributeValue#b()}</li>
+         * <li><strong>{@link ByteBuffer}</strong> becomes {@link AttributeValue#b()}</li>
+         * <li><strong>{@link List}&lt;Object&gt;</strong> (where the containing objects are one of the types in
+         * this list) becomes {@link AttributeValue#l()}</li>
+         * <li><strong>{@link Map}&lt;String, Object&gt;</strong> (where the containing object values are one of the types
+         * in this list) becomes {@link AttributeValue#m()}</li>
+         * </ul>
+         *
+         * @param key the key of this attribute
+         * @param values the object values
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, List<?> values) {
+            item.put(key, fromObject(values));
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a map of string to AttributeValues to the item with the specified key.
+         *
+         * This will attempt to infer the most appropriate {@link AttributeValue} for each given {@link Object} value in the map
+         * based on the type. Supported types are:
+         * <ul>
+         * <li><strong>{@link AttributeValue}</strong> which is unaltered</li>
+         * <li><strong>{@link String}</strong> becomes {@link AttributeValue#s()}</li>
+         * <li><strong>{@link Number}</strong> (and anything that can be automatically boxed to {@link Number} including
+         * int, long, float etc.) becomes {@link AttributeValue#n()}</li>
+         * <li><strong>{@link Boolean}</strong> (and bool) becomes {@link AttributeValue#bool()}</li>
+         * <li><strong>byte[]</strong> becomes {@link AttributeValue#b()}</li>
+         * <li><strong>{@link ByteBuffer}</strong> becomes {@link AttributeValue#b()}</li>
+         * <li><strong>{@link List}&lt;Object&gt;</strong> (where the containing objects are one of the types in
+         * this list) becomes {@link AttributeValue#l()}</li>
+         * <li><strong>{@link Map}&lt;String, Object&gt;</strong> (where the containing object values are one of the types
+         * in this list) becomes {@link AttributeValue#m()}</li>
+         * </ul>
+         *
+         * @param key the key of this attribute
+         * @param values the map of key to object
+         * @return the builder for method chaining
+         */
+        public Builder attribute(String key, Map<String, ?> values) {
+            item.put(key, fromObject(values));
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of strings to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().ss(stringValue1, stringValue2, ...).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param stringValues the string values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder strings(String key, String... stringValues) {
+            return strings(key, Arrays.asList(stringValues));
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of strings to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().ss(stringValues).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param stringValues the string values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder strings(String key, Collection<String> stringValues) {
+            item.put(key, AttributeValue.builder().ss(stringValues).build());
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of numbers to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().ns(numberValues1, numberValues2, ...).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param numberValues the number values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder numbers(String key, Number... numberValues) {
+            return numbers(key, Arrays.asList(numberValues));
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of numbers to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().ns(numberValues).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param numberValues the number values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder numbers(String key, Collection<? extends Number> numberValues) {
+            item.put(key, AttributeValue.builder().ns(numberValues.stream().map(String::valueOf).collect(toList())).build());
+            return this;
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of binary data to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().bs(Arrays.stream(byteArrays)
+         *                                                    .map(ByteBuffer::wrap)
+         *                                                    .collect(Collectors.toList())).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param byteArrays the binary values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder byteArrays(String key, byte[]... byteArrays) {
+            return byteArrays(key, Arrays.asList(byteArrays));
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of binary data to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().bs(byteArrays.stream()
+         *                                                        .map(ByteBuffer::wrap)
+         *                                                        .collect(Collectors.toList())).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param byteArrays the binary values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder byteArrays(String key, Collection<byte[]> byteArrays) {
+            return byteBuffers(key, byteArrays.stream().map(ByteBuffer::wrap).collect(Collectors.toList()));
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of binary data to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().bs(binaryValues1, binaryValues2, ...)).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param byteArrays the binary values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder byteBuffers(String key, ByteBuffer... binaryValues) {
+            return byteBuffers(key, Arrays.asList(binaryValues));
+        }
+
+        /**
+         * Adds an {@link AttributeValue} representing a list of binary data to the item with the specified key.
+         *
+         * Equivalent of:
+         * <pre><code>
+         * itemMap.put(key, AttributeValue.builder().bs(binaryValues).build());
+         * </code></pre>
+         *
+         * @param key the key of this attribute
+         * @param byteArrays the binary values of the attribute
+         * @return the builder for method chaining
+         */
+        public Builder byteBuffers(String key, Collection<? extends ByteBuffer> binaryValues) {
+            item.put(key, AttributeValue.builder().bs(binaryValues.stream().collect(toList())).build());
+            return this;
+        }
+
+        private static AttributeValue fromObject(Object object) {
+            if (object instanceof AttributeValue) {
+                return (AttributeValue) object;
+            }
+            if (object instanceof String) {
+                return AttributeValue.builder().s((String) object).build();
+            }
+            if (object instanceof Number) {
+                return AttributeValue.builder().n(String.valueOf((Number) object)).build();
+            }
+            if (object instanceof byte[]) {
+                return AttributeValue.builder().b(ByteBuffer.wrap((byte[]) object)).build();
+            }
+            if (object instanceof ByteBuffer) {
+                return AttributeValue.builder().b((ByteBuffer) object).build();
+            }
+            if (object instanceof Boolean) {
+                return AttributeValue.builder().bool((Boolean) object).build();
+            }
+            if (object instanceof List) {
+                List<AttributeValue> attributeValues = ((List<?>) object).stream()
+                                                                         .map(Builder::fromObject)
+                                                                         .collect(toList());
+                return AttributeValue.builder().l(attributeValues).build();
+            }
+            if (object instanceof Map) {
+                Map<String, AttributeValue> attributeValues =
+                    ((Map<String, ?>) object).entrySet()
+                                             .stream()
+                                             .map(e -> new SimpleImmutableEntry<>(e.getKey(), fromObject(e.getValue())))
+                                             .collect(toMap());
+                return AttributeValue.builder().m(attributeValues).build();
+            }
+            throw new IllegalArgumentException("Unsupported type: " + object.getClass());
+        }
+    }
+}

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/model/ItemTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/model/ItemTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb.model;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+public class ItemTest {
+
+    public static final byte[] BYTES1 = "value1".getBytes(UTF_8);
+    public static final byte[] BYTES2 = "value2".getBytes(UTF_8);
+
+    @Test
+    public void testItemBuilder() {
+
+        Map<String, Object> testMap = new HashMap<>();
+        testMap.put("String", "stringValue");
+        testMap.put("int", 15);
+        testMap.put("byteArray", BYTES1);
+        testMap.put("ByteBuffer", ByteBuffer.wrap(BYTES2));
+        testMap.put("bool", true);
+
+        List<Long> longs = Arrays.asList(1l, 2l, 3l);
+
+        Map<String, AttributeValue> item =
+            Item.builder()
+                .attribute("String", "stringValue")
+                .attribute("int", 15)
+                .attribute("long", 200L)
+                .attribute("float", 15.5)
+                .attribute("Integer", new Integer(15))
+                .attribute("Long", new Long(200))
+                .attribute("Float", new Float(15.5))
+                .attribute("bool", true)
+                .attribute("Boolean", Boolean.TRUE)
+                .attribute("bytes", BYTES1)
+                .attribute("ByteBuffer", ByteBuffer.wrap(BYTES1))
+                .strings("StringsVarArgs", "value1", "value2")
+                .strings("StringsCollection", Arrays.asList("value1", "value2"))
+                .numbers("NumbersVarArgs", 1, 2.0, 3L)
+                .numbers("NumbersCollection", Arrays.asList(1, 2.0, 3L))
+                .numbers("LongCollection", longs)
+                .byteArrays("bytesVarArgs", BYTES1, BYTES2)
+                .byteArrays("bytesCollection", Arrays.asList(BYTES1, BYTES2))
+                .byteBuffers("ByteBuffersVarArgs", ByteBuffer.wrap(BYTES1), ByteBuffer.wrap(BYTES2))
+                .byteBuffers("ByteBuffersCollection", Arrays.asList(ByteBuffer.wrap(BYTES1), ByteBuffer.wrap(BYTES2)))
+                .attribute("list", Arrays.asList(15, 200L, 15.5, "stringValue", BYTES1, ByteBuffer.wrap(BYTES2), true))
+                .attribute("map", testMap)
+                .attribute("nested", Arrays.asList(15, singletonMap("nestedList", Arrays.asList("stringValue", BYTES1))))
+                .build();
+
+
+        assertThat(item).containsEntry("String", AttributeValue.builder().s("stringValue").build());
+        assertThat(item).containsEntry("int", AttributeValue.builder().n("15").build());
+        assertThat(item).containsEntry("long", AttributeValue.builder().n("200").build());
+        assertThat(item).containsEntry("float", AttributeValue.builder().n("15.5").build());
+        assertThat(item).containsEntry("Integer", AttributeValue.builder().n("15").build());
+        assertThat(item).containsEntry("Long", AttributeValue.builder().n("200").build());
+        assertThat(item).containsEntry("Float", AttributeValue.builder().n("15.5").build());
+        assertThat(item).containsEntry("bool", AttributeValue.builder().bool(true).build());
+        assertThat(item).containsEntry("Boolean", AttributeValue.builder().bool(true).build());
+        assertThat(item).containsEntry("StringsVarArgs", AttributeValue.builder().ss("value1", "value2").build());
+        assertThat(item).containsEntry("StringsCollection", AttributeValue.builder().ss("value1", "value2").build());
+        assertThat(item).containsEntry("NumbersVarArgs", AttributeValue.builder().ns("1", "2.0", "3").build());
+        assertThat(item).containsEntry("NumbersCollection", AttributeValue.builder().ns("1", "2.0", "3").build());
+        assertThat(item).containsEntry("LongCollection", AttributeValue.builder().ns("1", "2", "3").build());
+
+        assertThat(item).hasEntrySatisfying("bytes", bytesMatching(BYTES1));
+        assertThat(item).hasEntrySatisfying("ByteBuffer", bytesMatching(BYTES1));
+        assertThat(item).hasEntrySatisfying("bytesVarArgs", bytesMatching(BYTES1, BYTES2));
+        assertThat(item).hasEntrySatisfying("bytesCollection", bytesMatching(BYTES1, BYTES2));
+        assertThat(item).hasEntrySatisfying("ByteBuffersVarArgs", bytesMatching(BYTES1, BYTES2));
+        assertThat(item).hasEntrySatisfying("ByteBuffersCollection", bytesMatching(BYTES1, BYTES2));
+
+        assertThat(item.get("list").l()).hasSize(7);
+        assertThat(item.get("list").l().get(0)).isEqualTo(AttributeValue.builder().n("15").build());
+        assertThat(item.get("list").l().get(1)).isEqualTo(AttributeValue.builder().n("200").build());
+        assertThat(item.get("list").l().get(2)).isEqualTo(AttributeValue.builder().n("15.5").build());
+        assertThat(item.get("list").l().get(3)).isEqualTo(AttributeValue.builder().s("stringValue").build());
+        assertThat(item.get("list").l().get(4)).has(bytesMatching(BYTES1));
+        assertThat(item.get("list").l().get(5)).has(bytesMatching(BYTES2));
+        assertThat(item.get("list").l().get(6)).isEqualTo(AttributeValue.builder().bool(true).build());
+
+        assertThat(item.get("map").m().entrySet()).hasSize(5);
+        assertThat(item.get("map").m().get("String")).isEqualTo(AttributeValue.builder().s("stringValue").build());
+        assertThat(item.get("map").m().get("int")).isEqualTo(AttributeValue.builder().n("15").build());
+        assertThat(item.get("map").m().get("byteArray")).has(bytesMatching(BYTES1));
+        assertThat(item.get("map").m().get("ByteBuffer")).has(bytesMatching(BYTES2));
+        assertThat(item.get("map").m().get("bool")).isEqualTo(AttributeValue.builder().bool(true).build());
+
+        assertThat(item.get("nested").l()).hasSize(2);
+        assertThat(item.get("nested").l().get(0)).isEqualTo(AttributeValue.builder().n("15").build());
+        assertThat(item.get("nested").l().get(1).m().entrySet()).hasSize(1);
+        assertThat(item.get("nested").l().get(1).m().get("nestedList").l()).hasSize(2);
+        assertThat(item.get("nested").l().get(1).m().get("nestedList").l().get(0)).isEqualTo(AttributeValue.builder().s("stringValue").build());
+        assertThat(item.get("nested").l().get(1).m().get("nestedList").l().get(1)).has(bytesMatching(BYTES1));
+    }
+
+    private static Condition<AttributeValue> bytesMatching(byte[] bytes) {
+        return new Condition<>(item -> byteBufferEquals(item.b(), bytes), "bytes matching");
+    }
+
+    private static Condition<AttributeValue> bytesMatching(byte[] firstByteArray, byte[] secondByteArray) {
+        return new Condition<>(item -> {
+            return item.bs().size() == 2 &&
+                   byteBufferEquals(item.bs().get(0), firstByteArray) &&
+                   byteBufferEquals(item.bs().get(1), secondByteArray);
+        }, "List<" + String.valueOf(firstByteArray) + ", " + String.valueOf(secondByteArray) + ">");
+    }
+
+    private static boolean byteBufferEquals(ByteBuffer byteBuffer, byte[] bytes) {
+        if (byteBuffer.remaining() != bytes.length) {
+            return false;
+        }
+        byte[] actual = new byte[bytes.length];
+        byteBuffer.duplicate().get(actual);
+        return Arrays.equals(actual, bytes);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Creating `AttributeValues` is very verbose for such a simple data-type, these helpers allow creating item maps and attribute values from simple method calls.

## Testing
Added new unit tests

