### PR TITLE
Move AWS specific retry policies to aws-core

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d238705.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d238705.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Moved AWS specific retry policies to aws-core module, created AwsServiceException and moved isThrottlingException and isClockSkewException methods to SdkServiceException."
+}

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/config/defaults/AwsGlobalClientConfigurationDefaults.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/config/defaults/AwsGlobalClientConfigurationDefaults.java
@@ -24,12 +24,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
 import software.amazon.awssdk.core.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.config.InternalAdvancedClientOption;
 import software.amazon.awssdk.core.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.util.UserAgentUtils;
 
 /**
@@ -55,7 +55,7 @@ public final class AwsGlobalClientConfigurationDefaults extends AwsClientConfigu
                                applyDefault(configuration.advancedOption(InternalAdvancedClientOption
                                                                              .CRC32_FROM_COMPRESSED_DATA_ENABLED), () -> false));
 
-        builder.retryPolicy(applyDefault(configuration.retryPolicy(), () -> RetryPolicy.DEFAULT));
+        builder.retryPolicy(applyDefault(configuration.retryPolicy(), () -> AwsRetryPolicy.DEFAULT));
 
         // Put global interceptors before the ones currently configured.
         List<ExecutionInterceptor> globalInterceptors = new ClasspathInterceptorChainFactory().getGlobalInterceptors();

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsErrorCodes.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsErrorCodes.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.exception;
+
+import static java.util.Collections.unmodifiableSet;
+
+import java.util.HashSet;
+import java.util.Set;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Contains AWS error codes.
+ */
+@SdkInternalApi
+public final class AwsErrorCodes {
+
+    public static final Set<String> RETRYABLE_ERROR_CODES;
+    public static final Set<String> THROTTLING_ERROR_CODES;
+    public static final Set<String> CLOCK_SKEW_ERROR_CODES;
+
+    static {
+        Set<String> throttlingErrorCodes = new HashSet<>(9);
+
+        throttlingErrorCodes.add("Throttling");
+        throttlingErrorCodes.add("ThrottlingException");
+        throttlingErrorCodes.add("ThrottledException");
+        throttlingErrorCodes.add("ProvisionedThroughputExceededException");
+        throttlingErrorCodes.add("SlowDown");
+        throttlingErrorCodes.add("TooManyRequestsException");
+        throttlingErrorCodes.add("RequestLimitExceeded");
+        throttlingErrorCodes.add("BandwidthLimitExceeded");
+        throttlingErrorCodes.add("RequestThrottled");
+        THROTTLING_ERROR_CODES = unmodifiableSet(throttlingErrorCodes);
+
+        Set<String> clockSkewErrorCodes = new HashSet<>(6);
+        clockSkewErrorCodes.add("RequestTimeTooSkewed");
+        clockSkewErrorCodes.add("RequestExpired");
+        clockSkewErrorCodes.add("InvalidSignatureException");
+        clockSkewErrorCodes.add("SignatureDoesNotMatch");
+        clockSkewErrorCodes.add("AuthFailure");
+        clockSkewErrorCodes.add("RequestInTheFuture");
+        CLOCK_SKEW_ERROR_CODES = unmodifiableSet(clockSkewErrorCodes);
+
+        Set<String> retryableErrorCodes = new HashSet<>(1);
+        retryableErrorCodes.add("PriorRequestNotComplete");
+        RETRYABLE_ERROR_CODES = unmodifiableSet(retryableErrorCodes);
+    }
+
+    private AwsErrorCodes() {
+    }
+}

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.exception;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+
+/**
+ * Extension of {@link SdkServiceException} that represents an error response returned
+ * by an Amazon web service.
+ *
+ * <p>
+ * AmazonServiceException provides callers several pieces of
+ * information that can be used to obtain more information about the error and
+ * why it occurred. In particular, the errorType field can be used to determine
+ * if the caller's request was invalid, or the service encountered an error on
+ * the server side while processing it.
+ *
+ * @see SdkServiceException
+ */
+@SdkPublicApi
+public class AwsServiceException extends SdkServiceException {
+
+    public AwsServiceException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public AwsServiceException(String errorMessage, Exception cause) {
+        super(errorMessage, cause);
+    }
+
+    @Override
+    public boolean isClockSkewException() {
+        return Optional.ofNullable(errorCode())
+                       .map(AwsErrorCodes.CLOCK_SKEW_ERROR_CODES::contains)
+                       .orElse(false);
+    }
+
+    @Override
+    public boolean additionalThrottlingCondition() {
+        return Optional.ofNullable(errorCode())
+                       .map(AwsErrorCodes.THROTTLING_ERROR_CODES::contains)
+                       .orElse(false);
+    }
+}

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/DefaultErrorResponseHandler.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/DefaultErrorResponseHandler.java
@@ -25,8 +25,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponse;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.http.pipeline.stages.ApplyTransactionIdStage;
@@ -45,13 +45,13 @@ import software.amazon.awssdk.utils.IoUtils;
  * message, AWS error code, AWS request ID, etc).
  */
 @SdkProtectedApi
