### PR TITLE
Renamed ClientConfiguration#lastExecutionInterceptors to executionInterceptors. Marked ExecutionInterceptor as internal.

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/client/BaseClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/BaseClientHandler.java
@@ -67,7 +67,7 @@ abstract class BaseClientHandler {
                               overrideConfiguration.advancedOption(AdvancedClientOption.AWS_REGION));
 
         return ExecutionContext.builder()
-                               .interceptorChain(new ExecutionInterceptorChain(overrideConfiguration.lastExecutionInterceptors()))
+                               .interceptorChain(new ExecutionInterceptorChain(overrideConfiguration.executionInterceptors()))
                                .interceptorContext(InterceptorContext.builder()
                                                                      .request(originalRequest)
                                                                      .build())

--- a/core/src/main/java/software/amazon/awssdk/core/config/ClientOverrideConfiguration.java
+++ b/core/src/main/java/software/amazon/awssdk/core/config/ClientOverrideConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -44,7 +45,7 @@ public class ClientOverrideConfiguration
     private final Map<String, List<String>> additionalHttpHeaders;
     private final Boolean gzipEnabled;
     private final RetryPolicy retryPolicy;
-    private final List<ExecutionInterceptor> lastExecutionInterceptors;
+    private final List<ExecutionInterceptor> executionInterceptors;
     private final AttributeMap advancedOptions;
 
     /**
@@ -56,7 +57,7 @@ public class ClientOverrideConfiguration
         this.additionalHttpHeaders = CollectionUtils.deepUnmodifiableMap(builder.additionalHttpHeaders);
         this.gzipEnabled = builder.gzipEnabled;
         this.retryPolicy = builder.retryPolicy;
-        this.lastExecutionInterceptors = Collections.unmodifiableList(new ArrayList<>(builder.lastExecutionInterceptors));
+        this.executionInterceptors = Collections.unmodifiableList(new ArrayList<>(builder.executionInterceptors));
         this.advancedOptions = builder.advancedOptions.build();
     }
 
@@ -68,7 +69,7 @@ public class ClientOverrideConfiguration
                                                               .additionalHttpHeaders(additionalHttpHeaders)
                                                               .gzipEnabled(gzipEnabled)
                                                               .retryPolicy(retryPolicy)
-                                                              .lastExecutionInterceptors(lastExecutionInterceptors);
+                                                              .executionInterceptors(executionInterceptors);
     }
 
     /**
@@ -163,10 +164,10 @@ public class ClientOverrideConfiguration
      * An immutable collection of {@link ExecutionInterceptor}s that should be hooked into the execution of each request, in the
      * order that they should be applied.
      *
-     * @see Builder#lastExecutionInterceptors(List)
+     * @see Builder#executionInterceptors(List)
      */
-    public List<ExecutionInterceptor> lastExecutionInterceptors() {
-        return lastExecutionInterceptors;
+    public List<ExecutionInterceptor> executionInterceptors() {
+        return executionInterceptors;
     }
 
     @Override
@@ -177,7 +178,7 @@ public class ClientOverrideConfiguration
                        .add("additionalHttpHeaders", additionalHttpHeaders)
                        .add("gzipEnabled", gzipEnabled)
                        .add("retryPolicy", retryPolicy)
-                       .add("lastExecutionInterceptors", lastExecutionInterceptors)
+                       .add("executionInterceptors", executionInterceptors)
                        .add("advancedOptions", advancedOptions)
                        .build();
     }
@@ -273,14 +274,17 @@ public class ClientOverrideConfiguration
         /**
          * Configure a list of execution interceptors that will have access to read and modify the request and response objcets as
          * they are processed by the SDK. These will replace any interceptors configured previously with this method or
-         * {@link #addLastExecutionInterceptor(ExecutionInterceptor)}.
+         * {@link #addExecutionInterceptor(ExecutionInterceptor)}.
          *
          * The provided interceptors are executed in the order they are configured and are always later in the order than the ones
          * automatically added by the SDK. See {@link ExecutionInterceptor} for a more detailed explanation of interceptor order.
          *
-         * @see ClientOverrideConfiguration#lastExecutionInterceptors()
+         * <b><i>This is currently an INTERNAL api, which means it is subject to change and should not be used.</i></b>
+         *
+         * @see ClientOverrideConfiguration#executionInterceptors()
          */
