### PR TITLE
Fix S3 exception unmarshalling #297

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-4392508.json
+++ b/.changes/next-release/bugfix-AmazonS3-4392508.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Fixing exception unmarshalling for S3. [#297](https://github.com/aws/aws-sdk-java-v2/issues/297)"
+}

--- a/codegen/src/main/resources/templates/rest-xml/s3/ExceptionUnmarshaller.ftl
+++ b/codegen/src/main/resources/templates/rest-xml/s3/ExceptionUnmarshaller.ftl
@@ -1,0 +1,23 @@
+${fileHeader}
+package ${transformPackage};
+
+import org.w3c.dom.Node;
+import javax.annotation.Generated;
+
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.util.XpathUtils;
+import software.amazon.awssdk.services.s3.transform.S3ExceptionUnmarshaller;
+import ${metadata.fullModelPackageName}.${shape.shapeName};
+
+@Generated("software.amazon.awssdk:aws-java-sdk-code-generator")
+public class ${shape.shapeName}Unmarshaller extends S3ExceptionUnmarshaller {
+
+    public ${shape.shapeName}Unmarshaller() {
+        super(${shape.shapeName}.class, "${shape.errorCode}");
+    }
+
+    @Override
+    public SdkServiceException unmarshall(Node node) throws Exception {
+        return super.unmarshall(node);
+    }
+}

