### PR TITLE
Implementing Consumer<Builder> fluent setters on model builders.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
@@ -377,33 +377,56 @@ public class MemberModel extends DocumentationModel {
     }
 
     public String getFluentSetterDocumentation() {
-        StringBuilder docBuilder = new StringBuilder();
-        docBuilder.append(getSetterDocumentation())
-                .append(LF)
-                .append("@return " + stripHtmlTags(DEFAULT_FLUENT_RETURN))
-                .append(getEnumDoc());
-        return docBuilder.toString();
+        return getSetterDocumentation()
+               + LF
+               + "@return " + stripHtmlTags(DEFAULT_FLUENT_RETURN)
+               + getEnumDoc();
+    }
+
+    public String getDefaultConsumerFluentSetterDocumentation() {
+        return (StringUtils.isNotBlank(documentation) ? documentation : DEFAULT_SETTER.replace("%s", name) + "\n")
+               + LF
+               + "This is a convenience that creates an instance of the {@link "
+               + variable.getSimpleType()
+               + ".Builder} avoiding the need to create one manually via {@link "
+               + variable.getSimpleType()
+               + "#builder()}.\n"
+               + LF
+               + "When the {@link Consumer} completes, {@link "
+               + variable.getSimpleType()
+               + ".Builder#build()} is called immediately and its result is passed to {@link #"
+               + getFluentGetterMethodName()
+               + "("
+               + variable.getSimpleType()
+               + ")}."
+               + LF
+               + "@param "
+               + variable.getVariableName()
+               + " a consumer that will call methods on {@link "
+               + variable.getSimpleType() + ".Builder}"
+               + LF
+               + "@return " + stripHtmlTags(DEFAULT_FLUENT_RETURN)
+               + LF
+               + "@see #"
+               + getFluentSetterMethodName()
+               + "("
+               + variable.getSimpleType()
+               + ")";
     }
 
     private String getParamDoc() {
-        StringBuilder docBuilder = new StringBuilder();
-
-        String variableDesc = StringUtils.isNotBlank(documentation) ? documentation : DEFAULT_SETTER_PARAM.replace("%s", name);
-
-        docBuilder.append(LF)
-                  .append("@param ")
-                  .append(variable.getVariableName())
-                  .append(" ")
-                  .append(stripHtmlTags(variableDesc));
-        return docBuilder.toString();
+        return LF
+               + "@param "
+               + variable.getVariableName()
+               + " "
+               + stripHtmlTags(StringUtils.isNotBlank(documentation) ? documentation : DEFAULT_SETTER_PARAM.replace("%s", name));
     }
 
     private String getEnumDoc() {
         StringBuilder docBuilder = new StringBuilder();
 
         if (enumType != null) {
-            docBuilder.append(LF);
-            docBuilder.append("@see " + enumType);
+            docBuilder.append(LF).append("@see ").append(enumType);
         }
 
         return docBuilder.toString();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AbstractMemberSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AbstractMemberSetters.java
@@ -54,11 +54,12 @@ abstract class AbstractMemberSetters implements MemberSetters {
         this.poetExtensions = new PoetExtensions(intermediateModel);
     }
 
-    protected MethodSpec.Builder fluentSetterDeclaration(ParameterSpec parameter, TypeName returnType) {
-        return MethodSpec.methodBuilder(memberModel().getFluentSetterMethodName())
-                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                .addParameter(parameter)
-                .returns(returnType);
+    protected MethodSpec.Builder fluentAbstractSetterDeclaration(ParameterSpec parameter, TypeName returnType) {
+        return fluentSetterDeclaration(parameter, returnType).addModifiers(Modifier.ABSTRACT);
+    }
+
+    protected MethodSpec.Builder fluentDefaultSetterDeclaration(ParameterSpec parameter, TypeName returnType) {
+        return fluentSetterDeclaration(parameter, returnType).addModifiers(Modifier.DEFAULT);
     }
 
     protected MethodSpec.Builder fluentSetterBuilder(TypeName returnType) {
@@ -140,6 +141,13 @@ abstract class AbstractMemberSetters implements MemberSetters {
 
     protected boolean annotateJsonProperty() {
         return intermediateModel.getMetadata().isJsonProtocol() && shapeModel.getShapeType() == ShapeType.Exception;
+    }
+
+    private MethodSpec.Builder fluentSetterDeclaration(ParameterSpec parameter, TypeName returnType) {
+        return MethodSpec.methodBuilder(memberModel().getFluentSetterMethodName())
+                         .addModifiers(Modifier.PUBLIC)
+                         .addParameter(parameter)
+                         .returns(returnType);
     }
 
     private CodeBlock copySetterBody(String copyAssignment, String regularAssignment, String copyMethodName) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ListSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ListSetters.java
@@ -49,17 +49,17 @@ class ListSetters extends AbstractMemberSetters {
 
         String setterDocumentation = memberModel().getFluentSetterDocumentation();
 
-        fluentDeclarations.add(fluentSetterDeclaration(memberAsParameter(), returnType)
+        fluentDeclarations.add(fluentAbstractSetterDeclaration(memberAsParameter(), returnType)
                 .addJavadoc("$L", setterDocumentation)
                 .build());
 
-        fluentDeclarations.add(fluentSetterDeclaration(ParameterSpec.builder(asArray(), fieldName()).build(), returnType)
+        fluentDeclarations.add(fluentAbstractSetterDeclaration(ParameterSpec.builder(asArray(), fieldName()).build(), returnType)
                 .addJavadoc("$L", setterDocumentation)
                 .varargs(true)
                 .build());
 
         if (memberModel().getEnumType() != null) {
-            fluentDeclarations.add(fluentSetterDeclaration(ParameterSpec.builder(
+            fluentDeclarations.add(fluentAbstractSetterDeclaration(ParameterSpec.builder(
                     asArrayOfModeledEnum(), fieldName()).build(), returnType)
                     .varargs(true)
                     .addJavadoc("$L", setterDocumentation)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MapSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MapSetters.java
@@ -32,7 +32,7 @@ class MapSetters extends AbstractMemberSetters {
     }
 
     public List<MethodSpec> fluentDeclarations(TypeName returnType) {
-        return Collections.singletonList(fluentSetterDeclaration(memberAsParameter(), returnType)
+        return Collections.singletonList(fluentAbstractSetterDeclaration(memberAsParameter(), returnType)
                 .addJavadoc("$L", memberModel().getFluentSetterDocumentation())
                 .build());
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/NonCollectionSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/NonCollectionSetters.java
@@ -17,12 +17,16 @@ package software.amazon.awssdk.codegen.poet.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
@@ -37,14 +41,18 @@ class NonCollectionSetters extends AbstractMemberSetters {
 
     public List<MethodSpec> fluentDeclarations(TypeName returnType) {
         List<MethodSpec> fluentDeclarations = new ArrayList<>();
-        fluentDeclarations.add(fluentSetterDeclaration(memberAsParameter(), returnType)
-                .addJavadoc("$L", memberModel().getFluentSetterDocumentation())
-                .build());
+        fluentDeclarations.add(fluentAbstractSetterDeclaration(memberAsParameter(), returnType)
+                                   .addJavadoc("$L", memberModel().getFluentSetterDocumentation())
+                                   .build());
 
         if (memberModel().getEnumType() != null) {
-            fluentDeclarations.add(fluentSetterDeclaration(modeledParam(), returnType)
-                    .addJavadoc("$L", memberModel().getFluentSetterDocumentation())
-                    .build());
+            fluentDeclarations.add(fluentAbstractSetterDeclaration(modeledParam(), returnType)
+                                       .addJavadoc("$L", memberModel().getFluentSetterDocumentation())
+                                       .build());
+        }
+
+        if (memberModel().hasBuilder()) {
+            fluentDeclarations.add(fluentConsumerFluentSetter(returnType));
         }
 
         return fluentDeclarations;
@@ -79,23 +87,40 @@ class NonCollectionSetters extends AbstractMemberSetters {
 
     private MethodSpec fluentAssignmentSetter(TypeName returnType) {
         return fluentSetterBuilder(returnType)
-                .addCode(copySetterBody().toBuilder().addStatement("return this").build())
-                .build();
+            .addCode(copySetterBody().toBuilder().addStatement("return this").build())
+            .build();
     }
 
     private MethodSpec fluentEnumToStringSetter(TypeName returnType) {
         return fluentSetterBuilder(modeledParam(), returnType)
-                .addCode(enumToStringAssignmentBody().toBuilder().addStatement("return this").build())
-                .build();
+            .addCode(enumToStringAssignmentBody().toBuilder().addStatement("return this").build())
+            .build();
+    }
+
+    private MethodSpec fluentConsumerFluentSetter(TypeName returnType) {
+        ClassName memberClass = poetExtensions.getModelClass(memberModel().getShape().getC2jName());
+        ClassName builderClass = memberClass.nestedClass("Builder");
+        return fluentDefaultSetterDeclaration(builderConsumerParam(builderClass), returnType)
+            .addModifiers(Modifier.DEFAULT)
+            .addStatement("return $N($T.builder().apply($N).build())",
+                          memberModel().getFluentSetterMethodName(),
+                          memberClass,
+                          fieldName())
+            .addJavadoc("$L", memberModel().getDefaultConsumerFluentSetterDocumentation())
+            .build();
     }
 
     private CodeBlock enumToStringAssignmentBody() {
         return CodeBlock.builder()
-                .addStatement("this.$N($N.toString())", fieldName(), fieldName())
-                .build();
+                        .addStatement("this.$N($N.toString())", fieldName(), fieldName())
+                        .build();
     }
 
     private ParameterSpec modeledParam() {
         return ParameterSpec.builder(poetExtensions.getModelClass(memberModel().getShape().getShapeName()), fieldName()).build();
+    }
+
+    private ParameterSpec builderConsumerParam(ClassName builderClass) {
+        return ParameterSpec.builder(ParameterizedTypeName.get(ClassName.get(Consumer.class), builderClass), fieldName()).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
@@ -450,7 +451,8 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
      * Returns the value of the EnumType property for this object.
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
-     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
+     * {@link #enumTypeString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
@@ -464,7 +466,8 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
      * Returns the value of the EnumType property for this object.
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
-     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
+     * {@link #enumTypeString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
@@ -1064,6 +1067,24 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         Builder structWithNestedTimestampMember(StructWithTimestamp structWithNestedTimestampMember);
 
         /**
+         * Sets the value of the StructWithNestedTimestampMember property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link StructWithTimestamp.Builder} avoiding the need
+         * to create one manually via {@link StructWithTimestamp#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link StructWithTimestamp.Builder#build()} is called immediately and
+         * its result is passed to {@link #structWithNestedTimestampMember(StructWithTimestamp)}.
+         *
+         * @param structWithNestedTimestampMember
+         *        a consumer that will call methods on {@link StructWithTimestamp.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #structWithNestedTimestampMember(StructWithTimestamp)
+         */
+        default Builder structWithNestedTimestampMember(Consumer<StructWithTimestamp.Builder> structWithNestedTimestampMember) {
+            return structWithNestedTimestampMember(StructWithTimestamp.builder().apply(structWithNestedTimestampMember).build());
+        }
+
+        /**
          * Sets the value of the BlobArg property for this object.
          * <p>
          * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
@@ -1084,6 +1105,24 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder structWithNestedBlob(StructWithNestedBlobType structWithNestedBlob);
+
+        /**
+         * Sets the value of the StructWithNestedBlob property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link StructWithNestedBlobType.Builder} avoiding the
+         * need to create one manually via {@link StructWithNestedBlobType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link StructWithNestedBlobType.Builder#build()} is called immediately
+         * and its result is passed to {@link #structWithNestedBlob(StructWithNestedBlobType)}.
+         *
+         * @param structWithNestedBlob
+         *        a consumer that will call methods on {@link StructWithNestedBlobType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #structWithNestedBlob(StructWithNestedBlobType)
+         */
+        default Builder structWithNestedBlob(Consumer<StructWithNestedBlobType.Builder> structWithNestedBlob) {
+            return structWithNestedBlob(StructWithNestedBlobType.builder().apply(structWithNestedBlob).build());
+        }
 
         /**
          * Sets the value of the BlobMap property for this object.
@@ -1122,6 +1161,24 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         Builder recursiveStruct(RecursiveStructType recursiveStruct);
 
         /**
+         * Sets the value of the RecursiveStruct property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link RecursiveStructType.Builder} avoiding the need
+         * to create one manually via {@link RecursiveStructType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
+         * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
+         *
+         * @param recursiveStruct
+         *        a consumer that will call methods on {@link RecursiveStructType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #recursiveStruct(RecursiveStructType)
+         */
+        default Builder recursiveStruct(Consumer<RecursiveStructType.Builder> recursiveStruct) {
+            return recursiveStruct(RecursiveStructType.builder().apply(recursiveStruct).build());
+        }
+
+        /**
          * Sets the value of the PolymorphicTypeWithSubTypes property for this object.
          *
          * @param polymorphicTypeWithSubTypes
@@ -1131,6 +1188,24 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
         Builder polymorphicTypeWithSubTypes(BaseType polymorphicTypeWithSubTypes);
 
         /**
+         * Sets the value of the PolymorphicTypeWithSubTypes property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link BaseType.Builder} avoiding the need to create
+         * one manually via {@link BaseType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link BaseType.Builder#build()} is called immediately and its result is
+         * passed to {@link #polymorphicTypeWithSubTypes(BaseType)}.
+         *
+         * @param polymorphicTypeWithSubTypes
+         *        a consumer that will call methods on {@link BaseType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #polymorphicTypeWithSubTypes(BaseType)
+         */
+        default Builder polymorphicTypeWithSubTypes(Consumer<BaseType.Builder> polymorphicTypeWithSubTypes) {
+            return polymorphicTypeWithSubTypes(BaseType.builder().apply(polymorphicTypeWithSubTypes).build());
+        }
+
+        /**
          * Sets the value of the PolymorphicTypeWithoutSubTypes property for this object.
          *
          * @param polymorphicTypeWithoutSubTypes
@@ -1138,6 +1213,24 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder polymorphicTypeWithoutSubTypes(SubTypeOne polymorphicTypeWithoutSubTypes);
+
+        /**
+         * Sets the value of the PolymorphicTypeWithoutSubTypes property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link SubTypeOne.Builder} avoiding the need to create
+         * one manually via {@link SubTypeOne#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link SubTypeOne.Builder#build()} is called immediately and its result
+         * is passed to {@link #polymorphicTypeWithoutSubTypes(SubTypeOne)}.
+         *
+         * @param polymorphicTypeWithoutSubTypes
+         *        a consumer that will call methods on {@link SubTypeOne.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #polymorphicTypeWithoutSubTypes(SubTypeOne)
+         */
+        default Builder polymorphicTypeWithoutSubTypes(Consumer<SubTypeOne.Builder> polymorphicTypeWithoutSubTypes) {
+            return polymorphicTypeWithoutSubTypes(SubTypeOne.builder().apply(polymorphicTypeWithoutSubTypes).build());
+        }
 
         /**
          * Sets the value of the EnumType property for this object.
@@ -1545,7 +1638,7 @@ public class AllTypesRequest extends AmazonWebServiceRequest implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                    .build() : null;
+                .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
@@ -451,7 +452,8 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
      * Returns the value of the EnumType property for this object.
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
-     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
+     * {@link #enumTypeString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
@@ -465,7 +467,8 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
      * Returns the value of the EnumType property for this object.
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
-     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from {@link #enumTypeString}.
+     * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
+     * {@link #enumTypeString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
@@ -1065,6 +1068,24 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         Builder structWithNestedTimestampMember(StructWithTimestamp structWithNestedTimestampMember);
 
         /**
+         * Sets the value of the StructWithNestedTimestampMember property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link StructWithTimestamp.Builder} avoiding the need
+         * to create one manually via {@link StructWithTimestamp#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link StructWithTimestamp.Builder#build()} is called immediately and
+         * its result is passed to {@link #structWithNestedTimestampMember(StructWithTimestamp)}.
+         *
+         * @param structWithNestedTimestampMember
+         *        a consumer that will call methods on {@link StructWithTimestamp.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #structWithNestedTimestampMember(StructWithTimestamp)
+         */
+        default Builder structWithNestedTimestampMember(Consumer<StructWithTimestamp.Builder> structWithNestedTimestampMember) {
+            return structWithNestedTimestampMember(StructWithTimestamp.builder().apply(structWithNestedTimestampMember).build());
+        }
+
+        /**
          * Sets the value of the BlobArg property for this object.
          * <p>
          * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
@@ -1085,6 +1106,24 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder structWithNestedBlob(StructWithNestedBlobType structWithNestedBlob);
+
+        /**
+         * Sets the value of the StructWithNestedBlob property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link StructWithNestedBlobType.Builder} avoiding the
+         * need to create one manually via {@link StructWithNestedBlobType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link StructWithNestedBlobType.Builder#build()} is called immediately
+         * and its result is passed to {@link #structWithNestedBlob(StructWithNestedBlobType)}.
+         *
+         * @param structWithNestedBlob
+         *        a consumer that will call methods on {@link StructWithNestedBlobType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #structWithNestedBlob(StructWithNestedBlobType)
+         */
+        default Builder structWithNestedBlob(Consumer<StructWithNestedBlobType.Builder> structWithNestedBlob) {
+            return structWithNestedBlob(StructWithNestedBlobType.builder().apply(structWithNestedBlob).build());
+        }
 
         /**
          * Sets the value of the BlobMap property for this object.
@@ -1123,6 +1162,24 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         Builder recursiveStruct(RecursiveStructType recursiveStruct);
 
         /**
+         * Sets the value of the RecursiveStruct property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link RecursiveStructType.Builder} avoiding the need
+         * to create one manually via {@link RecursiveStructType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
+         * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
+         *
+         * @param recursiveStruct
+         *        a consumer that will call methods on {@link RecursiveStructType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #recursiveStruct(RecursiveStructType)
+         */
+        default Builder recursiveStruct(Consumer<RecursiveStructType.Builder> recursiveStruct) {
+            return recursiveStruct(RecursiveStructType.builder().apply(recursiveStruct).build());
+        }
+
+        /**
          * Sets the value of the PolymorphicTypeWithSubTypes property for this object.
          *
          * @param polymorphicTypeWithSubTypes
@@ -1132,6 +1189,24 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
         Builder polymorphicTypeWithSubTypes(BaseType polymorphicTypeWithSubTypes);
 
         /**
+         * Sets the value of the PolymorphicTypeWithSubTypes property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link BaseType.Builder} avoiding the need to create
+         * one manually via {@link BaseType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link BaseType.Builder#build()} is called immediately and its result is
+         * passed to {@link #polymorphicTypeWithSubTypes(BaseType)}.
+         *
+         * @param polymorphicTypeWithSubTypes
+         *        a consumer that will call methods on {@link BaseType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #polymorphicTypeWithSubTypes(BaseType)
+         */
+        default Builder polymorphicTypeWithSubTypes(Consumer<BaseType.Builder> polymorphicTypeWithSubTypes) {
+            return polymorphicTypeWithSubTypes(BaseType.builder().apply(polymorphicTypeWithSubTypes).build());
+        }
+
+        /**
          * Sets the value of the PolymorphicTypeWithoutSubTypes property for this object.
          *
          * @param polymorphicTypeWithoutSubTypes
@@ -1139,6 +1214,24 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder polymorphicTypeWithoutSubTypes(SubTypeOne polymorphicTypeWithoutSubTypes);
+
+        /**
+         * Sets the value of the PolymorphicTypeWithoutSubTypes property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link SubTypeOne.Builder} avoiding the need to create
+         * one manually via {@link SubTypeOne#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link SubTypeOne.Builder#build()} is called immediately and its result
+         * is passed to {@link #polymorphicTypeWithoutSubTypes(SubTypeOne)}.
+         *
+         * @param polymorphicTypeWithoutSubTypes
+         *        a consumer that will call methods on {@link SubTypeOne.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #polymorphicTypeWithoutSubTypes(SubTypeOne)
+         */
+        default Builder polymorphicTypeWithoutSubTypes(Consumer<SubTypeOne.Builder> polymorphicTypeWithoutSubTypes) {
+            return polymorphicTypeWithoutSubTypes(SubTypeOne.builder().apply(polymorphicTypeWithoutSubTypes).build());
+        }
 
         /**
          * Sets the value of the EnumType property for this object.
@@ -1546,7 +1639,7 @@ public class AllTypesResponse extends AmazonWebServiceResult<ResponseMetadata> i
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                    .build() : null;
+                .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -162,16 +163,16 @@ public class RecursiveStructType implements StructuredPojo, ToCopyableBuilder<Re
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "NoRecurse":
-            return Optional.of(clazz.cast(noRecurse()));
-        case "RecursiveStruct":
-            return Optional.of(clazz.cast(recursiveStruct()));
-        case "RecursiveList":
-            return Optional.of(clazz.cast(recursiveList()));
-        case "RecursiveMap":
-            return Optional.of(clazz.cast(recursiveMap()));
-        default:
-            return Optional.empty();
+            case "NoRecurse":
+                return Optional.of(clazz.cast(noRecurse()));
+            case "RecursiveStruct":
+                return Optional.of(clazz.cast(recursiveStruct()));
+            case "RecursiveList":
+                return Optional.of(clazz.cast(recursiveList()));
+            case "RecursiveMap":
+                return Optional.of(clazz.cast(recursiveMap()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -199,6 +200,24 @@ public class RecursiveStructType implements StructuredPojo, ToCopyableBuilder<Re
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder recursiveStruct(RecursiveStructType recursiveStruct);
+
+        /**
+         * Sets the value of the RecursiveStruct property for this object.
+         *
+         * This is a convenience that creates an instance of the {@link RecursiveStructType.Builder} avoiding the need
+         * to create one manually via {@link RecursiveStructType#builder()}.
+         *
+         * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
+         * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
+         *
+         * @param recursiveStruct
+         *        a consumer that will call methods on {@link RecursiveStructType.Builder}
+         * @return Returns a reference to this object so that method calls can be chained together.
+         * @see #recursiveStruct(RecursiveStructType)
+         */
+        default Builder recursiveStruct(Consumer<Builder> recursiveStruct) {
+            return recursiveStruct(RecursiveStructType.builder().apply(recursiveStruct).build());
+        }
 
         /**
          * Sets the value of the RecursiveList property for this object.


### PR DESCRIPTION
## Description
Allows providing a `Consumer<Builder>` to complex fluent models setters to avoid having to create the appropriate builder yourself. As an example SES send message goes from:

```java
client.sendEmail(SendEmailRequest.builder()
                                 .destination(Destination.builder()
                                                         .toAddresses("kiiadi@gmail.com")
                                                         .build())
                                 .message(Message.builder().body(Body.builder()
                                                                     .text(Content.builder().data("Crud").charset("UTF-8").build())
                                                                     .build())
                                                 .subject(Content.builder().data("Hello").build())
                                                 .build())
                                 .build());
```
to a:

```java
client.sendEmail(SendEmailRequest.builder()
                                 .destination(d -> d.toAddresses("kiiadi@gmail.com"))
                                 .message(m -> m.body(b -> b.text(t -> t.data("Crud").charset("UTF-8")))
                                                .subject(s -> s.data("Hello")))
                                 .build());
```

## Motivation and Context
Allows customers who dislike the verbose `ComplexObject.builder().property("..").build()` pattern to create object hierarchies with a shorter syntax.

## Testing
New poet tests added.