-public class DefaultErrorResponseHandler implements HttpResponseHandler<SdkServiceException> {
+public class DefaultErrorResponseHandler implements HttpResponseHandler<AwsServiceException> {
     private static final Logger log = LoggerFactory.getLogger(DefaultErrorResponseHandler.class);
 
     /**
      * The list of error response unmarshallers to try to apply to error responses.
      */
-    private List<Unmarshaller<SdkServiceException, Node>> unmarshallerList;
+    private List<Unmarshaller<AwsServiceException, Node>> unmarshallerList;
 
     /**
      * Constructs a new DefaultErrorResponseHandler that will handle error responses from Amazon
@@ -62,14 +62,14 @@ public class DefaultErrorResponseHandler implements HttpResponseHandler<SdkServi
      *                         response.
      */
     public DefaultErrorResponseHandler(
-            List<Unmarshaller<SdkServiceException, Node>> unmarshallerList) {
+            List<Unmarshaller<AwsServiceException, Node>> unmarshallerList) {
         this.unmarshallerList = unmarshallerList;
     }
 
     @Override
-    public SdkServiceException handle(HttpResponse errorResponse,
+    public AwsServiceException handle(HttpResponse errorResponse,
                                       ExecutionAttributes executionAttributes) throws Exception {
-        SdkServiceException exception = createServiceException(errorResponse);
+        AwsServiceException exception = createServiceException(errorResponse);
         if (exception == null) {
             throw new SdkClientException("Unable to unmarshall error response from service");
         }
@@ -80,7 +80,7 @@ public class DefaultErrorResponseHandler implements HttpResponseHandler<SdkServi
         return exception;
     }
 
-    private SdkServiceException createServiceException(HttpResponse errorResponse) throws Exception {
+    private AwsServiceException createServiceException(HttpResponse errorResponse) throws Exception {
         // Try to parse the error response as XML
         final Document document = documentFromContent(errorResponse.getContent(), idString(errorResponse));
 
@@ -91,8 +91,8 @@ public class DefaultErrorResponseHandler implements HttpResponseHandler<SdkServi
          * unmarshall the response, but we might need something a little more
          * sophisticated in the future.
          */
-        for (Unmarshaller<SdkServiceException, Node> unmarshaller : unmarshallerList) {
-            SdkServiceException exception = unmarshaller.unmarshall(document);
+        for (Unmarshaller<AwsServiceException, Node> unmarshaller : unmarshallerList) {
+            AwsServiceException exception = unmarshaller.unmarshall(document);
             if (exception != null) {
                 exception.statusCode(errorResponse.getStatusCode());
                 return exception;

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/StaxResponseHandler.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/StaxResponseHandler.java
@@ -47,7 +47,7 @@ import software.amazon.awssdk.utils.XmlUtils;
  */
 @SdkProtectedApi
 @ReviewBeforeRelease("ResponseMetadata is currently broken. Revisit when base result types are refactored")
-public class StaxResponseHandler<T extends SdkResponse> implements HttpResponseHandler<T> {
+public class StaxResponseHandler<T> implements HttpResponseHandler<T> {
     private static final Logger log = Logger.loggerFor(StaxResponseHandler.class);
 
     /**

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonErrorUnmarshaller.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonErrorUnmarshaller.java
@@ -15,13 +15,9 @@
 
 package software.amazon.awssdk.awscore.protocol.json;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.UPPER_CAMEL_CASE;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.protocol.json.JsonErrorUnmarshaller;
 
 /**
@@ -29,13 +25,10 @@ import software.amazon.awssdk.core.protocol.json.JsonErrorUnmarshaller;
  */
 @SdkInternalApi
 @ThreadSafe
-public class AwsJsonErrorUnmarshaller extends JsonErrorUnmarshaller {
+public class AwsJsonErrorUnmarshaller extends JsonErrorUnmarshaller<AwsServiceException> {
 
     public static final AwsJsonErrorUnmarshaller DEFAULT_UNMARSHALLER = new AwsJsonErrorUnmarshaller(
-        SdkServiceException.class, null);
-
-    private static final ObjectMapper MAPPER = new ObjectMapper().configure(
-            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).setPropertyNamingStrategy(UPPER_CAMEL_CASE);
+        AwsServiceException.class, null);
 
     private final String handledErrorCode;
 
@@ -43,7 +36,7 @@ public class AwsJsonErrorUnmarshaller extends JsonErrorUnmarshaller {
      * @param exceptionClass   Exception class this unmarshaller will attempt to deserialize error response into
      * @param handledErrorCode AWS error code that this unmarshaller handles. Pass null to handle all exceptions
      */
-    public AwsJsonErrorUnmarshaller(Class<? extends SdkServiceException> exceptionClass, String handledErrorCode) {
+    public AwsJsonErrorUnmarshaller(Class<? extends AwsServiceException> exceptionClass, String handledErrorCode) {
         super(exceptionClass);
         this.handledErrorCode = handledErrorCode;
     }

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonProtocolFactory.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonProtocolFactory.java
@@ -20,8 +20,8 @@ import java.util.List;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
-import software.amazon.awssdk.core.SdkResponse;
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.OperationInfo;
 import software.amazon.awssdk.core.protocol.json.BaseJsonProtocolFactory;
@@ -40,7 +40,7 @@ import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
  */
 @ThreadSafe
 @SdkProtectedApi
-public final class AwsJsonProtocolFactory extends BaseJsonProtocolFactory {
+public final class AwsJsonProtocolFactory extends BaseJsonProtocolFactory<AwsRequest, AwsServiceException> {
 
     private final AwsJsonProtocolMetadata protocolMetadata;
     private final List<AwsJsonErrorUnmarshaller> errorUnmarshallers = new ArrayList<>();
@@ -57,7 +57,7 @@ public final class AwsJsonProtocolFactory extends BaseJsonProtocolFactory {
      * @param operationMetadata Additional context information about an operation to create the appropriate response handler.
      */
     @Override
-    public <T extends SdkResponse> JsonResponseHandler<T> createResponseHandler(
+    public <T> JsonResponseHandler<T> createResponseHandler(
         JsonOperationMetadata operationMetadata,
         Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller) {
         return getSdkFactory().createResponseHandler(operationMetadata, responseUnmarshaller);
@@ -67,7 +67,7 @@ public final class AwsJsonProtocolFactory extends BaseJsonProtocolFactory {
      * Creates a response handler for handling a error response (non 2xx response).
      */
     @Override
-    public HttpResponseHandler<SdkServiceException> createErrorResponseHandler(
+    public HttpResponseHandler<AwsServiceException> createErrorResponseHandler(
         JsonErrorResponseMetadata errorResponseMetadata) {
         return getSdkFactory().createErrorResponseHandler(errorUnmarshallers, errorResponseMetadata
             .getCustomErrorCodeFieldName());
@@ -95,12 +95,12 @@ public final class AwsJsonProtocolFactory extends BaseJsonProtocolFactory {
     private void createErrorUnmarshallers() {
         for (JsonErrorShapeMetadata errorMetadata : jsonClientMetadata.getErrorShapeMetadata()) {
             errorUnmarshallers.add(new AwsJsonErrorUnmarshaller(
-                (Class<? extends SdkServiceException>) errorMetadata.getModeledClass(),
+                (Class<? extends AwsServiceException>) errorMetadata.getModeledClass(),
                 errorMetadata.getErrorCode()));
-
         }
+
         errorUnmarshallers.add(new AwsJsonErrorUnmarshaller(
-            (Class<? extends SdkServiceException>) jsonClientMetadata.getBaseServiceExceptionClass(),
+            (Class<? extends AwsServiceException>) jsonClientMetadata.getBaseServiceExceptionClass(),
             null));
     }
 

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsStructuredJsonFactory.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsStructuredJsonFactory.java
@@ -35,5 +35,4 @@ public interface AwsStructuredJsonFactory extends StructuredJsonFactory {
      */
     AwsJsonErrorResponseHandler createErrorResponseHandler(
         List<AwsJsonErrorUnmarshaller> errorUnmarshallers, String customErrorCodeFieldName);
-
 }

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/BaseAwsStructuredJsonFactory.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/BaseAwsStructuredJsonFactory.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.awscore.http.response.AwsJsonErrorResponseHandler;
-import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.protocol.json.JsonOperationMetadata;
 import software.amazon.awssdk.core.protocol.json.StructuredJsonGenerator;
 import software.amazon.awssdk.core.runtime.http.response.JsonResponseHandler;
@@ -48,12 +47,12 @@ abstract class BaseAwsStructuredJsonFactory implements AwsStructuredJsonFactory 
     }
 
     @Override
-    public <T extends SdkResponse> JsonResponseHandler<T> createResponseHandler(
-            JsonOperationMetadata operationMetadata,
-            Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller) {
-        return new JsonResponseHandler(responseUnmarshaller, unmarshallers, jsonFactory,
-                                       operationMetadata.isHasStreamingSuccessResponse(),
-                                       operationMetadata.isPayloadJson());
+    public <T> JsonResponseHandler<T> createResponseHandler(
+        JsonOperationMetadata operationMetadata,
+        Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller) {
+        return new JsonResponseHandler<>(responseUnmarshaller, unmarshallers, jsonFactory,
+                                         operationMetadata.isHasStreamingSuccessResponse(),
+                                         operationMetadata.isPayloadJson());
     }
 
     @Override

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/LegacyErrorUnmarshaller.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/LegacyErrorUnmarshaller.java
@@ -18,8 +18,8 @@ package software.amazon.awssdk.awscore.protocol.xml;
 import javax.xml.xpath.XPath;
 import org.w3c.dom.Node;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.ErrorType;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.runtime.transform.AbstractErrorUnmarshaller;
 import software.amazon.awssdk.core.util.XpathUtils;
 
@@ -28,14 +28,14 @@ import software.amazon.awssdk.core.util.XpathUtils;
  * optionally, a subclass of SdkServiceException if this class is extended.
  */
 @SdkProtectedApi
-public class LegacyErrorUnmarshaller extends AbstractErrorUnmarshaller<Node> {
+public class LegacyErrorUnmarshaller extends AbstractErrorUnmarshaller<AwsServiceException, Node> {
 
     /**
      * Constructs a new unmarshaller that will unmarshall AWS error responses as
      * a generic SdkServiceException object.
      */
     public LegacyErrorUnmarshaller() {
-        this(SdkServiceException.class);
+        this(AwsServiceException.class);
     }
 
     /**
@@ -44,21 +44,21 @@ public class LegacyErrorUnmarshaller extends AbstractErrorUnmarshaller<Node> {
      * object with data from the AWS error response.
      *
      * @param exceptionClass The class of SdkServiceException to create and populate
-     *                       when unmarshalling the AWS error response.
+     * when unmarshalling the AWS error response.
      */
-    public LegacyErrorUnmarshaller(Class<? extends SdkServiceException> exceptionClass) {
+    public LegacyErrorUnmarshaller(Class<? extends AwsServiceException> exceptionClass) {
         super(exceptionClass);
     }
 
     @Override
-    public SdkServiceException unmarshall(Node in) throws Exception {
+    public AwsServiceException unmarshall(Node in) throws Exception {
         XPath xpath = XpathUtils.xpath();
         String errorCode = parseErrorCode(in, xpath);
         String message = XpathUtils.asString("Response/Errors/Error/Message", in, xpath);
         String requestId = XpathUtils.asString("Response/RequestID", in, xpath);
         String errorType = XpathUtils.asString("Response/Errors/Error/Type", in, xpath);
 
-        SdkServiceException exception = newException(message);
+        AwsServiceException exception = newException(message);
         exception.errorCode(errorCode);
         exception.requestId(requestId);
 
@@ -79,7 +79,7 @@ public class LegacyErrorUnmarshaller extends AbstractErrorUnmarshaller<Node> {
      * @param in The DOM tree node containing the error response.
      * @return The AWS error code contained in the specified error response.
      * @throws Exception If any problems were encountered pulling out the AWS error
-     *                   code.
+     * code.
      */
     public String parseErrorCode(Node in) throws Exception {
         return XpathUtils.asString("Response/Errors/Error/Code", in);

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryPolicy.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/AwsRetryPolicy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.retry;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.awscore.exception.AwsErrorCodes;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+
+/**
+ * Retry Policy used by clients when communicating with AWS services.
+ */
+@SdkPublicApi
+public final class AwsRetryPolicy {
+
+    public static final RetryCondition AWS_DEFAULT_RETRY_CONDITION =
+        RetryCondition.DEFAULT.or(new RetryOnErrorCodeCondition(AwsErrorCodes.RETRYABLE_ERROR_CODES));
+
+    public static final RetryPolicy DEFAULT =
+        RetryPolicy.DEFAULT.toBuilder()
+                           .retryCondition(AWS_DEFAULT_RETRY_CONDITION)
+                           .build();
+
+    private AwsRetryPolicy() {
+    }
+}

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/RetryOnErrorCodeCondition.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/RetryOnErrorCodeCondition.java
@@ -13,19 +13,22 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.retry.conditions;
+package software.amazon.awssdk.awscore.retry;
 
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 
+/**
+ * Retry condition implementation that retries if the exception or the cause of the exception matches the error codes defined.
+ */
 @SdkPublicApi
 public class RetryOnErrorCodeCondition implements RetryCondition {
 
     private final Set<String> retryableErrorCodes;
 
-    // TODO: Switch to varargs and Set.of()
     public RetryOnErrorCodeCondition(Set<String> retryableErrorCodes) {
         this.retryableErrorCodes = retryableErrorCodes;
     }
@@ -34,12 +37,10 @@ public class RetryOnErrorCodeCondition implements RetryCondition {
     public boolean shouldRetry(RetryPolicyContext context) {
 
         Exception ex = context.exception();
-        if (ex != null && ex instanceof SdkServiceException) {
+        if (ex instanceof SdkServiceException) {
             SdkServiceException exception = (SdkServiceException) ex;
 
-            if (retryableErrorCodes.contains(exception.errorCode())) {
-                return true;
-            }
+            return retryableErrorCodes.contains(exception.errorCode());
         }
         return false;
     }

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/client/utils/WireMockTestBase.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/client/utils/WireMockTestBase.java
@@ -23,14 +23,14 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;
 import org.junit.Rule;
 import software.amazon.awssdk.awscore.client.http.NoopTestAwsRequest;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.awscore.http.response.AwsJsonErrorResponseHandler;
 import software.amazon.awssdk.core.DefaultRequest;
 import software.amazon.awssdk.core.Request;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpMethodName;
 import software.amazon.awssdk.core.http.HttpResponse;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.awscore.http.response.AwsJsonErrorResponseHandler;
 
 /**
  * Base class for tests that use a WireMock server
@@ -52,14 +52,14 @@ public abstract class WireMockTestBase {
         return request;
     }
 
-    protected HttpResponseHandler<SdkServiceException> stubErrorHandler() throws Exception {
-        HttpResponseHandler<SdkServiceException> errorHandler = mock(AwsJsonErrorResponseHandler.class);
+    protected HttpResponseHandler<AwsServiceException> stubErrorHandler() throws Exception {
+        HttpResponseHandler<AwsServiceException> errorHandler = mock(AwsJsonErrorResponseHandler.class);
         when(errorHandler.handle(any(HttpResponse.class), any(ExecutionAttributes.class))).thenReturn(mockException());
         return errorHandler;
     }
 
-    private SdkServiceException mockException() {
-        SdkServiceException exception = new SdkServiceException("Dummy error response");
+    private AwsServiceException mockException() {
+        AwsServiceException exception = new AwsServiceException("Dummy error response");
         exception.statusCode(500);
         return exception;
     }

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/http/response/AwsJsonErrorResponseHandlerTest.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/http/response/AwsJsonErrorResponseHandlerTest.java
@@ -31,8 +31,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.awscore.client.utils.ValidSdkObjects;
-import software.amazon.awssdk.awscore.protocol.json.JsonErrorCodeParser;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonErrorUnmarshaller;
+import software.amazon.awssdk.awscore.protocol.json.JsonErrorCodeParser;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponse;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
@@ -216,7 +217,7 @@ public class AwsJsonErrorResponseHandlerTest {
         when(unmarshaller.matchErrorCode(anyString())).thenReturn(false);
     }
 
-    private static class CustomException extends SdkServiceException {
+    private static class CustomException extends AwsServiceException {
 
         private static final long serialVersionUID = 1305027296023640779L;
 

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonErrorUnmarshallerTest.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonErrorUnmarshallerTest.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 public class AwsJsonErrorUnmarshallerTest {
 
@@ -84,7 +84,7 @@ public class AwsJsonErrorUnmarshallerTest {
         assertFalse(unmarshaller.matchErrorCode(null));
     }
 
-    private static class CustomException extends SdkServiceException {
+    private static class CustomException extends AwsServiceException {
 
         private static final long serialVersionUID = 4140670458615826397L;
 

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/protocol/json/AwsStructuredIonFactoryTest.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/protocol/json/AwsStructuredIonFactoryTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.client.utils.ValidSdkObjects;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.http.response.AwsJsonErrorResponseHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -139,7 +140,7 @@ public class AwsStructuredIonFactoryTest {
         return handler.handle(error, new ExecutionAttributes());
     }
 
-    private static class InvalidParameterException extends SdkServiceException {
+    private static class InvalidParameterException extends AwsServiceException {
         private static final long serialVersionUID = 0;
 
         public InvalidParameterException(BeanStyleBuilder builder) {

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/retry/AwsRetryPolicyTest.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/retry/AwsRetryPolicyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.awscore.retry;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static software.amazon.awssdk.awscore.retry.AwsRetryPolicy.AWS_DEFAULT_RETRY_CONDITION;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+
+public class AwsRetryPolicyTest {
+
+    @Test
+    public void retriesOnRetryableErrorCodes() {
+        assertTrue(shouldRetry(applyErrorCode("PriorRequestNotComplete")));
+    }
+
+    @Test
+    public void retriesOnThrottlingExceptions() {
+        assertTrue(shouldRetry(applyErrorCode("ThrottlingException")));
+        assertTrue(shouldRetry(applyErrorCode("ThrottledException")));
+        assertTrue(shouldRetry(applyStatusCode(429)));
+    }
+
+    @Test
+    public void retriesOnClockSkewErrors() {
+        assertTrue(shouldRetry(applyErrorCode("RequestTimeTooSkewed")));
+        assertTrue(shouldRetry(applyErrorCode("AuthFailure")));
+    }
+
+    @Test
+    public void retriesOnInternalError() {
+        assertTrue(shouldRetry(applyStatusCode(500)));
+    }
+
+    @Test
+    public void retriesOnBadGateway() {
+        assertTrue(shouldRetry(applyStatusCode(502)));
+    }
+
+    @Test
+    public void retriesOnServiceUnavailable() {
+        assertTrue(shouldRetry(applyStatusCode(503)));
+    }
+
+    @Test
+    public void retriesOnGatewayTimeout() {
+        assertTrue(shouldRetry(applyStatusCode(504)));
+    }
+
+    @Test
+    public void retriesOnIOException() {
+        assertTrue(shouldRetry(b -> b.exception(new SdkClientException("IO", new IOException()))));
+    }
+
+    @Test
+    public void retriesOnRetryableException() {
+        assertTrue(shouldRetry(b -> b.exception(new RetryableException("this is retryable"))));
+    }
+
+    @Test
+    public void doesNotRetryOnNonRetryableException() {
+        assertFalse(shouldRetry(b -> b.exception(new NonRetryableException("this is NOT retryable"))));
+    }
+
+    @Test
+    public void doesNotRetryOnNonRetryableStatusCode() {
+        assertFalse(shouldRetry(applyStatusCode(404)));
+    }
+
+    @Test
+    public void doesNotRetryOnNonRetryableErrorCode() {
+        assertFalse(shouldRetry(applyErrorCode("ValidationError")));
+    }
+
+    private boolean shouldRetry(Consumer<RetryPolicyContext.Builder> builder) {
+        return AWS_DEFAULT_RETRY_CONDITION.shouldRetry(RetryPolicyContext.builder().apply(builder).build());
+    }
+
+    private Consumer<RetryPolicyContext.Builder> applyErrorCode(String errorCode) {
+        AwsServiceException exception = new AwsServiceException("");
+        exception.statusCode(404);
+        exception.errorCode(errorCode);
+        return b -> b.exception(exception);
+    }
+
+    private Consumer<RetryPolicyContext.Builder> applyStatusCode(Integer statusCode) {
+        AwsServiceException exception = new AwsServiceException("");
+        exception.statusCode(statusCode);
+        exception.errorCode("Foo");
+        return b -> b.exception(exception)
+                     .httpStatusCode(statusCode);
+    }
+}

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/retry/RetryOnErrorCodeConditionTest.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/retry/RetryOnErrorCodeConditionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.retry;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
+import java.util.function.Consumer;
+import org.junit.Test;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+
+public class RetryOnErrorCodeConditionTest {
+
+    private RetryOnErrorCodeCondition condition = new RetryOnErrorCodeCondition(Sets.newHashSet(
+        "Foo", "Bar"));
+
+    @Test
+    public void noExceptionInContext_ReturnsFalse() {
+        assertFalse(shouldRetry(builder -> builder.exception(null)));
+    }
+
+    @Test
+    public void retryableErrorCodes_ReturnsTrue() {
+        assertTrue(shouldRetry(applyErrorCode("Foo")));
+        assertTrue(shouldRetry(applyErrorCode("Bar")));
+    }
+
+    @Test
+    public void nonRetryableErrorCode_ReturnsFalse() {
+        assertFalse(shouldRetry(applyErrorCode("HelloWorld")));
+    }
+
+    private boolean shouldRetry(Consumer<RetryPolicyContext.Builder> builder) {
+        return condition.shouldRetry(RetryPolicyContext.builder().apply(builder).build());
+    }
+
+    private Consumer<RetryPolicyContext.Builder> applyErrorCode(String errorCode) {
+        SdkServiceException exception = new SdkServiceException("");
+        exception.statusCode(404);
+        exception.errorCode(errorCode);
+        return b -> b.exception(exception);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.codegen.docs.ClientType;
 import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
@@ -45,7 +46,6 @@ import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.ServiceMetadata;
@@ -390,7 +390,7 @@ public final class SyncClientInterface implements ClassSpec {
                                             .map(e -> ClassName.get(model.getMetadata().getFullModelPackageName(),
                                                                     e.getExceptionName()))
                                             .collect(toCollection(ArrayList::new));
-        Collections.addAll(exceptions, ClassName.get(SdkServiceException.class),
+        Collections.addAll(exceptions, ClassName.get(AwsServiceException.class),
                            ClassName.get(SdkClientException.class),
                            ClassName.get(model.getMetadata().getFullModelPackageName(),
                                          model.getSdkModeledExceptionBaseClassName()));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/Ec2ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/Ec2ProtocolSpec.java
@@ -68,7 +68,7 @@ public class Ec2ProtocolSpec extends QueryXmlProtocolSpec {
                 .addStatement("throw new $T($S)", SdkClientException.class,
                         "Unrecognized service response for the dry-run request.")
                 .endControlFlow()
-                .beginControlFlow("catch (SdkServiceException exception)")
+                .beginControlFlow("catch (AwsServiceException exception)")
                 .beginControlFlow("if (exception.errorCode().equals($S) && exception.statusCode() == 412)",
                         "DryRunOperation")
                 .addStatement("return new $T(true, request, exception.getMessage(), exception)", dryRunResultGeneric)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocol;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolMetadata;
@@ -37,7 +38,6 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeType;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.core.client.ClientExecutionParams;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.json.JsonClientMetadata;
 import software.amazon.awssdk.core.protocol.json.JsonErrorResponseMetadata;
@@ -123,7 +123,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
         return CodeBlock
                 .builder()
                 .add("\n\n$T<$T> errorResponseHandler = createErrorResponseHandler();",
-                     HttpResponseHandler.class, SdkServiceException.class)
+                     HttpResponseHandler.class, AwsServiceException.class)
                 .build();
     }
 
@@ -184,7 +184,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
     @Override
     public Optional<MethodSpec> createErrorResponseHandler() {
         ClassName httpResponseHandler = ClassName.get(HttpResponseHandler.class);
-        ClassName sdkBaseException = ClassName.get(SdkServiceException.class);
+        ClassName sdkBaseException = ClassName.get(AwsServiceException.class);
         TypeName responseHandlerOfException = ParameterizedTypeName.get(httpResponseHandler, sdkBaseException);
 
         return Optional.of(MethodSpec.methodBuilder("createErrorResponseHandler")

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryXmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryXmlProtocolSpec.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import org.w3c.dom.Node;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.http.response.DefaultErrorResponseHandler;
 import software.amazon.awssdk.awscore.http.response.StaxResponseHandler;
 import software.amazon.awssdk.awscore.protocol.xml.StandardErrorUnmarshaller;
@@ -36,7 +37,6 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.core.client.ClientExecutionParams;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
@@ -46,7 +46,7 @@ public class QueryXmlProtocolSpec implements ProtocolSpec {
 
     private final PoetExtensions poetExtensions;
     private final TypeName unmarshallerType = ParameterizedTypeName.get(Unmarshaller.class,
-                                                                        SdkServiceException.class,
+                                                                        AwsServiceException.class,
                                                                         Node.class);
     private final TypeName listOfUnmarshallersType = ParameterizedTypeName.get(ClassName.get("java.util", "List"),
                                                                                unmarshallerType);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/protocol/BaseProtocolMetadataProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/protocol/BaseProtocolMetadataProvider.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.codegen.protocol;
 
 import software.amazon.awssdk.awscore.AwsRequest;
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 /**
  * Base class for all {@link ProtocolMetadataProvider}. Provides convenient default implementations
@@ -67,7 +67,7 @@ public abstract class BaseProtocolMetadataProvider implements ProtocolMetadataPr
 
     @Override
     public String getBaseExceptionFqcn() {
-        return SdkServiceException.class.getName();
+        return AwsServiceException.class.getName();
     }
 
     /**

--- a/codegen/src/main/resources/templates/query/exception-unmarshaller.ftl
+++ b/codegen/src/main/resources/templates/query/exception-unmarshaller.ftl
@@ -4,7 +4,7 @@ package ${transformPackage};
 import org.w3c.dom.Node;
 import javax.annotation.Generated;
 
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.util.XpathUtils;
 
 import ${metadata.fullModelPackageName}.${shape.shapeName};
@@ -17,7 +17,7 @@ public class ${shape.shapeName}Unmarshaller extends ${exceptionUnmarshallerImpl}
     }
 
     @Override
-    public SdkServiceException unmarshall(Node node) throws Exception {
+    public AwsServiceException unmarshall(Node node) throws Exception {
         // Bail out if this isn't the right error code that this
         // marshaller understands
         String errorCode = parseErrorCode(node);

--- a/codegen/src/main/resources/templates/rest-xml/s3/ExceptionUnmarshaller.ftl
+++ b/codegen/src/main/resources/templates/rest-xml/s3/ExceptionUnmarshaller.ftl
@@ -4,7 +4,7 @@ package ${transformPackage};
 import org.w3c.dom.Node;
 import javax.annotation.Generated;
 
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.util.XpathUtils;
 import software.amazon.awssdk.services.s3.transform.S3ExceptionUnmarshaller;
 import ${metadata.fullModelPackageName}.${shape.shapeName};
@@ -17,7 +17,7 @@ public class ${shape.shapeName}Unmarshaller extends S3ExceptionUnmarshaller {
     }
 
     @Override
-    public SdkServiceException unmarshall(Node node) throws Exception {
+    public AwsServiceException unmarshall(Node node) throws Exception {
         return super.unmarshall(node);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -5,6 +5,7 @@ import javax.annotation.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
 import software.amazon.awssdk.awscore.config.AwsAsyncClientConfiguration;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocol;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolMetadata;
@@ -12,7 +13,6 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.client.AsyncClientHandler;
 import software.amazon.awssdk.core.client.ClientExecutionParams;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.json.JsonClientMetadata;
 import software.amazon.awssdk.core.protocol.json.JsonErrorResponseMetadata;
@@ -102,7 +102,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new APostOperationResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
                                          .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
@@ -140,7 +140,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new APostOperationWithOutputResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
@@ -180,7 +180,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new GetWithoutRequiredMembersResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
@@ -217,7 +217,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new PaginatedOperationWithResultKeyResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
@@ -327,7 +327,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new PaginatedOperationWithoutResultKeyResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
@@ -441,7 +441,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new StreamingInputOperationResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
                                          .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
@@ -482,7 +482,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
             new StreamingOutputOperationResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(
             new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
@@ -509,7 +509,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                                                                               .protocol(AwsJsonProtocol.REST_JSON).build());
     }
 
-    private HttpResponseHandler<SdkServiceException> createErrorResponseHandler() {
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler() {
         return protocolFactory.createErrorResponseHandler(new JsonErrorResponseMetadata());
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -4,13 +4,13 @@ import javax.annotation.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.config.AwsSyncClientConfiguration;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocol;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolMetadata;
 import software.amazon.awssdk.core.client.ClientExecutionParams;
 import software.amazon.awssdk.core.client.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.json.JsonClientMetadata;
 import software.amazon.awssdk.core.protocol.json.JsonErrorResponseMetadata;
@@ -99,13 +99,13 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
-                                                                                                     SdkServiceException, SdkClientException, JsonException {
+                                                                                                     AwsServiceException, SdkClientException, JsonException {
 
         HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new APostOperationResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
                                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
@@ -134,14 +134,14 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public APostOperationWithOutputResponse aPostOperationWithOutput(
-        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkServiceException,
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
                                                                                 SdkClientException, JsonException {
 
         HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new APostOperationWithOutputResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
@@ -172,14 +172,14 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, SdkServiceException,
+        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
                                                                                   SdkClientException, JsonException {
 
         HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new GetWithoutRequiredMembersResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
@@ -206,14 +206,14 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
 
         HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new PaginatedOperationWithResultKeyResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
@@ -291,7 +291,7 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
         return new PaginatedOperationWithResultKeyIterable(this, paginatedOperationWithResultKeyRequest);
     }
@@ -314,14 +314,14 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
 
         HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new PaginatedOperationWithoutResultKeyResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler
             .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
@@ -399,7 +399,7 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
         return new PaginatedOperationWithoutResultKeyIterable(this, paginatedOperationWithoutResultKeyRequest);
     }
@@ -433,13 +433,13 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
-                                                                   RequestBody requestBody) throws SdkServiceException, SdkClientException, JsonException {
+                                                                   RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
 
         HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
             new StreamingInputOperationResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
                                          .withResponseHandler(responseHandler)
@@ -475,14 +475,14 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
-                                                      ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws SdkServiceException,
+                                                      ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                                                                  SdkClientException, JsonException {
 
         HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
             new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
             new StreamingOutputOperationResponseUnmarshaller());
 
-        HttpResponseHandler<SdkServiceException> errorResponseHandler = createErrorResponseHandler();
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
         return clientHandler.execute(
             new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
@@ -491,7 +491,7 @@ final class DefaultJsonClient implements JsonClient {
                 .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
     }
 
-    private HttpResponseHandler<SdkServiceException> createErrorResponseHandler() {
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler() {
         return protocolFactory.createErrorResponseHandler(new JsonErrorResponseMetadata());
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -3,11 +3,11 @@ package software.amazon.awssdk.services.json;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import javax.annotation.Generated;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.ServiceMetadata;
@@ -77,7 +77,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      API Documentation</a>
      */
     default APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
-                                                                                                      SdkServiceException, SdkClientException, JsonException {
+                                                                                                      AwsServiceException, SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -108,7 +108,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      API Documentation</a>
      */
     default APostOperationResponse aPostOperation(Consumer<APostOperationRequest.Builder> aPostOperationRequest)
-        throws InvalidInputException, SdkServiceException, SdkClientException, JsonException {
+        throws InvalidInputException, AwsServiceException, SdkClientException, JsonException {
         return aPostOperation(APostOperationRequest.builder().apply(aPostOperationRequest).build());
     }
 
@@ -133,7 +133,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default APostOperationWithOutputResponse aPostOperationWithOutput(
-        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkServiceException,
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
                                                                                 SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -167,7 +167,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default APostOperationWithOutputResponse aPostOperationWithOutput(
         Consumer<APostOperationWithOutputRequest.Builder> aPostOperationWithOutputRequest) throws InvalidInputException,
-                                                                                                  SdkServiceException, SdkClientException, JsonException {
+                                                                                                  AwsServiceException, SdkClientException, JsonException {
         return aPostOperationWithOutput(APostOperationWithOutputRequest.builder().apply(aPostOperationWithOutputRequest).build());
     }
 
@@ -191,7 +191,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/GetWithoutRequiredMembers"
      *      target="_top">AWS API Documentation</a>
      */
-    default GetWithoutRequiredMembersResponse getWithoutRequiredMembers() throws InvalidInputException, SdkServiceException,
+    default GetWithoutRequiredMembersResponse getWithoutRequiredMembers() throws InvalidInputException, AwsServiceException,
                                                                                  SdkClientException, JsonException {
         return getWithoutRequiredMembers(GetWithoutRequiredMembersRequest.builder().build());
     }
@@ -217,7 +217,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, SdkServiceException,
+        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
                                                                                   SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -251,7 +251,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
         Consumer<GetWithoutRequiredMembersRequest.Builder> getWithoutRequiredMembersRequest) throws InvalidInputException,
-                                                                                                    SdkServiceException, SdkClientException, JsonException {
+                                                                                                    AwsServiceException, SdkClientException, JsonException {
         return getWithoutRequiredMembers(GetWithoutRequiredMembersRequest.builder().apply(getWithoutRequiredMembersRequest)
                                                                          .build());
     }
@@ -272,7 +272,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
      *      target="_top">AWS API Documentation</a>
      */
-    default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws SdkServiceException,
+    default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey() throws AwsServiceException,
                                                                                              SdkClientException, JsonException {
         return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder().build());
     }
@@ -294,7 +294,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -323,7 +323,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
         Consumer<PaginatedOperationWithResultKeyRequest.Builder> paginatedOperationWithResultKeyRequest)
-        throws SdkServiceException, SdkClientException, JsonException {
+        throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder()
                                                                                      .apply(paginatedOperationWithResultKeyRequest).build());
     }
@@ -396,7 +396,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
                                                                                               SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -468,7 +468,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
      *      target="_top">AWS API Documentation</a>
      */
-    default PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator() throws SdkServiceException,
+    default PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator() throws AwsServiceException,
                                                                                                       SdkClientException, JsonException {
         return paginatedOperationWithResultKeyPaginator(PaginatedOperationWithResultKeyRequest.builder().build());
     }
@@ -490,7 +490,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -519,7 +519,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
         Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
-        throws SdkServiceException, SdkClientException, JsonException {
+        throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithoutResultKey(PaginatedOperationWithoutResultKeyRequest.builder()
                                                                                            .apply(paginatedOperationWithoutResultKeyRequest).build());
     }
@@ -592,7 +592,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws SdkServiceException,
+        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
                                                                                                     SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -672,7 +672,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
         Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
-        throws SdkServiceException, SdkClientException, JsonException {
+        throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithoutResultKeyPaginator(PaginatedOperationWithoutResultKeyRequest.builder()
                                                                                                     .apply(paginatedOperationWithoutResultKeyRequest).build());
     }
@@ -705,7 +705,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-        StreamingInputOperationRequest streamingInputOperationRequest, RequestBody requestBody) throws SdkServiceException,
+        StreamingInputOperationRequest streamingInputOperationRequest, RequestBody requestBody) throws AwsServiceException,
                                                                                                        SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -745,7 +745,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default StreamingInputOperationResponse streamingInputOperation(
         Consumer<StreamingInputOperationRequest.Builder> streamingInputOperationRequest, RequestBody requestBody)
-        throws SdkServiceException, SdkClientException, JsonException {
+        throws AwsServiceException, SdkClientException, JsonException {
         return streamingInputOperation(StreamingInputOperationRequest.builder().apply(streamingInputOperationRequest).build(),
                                        requestBody);
     }
@@ -773,7 +773,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-        StreamingInputOperationRequest streamingInputOperationRequest, Path filePath) throws SdkServiceException,
+        StreamingInputOperationRequest streamingInputOperationRequest, Path filePath) throws AwsServiceException,
                                                                                              SdkClientException, JsonException {
         return streamingInputOperation(streamingInputOperationRequest, RequestBody.fromFile(filePath));
     }
@@ -808,7 +808,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default StreamingInputOperationResponse streamingInputOperation(
         Consumer<StreamingInputOperationRequest.Builder> streamingInputOperationRequest, Path filePath)
-        throws SdkServiceException, SdkClientException, JsonException {
+        throws AwsServiceException, SdkClientException, JsonException {
         return streamingInputOperation(StreamingInputOperationRequest.builder().apply(streamingInputOperationRequest).build(),
                                        filePath);
     }
@@ -837,7 +837,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
-                                                       ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws SdkServiceException,
+                                                       ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                                                                   SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
@@ -873,7 +873,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default <ReturnT> ReturnT streamingOutputOperation(
         Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest,
-        ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws SdkServiceException,
+        ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
                                                                                                    SdkClientException, JsonException {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest).build(),
                                         responseTransformer);
@@ -901,7 +901,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingOutputOperationResponse streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest, Path filePath) throws SdkServiceException,
+        StreamingOutputOperationRequest streamingOutputOperationRequest, Path filePath) throws AwsServiceException,
                                                                                                SdkClientException, JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toFile(filePath));
     }
@@ -935,7 +935,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      */
     default StreamingOutputOperationResponse streamingOutputOperation(
         Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest, Path filePath)
-        throws SdkServiceException, SdkClientException, JsonException {
+        throws AwsServiceException, SdkClientException, JsonException {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest).build(),
                                         filePath);
     }
@@ -963,7 +963,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws SdkServiceException, SdkClientException,
+        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
                                                                                 JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toInputStream());
     }
@@ -997,7 +997,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws SdkServiceException,
+        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws AwsServiceException,
                                                                                                   SdkClientException, JsonException {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest).build());
     }
@@ -1023,7 +1023,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationBytes(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws SdkServiceException, SdkClientException,
+        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
                                                                                 JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toBytes());
     }
@@ -1055,7 +1055,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationBytes(
-        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws SdkServiceException,
+        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws AwsServiceException,
                                                                                                   SdkClientException, JsonException {
         return streamingOutputOperationBytes(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest)
                                                                             .build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -7,13 +7,13 @@ import org.w3c.dom.Node;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.config.AwsSyncClientConfiguration;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.http.response.DefaultErrorResponseHandler;
 import software.amazon.awssdk.awscore.http.response.StaxResponseHandler;
 import software.amazon.awssdk.awscore.protocol.xml.StandardErrorUnmarshaller;
 import software.amazon.awssdk.core.client.ClientExecutionParams;
 import software.amazon.awssdk.core.client.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 import software.amazon.awssdk.services.query.model.APostOperationRequest;
 import software.amazon.awssdk.services.query.model.APostOperationResponse;
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.query.transform.InvalidInputExceptionUnma
 final class DefaultQueryClient implements QueryClient {
     private final SyncClientHandler clientHandler;
 
-    private final List<Unmarshaller<SdkServiceException, Node>> exceptionUnmarshallers;
+    private final List<Unmarshaller<AwsServiceException, Node>> exceptionUnmarshallers;
 
     private final AwsSyncClientConfiguration clientConfiguration;
 
@@ -74,7 +74,7 @@ final class DefaultQueryClient implements QueryClient {
      */
     @Override
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
-                                                                                                     SdkServiceException, SdkClientException, QueryException {
+                                                                                                     AwsServiceException, SdkClientException, QueryException {
 
         StaxResponseHandler<APostOperationResponse> responseHandler = new StaxResponseHandler<APostOperationResponse>(
             new APostOperationResponseUnmarshaller());
@@ -108,7 +108,7 @@ final class DefaultQueryClient implements QueryClient {
      */
     @Override
     public APostOperationWithOutputResponse aPostOperationWithOutput(
-        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, SdkServiceException,
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
                                                                                 SdkClientException, QueryException {
 
         StaxResponseHandler<APostOperationWithOutputResponse> responseHandler = new StaxResponseHandler<APostOperationWithOutputResponse>(
@@ -123,8 +123,8 @@ final class DefaultQueryClient implements QueryClient {
                          .withMarshaller(new APostOperationWithOutputRequestMarshaller()));
     }
 
-    private List<Unmarshaller<SdkServiceException, Node>> init() {
-        List<Unmarshaller<SdkServiceException, Node>> unmarshallers = new ArrayList<>();
+    private List<Unmarshaller<AwsServiceException, Node>> init() {
+        List<Unmarshaller<AwsServiceException, Node>> unmarshallers = new ArrayList<>();
         unmarshallers.add(new InvalidInputExceptionUnmarshaller());
         unmarshallers.add(new StandardErrorUnmarshaller(QueryException.class));
         return unmarshallers;

--- a/core/src/main/java/software/amazon/awssdk/core/config/ClientOverrideConfiguration.java
+++ b/core/src/main/java/software/amazon/awssdk/core/config/ClientOverrideConfiguration.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -36,6 +37,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  *
  * <p>Use {@link #builder()} to create a set of options.</p>
  */
+@SdkPublicApi
 public class ClientOverrideConfiguration
     implements ToCopyableBuilder<ClientOverrideConfiguration.Builder, ClientOverrideConfiguration> {
     private final Map<String, List<String>> additionalHttpHeaders;

--- a/core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.http.HttpStatusCodes;
 
 /**
  * Extension of SdkException that represents an error response returned by
@@ -224,5 +225,28 @@ public class SdkServiceException extends SdkException {
                + " (Service: " + serviceName()
                + "; Status Code: " + statusCode()
                + "; Request ID: " + requestId() + ")";
+    }
+
+    /**
+     * Specifies whether or not an exception is caused by clock skew.
+     */
+    public boolean isClockSkewException() {
+        return false;
+    }
+
+    /**
+     * Specifies whether or not an exception is caused by throttling.
+     *
+     * @return true if the status code is 429, otherwise false.
+     */
+    public final boolean isThrottlingException() {
+        return statusCode() == HttpStatusCodes.THROTTLING || additionalThrottlingCondition();
+    }
+
+    /**
+     * Can be overridden by subclasses to provide additional throttling conditions.
+     */
+    protected boolean additionalThrottlingCondition() {
+        return false;
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/AsyncRetryableStage.java
+++ b/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/AsyncRetryableStage.java
@@ -174,7 +174,7 @@ public class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHttpFull
              * for every service exception.
              */
 
-            if (RetryUtils.isClockSkewError(exception)) {
+            if (RetryUtils.isClockSkewException(exception)) {
                 int clockSkew = ClockSkewUtil.parseClockSkewOffset(response.httpResponse());
                 dependencies.updateTimeOffset(clockSkew);
             }

--- a/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/RetryableStage.java
+++ b/core/src/main/java/software/amazon/awssdk/core/http/pipeline/stages/RetryableStage.java
@@ -148,7 +148,7 @@ public class RetryableStage<OutputT> implements RequestToResponsePipeline<Output
              * Checking for clock skew error again because we don't want to set the global time offset
              * for every service exception.
              */
-            if (RetryUtils.isClockSkewError(exception)) {
+            if (RetryUtils.isClockSkewException(exception)) {
                 int clockSkew = ClockSkewUtil.parseClockSkewOffset(response.httpResponse());
                 dependencies.updateTimeOffset(clockSkew);
             }

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/BaseJsonProtocolFactory.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/BaseJsonProtocolFactory.java
@@ -21,7 +21,6 @@ import static software.amazon.awssdk.core.SdkSystemSetting.CBOR_ENABLED;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.SdkRequest;
-import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.OperationInfo;
@@ -33,10 +32,13 @@ import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 /**
  * Factory to generate the various JSON protocol handlers and generators depending on the wire protocol to be used for
  * communicating with the service.
+ *
+ * @param <RequestT> The type of the request
+ * @param <ExceptionT> the type of the exception
  */
 @ThreadSafe
 @SdkProtectedApi
-public abstract class BaseJsonProtocolFactory {
+public abstract class BaseJsonProtocolFactory<RequestT extends SdkRequest, ExceptionT extends SdkServiceException> {
 
     protected final JsonClientMetadata jsonClientMetadata;
 
@@ -44,7 +46,7 @@ public abstract class BaseJsonProtocolFactory {
         this.jsonClientMetadata = metadata;
     }
 
-    public <T extends SdkRequest> ProtocolRequestMarshaller<T> createProtocolMarshaller(
+    public <T extends RequestT> ProtocolRequestMarshaller<T> createProtocolMarshaller(
         OperationInfo operationInfo, T origRequest) {
         return JsonProtocolMarshallerBuilder.<T>standard()
             .jsonGenerator(createGenerator(operationInfo))
@@ -58,15 +60,15 @@ public abstract class BaseJsonProtocolFactory {
     /**
      * Creates a response handler for handling a error response (non 2xx response).
      */
-    public abstract HttpResponseHandler<SdkServiceException> createErrorResponseHandler(JsonErrorResponseMetadata
-                                                                                            errorResponseMetadata);
+    public abstract HttpResponseHandler<ExceptionT> createErrorResponseHandler(
+        JsonErrorResponseMetadata errorResponseMetadata);
 
     /**
      * Returns the response handler to be used for handling a successful response.
      *
      * @param operationMetadata Additional context information about an operation to create the appropriate response handler.
      */
-    public abstract <T extends SdkResponse> JsonResponseHandler<T> createResponseHandler(
+    public abstract <T> JsonResponseHandler<T> createResponseHandler(
         JsonOperationMetadata operationMetadata, Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller);
 
     protected abstract String getContentType();

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/BaseSdkStructuredJsonFactory.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/BaseSdkStructuredJsonFactory.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.runtime.http.response.JsonResponseHandler;
 import software.amazon.awssdk.core.runtime.http.response.SdkJsonErrorResponseHandler;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
@@ -47,7 +46,7 @@ public abstract class BaseSdkStructuredJsonFactory implements SdkStructuredJsonF
     }
 
     @Override
-    public <T extends SdkResponse> JsonResponseHandler<T> createResponseHandler(
+    public <T> JsonResponseHandler<T> createResponseHandler(
         JsonOperationMetadata operationMetadata, Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller) {
         return new JsonResponseHandler<>(responseUnmarshaller, unmarshallers, jsonFactory,
                                          operationMetadata.isHasStreamingSuccessResponse(),
@@ -56,9 +55,10 @@ public abstract class BaseSdkStructuredJsonFactory implements SdkStructuredJsonF
 
     @Override
     public SdkJsonErrorResponseHandler createErrorResponseHandler(
-        final List<SdkJsonErrorUnmarshaller> errorUnmarshallers) {
+        List<SdkJsonErrorUnmarshaller> errorUnmarshallers) {
         return new SdkJsonErrorResponseHandler(errorUnmarshallers,
-                                               SdkJsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
+                                               SdkJsonErrorMessageParser
+                                                   .DEFAULT_ERROR_MESSAGE_PARSER,
                                                jsonFactory);
     }
 

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/JsonErrorShapeMetadata.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/JsonErrorShapeMetadata.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.protocol.json;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 
 /**
  * Wrapper object to provide additional metadata about a client's error shapes to {@link
@@ -32,7 +33,7 @@ public class JsonErrorShapeMetadata {
 
     private Integer httpStatusCode;
 
-    private Class<? extends RuntimeException> modeledClass;
+    private Class<? extends SdkServiceException> modeledClass;
 
 
     public String getErrorCode() {
@@ -53,11 +54,11 @@ public class JsonErrorShapeMetadata {
         return this;
     }
 
-    public Class<? extends RuntimeException> getModeledClass() {
+    public Class<? extends SdkServiceException> getModeledClass() {
         return modeledClass;
     }
 
-    public JsonErrorShapeMetadata withModeledClass(Class<? extends RuntimeException> modeledClass) {
+    public JsonErrorShapeMetadata withModeledClass(Class<? extends SdkServiceException> modeledClass) {
         this.modeledClass = modeledClass;
         return this;
     }

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkJsonErrorUnmarshaller.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkJsonErrorUnmarshaller.java
@@ -21,14 +21,11 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 
 /**
- * Unmarshaller for JSON error responses from upstream services.
+ * Unmarshaller for JSON error responses from upstream services to unmarshall to a {@link SdkServiceException}.
  */
 @SdkInternalApi
 @ThreadSafe
-public class SdkJsonErrorUnmarshaller extends JsonErrorUnmarshaller {
-
-    public static final SdkJsonErrorUnmarshaller DEFAULT_UNMARSHALLER = new SdkJsonErrorUnmarshaller(
-        SdkServiceException.class, null);
+public class SdkJsonErrorUnmarshaller extends JsonErrorUnmarshaller<SdkServiceException> {
 
     private final Optional<Integer> httpStatusCode;
 

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkJsonProtocolFactory.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkJsonProtocolFactory.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
-import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.OperationInfo;
@@ -35,10 +35,10 @@ import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
  */
 @ThreadSafe
 @SdkProtectedApi
-public class SdkJsonProtocolFactory extends BaseJsonProtocolFactory {
+public class SdkJsonProtocolFactory extends BaseJsonProtocolFactory<SdkRequest, SdkServiceException> {
 
     private static final SdkStructuredJsonFactory JSON_FACTORY = SdkStructuredPlainJsonFactory.SDK_JSON_FACTORY;
-    private static final String CONTENT_TYPE =  "application/json";
+    private static final String CONTENT_TYPE = "application/json";
 
     SdkJsonProtocolFactory(JsonClientMetadata metadata) {
         super(metadata);
@@ -67,15 +67,17 @@ public class SdkJsonProtocolFactory extends BaseJsonProtocolFactory {
      *
      * @param operationMetadata Additional context information about an operation to create the appropriate response handler.
      */
-    public <T extends SdkResponse> JsonResponseHandler<T> createResponseHandler(
-        JsonOperationMetadata operationMetadata,
-        Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller) {
+    @Override
+    public <T> JsonResponseHandler<T> createResponseHandler(JsonOperationMetadata operationMetadata,
+                                                                                Unmarshaller<T, JsonUnmarshallerContext>
+                                                                                    responseUnmarshaller) {
         return JSON_FACTORY.createResponseHandler(operationMetadata, responseUnmarshaller);
     }
 
     /**
      * Creates a response handler for handling a error response (non 2xx response).
      */
+    @Override
     public HttpResponseHandler<SdkServiceException> createErrorResponseHandler(
         JsonErrorResponseMetadata errorResponseMetadata) {
         return JSON_FACTORY.createErrorResponseHandler(createErrorUnmarshallers());
@@ -85,8 +87,8 @@ public class SdkJsonProtocolFactory extends BaseJsonProtocolFactory {
     private List<SdkJsonErrorUnmarshaller> createErrorUnmarshallers() {
 
         List<SdkJsonErrorUnmarshaller> errorUnmarshallers = jsonClientMetadata.getErrorShapeMetadata().stream()
-                                                                                    .map(this::createErrorUnmarshaller)
-                                                                                    .collect(Collectors.toList());
+                                                                              .map(this::createErrorUnmarshaller)
+                                                                              .collect(Collectors.toList());
         // All unmodeled/unknown exceptions are unmarshalled into the service specific base
         // exception class.
         errorUnmarshallers.add(new SdkJsonErrorUnmarshaller(
@@ -98,7 +100,7 @@ public class SdkJsonProtocolFactory extends BaseJsonProtocolFactory {
     @SuppressWarnings("unchecked")
     private SdkJsonErrorUnmarshaller createErrorUnmarshaller(JsonErrorShapeMetadata errorShape) {
         return new SdkJsonErrorUnmarshaller(
-            (Class<? extends SdkServiceException>) errorShape.getModeledClass(),
+            errorShape.getModeledClass(),
             Optional.of(errorShape.getHttpStatusCode()));
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkStructuredJsonFactory.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkStructuredJsonFactory.java
@@ -34,5 +34,4 @@ public interface SdkStructuredJsonFactory extends StructuredJsonFactory {
      */
     SdkJsonErrorResponseHandler createErrorResponseHandler(
         List<SdkJsonErrorUnmarshaller> errorUnmarshallers);
-
 }

--- a/core/src/main/java/software/amazon/awssdk/core/protocol/json/StructuredJsonFactory.java
+++ b/core/src/main/java/software/amazon/awssdk/core/protocol/json/StructuredJsonFactory.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.core.protocol.json;
 
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.runtime.http.response.JsonResponseHandler;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
@@ -40,7 +39,7 @@ public interface StructuredJsonFactory {
      * @param operationMetadata Additional context information about an operation to create the
      * appropriate response handler.
      */
-    <T extends SdkResponse> JsonResponseHandler<T> createResponseHandler(
+    <T> JsonResponseHandler<T> createResponseHandler(
         JsonOperationMetadata operationMetadata,
         Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller);
 }

--- a/core/src/main/java/software/amazon/awssdk/core/retry/RetryUtils.java
+++ b/core/src/main/java/software/amazon/awssdk/core/retry/RetryUtils.java
@@ -15,49 +15,13 @@
 
 package software.amazon.awssdk.core.retry;
 
-import java.util.HashSet;
-import java.util.Set;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.http.HttpStatusCodes;
 
 public final class RetryUtils {
 
-    private static final Set<String> THROTTLING_ERROR_CODES = new HashSet<>(9);
-    private static final Set<String> CLOCK_SKEW_ERROR_CODES = new HashSet<>(6);
-
-    static {
-        THROTTLING_ERROR_CODES.add("Throttling");
-        THROTTLING_ERROR_CODES.add("ThrottlingException");
-        THROTTLING_ERROR_CODES.add("ThrottledException");
-        THROTTLING_ERROR_CODES.add("ProvisionedThroughputExceededException");
-        THROTTLING_ERROR_CODES.add("SlowDown");
-        THROTTLING_ERROR_CODES.add("TooManyRequestsException");
-        THROTTLING_ERROR_CODES.add("RequestLimitExceeded");
-        THROTTLING_ERROR_CODES.add("BandwidthLimitExceeded");
-        THROTTLING_ERROR_CODES.add("RequestThrottled");
-
-        CLOCK_SKEW_ERROR_CODES.add("RequestTimeTooSkewed");
-        CLOCK_SKEW_ERROR_CODES.add("RequestExpired");
-        CLOCK_SKEW_ERROR_CODES.add("InvalidSignatureException");
-        CLOCK_SKEW_ERROR_CODES.add("SignatureDoesNotMatch");
-        CLOCK_SKEW_ERROR_CODES.add("AuthFailure");
-        CLOCK_SKEW_ERROR_CODES.add("RequestInTheFuture");
-    }
-
     private RetryUtils() {
-    }
-
-    /**
-     * Returns true if the specified exception is a throttling error.
-     *
-     * @param exception The exception to test.
-     * @return True if the exception resulted from a throttling error message from a service, otherwise false.
-     */
-    public static boolean isThrottlingException(SdkException exception) {
-        return isServiceException(exception)
-               && (THROTTLING_ERROR_CODES.contains(toServiceException(exception).errorCode())
-                   || toServiceException(exception).statusCode() == 429);
     }
 
     /**
@@ -70,25 +34,34 @@ public final class RetryUtils {
         return isServiceException(exception) && toServiceException(exception).statusCode() == HttpStatusCodes.REQUEST_TOO_LONG;
     }
 
-    /**
-     * Returns true if the specified exception is a clock skew error.
-     *
-     * @param exception The exception to test.
-     * @return True if the exception resulted from a clock skews error message from a service, otherwise false.
-     */
-    public static boolean isClockSkewError(SdkException exception) {
-        return isServiceException(exception) && CLOCK_SKEW_ERROR_CODES.contains(toServiceException(exception).errorCode());
-    }
-
-    private static boolean isServiceException(SdkException e) {
+    public static boolean isServiceException(SdkException e) {
         return e instanceof SdkServiceException;
     }
 
-    private static SdkServiceException toServiceException(SdkException e) {
+    public static SdkServiceException toServiceException(SdkException e) {
         if (!(e instanceof SdkServiceException)) {
             throw new IllegalStateException("Received non-SdkServiceException where one was expected.", e);
         }
         return (SdkServiceException) e;
     }
 
+    /**
+     * Returns true if the specified exception is a clock skew error.
+     *
+     * @param exception The exception to test.
+     * @return True if the exception resulted from a clock skews error message from a service, otherwise false.
+     */
+    public static boolean isClockSkewException(SdkException exception) {
+        return isServiceException(exception) && toServiceException(exception).isClockSkewException();
+    }
+
+    /**
+     * Returns true if the specified exception is a throttling error.
+     *
+     * @param exception The exception to test.
+     * @return True if the exception resulted from a throttling error message from a service, otherwise false.
+     */
+    public static boolean isThrottlingException(SdkException exception) {
+        return isServiceException(exception) && toServiceException(exception).isThrottlingException();
+    }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/retry/SdkDefaultRetrySettings.java
+++ b/core/src/main/java/software/amazon/awssdk/core/retry/SdkDefaultRetrySettings.java
@@ -48,15 +48,10 @@ public final class SdkDefaultRetrySettings {
 
     public static final Integer DEFAULT_MAX_RETRIES = 3;
 
-    public static final Set<String> RETRYABLE_ERROR_CODES;
     public static final Set<Integer> RETRYABLE_STATUS_CODES;
     public static final Set<Class<? extends Exception>> RETRYABLE_EXCEPTIONS;
 
     static {
-        Set<String> retryableErrorCodes = new HashSet<>();
-        retryableErrorCodes.add("PriorRequestNotComplete");
-        RETRYABLE_ERROR_CODES = unmodifiableSet(retryableErrorCodes);
-
         Set<Integer> retryableStatusCodes = new HashSet<>();
         retryableStatusCodes.add(HttpStatusCodes.INTERNAL_SERVER_ERROR);
         retryableStatusCodes.add(HttpStatusCodes.BAD_GATEWAY);

--- a/core/src/main/java/software/amazon/awssdk/core/retry/conditions/AndRetryCondition.java
+++ b/core/src/main/java/software/amazon/awssdk/core/retry/conditions/AndRetryCondition.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.core.retry.RetryPolicyContext;
 @SdkPublicApi
 public class AndRetryCondition implements RetryCondition {
 
-    private List<RetryCondition> conditions = new ArrayList<RetryCondition>();
+    private List<RetryCondition> conditions = new ArrayList<>();
 
     public AndRetryCondition(RetryCondition... conditions) {
         Collections.addAll(this.conditions, assertNotEmpty(conditions, "conditions"));
@@ -40,11 +40,6 @@ public class AndRetryCondition implements RetryCondition {
      */
     @Override
     public boolean shouldRetry(RetryPolicyContext context) {
-        for (RetryCondition retryCondition : conditions) {
-            if (!retryCondition.shouldRetry(context)) {
-                return false;
-            }
-        }
-        return true;
+        return conditions.stream().allMatch(r -> r.shouldRetry(context));
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/retry/conditions/OrRetryCondition.java
+++ b/core/src/main/java/software/amazon/awssdk/core/retry/conditions/OrRetryCondition.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.core.retry.RetryPolicyContext;
 @SdkPublicApi
 public class OrRetryCondition implements RetryCondition {
 
-    private List<RetryCondition> conditions = new ArrayList<RetryCondition>();
+    private List<RetryCondition> conditions = new ArrayList<>();
 
     public OrRetryCondition(RetryCondition... conditions) {
         Collections.addAll(this.conditions, conditions);
@@ -38,11 +38,6 @@ public class OrRetryCondition implements RetryCondition {
      */
     @Override
     public boolean shouldRetry(RetryPolicyContext context) {
-        for (RetryCondition retryCondition : conditions) {
-            if (retryCondition.shouldRetry(context)) {
-                return true;
-            }
-        }
-        return false;
+        return conditions.stream().anyMatch(r -> r.shouldRetry(context));
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryCondition.java
+++ b/core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryCondition.java
@@ -25,11 +25,10 @@ import software.amazon.awssdk.core.retry.SdkDefaultRetrySettings;
 public interface RetryCondition {
 
     RetryCondition DEFAULT = new OrRetryCondition(
-        new RetryOnErrorCodeCondition(SdkDefaultRetrySettings.RETRYABLE_ERROR_CODES),
         new RetryOnStatusCodeCondition(SdkDefaultRetrySettings.RETRYABLE_STATUS_CODES),
         new RetryOnExceptionsCondition(SdkDefaultRetrySettings.RETRYABLE_EXCEPTIONS),
-        c -> RetryUtils.isThrottlingException(c.exception()),
-        c -> RetryUtils.isClockSkewError(c.exception()));
+        c -> RetryUtils.isClockSkewException(c.exception()),
+        c -> RetryUtils.isThrottlingException(c.exception()));
     RetryCondition NONE = new MaxNumberOfRetriesCondition(0);
 
     default OrRetryCondition or(RetryCondition other) {

--- a/core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnStatusCodeCondition.java
+++ b/core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnStatusCodeCondition.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.retry.conditions;
 import static software.amazon.awssdk.core.util.ValidationUtils.assertNotNull;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
@@ -42,13 +43,7 @@ public class RetryOnStatusCodeCondition implements RetryCondition {
      */
     @Override
     public boolean shouldRetry(RetryPolicyContext context) {
-        if (context.httpStatusCode() != null) {
-            for (Integer statusCode : statusCodesToRetryOn) {
-                if (statusCode.equals(context.httpStatusCode())) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return Optional.ofNullable(context.httpStatusCode()).map(s ->
+            statusCodesToRetryOn.stream().anyMatch(code -> code.equals(s))).orElse(false);
     }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/runtime/http/response/JsonErrorResponseHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/runtime/http/response/JsonErrorResponseHandler.java
@@ -30,11 +30,12 @@ import software.amazon.awssdk.http.HttpStatusFamily;
  * Base error response handler for JSON protocol.
  */
 @SdkInternalApi
-public abstract class JsonErrorResponseHandler implements HttpResponseHandler<SdkServiceException> {
+public abstract class JsonErrorResponseHandler<ExceptionT extends SdkServiceException> implements
+                                                                                       HttpResponseHandler<ExceptionT> {
     private static final Logger LOG = LoggerFactory.getLogger(JsonErrorResponseHandler.class);
 
-    protected SdkServiceException safeUnmarshall(JsonContent jsonContent,
-                                                 JsonErrorUnmarshaller unmarshaller) {
+    protected ExceptionT safeUnmarshall(JsonContent jsonContent,
+                                        JsonErrorUnmarshaller<ExceptionT> unmarshaller) {
         try {
             return unmarshaller.unmarshall(jsonContent.getJsonNode());
         } catch (Exception e) {
@@ -47,10 +48,7 @@ public abstract class JsonErrorResponseHandler implements HttpResponseHandler<Sd
      * The default unmarshaller should always work but if it doesn't we fall back to creating an
      * exception explicitly.
      */
-    protected SdkServiceException createUnknownException() {
-        return new SdkServiceException(
-            "Unable to unmarshall exception response with the unmarshallers provided");
-    }
+    protected abstract ExceptionT createUnknownException();
 
     protected ErrorType getErrorType(int statusCode) {
         return HttpStatusFamily.of(statusCode) == HttpStatusFamily.SERVER_ERROR ? ErrorType.SERVICE : ErrorType.CLIENT;

--- a/core/src/main/java/software/amazon/awssdk/core/runtime/http/response/JsonResponseHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/runtime/http/response/JsonResponseHandler.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.Map;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.SdkStandardLoggers;
 import software.amazon.awssdk.core.exception.Crc32MismatchException;
 import software.amazon.awssdk.core.http.HttpResponse;
@@ -43,7 +42,7 @@ import software.amazon.awssdk.utils.Logger;
  */
 @SdkProtectedApi
 @ReviewBeforeRelease("Metadata in base result has been broken. Fix this and deal with AwsResponseHandlerAdapter")
-public class JsonResponseHandler<T extends SdkResponse> implements HttpResponseHandler<T> {
+public class JsonResponseHandler<T> implements HttpResponseHandler<T> {
     private static final Logger log = Logger.loggerFor(JsonResponseHandler.class);
 
     private final JsonFactory jsonFactory;

--- a/core/src/main/java/software/amazon/awssdk/core/runtime/http/response/SdkJsonErrorResponseHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/runtime/http/response/SdkJsonErrorResponseHandler.java
@@ -27,11 +27,11 @@ import software.amazon.awssdk.core.protocol.json.JsonContent;
 import software.amazon.awssdk.core.protocol.json.SdkJsonErrorUnmarshaller;
 
 /**
- * Default implementation of HttpResponseHandler that handles a successful response from a
- * service and unmarshalls the result using a JSON unmarshaller.
+ * Default implementation of {@link JsonErrorResponseHandler} that handles an error response from a
+ * service and unmarshalls the result using an JSON error unmarshaller.
  */
 @SdkInternalApi
-public class SdkJsonErrorResponseHandler extends JsonErrorResponseHandler {
+public class SdkJsonErrorResponseHandler extends JsonErrorResponseHandler<SdkServiceException> {
 
     private final List<SdkJsonErrorUnmarshaller> unmarshallers;
     private final ErrorMessageParser errorMessageParser;
@@ -89,4 +89,9 @@ public class SdkJsonErrorResponseHandler extends JsonErrorResponseHandler {
                             .orElseGet(this::createUnknownException);
     }
 
+    @Override
+    protected SdkServiceException createUnknownException() {
+        return new SdkServiceException(
+            "Unable to unmarshall exception response with the unmarshallers provided");
+    }
 }

--- a/core/src/main/java/software/amazon/awssdk/core/runtime/transform/AbstractErrorUnmarshaller.java
+++ b/core/src/main/java/software/amazon/awssdk/core/runtime/transform/AbstractErrorUnmarshaller.java
@@ -24,7 +24,8 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 
 @SdkProtectedApi
-public abstract class AbstractErrorUnmarshaller<T> implements Unmarshaller<SdkServiceException, T> {
+public abstract class AbstractErrorUnmarshaller<ExceptionT extends SdkServiceException, T>
+    implements Unmarshaller<ExceptionT, T> {
 
     /**
      * The type of SdkServiceException that will be instantiated. Subclasses
@@ -35,19 +36,10 @@ public abstract class AbstractErrorUnmarshaller<T> implements Unmarshaller<SdkSe
 
     /**
      * Constructs a new error unmarshaller that will unmarshall error responses
-     * into SdkServiceException objects.
-     */
-    public AbstractErrorUnmarshaller() {
-        this(SdkServiceException.class);
-    }
-
-    /**
-     * Constructs a new error unmarshaller that will unmarshall error responses
      * into objects of the specified class, extending SdkServiceException.
      *
-     * @param exceptionClass
-     *            The subclass of SdkServiceException which will be
-     *            instantiated and populated by this class.
+     * @param exceptionClass The subclass of SdkServiceException which will be
+     * instantiated and populated by this class.
      */
     public AbstractErrorUnmarshaller(Class<? extends SdkServiceException> exceptionClass) {
         this.exceptionClass = exceptionClass;
@@ -57,17 +49,13 @@ public abstract class AbstractErrorUnmarshaller<T> implements Unmarshaller<SdkSe
      * Constructs a new exception object of the type specified in this class's
      * constructor and sets the specified error message.
      *
-     * @param message
-     *            The error message to set in the new exception object.
-     *
+     * @param message The error message to set in the new exception object.
      * @return A new exception object of the type specified in this class's
-     *         constructor and sets the specified error message.
-     *
-     * @throws Exception
-     *             If there are any problems using reflection to invoke the
-     *             exception class's constructor.
+     * constructor and sets the specified error message.
+     * @throws Exception If there are any problems using reflection to invoke the
+     * exception class's constructor.
      */
-    protected SdkServiceException newException(String message) throws Exception {
+    protected ExceptionT newException(String message) throws Exception {
         Method builderMethod = null;
 
         try {
@@ -86,9 +74,9 @@ public abstract class AbstractErrorUnmarshaller<T> implements Unmarshaller<SdkSe
 
             messageSetter.invoke(exceptionBuilder, message);
 
-            return (SdkServiceException) buildMethod.invoke(exceptionBuilder);
+            return (ExceptionT) buildMethod.invoke(exceptionBuilder);
         } else {
-            Constructor<? extends SdkServiceException> constructor = exceptionClass.getConstructor(String.class);
+            Constructor<ExceptionT> constructor = (Constructor<ExceptionT>) exceptionClass.getConstructor(String.class);
             return constructor.newInstance(message);
         }
     }

--- a/core/src/test/java/software/amazon/awssdk/core/retry/DefaultRetryConditionTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/retry/DefaultRetryConditionTest.java
@@ -27,21 +27,8 @@ import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 public class DefaultRetryConditionTest {
 
     @Test
-    public void retriesOnRetryableErrorCodes() {
-        assertTrue(shouldRetry(applyErrorCode("PriorRequestNotComplete")));
-    }
-
-    @Test
     public void retriesOnThrottlingExceptions() {
-        assertTrue(shouldRetry(applyErrorCode("ThrottlingException")));
-        assertTrue(shouldRetry(applyErrorCode("ThrottledException")));
         assertTrue(shouldRetry(applyStatusCode(429)));
-    }
-
-    @Test
-    public void retriesOnClockSkewErrors() {
-        assertTrue(shouldRetry(applyErrorCode("RequestTimeTooSkewed")));
-        assertTrue(shouldRetry(applyErrorCode("AuthFailure")));
     }
 
     @Test
@@ -84,22 +71,10 @@ public class DefaultRetryConditionTest {
         assertFalse(shouldRetry(applyStatusCode(404)));
     }
 
-    @Test
-    public void doesNotRetryOnNonRetryableErrorCode() {
-        assertFalse(shouldRetry(applyErrorCode("ValidationError")));
-    }
-
     private boolean shouldRetry(Consumer<RetryPolicyContext.Builder> builder) {
         return RetryCondition.DEFAULT.shouldRetry(RetryPolicyContext.builder()
                                                                     .apply(builder)
                                                                     .build());
-    }
-
-    private Consumer<RetryPolicyContext.Builder> applyErrorCode(String errorCode) {
-        SdkServiceException exception = new SdkServiceException("");
-        exception.statusCode(404);
-        exception.errorCode(errorCode);
-        return b -> b.exception(exception);
     }
 
     private Consumer<RetryPolicyContext.Builder> applyStatusCode(Integer statusCode) {

--- a/core/src/test/java/software/amazon/awssdk/core/util/RetryUtilsTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/util/RetryUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.retry.RetryUtils;
+import software.amazon.awssdk.http.HttpStatusCodes;
+
+public class RetryUtilsTest {
+
+    @Test
+    public void nonSdkServiceException_shouldReturnFalse() {
+        SdkClientException exception = new SdkClientException("exception");
+        assertThat(RetryUtils.isServiceException(exception)).isFalse();
+        assertThat(RetryUtils.isClockSkewException(exception)).isFalse();
+        assertThat(RetryUtils.isThrottlingException(exception)).isFalse();
+        assertThat(RetryUtils.isRequestEntityTooLargeException(exception)).isFalse();
+    }
+
+    @Test
+    public void statusCode429_isThrottlingExceptionShouldReturnTrue() {
+        SdkServiceException throttlingException = new SdkServiceException("throttling");
+        throttlingException.statusCode(429);
+        assertThat(RetryUtils.isThrottlingException(throttlingException)).isTrue();
+    }
+
+    @Test
+    public void sdkServiceException_shouldReturnFalseIfNotOverridden() {
+        SdkServiceException clockSkewException = new SdkServiceException("default");
+        assertThat(RetryUtils.isClockSkewException(clockSkewException)).isFalse();
+    }
+
+    @Test
+    public void clockSkewException_shouldReturnTrue() {
+        SdkServiceException clockSkewException = new SdkServiceException("clockSkew") {
+            @Override
+            public boolean isClockSkewException() {
+                return true;
+            }
+        };
+
+        assertThat(RetryUtils.isClockSkewException(clockSkewException)).isTrue();
+    }
+
+    @Test
+    public void statusCode413_isRequestEntityTooLargeShouldReturnTrue() {
+        SdkServiceException exception = new SdkServiceException("boom");
+        exception.statusCode(HttpStatusCodes.REQUEST_TOO_LONG);
+        assertThat(RetryUtils.isRequestEntityTooLargeException(exception)).isTrue();
+    }
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpStatusCodes.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpStatusCodes.java
@@ -50,6 +50,7 @@ public final class HttpStatusCodes {
     public static final int NOT_ACCEPTABLE = 406;
     public static final int REQUEST_TIMEOUT = 408;
     public static final int REQUEST_TOO_LONG = 413;
+    public static final int THROTTLING = 429;
 
     // --- 5xx Server Error ---
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
@@ -20,24 +20,24 @@ import static software.amazon.awssdk.core.util.XpathUtils.xpath;
 
 import javax.xml.xpath.XPath;
 import org.w3c.dom.Node;
-import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.runtime.transform.AbstractErrorUnmarshaller;
 import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * Base exception unmarshaller for S3.
  */
-public abstract class S3ExceptionUnmarshaller extends AbstractErrorUnmarshaller<Node> {
+public abstract class S3ExceptionUnmarshaller extends AbstractErrorUnmarshaller<AwsServiceException, Node> {
 
     private final String errorCode;
 
-    public S3ExceptionUnmarshaller(Class<? extends SdkServiceException> exceptionClass, String errorCode) {
+    S3ExceptionUnmarshaller(Class<? extends AwsServiceException> exceptionClass, String errorCode) {
         super(exceptionClass);
         this.errorCode = errorCode;
     }
 
     @Override
-    public SdkServiceException unmarshall(Node in) throws Exception {
+    public AwsServiceException unmarshall(Node in) throws Exception {
 
         XPath xpath = xpath();
 
@@ -49,7 +49,7 @@ public abstract class S3ExceptionUnmarshaller extends AbstractErrorUnmarshaller<
             return null;
         }
 
-        SdkServiceException exception = newException(message);
+        AwsServiceException exception = newException(message);
         exception.errorCode(errorCode);
         exception.requestId(requestId);
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/StandardS3ExceptionUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/StandardS3ExceptionUnmarshaller.java
@@ -15,15 +15,15 @@
 
 package software.amazon.awssdk.services.s3.transform;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.protocol.xml.StandardErrorUnmarshaller;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 
 /**
  * The unmarshaller used to read S3 exceptions when no more-specific exception unmarshaller is found. This is the S3 equivalent
  * of {@link StandardErrorUnmarshaller}.
  */
 public final class StandardS3ExceptionUnmarshaller extends S3ExceptionUnmarshaller {
-    public StandardS3ExceptionUnmarshaller(Class<? extends SdkServiceException> exceptionClass) {
+    public StandardS3ExceptionUnmarshaller(Class<? extends AwsServiceException> exceptionClass) {
         super(exceptionClass, null);
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMapper.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMapper.java
@@ -15,7 +15,10 @@
 
 package software.amazon.awssdk.services.dynamodb.datamodeling;
 
+import static java.util.stream.Collectors.reducing;
 import static java.util.stream.Collectors.toMap;
+import static software.amazon.awssdk.core.retry.RetryUtils.isServiceException;
+import static software.amazon.awssdk.core.retry.RetryUtils.toServiceException;
 import static software.amazon.awssdk.services.dynamodb.model.KeyType.HASH;
 import static software.amazon.awssdk.services.dynamodb.model.KeyType.RANGE;
 
@@ -34,12 +37,13 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfig;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.retry.RetryUtils;
 import software.amazon.awssdk.core.util.VersionInfo;
@@ -1865,8 +1869,7 @@ public class DynamoDbMapper extends AbstractDynamoDbMapper {
         }
 
         private boolean isThrottling() {
-            return exception instanceof SdkException &&
-                   RetryUtils.isThrottlingException((SdkException) exception);
+            return exception instanceof SdkServiceException && ((SdkServiceException) exception).isThrottlingException();
         }
 
         private int size() {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
@@ -15,9 +15,7 @@
 
 package software.amazon.awssdk.protocol.tests.exception;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -56,40 +54,28 @@ public class AwsJsonExceptionTest {
     @Test
     public void unmodeledException_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH, "{\"__type\": \"SomeUnknownType\"}");
-        assertThrowsServiceBaseException(this::callAllTypes);
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolJsonRpcException.class);
     }
 
     @Test
     public void modeledException_UnmarshalledIntoModeledException() {
         stub404Response(PATH, "{\"__type\": \"EmptyModeledException\"}");
-        try {
-            callAllTypes();
-        } catch (EmptyModeledException e) {
-            assertThat(e, instanceOf(ProtocolJsonRpcException.class));
-        }
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(EmptyModeledException.class);
     }
 
     @Test
     public void emptyErrorResponse_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH, "");
-        assertThrowsServiceBaseException(this::callAllTypes);
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolJsonRpcException.class);
     }
 
     @Test
     public void malformedErrorResponse_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH, "THIS ISN'T JSON");
-        assertThrowsServiceBaseException(this::callAllTypes);
-    }
-
-    private void callAllTypes() {
-        client.allTypes(AllTypesRequest.builder().build());
-    }
-
-    private void assertThrowsServiceBaseException(Runnable runnable) {
-        try {
-            runnable.run();
-        } catch (ProtocolJsonRpcException e) {
-            assertEquals(ProtocolJsonRpcException.class, e.getClass());
-        }
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolJsonRpcException.class);
     }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/Ec2ExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/Ec2ExceptionTests.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.protocol.tests.exception;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -51,30 +51,21 @@ public class Ec2ExceptionTests {
     public void unmodeledException_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH,
                         "<Response><Errors><Error><Code>UnmodeledException</Code></Error></Errors></Response>");
-        assertThrowsServiceBaseException(this::callAllTypes);
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolEc2Exception.class);
     }
 
     @Test
     public void emptyErrorResponse_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH, "");
-        assertThrowsServiceBaseException(this::callAllTypes);
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolEc2Exception.class);
     }
 
     @Test
     public void malformedErrorResponse_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH, "THIS ISN'T XML");
-        assertThrowsServiceBaseException(this::callAllTypes);
-    }
-
-    private void callAllTypes() {
-        client.allTypes(AllTypesRequest.builder().build());
-    }
-
-    private void assertThrowsServiceBaseException(Runnable runnable) {
-        try {
-            runnable.run();
-        } catch (ProtocolEc2Exception e) {
-            assertEquals(ProtocolEc2Exception.class, e.getClass());
-        }
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolEc2Exception.class);
     }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.protocol.tests.exception;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -57,7 +58,8 @@ public class QueryExceptionTests {
     public void unmodeledException_UnmarshalledIntoBaseServiceException() {
         stub404Response(PATH,
                 "<ErrorResponse><Error><Code>UnmodeledException</Code></Error></ErrorResponse>");
-        assertThrowsServiceBaseException(this::callAllTypes);
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolQueryException.class);
     }
 
     @Test


### PR DESCRIPTION
## Description
Revision 1 https://github.com/aws/aws-sdk-java-v2/pull/486/commits/f876905fe788afdc47147f2cf09cdf685e3ab380: 
- Moved AWS specific retry policies to aws-core.
- added `ThrottlingCondition` and `ClockSkewCondition` in `RetryPolicy`

Revision 2 https://github.com/aws/aws-sdk-java-v2/pull/486/commits/30fdac760592db9ead1dd6b5d1b607fdd1f5dde3:
- created `AwsServiceException` and moved `isThrottlingException` and `isClockSkewException` Apis to `SdkServiceException`.

Revision 3 https://github.com/aws/aws-sdk-java-v2/pull/486/commits/bbdc012425fef83867bb7776500c36d6e204b233
- removed sdkResponse bound in ResponseHandler

## Testing
`mvn clean install`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
