### PR TITLE
Fix default user agent to comply with RFC 7231

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-635a047.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-635a047.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix default user agent to comply with [RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.5.3). Related to [#80](https://github.com/aws/aws-sdk-java-v2/issues/80)"
+}

--- a/core/src/test/java/software/amazon/awssdk/core/util/UserAgentUtilsTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/util/UserAgentUtilsTest.java
@@ -15,8 +15,10 @@
 
 package software.amazon.awssdk.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Arrays;
 import org.junit.Test;
 
 public class UserAgentUtilsTest {
@@ -25,5 +27,10 @@ public class UserAgentUtilsTest {
     public void userAgent() {
         String userAgent = UserAgentUtils.userAgent();
         assertNotNull(userAgent);
+        Arrays.stream(userAgent.split(" ")).forEach(str -> assertThat(isValidInput(str)).isTrue());
+    }
+
+    private boolean isValidInput(String input) {
+        return input.startsWith("(") || input.contains("/") && input.split("/").length == 2;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update default user agent to comply with [RFC 7231](https://tools.ietf.org/html/rfc7231#section-5.5.3)
after the change, user-agent would be something like this
 `aws-sdk-java/2.0.0-preview-9-SNAPSHOT Mac_OS_X/10.11.6 Java_HotSpot_TM__64-Bit_Server_VM/25.151-b12 Java/1.8.0_151`
fix #80 

## Testing
`mvn clean install`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
