### PR TITLE
Reduce DEBUG logging when running tests

### DIFF
--- a/core/src/test/java/software/amazon/awssdk/core/http/DefaultErrorResponseHandlerTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/http/DefaultErrorResponseHandlerTest.java
@@ -23,13 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.core.http.HttpResponseHandler.X_AMZN_REQUEST_ID_HEADER;
 import static software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils.executionContext;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.Request;
 import software.amazon.awssdk.core.util.LogCaptor;
@@ -39,12 +42,22 @@ import utils.http.WireMockTestBase;
 public class DefaultErrorResponseHandlerTest extends WireMockTestBase {
 
     private static final String RESOURCE = "/some-path";
+    private static LogCaptor logCaptor;
     private final AmazonHttpClient client = HttpTestUtils.testAmazonHttpClient();
     private final DefaultErrorResponseHandler sut = new DefaultErrorResponseHandler(new ArrayList<>());
-    private LogCaptor logCaptor = new LogCaptor.DefaultLogCaptor(Level.DEBUG);
+
+    @BeforeClass
+    public static void setup() {
+        logCaptor = new LogCaptor.DefaultLogCaptor(Level.DEBUG);
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        logCaptor.close();
+    }
 
     @Before
-    public void setUp() {
+    public void methodSetup() {
         logCaptor.clear();
     }
 

--- a/core/src/test/resources/jetty-logging.properties
+++ b/core/src/test/resources/jetty-logging.properties
@@ -1,0 +1,3 @@
+# Set up logging implementation
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+org.eclipse.jetty.LEVEL=INFO

--- a/services/glacier/src/test/resources/log4j.properties
+++ b/services/glacier/src/test/resources/log4j.properties
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-log4j.rootLogger=DEBUG, A1
+log4j.rootLogger=WARN, A1
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 
@@ -21,14 +21,8 @@ log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 
 # Adjust to see more / less logging
-log4j.logger.com.amazonaws.ec2=DEBUG
-
-# HttpClient 3 Wire Logging
-log4j.logger.httpclient.wire=WARN
-
-# HttpClient 4 Wire Logging
-log4j.logger.org.apache.http.wire=WARN
-
+#log4j.logger.httpclient.wire=TRACE
 log4j.logger.com.amazonaws=DEBUG
 
-
+# HttpClient 4 Wire Logging
+log4j.logger.org.apache.http.wire=DEBUG


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

DefaultErrorResponseHandlerTest uses LogCaptor and sets the level of the
root logger to DEBUG but never resets it; this has the effect of making
all subsequent tests be at DEBUG as well. When combined with tests that
also happens to use WireMock, which spits out a ton of debug messages,
this results in lots of unnecessary debug log statements.

This also adds a jetty-logging.properties test resource to core so that
even when we need to temporarily set the root logger to DEBUG, we don't
log anything from Jetty/WireMock.

Finally, fix some test logging configs that were too verbose.

Fixes #396 

## Motivation and Context
Fix #396 

## Testing
`mvn clean install > build.out 2>&1` and check the file size.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
