### PR TITLE
Adding back parent element in bom pom.xml

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,9 +18,14 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>software.amazon.awssdk</groupId>
+    <parent>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <version>2.0.0-preview-9-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>bom</artifactId>
-    <version>2.0.0-preview-9-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>AWS Java SDK :: Bill of Materials</name>
     <description>The AWS SDK for Java - BOM module holds the dependency managements for individual java clients.
@@ -28,7 +33,6 @@
     <url>https://aws.amazon.com/sdkforjava</url>
 
     <properties>
-        <awsjavasdk.version>${project.version}</awsjavasdk.version>
         <sonar.skip>true</sonar.skip>
     </properties>
 


### PR DESCRIPTION
Partial revert of the #404 

Without the parent element, pom.xml of bom module doesn't satisfy the requirements for publishing to maven. To unblock the releases, adding back the parent element. This reintroduces the issue #295 

To fix #295, we have couple of options:
1) Remove parent element from BOM's pom file and add all the required elements to satisfy maven publish rules
2) Remove dependency management from parent pom and add it to a different module which can be added as a dependency to all other modules. For example, move the dependencies in parent pom to core pom file. Then add core as dependency to other modules which need those dependencies.

I would prefer to go with Option 2. This is a bit similar to v1. This options needs a bit refactoring to entire project. I will reopen the Issue 295 and continue discussion over there. For now, need to merge this PR to do a v2 release.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
