### PR TITLE
Make AWSCredentialsProviderChain exceptions easier to troubleshoot

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-6ec70c4.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-6ec70c4.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2",
+    "type": "feature",
+    "description": "Include root causes in the exception message from AWSCredentialsProviderChain to ease troubleshooting."
+}

--- a/core/src/main/java/software/amazon/awssdk/core/auth/AwsCredentialsProviderChain.java
+++ b/core/src/main/java/software/amazon/awssdk/core/auth/AwsCredentialsProviderChain.java
@@ -84,6 +84,7 @@ public final class AwsCredentialsProviderChain implements AwsCredentialsProvider
             return lastUsedProvider.getCredentials();
         }
 
+        List<String> exceptionMessages = null;
         for (AwsCredentialsProvider provider : credentialsProviders) {
             try {
                 AwsCredentials credentials = provider.getCredentials();
@@ -94,11 +95,17 @@ public final class AwsCredentialsProviderChain implements AwsCredentialsProvider
                 return credentials;
             } catch (RuntimeException e) {
                 // Ignore any exceptions and move onto the next provider
-                log.debug("Unable to load credentials from {}: {}", provider.toString(), e.getMessage(), e);
+                String message = provider + ": " + e.getMessage();
+                log.debug("Unable to load credentials from " + message, e);
+                if (exceptionMessages == null) {
+                    exceptionMessages = new ArrayList<>();
+                }
+                exceptionMessages.add(message);
             }
         }
 
-        throw new SdkClientException("Unable to load credentials from any of the providers in the chain: " + this);
+        throw new SdkClientException("Unable to load credentials from any of the providers in the chain " + this
+                + ": " + exceptionMessages);
     }
 
     @Override


### PR DESCRIPTION
## Description
This PR modifies the exception path of `AWSCredentialsProviderChain.getCredentials` to include all root causes in the exception message.

## Motivation and Context
Before this PR, when all providers in an `AWSCredentialsProviderChain` fail to provide credentials, the exception gives no hint of the underlying exceptions. That makes troubleshooting difficult unless your log level is already set to DEBUG, which is rarely the case in production.

## Testing
A new unit test case is included.

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
