### PR TITLE
Use path style addressing for bucket names containing period

### DIFF
--- a/regions/src/main/resources/software/amazon/awssdk/regions/internal/region/endpoints.json
+++ b/regions/src/main/resources/software/amazon/awssdk/regions/internal/region/endpoints.json
@@ -1154,23 +1154,23 @@
         },
         "endpoints" : {
           "ap-northeast-1" : {
-            "hostname" : "s3-ap-northeast-1.amazonaws.com",
+            "hostname" : "s3.ap-northeast-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "ap-northeast-2" : { },
           "ap-south-1" : { },
           "ap-southeast-1" : {
-            "hostname" : "s3-ap-southeast-1.amazonaws.com",
+            "hostname" : "s3.ap-southeast-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "ap-southeast-2" : {
-            "hostname" : "s3-ap-southeast-2.amazonaws.com",
+            "hostname" : "s3.ap-southeast-2.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-west-1" : {
-            "hostname" : "s3-eu-west-1.amazonaws.com",
+            "hostname" : "s3.eu-west-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "eu-west-2" : { },
@@ -1182,7 +1182,7 @@
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "sa-east-1" : {
-            "hostname" : "s3-sa-east-1.amazonaws.com",
+            "hostname" : "s3.sa-east-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "us-east-1" : {
@@ -1191,11 +1191,11 @@
           },
           "us-east-2" : { },
           "us-west-1" : {
-            "hostname" : "s3-us-west-1.amazonaws.com",
+            "hostname" : "s3.us-west-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "us-west-2" : {
-            "hostname" : "s3-us-west-2.amazonaws.com",
+            "hostname" : "s3.us-west-2.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           }
         },
@@ -1925,7 +1925,7 @@
             "hostname" : "s3-fips-us-gov-west-1.amazonaws.com"
           },
           "us-gov-west-1" : {
-            "hostname" : "s3-us-gov-west-1.amazonaws.com",
+            "hostname" : "s3.us-gov-west-1.amazonaws.com",
             "protocols" : [ "http", "https" ]
           }
         }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptor.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.BucketUtils;
+import software.amazon.awssdk.services.s3.internal.BucketUtils;
 import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
@@ -29,8 +29,8 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.RegionMetadata;
-import software.amazon.awssdk.services.s3.BucketUtils;
 import software.amazon.awssdk.services.s3.S3AdvancedConfiguration;
+import software.amazon.awssdk.services.s3.internal.BucketUtils;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
@@ -59,7 +59,7 @@ public class EndpointAddressInterceptor implements ExecutionInterceptor {
 
         if (advancedConfiguration == null || !advancedConfiguration.pathStyleAccessEnabled()) {
             sdkRequest.getValueForField("Bucket", String.class).ifPresent(b -> {
-                if (BucketUtils.isValidDnsBucketName(b, false)) {
+                if (BucketUtils.isVirtualAddressingCompatibleBucketName(b, false)) {
                     changeToDnsEndpoint(mutableRequest, b);
                 }
             });

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/BucketUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/BucketUtils.java
@@ -13,14 +13,16 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.s3;
+package software.amazon.awssdk.services.s3.internal;
 
 import java.util.regex.Pattern;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
  * Utilities for working with Amazon S3 bucket names, such as validation and
  * checked to see if they are compatible with DNS addressing.
  */
+@SdkProtectedApi
 public class BucketUtils {
 
     private static final int MIN_BUCKET_NAME_LENGTH = 3;
@@ -140,6 +142,18 @@ public class BucketUtils {
         }
 
         return true;
+    }
+
+    /**
+     * Validates if the given bucket name follows naming guidelines that are acceptable for using
+     * virtual host style addressing.
+     *
+     * @param bucketName The bucket name to validate.
+     * @param throwOnError boolean to decide if an error should be thrown if the bucket name doesn't follow the naming convention
+     */
+    public static boolean isVirtualAddressingCompatibleBucketName(final String bucketName,
+                                                                  final boolean throwOnError) {
+        return isValidDnsBucketName(bucketName, throwOnError) && !bucketName.contains(".");
     }
 
     /**

--- a/services/s3/src/main/resources/software/amazon/awssdk/services/s3/bucketaddressingsep/VirtualAddressingSepTestCases.json
+++ b/services/s3/src/main/resources/software/amazon/awssdk/services/s3/bucketaddressingsep/VirtualAddressingSepTestCases.json
@@ -1,0 +1,162 @@
+[
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3.amazonaws.com",
+    "Region": "us-east-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3.us-west-1.amazonaws.com",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-with-number-1",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-with-number-1.s3.us-west-1.amazonaws.com",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3.cn-north-1.amazonaws.com.cn",
+    "Region": "cn-north-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "BucketName",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.amazonaws.com/BucketName",
+    "Region": "us-east-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "BucketName",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.amazonaws.com/BucketName",
+    "Region": "us-east-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket_name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.us-west-1.amazonaws.com/bucket_name",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket.name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.us-west-1.amazonaws.com/bucket.name",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "-bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.us-west-1.amazonaws.com/-bucket-name",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name-",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.us-west-1.amazonaws.com/bucket-name-",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "aa",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.us-west-1.amazonaws.com/aa",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.us-west-1.amazonaws.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3-accelerate.amazonaws.com",
+    "Region": "us-east-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": true
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3-accelerate.amazonaws.com",
+    "Region": "us-west-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": true
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3.dualstack.us-east-1.amazonaws.com",
+    "Region": "us-east-1",
+    "UseDualstack": true,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3.dualstack.us-west-2.amazonaws.com",
+    "Region": "us-west-2",
+    "UseDualstack": true,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket.name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://s3.dualstack.us-west-2.amazonaws.com/bucket.name",
+    "Region": "us-west-2",
+    "UseDualstack": true,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "default",
+    "ExpectedUri": "https://bucket-name.s3-accelerate.dualstack.amazonaws.com",
+    "Region": "us-east-1",
+    "UseDualstack": true,
+    "UseS3Accelerate": true
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "path",
+    "ExpectedUri": "https://s3.amazonaws.com/bucket-name",
+    "Region": "us-east-1",
+    "UseDualstack": false,
+    "UseS3Accelerate": false
+  },
+  {
+    "Bucket": "bucket-name",
+    "ConfiguredAddressingStyle": "path",
+    "ExpectedUri": "https://s3.dualstack.us-east-1.amazonaws.com/bucket-name",
+    "Region": "us-east-1",
+    "UseDualstack": true,
+    "UseS3Accelerate": false
+  }
+]

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/bucketaddressingsep/VirtualHostAddressingSepTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/bucketaddressingsep/VirtualHostAddressingSepTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.bucketaddressingsep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static utils.S3MockUtils.mockListObjectsResponse;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.builder.ClientHttpConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AdvancedConfiguration;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.testutils.service.http.MockHttpClient;
+
+@RunWith(Parameterized.class)
+public class VirtualHostAddressingSepTest {
+    private static final String TEST_FILE_PATH = "VirtualAddressingSepTestCases.json";
+    private MockHttpClient mockHttpClient;
+    private TestCaseModel testCaseModel;
+
+    public VirtualHostAddressingSepTest(TestCaseModel testCaseModel) {
+        this.testCaseModel = testCaseModel;
+    }
+
+    @Before
+    public void setup() {
+        mockHttpClient = new MockHttpClient();
+    }
+
+    @Parameterized.Parameters
+    public static List<TestCaseModel> testInputs() throws IOException {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        TypeFactory typeFactory = objectMapper.getTypeFactory();
+        InputStream jsonData = VirtualHostAddressingSepTest.class.getResourceAsStream(TEST_FILE_PATH);
+        return objectMapper.readValue(jsonData,
+                                      typeFactory.constructCollectionType(List.class, TestCaseModel.class));
+    }
+
+    @Test
+    public void assertTestCase() throws UnsupportedEncodingException {
+        final String bucket = testCaseModel.getBucket();
+        final String expectedUri = testCaseModel.getExpectedUri();
+
+        S3Client s3Client = constructClient(testCaseModel);
+
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        s3Client.listObjects(ListObjectsRequest.builder().bucket(bucket).build());
+
+        assertThat(mockHttpClient.getLastRequest().getUri())
+            .isEqualTo(URI.create(expectedUri));
+    }
+
+    private S3Client constructClient(TestCaseModel testCaseModel) {
+        ClientHttpConfiguration httpConfiguration = ClientHttpConfiguration.builder()
+                                                                           .httpClient(mockHttpClient)
+                                                                           .build();
+        return S3Client.builder()
+                       .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                       .httpConfiguration(httpConfiguration)
+                       .region(Region.of(testCaseModel.getRegion()))
+                       .advancedConfiguration(S3AdvancedConfiguration.builder()
+                                                                     .pathStyleAccessEnabled(testCaseModel.isPathStyle())
+                                                                     .accelerateModeEnabled(testCaseModel.isUseS3Accelerate())
+                                                                     .dualstackEnabled(testCaseModel.isUseDualstack())
+                                                                     .build())
+                       .build();
+    }
+
+
+    private static class TestCaseModel {
+        private String bucket;
+        private String configuredAddressingStyle;
+        private String expectedUri;
+        private String region;
+        private boolean useDualstack;
+        private boolean useS3Accelerate;
+
+        public String getBucket() {
+            return bucket;
+        }
+
+        @JsonProperty("Bucket")
+        public void setBucket(String bucket) {
+            this.bucket = bucket;
+        }
+
+        public String getConfiguredAddressingStyle() {
+            return configuredAddressingStyle;
+        }
+
+        @JsonProperty("ConfiguredAddressingStyle")
+        public void setConfiguredAddressingStyle(String configuredAddressingStyle) {
+            this.configuredAddressingStyle = configuredAddressingStyle;
+        }
+
+        public String getExpectedUri() {
+            return expectedUri;
+        }
+
+        @JsonProperty("ExpectedUri")
+        public void setExpectedUri(String expectedUri) {
+            this.expectedUri = expectedUri;
+        }
+
+        public String getRegion() {
+            return region;
+        }
+
+        @JsonProperty("Region")
+        public void setRegion(String region) {
+            this.region = region;
+        }
+
+        public boolean isUseDualstack() {
+            return useDualstack;
+        }
+
+        @JsonProperty("UseDualstack")
+        public void setUseDualstack(boolean useDualstack) {
+            this.useDualstack = useDualstack;
+        }
+
+        public boolean isUseS3Accelerate() {
+            return useS3Accelerate;
+        }
+
+        @JsonProperty("UseS3Accelerate")
+        public void setUseS3Accelerate(boolean useS3Accelerate) {
+            this.useS3Accelerate = useS3Accelerate;
+        }
+
+        public boolean isPathStyle() {
+            return configuredAddressingStyle.equals("path");
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* SDKs should use path style addressing for bucket names containing periods and using Https, but we currently use virtual style. This PR fixes the behavior by using path style.
I am using path style for both Https and Http endpoints to make the behavior less confusing. If we have a strong reason to use virtual style when using Http, I can change that.

* The new test covers all cases in SEP except for cases where bucket acceleration and path style are both enabled.

## Testing
Unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
