### PR TITLE
Removing unnecessary javax.mail dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,7 @@
         <spring.version>3.0.7.RELEASE</spring.version>
         <freemarker.version>2.3.9</freemarker.version>
         <aspectj.version>1.8.2</aspectj.version>
-
-        <!-- These properties are used by SES for its optional dependencies -->
-        <javax.mail.version>1.4.6</javax.mail.version>
+        
         <jre.version>1.8</jre.version>
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
 

--- a/services/ses/pom.xml
+++ b/services/ses/pom.xml
@@ -33,12 +33,6 @@
 
     <dependencies>
         <dependency>
-            <artifactId>javax.mail-api</artifactId>
-            <groupId>javax.mail</groupId>
-            <optional>true</optional>
-            <version>${javax.mail.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Testing
`mvn clean install -pl :ses -am`
Ran SES integration tests locally

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