--- a/core/src/main/java/software/amazon/awssdk/core/runtime/transform/StandardErrorUnmarshaller.java
+++ b/core/src/main/java/software/amazon/awssdk/core/runtime/transform/StandardErrorUnmarshaller.java
@@ -20,7 +20,6 @@ import static software.amazon.awssdk.core.util.XpathUtils.xpath;
 
 import javax.xml.xpath.XPath;
 import org.w3c.dom.Node;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.exception.ErrorType;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -62,11 +61,7 @@ public class StandardErrorUnmarshaller extends AbstractErrorUnmarshaller<Node> {
         XPath xpath = xpath();
         String errorCode = parseErrorCode(in, xpath);
 
-        if (errorCode != null) {
-            return standardErrorPathException(errorCode, in, xpath);
-        }
-
-        return s3ErrorPathException(in, xpath);
+        return standardErrorPathException(errorCode, in, xpath);
     }
 
     /**
@@ -135,20 +130,4 @@ public class StandardErrorUnmarshaller extends AbstractErrorUnmarshaller<Node> {
             return ErrorType.fromValue(errorType);
         }
     }
-
-    @ReviewBeforeRelease("We shouldn't have S3 speific code in core. Also the way this is doesn't" +
-                         " work with modeled exceptions as they are still looking for the error code" +
-                         " in the standard location.")
-    public SdkServiceException s3ErrorPathException(Node in, XPath xpath) throws Exception {
-        String errorCode = asString("Error/Code", in, xpath);
-        String requestId = asString("Error/RequestId", in, xpath);
-        String message = asString("Error/Message", in, xpath);
-
-        SdkServiceException exception = newException(message);
-        exception.errorCode(errorCode);
-        exception.requestId(requestId);
-
-        return exception;
-    }
-
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ExceptionUnmarshallingIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ExceptionUnmarshallingIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import java.io.IOException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.NoSuchUploadException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class ExceptionUnmarshallingIntegrationTest extends S3IntegrationTestBase {
+
+    private static final String BUCKET = temporaryBucketName(ExceptionUnmarshallingIntegrationTest.class);
+
+    private static final String KEY = "some-key";
+
+    @BeforeClass
+    public static void setupFixture() throws IOException {
+        createBucket(BUCKET);
+    }
+
+    @AfterClass
+    public static void tearDownFixture() {
+        deleteBucketAndAllContents(BUCKET);
+    }
+
+    @Test(expected = BucketAlreadyOwnedByYouException.class)
+    public void createBucketAlreadyOwnedByYou() {
+        s3.createBucket(b -> b.bucket(BUCKET));
+    }
+
+    @Test(expected = BucketAlreadyExistsException.class)
+    public void createBucketAlreadyExists() {
+        s3.createBucket(b -> b.bucket("development"));
+    }
+
+    @Test(expected = NoSuchKeyException.class)
+    public void getObjectNoSuchKey() {
+        s3.getObject(GetObjectRequest.builder().bucket(BUCKET).key(KEY).build());
+    }
+
+    @Test(expected = NoSuchBucketException.class)
+    public void getObjectNoSuchBucket() {
+        s3.getObject(GetObjectRequest.builder().bucket(BUCKET + KEY).key(KEY).build());
+    }
+
+    @Test(expected = NoSuchKeyException.class)
+    public void getObjectAclNoSuchKey() {
+        s3.getObjectAcl(b -> b.bucket(BUCKET).key(KEY));
+    }
+
+    @Test(expected = NoSuchBucketException.class)
+    public void getObjectAclNoSuchBucket() {
+        s3.getObjectAcl(b -> b.bucket(BUCKET + KEY).key(KEY));
+    }
+
+    @Test(expected = NoSuchUploadException.class)
+    public void abortMultipartNoSuchUpload() {
+        s3.abortMultipartUpload(b -> b.bucket(BUCKET).key(KEY).uploadId("23232"));
+    }
+
+    @Test
+    public void headObjectNoSuchKey() {
+        try {
+
+            s3.headObject(b -> b.bucket(BUCKET).key(KEY));
+            fail("No exception has been thrown");
+        } catch (S3Exception ex) {
+            // This is a limitation of HEAD requests since S3 doesn't return an XML body containing the error details.
+            assertThat(ex.statusCode()).isEqualTo(404);
+            assertThat(ex.errorCode()).isEqualTo("404 Not Found");
+        }
+    }
+
+    @Test
+    public void headBuckettNoSuchBucket() {
+        try {
+            s3.headBucket(b -> b.bucket(KEY));
+            fail("No exception has been thrown");
+        } catch (S3Exception ex) {
+            // This is a limitation of HEAD requests since S3 doesn't return an XML body containing the error details.
+            assertThat(ex.statusCode()).isEqualTo(404);
+            assertThat(ex.errorCode()).isEqualTo("404 Not Found");
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.transform;
+
+import static software.amazon.awssdk.core.util.XpathUtils.asString;
+import static software.amazon.awssdk.core.util.XpathUtils.xpath;
+
+import javax.xml.xpath.XPath;
+import org.w3c.dom.Node;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.runtime.transform.AbstractErrorUnmarshaller;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * Base exception unmarshaller for S3.
+ */
+public abstract class S3ExceptionUnmarshaller extends AbstractErrorUnmarshaller<Node> {
+
+    private final String errorCode;
+
+    public S3ExceptionUnmarshaller(Class<? extends SdkServiceException> exceptionClass, String errorCode) {
+        super(exceptionClass);
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public SdkServiceException unmarshall(Node in) throws Exception {
+
+        XPath xpath = xpath();
+
+        String error = asString("Error/Code", in, xpath);
+        String requestId = asString("Error/RequestId", in, xpath);
+        String message = asString("Error/Message", in, xpath);
+
+        if (!StringUtils.equals(error, this.errorCode)) {
+            return null;
+        }
+
+        SdkServiceException exception = newException(message);
+        exception.errorCode(errorCode);
+        exception.requestId(requestId);
+
+        return exception;
+    }
+}

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -15,5 +15,10 @@
         "GetBucketLocationOutput" : {
             "staxTargetDepthOffset": 0
         }
-    }
+    },
+    "customCodeTemplates" : {
+        "exceptionUnmarshaller" : {
+            "mainTemplate" : "/templates/rest-xml/s3/ExceptionUnmarshaller.ftl"
+        }
+     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
S3 exception unmarshalling. 
Fixes #297 #123 #147
**Note**: 
this will only fix exception unmarshalling for s3 error responses that are actually containing the error details such as `getObject`, `getObjectAcl`,
for operations such as `headObject`, `headBucket`, since s3 is not returning us any error details, we can't marshal it to the correct exceptions. we need to find a way to remove the exception from the javadoc.

## Testing
Added integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
