### PR TITLE
Adding Consumer<Builder> to overrideConfiguration on ClientBuilder

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/client/builder/ClientBuilder.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/builder/ClientBuilder.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.client.builder;
 
 import java.net.URI;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.core.auth.AwsCredentialsProvider;
 import software.amazon.awssdk.core.config.ClientOverrideConfiguration;
@@ -37,6 +38,10 @@ public interface ClientBuilder<B extends ClientBuilder<B, C>, C> extends SdkBuil
      * Specify overrides to the default SDK configuration that should be used for clients created by this builder.
      */
     B overrideConfiguration(ClientOverrideConfiguration overrideConfiguration);
+
+    default B overrideConfiguration(Consumer<ClientOverrideConfiguration.Builder> overrideConfiguration) {
+        return overrideConfiguration(ClientOverrideConfiguration.builder().apply(overrideConfiguration).build());
+    }
 
     /**
      * Configure the credentials that should be used to authenticate with AWS.

--- a/core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/client/builder/DefaultClientBuilderTest.java
@@ -195,7 +195,7 @@ public class DefaultClientBuilderTest {
         BeanInfo beanInfo = Introspector.getBeanInfo(builder.getClass());
         Method[] clientBuilderMethods = ClientBuilder.class.getDeclaredMethods();
 
-        Arrays.stream(clientBuilderMethods).forEach(builderMethod -> {
+        Arrays.stream(clientBuilderMethods).filter(m -> !m.isSynthetic()).forEach(builderMethod -> {
             String propertyName = builderMethod.getName();
 
             Optional<PropertyDescriptor> propertyForMethod =


### PR DESCRIPTION
Additional helper builder that can be used to configure overrideConfiguration.
