### PR TITLE
Add support to disable EC2 instance metadata service usage

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-1cb94c1.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-1cb94c1.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Add support to disable EC2 instance metadata service usage via environment variable and system property. [#430](https://github.com/aws/aws-sdk-java-v2/issues/430)"
+}

--- a/auth/src/it/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderIntegrationTest.java
+++ b/auth/src/it/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.testutils.LogCaptor;
 
@@ -96,6 +97,19 @@ public class InstanceProfileCredentialsProviderIntegrationTest extends LogCaptor
             } catch (SdkClientException ace) {
                 assertNotNull(ace.getMessage());
             }
+        }
+    }
+
+    @Test(expected = SdkClientException.class)
+    public void ec2MetadataDisabled_shouldReturnNull() {
+        mockServer.setResponseFileName("sessionResponse");
+        mockServer.setAvailableSecurityCredentials("test-credentials");
+
+        try (InstanceProfileCredentialsProvider credentialsProvider = InstanceProfileCredentialsProvider.create()) {
+            System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property(), "true");
+            credentialsProvider.getCredentials();
+        } finally {
+            System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property());
         }
     }
 }

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -25,6 +25,11 @@ import software.amazon.awssdk.utils.ToString;
 
 /**
  * Credentials provider implementation that loads credentials from the Amazon EC2 Instance Metadata Service.
+ *
+ * <P>
+ * If {@link SdkSystemSetting#AWS_EC2_METADATA_DISABLED} is set to true, it will not try to load
+ * credentials from EC2 metadata service and will return null.
+ *
  */
 public final class InstanceProfileCredentialsProvider extends HttpCredentialsProvider {
 
@@ -57,6 +62,11 @@ public final class InstanceProfileCredentialsProvider extends HttpCredentialsPro
     @Override
     protected ResourcesEndpointProvider getCredentialsEndpointProvider() {
         return credentialsEndpointProvider;
+    }
+
+    @Override
+    protected boolean isLocalCredentialLoadingDisabled() {
+        return SdkSystemSetting.AWS_EC2_METADATA_DISABLED.getBooleanValueOrThrow();
     }
 
     @Override

--- a/core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -82,6 +82,11 @@ public enum SdkSystemSetting implements SystemSetting {
     AWS_IN_REGION_OPTIMIZATION_ENABLED("aws.inRegionOptimizationEnabled", "false"),
 
     /**
+     * Whether to load information such as credentials, regions from EC2 Metadata instance service.
+     */
+    AWS_EC2_METADATA_DISABLED("aws.disableEc2Metadata", "false"),
+
+    /**
      * The EC2 instance metadata service endpoint.
      *
      * This allows a service running in EC2 to automatically load its credentials and region without needing to configure them

--- a/regions/src/it/java/software/amazon/awssdk/regions/util/EC2MetadataUtilsIntegrationTest.java
+++ b/regions/src/it/java/software/amazon/awssdk/regions/util/EC2MetadataUtilsIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.regions.util;
 
+
 import java.io.IOException;
 import java.util.Map;
 import org.junit.AfterClass;
@@ -22,6 +23,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 public class EC2MetadataUtilsIntegrationTest {
 
@@ -75,6 +77,16 @@ public class EC2MetadataUtilsIntegrationTest {
             Assert.assertEquals("moobily", entry.getValue().secretAccessKey);
             Assert.assertEquals("beebop", entry.getValue().token);
             Assert.assertNotNull(entry.getValue().expiration);
+        }
+    }
+
+    @Test(expected = SdkClientException.class)
+    public void ec2MetadataDisabled_shouldThrowException() {
+        try {
+            System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property(), "true");
+            EC2MetadataUtils.getInstanceId();
+        } finally {
+            System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property());
         }
     }
 

--- a/regions/src/main/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProvider.java
+++ b/regions/src/main/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProvider.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.regions.providers;
 
+import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.util.EC2MetadataUtils;
@@ -22,6 +23,10 @@ import software.amazon.awssdk.regions.util.EC2MetadataUtils;
 /**
  * Attempts to load region information from the EC2 Metadata service. If the application is not
  * running on EC2 this provider will thrown an exception.
+ *
+ * <P>
+ * If {@link SdkSystemSetting#AWS_EC2_METADATA_DISABLED} is set to true, it will not try to load
+ * region from EC2 metadata service and will return null.
  */
 public class InstanceProfileRegionProvider implements AwsRegionProvider {
 
@@ -32,6 +37,11 @@ public class InstanceProfileRegionProvider implements AwsRegionProvider {
 
     @Override
     public Region getRegion() throws SdkClientException {
+        if (SdkSystemSetting.AWS_EC2_METADATA_DISABLED.getBooleanValueOrThrow()) {
+            throw new SdkClientException("EC2 Metadata is disabled. Unable to retrieve region information from EC2 Metadata "
+                                         + "service.");
+        }
+
         if (region == null) {
             synchronized (this) {
                 if (region == null) {

--- a/regions/src/test/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProviderTest.java
+++ b/regions/src/test/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProviderTest.java
@@ -70,6 +70,15 @@ public class InstanceProfileRegionProviderTest {
             assertEquals(Region.US_EAST_1, regionProvider.getRegion());
         }
 
+        @Test(expected = SdkClientException.class)
+        public void ec2MetadataDisabled_shouldReturnNull() {
+            try {
+                System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property(), "true");
+                regionProvider.getRegion();
+            } finally {
+                System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Add support to disable EC2 instance metadata service usage (v1 parity)

fix #430 