### PR TITLE
Fix race codition between read and finalizeRequest

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-e5d4229.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-e5d4229.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Async HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fix race condition in the async client causing instability when making multiple concurent requests. Fixes [#202](https://github.com/aws/aws-sdk-java-v2/issues/202)"
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.mapping;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKeys.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKeys.RESPONSE_COMPLETE_KEY;
 
+import com.typesafe.netty.http.HttpStreamsClientHandler;
 import com.typesafe.netty.http.StreamedHttpResponse;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -31,6 +32,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -75,12 +77,10 @@ class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         if (msg instanceof StreamedHttpResponse) {
             requestContext.handler().onStream(new PublisherAdapter((StreamedHttpResponse) msg, channelContext, requestContext));
         } else if (msg instanceof FullHttpResponse) {
-            // TODO: HttpStreamsClientHandler leaves a dangling LastHttpContent
-            // in the pipeline. Consume it ourselves to make sure the channel
-            // is empty at the end of stream and before releasing it back to he
-            // pool.  The HttpStreamsClientHandler should really be doing this
-            // for us.
-            channelContext.read();
+            // Be prepared to take care of (ignore) a trailing LastHttpResponse
+            // from the HttpClientCodec if there is one.
+            channelContext.pipeline().replace(HttpStreamsClientHandler.class,
+                    channelContext.name() + "-LastHttpContentSwallower", new LastHttpContentSwallower());
 
             ByteBuf fullContent = ((FullHttpResponse) msg).content();
             final ByteBuffer bb = copyToByteBuffer(fullContent);
@@ -237,6 +237,22 @@ class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
             subscriber.onNext(fullContent);
             channelContext.channel().attr(ChannelAttributeKeys.SUBSCRIBER_KEY)
                     .set(subscriber);
+        }
+    }
+
+
+    private static class LastHttpContentSwallower extends SimpleChannelInboundHandler<HttpObject> {
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, HttpObject obj) throws Exception {
+            if (obj instanceof LastHttpContent) {
+                // Queue another read to make up for the one we just ignored
+                ctx.read();
+            } else {
+                ctx.fireChannelRead(obj);
+            }
+            // Remove self from pipeline since we only care about potentially
+            // ignoring the very first message
+            ctx.pipeline().remove(this);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

HttpStreamsClientHandler ignores the LastHttpContent decoded by the HTTP
codec when we get an empty response from the service, but if the channel
gets released (which causes the streams handler to get removed) before
the last content message comes through and is ignored by the handler,
the new HttpStreamsHandler (added by RunnableRquest) will not be in a
state to anticipate and ignore the LastHttpContent and will instead do
the wrong thing and attempt to remove a non-existent handler.

This commit fixes that race condition by explicitly replacing the
HttpStreamsClientHandler in the pipeline with a new handler that ignores
the next message read in the pipeline if it's a LastHttpContent.

Fixes #202

## Motivation and Context
Fix #202 

## Testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
