### PR TITLE
Changing retry-policy for WAF so that we back-off more aggressively

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/config/ClientOverrideConfiguration.java
+++ b/core/src/main/java/software/amazon/awssdk/core/config/ClientOverrideConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryPolicy;
@@ -247,6 +248,13 @@ public class ClientOverrideConfiguration
          * @see ClientOverrideConfiguration#retryPolicy()
          */
         Builder retryPolicy(RetryPolicy retryPolicy);
+
+        /**
+         * Configure the retry policy the should be used when handling failure cases.
+         */
+        default Builder retryPolicy(Consumer<RetryPolicy.Builder> retryPolicy) {
+            return retryPolicy(RetryPolicy.builder().apply(retryPolicy).build());
+        }
 
         /**
          * Configure a list of execution interceptors that will have access to read and modify the request and response objcets as

--- a/services/waf/src/it/java/software/amazon/awssdk/services/waf/WafIntegrationTest.java
+++ b/services/waf/src/it/java/software/amazon/awssdk/services/waf/WafIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.regions.Region;
+import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
 import software.amazon.awssdk.services.waf.model.ChangeAction;
 import software.amazon.awssdk.services.waf.model.CreateIPSetRequest;
 import software.amazon.awssdk.services.waf.model.CreateIPSetResponse;
@@ -50,12 +51,13 @@ public class WafIntegrationTest extends AwsTestBase {
 
     @BeforeClass
     public static void setup() throws IOException {
+        FixedDelayBackoffStrategy fixedBackoffStrategy = new FixedDelayBackoffStrategy(Duration.ofSeconds(30));
         setUpCredentials();
         client = WAFClient.builder()
-                .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
-                .region(Region.AWS_GLOBAL)
-                .build();
-
+                          .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                          .region(Region.AWS_GLOBAL)
+                          .overrideConfiguration(cfg -> cfg.retryPolicy(r -> r.backoffStrategy(fixedBackoffStrategy)))
+                          .build();
     }
 
     @AfterClass


### PR DESCRIPTION
Our integration tests keep getting rate exceeded exceptions.