-        Builder lastExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors);
+        @SdkInternalApi
+        Builder executionInterceptors(List<ExecutionInterceptor> executionInterceptors);
 
         /**
          * Add an execution interceptor that will have access to read and modify the request and response objects as they are
@@ -290,9 +294,12 @@ public class ClientOverrideConfiguration
          * than the ones automatically added by the SDK. See {@link ExecutionInterceptor} for a more detailed explanation of
          * interceptor order.
          *
-         * @see ClientOverrideConfiguration#lastExecutionInterceptors()
+         * <b><i>This is currently an INTERNAL api, which means it is subject to change and should not be used.</i></b>
+         *
+         * @see ClientOverrideConfiguration#executionInterceptors()
          */
-        Builder addLastExecutionInterceptor(ExecutionInterceptor executionInterceptor);
+        @SdkInternalApi
+        Builder addExecutionInterceptor(ExecutionInterceptor executionInterceptor);
 
         /**
          * Configure an advanced override option. These values are used very rarely, and the majority of SDK customers can ignore
@@ -320,7 +327,7 @@ public class ClientOverrideConfiguration
         private Map<String, List<String>> additionalHttpHeaders = new HashMap<>();
         private Boolean gzipEnabled;
         private RetryPolicy retryPolicy;
-        private List<ExecutionInterceptor> lastExecutionInterceptors = new ArrayList<>();
+        private List<ExecutionInterceptor> executionInterceptors = new ArrayList<>();
         private AttributeMap.Builder advancedOptions = AttributeMap.builder();
 
         @Override
@@ -381,20 +388,20 @@ public class ClientOverrideConfiguration
         }
 
         @Override
-        public Builder lastExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
-            this.lastExecutionInterceptors.clear();
-            this.lastExecutionInterceptors.addAll(executionInterceptors);
+        public Builder executionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
+            this.executionInterceptors.clear();
+            this.executionInterceptors.addAll(executionInterceptors);
             return this;
         }
 
         @Override
-        public Builder addLastExecutionInterceptor(ExecutionInterceptor executionInterceptors) {
-            this.lastExecutionInterceptors.add(executionInterceptors);
+        public Builder addExecutionInterceptor(ExecutionInterceptor executionInterceptors) {
+            this.executionInterceptors.add(executionInterceptors);
             return this;
         }
 
-        public void setLastExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
-            lastExecutionInterceptors(executionInterceptors);
+        public void setExecutionInterceptors(List<ExecutionInterceptor> executionInterceptors) {
+            executionInterceptors(executionInterceptors);
         }
 
         @Override

--- a/core/src/main/java/software/amazon/awssdk/core/config/defaults/GlobalClientConfigurationDefaults.java
+++ b/core/src/main/java/software/amazon/awssdk/core/config/defaults/GlobalClientConfigurationDefaults.java
@@ -58,7 +58,7 @@ public final class GlobalClientConfigurationDefaults extends ClientConfiguration
 
         // Put global interceptors before the ones currently configured.
         List<ExecutionInterceptor> globalInterceptors = new ClasspathInterceptorChainFactory().getGlobalInterceptors();
-        builder.lastExecutionInterceptors(mergeLists(globalInterceptors, configuration.lastExecutionInterceptors()));
+        builder.executionInterceptors(mergeLists(globalInterceptors, configuration.executionInterceptors()));
     }
 
     @Override

--- a/core/src/main/java/software/amazon/awssdk/core/config/defaults/ServiceBuilderConfigurationDefaults.java
+++ b/core/src/main/java/software/amazon/awssdk/core/config/defaults/ServiceBuilderConfigurationDefaults.java
@@ -70,8 +70,8 @@ public class ServiceBuilderConfigurationDefaults extends ClientConfigurationDefa
         // Add service interceptors before the ones currently configured.
         List<ExecutionInterceptor> serviceInterceptors = new ArrayList<>();
         requestHandlerPaths.forEach(p -> serviceInterceptors.addAll(chainFactory.getInterceptors(p)));
-        serviceInterceptors.addAll(config.lastExecutionInterceptors());
-        builder.lastExecutionInterceptors(serviceInterceptors);
+        serviceInterceptors.addAll(config.executionInterceptors());
+        builder.executionInterceptors(serviceInterceptors);
     }
 
     @Override

--- a/core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionInterceptor.java
+++ b/core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionInterceptor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.interceptor;
 
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -59,7 +60,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
  * <ol>
  *     <li><i>Override Configuration Interceptors</i> are the most common method for SDK users to register an interceptor. These
  *     interceptors are explicitly added to the client builder's override configuration when a client is created using the {@link
- *     software.amazon.awssdk.core.config.ClientOverrideConfiguration.Builder#addLastExecutionInterceptor(ExecutionInterceptor)}
+ *     software.amazon.awssdk.core.config.ClientOverrideConfiguration.Builder#addExecutionInterceptor(ExecutionInterceptor)}
  *     method.</li>
  *
  *     <li><i>Global Interceptors</i> are interceptors loaded from the classpath for all clients. When any service client is
@@ -90,7 +91,7 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
  *     the order than interceptors later in the file.</li>
  *
  *     <li><i>Override Configuration Interceptors</i>. Any interceptors registered using {@link
- *     software.amazon.awssdk.core.config.ClientOverrideConfiguration.Builder#addLastExecutionInterceptor(ExecutionInterceptor)}
+ *     software.amazon.awssdk.core.config.ClientOverrideConfiguration.Builder#addExecutionInterceptor(ExecutionInterceptor)}
  *     in the order they were added.</li>
  * </ol>
  * When a request is being processed (up to and including {@link #beforeTransmission}, interceptors are applied in forward-order,
@@ -106,7 +107,12 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
  * client call. These attributes are made available to every interceptor hook and is available for storing data between method
  * calls. The SDK provides some attributes automatically, available via {@link AwsExecutionAttributes}.
  * </p>
+ *
+ * <p>
+ * <b><i>Note: This interface will change between SDK versions and should not be implemented by SDK users.</i></b>
+ * </p>
  */
