### PR TITLE
Marking ConfigurationProvider as @ReviewBeforeRelease

### DIFF
--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/ConfigurationProvider.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/ConfigurationProvider.java
@@ -16,10 +16,12 @@
 package software.amazon.awssdk.http;
 
 import java.util.Optional;
+import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 
 /**
  * Interface to provide read only access to the configuration of the {@link SdkHttpClient}.
  */
+@ReviewBeforeRelease("Do we really need this?")
 public interface ConfigurationProvider {
 
     /**


### PR DESCRIPTION
It's not clear that we actually need this, and it bloats our Http SPI
