### PR TITLE
[PR for discussion] Showing Reactive Streams TCK, proposing some

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -141,6 +141,12 @@
             <version>${reactive-streams.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,6 +119,12 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>${reactive-streams.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -127,6 +133,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>test-utils</artifactId>
             <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>${reactive-streams.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/software/amazon/awssdk/core/async/ByteArrayAsyncResponseHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/async/ByteArrayAsyncResponseHandler.java
@@ -62,6 +62,7 @@ class ByteArrayAsyncResponseHandler<ResponseT> implements AsyncResponseHandler<R
     /**
      * Requests chunks sequentially and dumps them into a {@link ByteArrayOutputStream}.
      */
+    // TODO cover with Reactive Streams TCK, it's mostly ok, just a few edge cases / sanity checks should be covered AFAICS
     private class BaosSubscriber implements Subscriber<ByteBuffer> {
 
         private Subscription subscription;

--- a/core/src/main/java/software/amazon/awssdk/core/async/FileAsyncRequestProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/core/async/FileAsyncRequestProvider.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.core.async;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
@@ -23,7 +22,6 @@ import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.CompletionHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Subscriber;
@@ -43,7 +41,7 @@ public final class FileAsyncRequestProvider implements AsyncRequestProvider {
     /**
      * File to read.
      */
-    private final File file;
+    private final Path file;
 
     /**
      * Size (in bytes) of ByteBuffer chunks read from the file and delivered to the subscriber.
@@ -51,13 +49,13 @@ public final class FileAsyncRequestProvider implements AsyncRequestProvider {
     private final int chunkSizeInBytes;
 
     private FileAsyncRequestProvider(DefaultBuilder builder) {
-        this.file = builder.path.toFile();
+        this.file = builder.path;
         this.chunkSizeInBytes = builder.chunkSizeInBytes == null ? DEFAULT_CHUNK_SIZE : builder.chunkSizeInBytes;
     }
 
     @Override
     public long contentLength() {
-        return file.length();
+        return file.toFile().length();
     }
 
     @Override
@@ -140,10 +138,10 @@ public final class FileAsyncRequestProvider implements AsyncRequestProvider {
         private final int chunkSize;
 
         private long position = 0;
-        private AtomicLong outstandingRequests = new AtomicLong(0);
+        private AtomicLong outstandingDemand = new AtomicLong(0);
         private boolean writeInProgress = false;
 
-        private FileSubscription(File file, Subscriber<? super ByteBuffer> subscriber, int chunkSize) {
+        private FileSubscription(Path file, Subscriber<? super ByteBuffer> subscriber, int chunkSize) {
             this.inputChannel = openInputChannel(file);
             this.subscriber = subscriber;
             this.chunkSize = chunkSize;
@@ -151,18 +149,30 @@ public final class FileAsyncRequestProvider implements AsyncRequestProvider {
 
         @Override
         public void request(long n) {
-            try {
-                outstandingRequests.addAndGet(n);
-
-                synchronized (this) {
-                    if (!writeInProgress) {
-                        writeInProgress = true;
-                        readData();
+            if (n < 1) {
+                IllegalArgumentException ex =
+                    new IllegalArgumentException(subscriber + " violated the Reactive Streams rule 3.9 by requesting a non-positive number of elements.");
+                subscriber.onError(ex);
+            } else
+                try {
+                    long initialDemand = outstandingDemand.get();
+                    long newDemand = initialDemand + n;
+                    if (newDemand < 1) {
+                        // As governed by rule 3.17, when demand overflows `Long.MAX_VALUE` we treat the signalled demand as "effectively unbounded"
+                        outstandingDemand.set(Long.MAX_VALUE);
+                    } else {
+                        outstandingDemand.set(newDemand);
                     }
+
+                    synchronized (this) {
+                        if (!writeInProgress) {
+                            writeInProgress = true;
+                            readData();
+                        }
+                    }
+                } catch (Exception e) {
+                    subscriber.onError(e);
                 }
-            } catch (Exception e) {
-                subscriber.onError(e);
-            }
         }
 
         @Override
@@ -184,7 +194,7 @@ public final class FileAsyncRequestProvider implements AsyncRequestProvider {
                         position += attachment.remaining();
                         subscriber.onNext(attachment);
                         // If we have more permits, queue up another read.
-                        if (outstandingRequests.decrementAndGet() > 0) {
+                        if (outstandingDemand.decrementAndGet() > 0) {
                             readData();
                             return;
                         }
@@ -217,12 +227,9 @@ public final class FileAsyncRequestProvider implements AsyncRequestProvider {
 
     }
 
-    private static AsynchronousFileChannel openInputChannel(File file) {
+    private static AsynchronousFileChannel openInputChannel(Path path) {
         try {
-            final Path path = Paths.get(file.getAbsolutePath());
-            if (!Files.exists(path)) {
-                Files.createFile(path);
-            }
+            if (!Files.exists(path)) Files.createFile(path);
             return AsynchronousFileChannel.open(path, StandardOpenOption.READ);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/core/src/main/java/software/amazon/awssdk/core/async/FileAsyncResponseHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/async/FileAsyncResponseHandler.java
@@ -82,6 +82,7 @@ class FileAsyncResponseHandler<ResponseT> implements AsyncResponseHandler<Respon
     /**
      * {@link Subscriber} implementation that writes chunks to a file.
      */
+    // FIXME cover with Reactive Streams TCK, looks ok from a first brief look, but could be missing some edge cases
     private class FileSubscriber implements Subscriber<ByteBuffer> {
 
         private volatile boolean writeInProgress = false;

--- a/core/src/main/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProvider.java
@@ -16,61 +16,61 @@
 package software.amazon.awssdk.core.async;
 
 import java.nio.ByteBuffer;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+/**
+ * Signals a single byte buffer element;
+ * Can be subscribed to multiple times;
+ */
 class SingleByteArrayAsyncRequestProvider implements AsyncRequestProvider {
 
-    private final byte[] bytes;
+  private final byte[] bytes;
 
-    SingleByteArrayAsyncRequestProvider(byte[] bytes) {
-        this.bytes = bytes.clone();
-    }
+  SingleByteArrayAsyncRequestProvider(byte[] bytes) {
+    this.bytes = bytes.clone();
+  }
 
-    @Override
-    public long contentLength() {
-        return bytes.length;
-    }
+  @Override
+  public long contentLength() {
+    return bytes.length;
+  }
 
-    @Override
-    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
-        // FIXME missing protection abiding to rule 1.9, proposal:
-        // As per rule 1.09, we need to throw a `java.lang.NullPointerException`
-        // if the `Subscriber` is `null`
-        // if (subscriber == null) throw null;
+  @Override
+  public void subscribe(Subscriber<? super ByteBuffer> s) {
+    // As per rule 2.13, we need to throw a `java.lang.NullPointerException` if the `Subscription` is `null`
+    if (s == null) throw new NullPointerException("Subscription MUST NOT be null.");
 
-        // FIXME: onSubscribe is user code, and could be ill behaved, as library we should protect from this,
-        // FIXME: This is covered by spec rule 2.13; proposal:
-        // As per 2.13, this method must return normally (i.e. not throw).
-        // try {
-        subscriber.onSubscribe(
-            new Subscription() {
-                @Override
-                public void request(long n) {
-                    if (n > 0) {
-                        subscriber.onNext(ByteBuffer.wrap(bytes));
-                        subscriber.onComplete();
-                    }
-                    // FIXME missing required validation code (rule 1.9):
-                    //   "Non-positive requests should be honored with IllegalArgumentException"
-                    // proposal:
-                    // else {
-                    //  subscriber.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
-                    // }
+    // As per 2.13, this method must return normally (i.e. not throw).
+    try {
+      s.onSubscribe(
+          new Subscription() {
+            boolean done = false;
+            @Override
+            public void request(long n) {
+              if (n > 0) {
+                if (!done) {
+                  s.onNext(ByteBuffer.wrap(bytes));
+                  done = true;
+                  s.onComplete();
                 }
-
-                @Override
-                public void cancel() {
-                }
+              } else {
+                s.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
+              }
             }
-        );
-        // end of implementing 2.13 spec requirement
-        //  } catch (Throwable ex) {
-        //  new IllegalStateException(subscriber + " violated the Reactive Streams rule 2.13 " +
-        //      "by throwing an exception from onSubscribe.", ex)
-        //      // When onSubscribe fails this way, we don't know what state the
-        //      // subscriber is thus calling onError may cause more crashes.
-        //      .printStackTrace();
-        //    }
+
+            @Override
+            public void cancel() {
+            }
+          }
+      );
+    } catch (Throwable ex) {
+      new IllegalStateException(s + " violated the Reactive Streams rule 2.13 " +
+          "by throwing an exception from onSubscribe.", ex)
+          // When onSubscribe fails this way, we don't know what state the
+          // s is thus calling onError may cause more crashes.
+          .printStackTrace();
     }
+  }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProvider.java
@@ -34,6 +34,15 @@ class SingleByteArrayAsyncRequestProvider implements AsyncRequestProvider {
 
     @Override
     public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        // FIXME missing protection abiding to rule 1.9, proposal:
+        // As per rule 1.09, we need to throw a `java.lang.NullPointerException`
+        // if the `Subscriber` is `null`
+        // if (subscriber == null) throw null;
+
+        // FIXME: onSubscribe is user code, and could be ill behaved, as library we should protect from this,
+        // FIXME: This is covered by spec rule 2.13; proposal:
+        // As per 2.13, this method must return normally (i.e. not throw).
+        // try {
         subscriber.onSubscribe(
             new Subscription() {
                 @Override
@@ -42,6 +51,12 @@ class SingleByteArrayAsyncRequestProvider implements AsyncRequestProvider {
                         subscriber.onNext(ByteBuffer.wrap(bytes));
                         subscriber.onComplete();
                     }
+                    // FIXME missing required validation code (rule 1.9):
+                    //   "Non-positive requests should be honored with IllegalArgumentException"
+                    // proposal:
+                    // else {
+                    //  subscriber.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
+                    // }
                 }
 
                 @Override
@@ -49,5 +64,13 @@ class SingleByteArrayAsyncRequestProvider implements AsyncRequestProvider {
                 }
             }
         );
+        // end of implementing 2.13 spec requirement
+        //  } catch (Throwable ex) {
+        //  new IllegalStateException(subscriber + " violated the Reactive Streams rule 2.13 " +
+        //      "by throwing an exception from onSubscribe.", ex)
+        //      // When onSubscribe fails this way, we don't know what state the
+        //      // subscriber is thus calling onError may cause more crashes.
+        //      .printStackTrace();
+        //    }
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/util/UserAgentUtils.java
+++ b/core/src/main/java/software/amazon/awssdk/core/util/UserAgentUtils.java
@@ -72,7 +72,7 @@ public final class UserAgentUtils {
 
         ua = ua
                 .replace("{platform}", "java")
-                .replace("{version}", VersionInfo.SDK_VERSION)
+                .replace("{version}", "MOCK")//VersionInfo.SDK_VERSION)
                 .replace("{os.name}", replaceSpaces(JavaSystemSetting.OS_NAME.getStringValue().orElse(null)))
                 .replace("{os.version}", replaceSpaces(JavaSystemSetting.OS_VERSION.getStringValue().orElse(null)))
                 .replace("{java.vm.name}", replaceSpaces(JavaSystemSetting.JAVA_VM_NAME.getStringValue().orElse(null)))

--- a/core/src/test/java/software/amazon/awssdk/core/async/FileAsyncRequestPublisherTckTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/async/FileAsyncRequestPublisherTckTest.java
@@ -15,12 +15,25 @@
 
 package software.amazon.awssdk.core.async;
 
+import org.junit.Test;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 public class FileAsyncRequestPublisherTckTest extends org.reactivestreams.tck.PublisherVerification<ByteBuffer> {
 
@@ -29,6 +42,15 @@ public class FileAsyncRequestPublisherTckTest extends org.reactivestreams.tck.Pu
 
     public FileAsyncRequestPublisherTckTest() throws IOException {
         super(new TestEnvironment());
+
+        BufferedWriter writer = new BufferedWriter(new FileWriter(example));
+        writer.write("Hello world\n");
+        writer.write("Hello world\n");
+        writer.write("Hello world\n");
+        writer.write("Hello world\n");
+        writer.write("Hello world\n");
+        writer.flush();
+        writer.close();
     }
 
     @Override

--- a/core/src/test/java/software/amazon/awssdk/core/async/FileAsyncRequestPublisherTckTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/async/FileAsyncRequestPublisherTckTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class FileAsyncRequestPublisherTckTest extends org.reactivestreams.tck.PublisherVerification<ByteBuffer> {
+
+    final File example = File.createTempFile("example", ".tmp");
+    final File fileDoesNotExist = new File(example.getPath() + "-does-not-exist");
+
+    public FileAsyncRequestPublisherTckTest() throws IOException {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long l) {
+        return AsyncRequestProvider.fromFile(example.toPath());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        return AsyncRequestProvider.fromFile(fileDoesNotExist.toPath());
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/core/async/SimpleSubscriberTckTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/async/SimpleSubscriberTckTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.core.async;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
+
+import java.nio.ByteBuffer;
+
+public class SimpleSubscriberTckTest extends org.reactivestreams.tck.SubscriberBlackboxVerification<ByteBuffer> {
+
+  public SimpleSubscriberTckTest() {
+    super(new TestEnvironment());
+  }
+
+  @Override
+  public Subscriber<ByteBuffer> createSubscriber() {
+    return new SimpleSubscriber(buffer -> {
+      // ignore
+    });
+  }
+
+  @Override
+  public ByteBuffer createElement(int i) {
+    return ByteBuffer.wrap(String.valueOf(i).getBytes());
+  }
+
+}

--- a/core/src/test/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProviderTckTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProviderTckTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.core.async;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.TestEnvironment;
+
+import java.nio.ByteBuffer;
+
+public class SingleByteArrayAsyncRequestProviderTckTest extends org.reactivestreams.tck.PublisherVerification<ByteBuffer> {
+
+  public SingleByteArrayAsyncRequestProviderTckTest() {
+    super(new TestEnvironment());
+  }
+
+  @Override
+  public long maxElementsFromPublisher() {
+    return super.maxElementsFromPublisher();
+  }
+
+  @Override
+  public Publisher<ByteBuffer> createPublisher(long n) {
+    return AsyncRequestProvider.fromString("Hello world");
+  }
+
+  @Override
+  public Publisher<ByteBuffer> createFailedPublisher() {
+    return null;
+  }
+}

--- a/core/src/test/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProviderTckTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/async/SingleByteArrayAsyncRequestProviderTckTest.java
@@ -27,7 +27,8 @@ public class SingleByteArrayAsyncRequestProviderTckTest extends org.reactivestre
 
   @Override
   public long maxElementsFromPublisher() {
-    return super.maxElementsFromPublisher();
+    int canOnlySignalSingleElement = 1;
+    return canOnlySignalSingleElement;
   }
 
   @Override

--- a/http-client-spi/pom.xml
+++ b/http-client-spi/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
-            <version>1.0.0.final</version>
+            <version>${reactive-streams.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -51,6 +51,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>${reactive-streams.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SimpleSubscriber.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SimpleSubscriber.java
@@ -23,6 +23,8 @@ import org.reactivestreams.Subscription;
 /**
  * Simple subscriber that does no backpressure and doesn't care about errors or completion.
  */
+// TODO provided example how to cover it using the TCK, you may want to put those tests to a separate project,
+// TODO if you'd prefer to do so
 public class SimpleSubscriber implements Subscriber<ByteBuffer> {
 
     private final Consumer<ByteBuffer> consumer;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -170,6 +170,7 @@ class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         return bb;
     }
 
+    // TODO cover using Reactive Streams TCK
     private static class PublisherAdapter implements Publisher<ByteBuffer> {
         private final StreamedHttpResponse response;
         private final ChannelHandlerContext channelContext;
@@ -220,6 +221,7 @@ class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         }
     }
 
+    // TODO cover using Reactive Streams TCK (glad you seem to already have looked into the rules! :-))
     private static class FullResponseContentPublisher implements Publisher<ByteBuffer> {
         private final ChannelHandlerContext channelContext;
         private final ByteBuffer fullContent;

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,15 @@
         <spring.version>3.0.7.RELEASE</spring.version>
         <freemarker.version>2.3.9</freemarker.version>
         <aspectj.version>1.8.2</aspectj.version>
-        
+
         <jre.version>1.8</jre.version>
         <httpcomponents.httpclient.version>4.5.4</httpcomponents.httpclient.version>
 
         <!-- These properties are used by cucumber tests related code -->
         <unitils.version>3.3</unitils.version>
+
+        <!-- Reactive Streams version -->
+        <reactive-streams.version>1.0.2</reactive-streams.version>
 
         <!-- Sonar -->
         <root.offset>..</root.offset>
@@ -246,6 +249,17 @@
                 <groupId>com.typesafe.netty</groupId>
                 <artifactId>netty-reactive-streams-http</artifactId>
                 <version>2.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams</artifactId>
+                <version>${reactive-streams.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams-tck</artifactId>
+                <version>${reactive-streams.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The purpose of this PR is to show how to start using the reactive-streams tck (documented here: https://github.com/reactive-streams/reactive-streams-jvm/tree/master/tck )  to validate existing RS implementations in this library. Reactive streams implementations must pass the TCK in order to ensure good inter-op between all libraries.

This PR will fail, as not all implementations are currently compliant.

I can help making them compliant, but wanted to reach first with this preview PR to ask if you'd like to separate our the TCK tests into a separate project, or if you're ok keeping them side by side the other ones like this? They are a bit slow sometimes, as they test many runs, and also await for "things did not happen" etc.

Running the tests will show which specification rules have been violated which should help getting the library compliant pretty quickly, esp as the implementations I've seen are pretty simple so far.

Let me know if you'd want more assistance making all the implementations valid, or if you'd like to take the TCK for a spin yourself first -- I've seen you're aware of the specification requirements in some TODO/FIXME's, so perhaps this is something you've not yet gotten to yet?

Hope this helps, let me know what would be the best way to help you out here.

Refs https://github.com/aws/aws-sdk-java-v2/issues/406 and https://github.com/aws/aws-sdk-java-v2/issues/405