+@SdkInternalApi
 public interface ExecutionInterceptor {
     /**
      * Read a request that has been given to a service client before it is modified by other interceptors.

--- a/core/src/test/java/software/amazon/awssdk/core/config/ImmutableClientConfigurationTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/config/ImmutableClientConfigurationTest.java
@@ -28,7 +28,6 @@ import software.amazon.awssdk.core.auth.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.internal.auth.NoOpSignerProvider;
 import software.amazon.awssdk.core.retry.RetryPolicy;
-import software.amazon.awssdk.core.retry.RetryPolicyContext;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 
@@ -89,7 +88,7 @@ public class ImmutableClientConfigurationTest {
                                           .advancedOption(AdvancedClientOption.SIGNER_PROVIDER, SIGNER_PROVIDER)
                                           .advancedOption(AdvancedClientOption.ENABLE_DEFAULT_REGION_DETECTION, false)
                                           .retryPolicy(RETRY_POLICY)
-                                          .addLastExecutionInterceptor(EXECUTION_INTERCEPTOR)
+                                          .addExecutionInterceptor(EXECUTION_INTERCEPTOR)
                                           .build();
     }
 }

--- a/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
+++ b/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
@@ -40,7 +40,7 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
                               .credentialsProvider(getCredentialsProvider())
                               .overrideConfiguration(ClientOverrideConfiguration
                                                              .builder()
-                                                             .addLastExecutionInterceptor(capturingExecutionInterceptor)
+                                                             .addExecutionInterceptor(capturingExecutionInterceptor)
                                                              .build())
                               .build();
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
@@ -130,7 +130,7 @@ public class GetObjectAsyncIntegrationTest extends S3IntegrationTestBase {
     private S3AsyncClient createClientWithInterceptor(ExecutionInterceptor assertingInterceptor) {
         return s3AsyncClientBuilder()
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
-                                                                  .addLastExecutionInterceptor(assertingInterceptor)
+                                                                  .addExecutionInterceptor(assertingInterceptor)
                                                                   .build())
                 .build();
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
@@ -106,7 +106,7 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
 
     private S3Client createClientWithInterceptor(ExecutionInterceptor interceptor) {
         return s3ClientBuilder().overrideConfiguration(ClientOverrideConfiguration.builder()
-                                                                                  .addLastExecutionInterceptor(interceptor)
+                                                                                  .addExecutionInterceptor(interceptor)
                                                                                   .build())
                                 .build();
     }

--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/MessageAttributesIntegrationTest.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/MessageAttributesIntegrationTest.java
@@ -73,7 +73,7 @@ public class MessageAttributesIntegrationTest extends IntegrationTestBase {
                                                   .credentialsProvider(getCredentialsProvider())
                                                   .overrideConfiguration(ClientOverrideConfiguration
                                                                                  .builder()
-                                                                                 .addLastExecutionInterceptor(
+                                                                                 .addExecutionInterceptor(
                                                                                          new TamperingInterceptor())
                                                                                  .build())
                                                   .build()) {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
@@ -470,7 +470,7 @@ public class ExecutionInterceptorTest {
                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                       .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
                       .overrideConfiguration(ClientOverrideConfiguration.builder()
-                                                                        .addLastExecutionInterceptor(interceptor)
+                                                                        .addExecutionInterceptor(interceptor)
                                                                         .build())
                       .build();
     }


### PR DESCRIPTION
Renamed `ClientConfiguration#lastExecutionInterceptors` to `executionInterceptor`. Order shouldn't matter and the last name was awkward. Marked ExecutionInterceptor as internal for now. We have some changes we want to make, so we'd like to discourage people from implementing it.