### PR TITLE
CredentialsEndpointProvider.java: Adds the sending of a User-Agent other than default User-Agent to the metadata service

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-0a2ffb3.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-0a2ffb3.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Add a standard User-Agent when making requests to the metadata service.  User-Agent pattern: aws-sdk-java/<version>"
+}

--- a/core/src/main/java/software/amazon/awssdk/core/internal/CredentialsEndpointProvider.java
+++ b/core/src/main/java/software/amazon/awssdk/core/internal/CredentialsEndpointProvider.java
@@ -17,10 +17,11 @@ package software.amazon.awssdk.core.internal;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.retry.internal.CredentialsEndpointRetryPolicy;
+import software.amazon.awssdk.core.util.VersionInfo;
 
 /**
  * <p>
@@ -56,7 +57,12 @@ public interface CredentialsEndpointProvider {
      * Allows passing additional headers to the request
      */
     default Map<String, String> headers() {
-        return Collections.emptyMap();
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("User-Agent", String.format("aws-sdk-java/%s", VersionInfo.SDK_VERSION));
+        requestHeaders.put("Accept", "*/*");
+        requestHeaders.put("Connection", "keep-alive");
+
+        return requestHeaders;
     }
 
 }


### PR DESCRIPTION
Adds the sending of a User-Agent other than default User-Agent in Java when making requests to metadata service

Similar to AWS Golang SDK and Ruby SDK, send a User-Agent other than the default User-Agent when making requests to the EC2 metadata for credentials.
https://github.com/aws/aws-sdk-java/pull/1562 for aws-sdk-java addresses this also.  PR #1445 for botocore implements this too.

This will enable protection of AWS credentials from Server Side Request Forgery (SSRF) vectors by being able to use a metadata proxy to block requests that do not have the right User-Agent set.  User-Agent is not controllable by an attacker via SSRF.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Set default headers in the `CredentialsEndpointProvider` interface

## Motivation and Context
This will enable protection of AWS credentials from Server Side Request Forgery (SSRF) vectors by being able to use a metadata proxy to block requests that do not have the right User-Agent set.  User-Agent is not controllable by an attacker via SSRF.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
