### PR TITLE
Renamed "Bytes" overload for streaming operations to "AsBytes", and "String" overload for enums to "AsString".

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-897d75b.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-897d75b.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Renamed \"Bytes\" overload for streaming operations to \"AsBytes\", and \"String\" overload for enums to \"AsString\""
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -159,7 +159,7 @@ public class DefaultNamingStrategy implements NamingStrategy {
         String getterMethodName = Utils.unCapitialize(memberName);
 
         if (Utils.isOrContainsEnumShape(shape, serviceModel.getShapes())) {
-            getterMethodName += "String";
+            getterMethodName += "AsString";
 
             if (Utils.isListShape(shape) || Utils.isMapShape(shape)) {
                 getterMethodName += "s";

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -355,7 +355,7 @@ public final class SyncClientInterface implements ClassSpec {
      */
     private MethodSpec bytesSimpleMethod(OperationModel opModel, TypeName responseType, ClassName requestType) {
         TypeName returnType = ParameterizedTypeName.get(ClassName.get(ResponseBytes.class), responseType);
-        return MethodSpec.methodBuilder(opModel.getMethodName() + "Bytes")
+        return MethodSpec.methodBuilder(opModel.getMethodName() + "AsBytes")
                          .returns(returnType)
                          .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                          .addParameter(requestType, opModel.getInput().getVariableName())

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -108,7 +108,7 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      API Documentation</a>
      */
     default APostOperationResponse aPostOperation(Consumer<APostOperationRequest.Builder> aPostOperationRequest)
-        throws InvalidInputException, AwsServiceException, SdkClientException, JsonException {
+            throws InvalidInputException, AwsServiceException, SdkClientException, JsonException {
         return aPostOperation(APostOperationRequest.builder().apply(aPostOperationRequest).build());
     }
 
@@ -133,8 +133,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default APostOperationWithOutputResponse aPostOperationWithOutput(
-        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
-                                                                                SdkClientException, JsonException {
+            APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
+                                                                                    SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -166,8 +166,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default APostOperationWithOutputResponse aPostOperationWithOutput(
-        Consumer<APostOperationWithOutputRequest.Builder> aPostOperationWithOutputRequest) throws InvalidInputException,
-                                                                                                  AwsServiceException, SdkClientException, JsonException {
+            Consumer<APostOperationWithOutputRequest.Builder> aPostOperationWithOutputRequest) throws InvalidInputException,
+                                                                                                      AwsServiceException, SdkClientException, JsonException {
         return aPostOperationWithOutput(APostOperationWithOutputRequest.builder().apply(aPostOperationWithOutputRequest).build());
     }
 
@@ -217,8 +217,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
-                                                                                  SdkClientException, JsonException {
+            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
+                                                                                      SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -250,8 +250,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-        Consumer<GetWithoutRequiredMembersRequest.Builder> getWithoutRequiredMembersRequest) throws InvalidInputException,
-                                                                                                    AwsServiceException, SdkClientException, JsonException {
+            Consumer<GetWithoutRequiredMembersRequest.Builder> getWithoutRequiredMembersRequest) throws InvalidInputException,
+                                                                                                        AwsServiceException, SdkClientException, JsonException {
         return getWithoutRequiredMembers(GetWithoutRequiredMembersRequest.builder().apply(getWithoutRequiredMembersRequest)
                                                                          .build());
     }
@@ -294,8 +294,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
+                                                                                                  SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -322,8 +322,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
-        Consumer<PaginatedOperationWithResultKeyRequest.Builder> paginatedOperationWithResultKeyRequest)
-        throws AwsServiceException, SdkClientException, JsonException {
+            Consumer<PaginatedOperationWithResultKeyRequest.Builder> paginatedOperationWithResultKeyRequest)
+            throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithResultKey(PaginatedOperationWithResultKeyRequest.builder()
                                                                                      .apply(paginatedOperationWithResultKeyRequest).build());
     }
@@ -396,8 +396,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
+                                                                                                  SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -490,8 +490,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
+                                                                                                        SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -518,8 +518,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
-        Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
-        throws AwsServiceException, SdkClientException, JsonException {
+            Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
+            throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithoutResultKey(PaginatedOperationWithoutResultKeyRequest.builder()
                                                                                            .apply(paginatedOperationWithoutResultKeyRequest).build());
     }
@@ -592,8 +592,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
+                                                                                                        SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -671,8 +671,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
-        throws AwsServiceException, SdkClientException, JsonException {
+            Consumer<PaginatedOperationWithoutResultKeyRequest.Builder> paginatedOperationWithoutResultKeyRequest)
+            throws AwsServiceException, SdkClientException, JsonException {
         return paginatedOperationWithoutResultKeyPaginator(PaginatedOperationWithoutResultKeyRequest.builder()
                                                                                                     .apply(paginatedOperationWithoutResultKeyRequest).build());
     }
@@ -705,8 +705,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-        StreamingInputOperationRequest streamingInputOperationRequest, RequestBody requestBody) throws AwsServiceException,
-                                                                                                       SdkClientException, JsonException {
+            StreamingInputOperationRequest streamingInputOperationRequest, RequestBody requestBody) throws AwsServiceException,
+                                                                                                           SdkClientException, JsonException {
         throw new UnsupportedOperationException();
     }
 
@@ -744,8 +744,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-        Consumer<StreamingInputOperationRequest.Builder> streamingInputOperationRequest, RequestBody requestBody)
-        throws AwsServiceException, SdkClientException, JsonException {
+            Consumer<StreamingInputOperationRequest.Builder> streamingInputOperationRequest, RequestBody requestBody)
+            throws AwsServiceException, SdkClientException, JsonException {
         return streamingInputOperation(StreamingInputOperationRequest.builder().apply(streamingInputOperationRequest).build(),
                                        requestBody);
     }
@@ -773,8 +773,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-        StreamingInputOperationRequest streamingInputOperationRequest, Path filePath) throws AwsServiceException,
-                                                                                             SdkClientException, JsonException {
+            StreamingInputOperationRequest streamingInputOperationRequest, Path filePath) throws AwsServiceException,
+                                                                                                 SdkClientException, JsonException {
         return streamingInputOperation(streamingInputOperationRequest, RequestBody.fromFile(filePath));
     }
 
@@ -807,8 +807,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingInputOperationResponse streamingInputOperation(
-        Consumer<StreamingInputOperationRequest.Builder> streamingInputOperationRequest, Path filePath)
-        throws AwsServiceException, SdkClientException, JsonException {
+            Consumer<StreamingInputOperationRequest.Builder> streamingInputOperationRequest, Path filePath)
+            throws AwsServiceException, SdkClientException, JsonException {
         return streamingInputOperation(StreamingInputOperationRequest.builder().apply(streamingInputOperationRequest).build(),
                                        filePath);
     }
@@ -872,9 +872,9 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default <ReturnT> ReturnT streamingOutputOperation(
-        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest,
-        ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
-                                                                                                   SdkClientException, JsonException {
+            Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest,
+            ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
+                                                                                                       SdkClientException, JsonException {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest).build(),
                                         responseTransformer);
     }
@@ -901,8 +901,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingOutputOperationResponse streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest, Path filePath) throws AwsServiceException,
-                                                                                               SdkClientException, JsonException {
+            StreamingOutputOperationRequest streamingOutputOperationRequest, Path filePath) throws AwsServiceException,
+                                                                                                   SdkClientException, JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toFile(filePath));
     }
 
@@ -934,8 +934,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default StreamingOutputOperationResponse streamingOutputOperation(
-        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest, Path filePath)
-        throws AwsServiceException, SdkClientException, JsonException {
+            Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest, Path filePath)
+            throws AwsServiceException, SdkClientException, JsonException {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest).build(),
                                         filePath);
     }
@@ -963,8 +963,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
-                                                                                JsonException {
+            StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
+                                                                                    JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toInputStream());
     }
 
@@ -997,8 +997,8 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      *      target="_top">AWS API Documentation</a>
      */
     default ResponseInputStream<StreamingOutputOperationResponse> streamingOutputOperation(
-        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws AwsServiceException,
-                                                                                                  SdkClientException, JsonException {
+            Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws AwsServiceException,
+                                                                                                      SdkClientException, JsonException {
         return streamingOutputOperation(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest).build());
     }
 
@@ -1022,9 +1022,9 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
      *      target="_top">AWS API Documentation</a>
      */
-    default ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationBytes(
-        StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
-                                                                                JsonException {
+    default ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationAsBytes(
+            StreamingOutputOperationRequest streamingOutputOperationRequest) throws AwsServiceException, SdkClientException,
+                                                                                    JsonException {
         return streamingOutputOperation(streamingOutputOperationRequest, ResponseTransformer.toBytes());
     }
 
@@ -1054,11 +1054,11 @@ public interface JsonClient extends SdkClient, SdkAutoCloseable {
      * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
      *      target="_top">AWS API Documentation</a>
      */
-    default ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationBytes(
-        Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws AwsServiceException,
-                                                                                                  SdkClientException, JsonException {
-        return streamingOutputOperationBytes(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest)
-                                                                            .build());
+    default ResponseBytes<StreamingOutputOperationResponse> streamingOutputOperationAsBytes(
+            Consumer<StreamingOutputOperationRequest.Builder> streamingOutputOperationRequest) throws AwsServiceException,
+                                                                                                      SdkClientException, JsonException {
+        return streamingOutputOperationAsBytes(StreamingOutputOperationRequest.builder().apply(streamingOutputOperationRequest)
+                                                                              .build());
     }
 
     static ServiceMetadata serviceMetadata() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -198,7 +198,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the ListOfEnums property for this object.
      */
-    public List<String> listOfEnumsStrings() {
+    public List<String> listOfEnumsAsStrings() {
         return listOfEnums;
     }
 
@@ -283,7 +283,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
-    public Map<String, String> mapOfEnumToEnumStrings() {
+    public Map<String, String> mapOfEnumToEnumAsStrings() {
         return mapOfEnumToEnum;
     }
 
@@ -308,7 +308,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the MapOfEnumToString property for this object.
      */
-    public Map<String, String> mapOfEnumToStringStrings() {
+    public Map<String, String> mapOfEnumToStringAsStrings() {
         return mapOfEnumToString;
     }
 
@@ -332,7 +332,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the MapOfStringToEnum property for this object.
      */
-    public Map<String, String> mapOfStringToEnumStrings() {
+    public Map<String, String> mapOfStringToEnumAsStrings() {
         return mapOfStringToEnum;
     }
 
@@ -357,7 +357,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
-    public Map<String, SimpleStruct> mapOfEnumToSimpleStructStrings() {
+    public Map<String, SimpleStruct> mapOfEnumToSimpleStructAsStrings() {
         return mapOfEnumToSimpleStruct;
     }
 
@@ -456,7 +456,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
-     * {@link #enumTypeString}.
+     * {@link #enumTypeAsString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
@@ -471,13 +471,13 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
-     * {@link #enumTypeString}.
+     * {@link #enumTypeAsString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
-    public String enumTypeString() {
+    public String enumTypeAsString() {
         return enumType;
     }
 
@@ -504,16 +504,16 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
         hashCode = 31 * hashCode + Objects.hashCode(doubleMember());
         hashCode = 31 * hashCode + Objects.hashCode(longMember());
         hashCode = 31 * hashCode + Objects.hashCode(simpleList());
-        hashCode = 31 * hashCode + Objects.hashCode(listOfEnumsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(listOfEnumsAsStrings());
         hashCode = 31 * hashCode + Objects.hashCode(listOfMaps());
         hashCode = 31 * hashCode + Objects.hashCode(listOfStructs());
         hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToIntegerList());
         hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToString());
         hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToSimpleStruct());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToEnumStrings());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToStringStrings());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToEnumStrings());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToSimpleStructStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToEnumAsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToStringAsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToEnumAsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToSimpleStructAsStrings());
         hashCode = 31 * hashCode + Objects.hashCode(timestampMember());
         hashCode = 31 * hashCode + Objects.hashCode(structWithNestedTimestampMember());
         hashCode = 31 * hashCode + Objects.hashCode(blobArg());
@@ -523,7 +523,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
         hashCode = 31 * hashCode + Objects.hashCode(recursiveStruct());
         hashCode = 31 * hashCode + Objects.hashCode(polymorphicTypeWithSubTypes());
         hashCode = 31 * hashCode + Objects.hashCode(polymorphicTypeWithoutSubTypes());
-        hashCode = 31 * hashCode + Objects.hashCode(enumTypeString());
+        hashCode = 31 * hashCode + Objects.hashCode(enumTypeAsString());
         return hashCode;
     }
 
@@ -543,15 +543,15 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
                && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
                && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
                && Objects.equals(simpleList(), other.simpleList())
-               && Objects.equals(listOfEnumsStrings(), other.listOfEnumsStrings())
+               && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
                && Objects.equals(listOfMaps(), other.listOfMaps()) && Objects.equals(listOfStructs(), other.listOfStructs())
                && Objects.equals(mapOfStringToIntegerList(), other.mapOfStringToIntegerList())
                && Objects.equals(mapOfStringToString(), other.mapOfStringToString())
                && Objects.equals(mapOfStringToSimpleStruct(), other.mapOfStringToSimpleStruct())
-               && Objects.equals(mapOfEnumToEnumStrings(), other.mapOfEnumToEnumStrings())
-               && Objects.equals(mapOfEnumToStringStrings(), other.mapOfEnumToStringStrings())
-               && Objects.equals(mapOfStringToEnumStrings(), other.mapOfStringToEnumStrings())
-               && Objects.equals(mapOfEnumToSimpleStructStrings(), other.mapOfEnumToSimpleStructStrings())
+               && Objects.equals(mapOfEnumToEnumAsStrings(), other.mapOfEnumToEnumAsStrings())
+               && Objects.equals(mapOfEnumToStringAsStrings(), other.mapOfEnumToStringAsStrings())
+               && Objects.equals(mapOfStringToEnumAsStrings(), other.mapOfStringToEnumAsStrings())
+               && Objects.equals(mapOfEnumToSimpleStructAsStrings(), other.mapOfEnumToSimpleStructAsStrings())
                && Objects.equals(timestampMember(), other.timestampMember())
                && Objects.equals(structWithNestedTimestampMember(), other.structWithNestedTimestampMember())
                && Objects.equals(blobArg(), other.blobArg())
@@ -560,23 +560,23 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
                && Objects.equals(recursiveStruct(), other.recursiveStruct())
                && Objects.equals(polymorphicTypeWithSubTypes(), other.polymorphicTypeWithSubTypes())
                && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
-               && Objects.equals(enumTypeString(), other.enumTypeString());
+               && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
     }
 
     @Override
     public String toString() {
         return ToString.builder("AllTypesRequest").add("StringMember", stringMember()).add("IntegerMember", integerMember())
                        .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
-                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsStrings())
+                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
                        .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
                        .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
-                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumStrings())
-                       .add("MapOfEnumToString", mapOfEnumToStringStrings()).add("MapOfStringToEnum", mapOfStringToEnumStrings())
-                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructStrings()).add("TimestampMember", timestampMember())
+                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
+                       .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
+                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings()).add("TimestampMember", timestampMember())
                        .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
                        .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
                        .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
-                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeString())
+                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
                        .build();
     }
 
@@ -597,7 +597,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
             case "SimpleList":
                 return Optional.of(clazz.cast(simpleList()));
             case "ListOfEnums":
-                return Optional.of(clazz.cast(listOfEnumsStrings()));
+                return Optional.of(clazz.cast(listOfEnumsAsStrings()));
             case "ListOfMaps":
                 return Optional.of(clazz.cast(listOfMaps()));
             case "ListOfStructs":
@@ -609,13 +609,13 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
             case "MapOfStringToSimpleStruct":
                 return Optional.of(clazz.cast(mapOfStringToSimpleStruct()));
             case "MapOfEnumToEnum":
-                return Optional.of(clazz.cast(mapOfEnumToEnumStrings()));
+                return Optional.of(clazz.cast(mapOfEnumToEnumAsStrings()));
             case "MapOfEnumToString":
-                return Optional.of(clazz.cast(mapOfEnumToStringStrings()));
+                return Optional.of(clazz.cast(mapOfEnumToStringAsStrings()));
             case "MapOfStringToEnum":
-                return Optional.of(clazz.cast(mapOfStringToEnumStrings()));
+                return Optional.of(clazz.cast(mapOfStringToEnumAsStrings()));
             case "MapOfEnumToSimpleStruct":
-                return Optional.of(clazz.cast(mapOfEnumToSimpleStructStrings()));
+                return Optional.of(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
             case "TimestampMember":
                 return Optional.of(clazz.cast(timestampMember()));
             case "StructWithNestedTimestampMember":
@@ -635,7 +635,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
             case "PolymorphicTypeWithoutSubTypes":
                 return Optional.of(clazz.cast(polymorphicTypeWithoutSubTypes()));
             case "EnumType":
-                return Optional.of(clazz.cast(enumTypeString()));
+                return Optional.of(clazz.cast(enumTypeAsString()));
             default:
                 return Optional.empty();
         }
@@ -1453,7 +1453,7 @@ public class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                .build() : null;
+                    .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -197,7 +197,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the ListOfEnums property for this object.
      */
-    public List<String> listOfEnumsStrings() {
+    public List<String> listOfEnumsAsStrings() {
         return listOfEnums;
     }
 
@@ -282,7 +282,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
-    public Map<String, String> mapOfEnumToEnumStrings() {
+    public Map<String, String> mapOfEnumToEnumAsStrings() {
         return mapOfEnumToEnum;
     }
 
@@ -307,7 +307,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the MapOfEnumToString property for this object.
      */
-    public Map<String, String> mapOfEnumToStringStrings() {
+    public Map<String, String> mapOfEnumToStringAsStrings() {
         return mapOfEnumToString;
     }
 
@@ -331,7 +331,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the MapOfStringToEnum property for this object.
      */
-    public Map<String, String> mapOfStringToEnumStrings() {
+    public Map<String, String> mapOfStringToEnumAsStrings() {
         return mapOfStringToEnum;
     }
 
@@ -356,7 +356,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
-    public Map<String, SimpleStruct> mapOfEnumToSimpleStructStrings() {
+    public Map<String, SimpleStruct> mapOfEnumToSimpleStructAsStrings() {
         return mapOfEnumToSimpleStruct;
     }
 
@@ -455,7 +455,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
-     * {@link #enumTypeString}.
+     * {@link #enumTypeAsString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
@@ -470,13 +470,13 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * If the service returns an enum value that is not available in the current SDK version, {@link #enumType} will
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
-     * {@link #enumTypeString}.
+     * {@link #enumTypeAsString}.
      * </p>
      *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
-    public String enumTypeString() {
+    public String enumTypeAsString() {
         return enumType;
     }
 
@@ -503,16 +503,16 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
         hashCode = 31 * hashCode + Objects.hashCode(doubleMember());
         hashCode = 31 * hashCode + Objects.hashCode(longMember());
         hashCode = 31 * hashCode + Objects.hashCode(simpleList());
-        hashCode = 31 * hashCode + Objects.hashCode(listOfEnumsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(listOfEnumsAsStrings());
         hashCode = 31 * hashCode + Objects.hashCode(listOfMaps());
         hashCode = 31 * hashCode + Objects.hashCode(listOfStructs());
         hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToIntegerList());
         hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToString());
         hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToSimpleStruct());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToEnumStrings());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToStringStrings());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToEnumStrings());
-        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToSimpleStructStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToEnumAsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToStringAsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfStringToEnumAsStrings());
+        hashCode = 31 * hashCode + Objects.hashCode(mapOfEnumToSimpleStructAsStrings());
         hashCode = 31 * hashCode + Objects.hashCode(timestampMember());
         hashCode = 31 * hashCode + Objects.hashCode(structWithNestedTimestampMember());
         hashCode = 31 * hashCode + Objects.hashCode(blobArg());
@@ -522,7 +522,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
         hashCode = 31 * hashCode + Objects.hashCode(recursiveStruct());
         hashCode = 31 * hashCode + Objects.hashCode(polymorphicTypeWithSubTypes());
         hashCode = 31 * hashCode + Objects.hashCode(polymorphicTypeWithoutSubTypes());
-        hashCode = 31 * hashCode + Objects.hashCode(enumTypeString());
+        hashCode = 31 * hashCode + Objects.hashCode(enumTypeAsString());
         return hashCode;
     }
 
@@ -542,15 +542,15 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
                && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
                && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
                && Objects.equals(simpleList(), other.simpleList())
-               && Objects.equals(listOfEnumsStrings(), other.listOfEnumsStrings())
+               && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
                && Objects.equals(listOfMaps(), other.listOfMaps()) && Objects.equals(listOfStructs(), other.listOfStructs())
                && Objects.equals(mapOfStringToIntegerList(), other.mapOfStringToIntegerList())
                && Objects.equals(mapOfStringToString(), other.mapOfStringToString())
                && Objects.equals(mapOfStringToSimpleStruct(), other.mapOfStringToSimpleStruct())
-               && Objects.equals(mapOfEnumToEnumStrings(), other.mapOfEnumToEnumStrings())
-               && Objects.equals(mapOfEnumToStringStrings(), other.mapOfEnumToStringStrings())
-               && Objects.equals(mapOfStringToEnumStrings(), other.mapOfStringToEnumStrings())
-               && Objects.equals(mapOfEnumToSimpleStructStrings(), other.mapOfEnumToSimpleStructStrings())
+               && Objects.equals(mapOfEnumToEnumAsStrings(), other.mapOfEnumToEnumAsStrings())
+               && Objects.equals(mapOfEnumToStringAsStrings(), other.mapOfEnumToStringAsStrings())
+               && Objects.equals(mapOfStringToEnumAsStrings(), other.mapOfStringToEnumAsStrings())
+               && Objects.equals(mapOfEnumToSimpleStructAsStrings(), other.mapOfEnumToSimpleStructAsStrings())
                && Objects.equals(timestampMember(), other.timestampMember())
                && Objects.equals(structWithNestedTimestampMember(), other.structWithNestedTimestampMember())
                && Objects.equals(blobArg(), other.blobArg())
@@ -559,23 +559,23 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
                && Objects.equals(recursiveStruct(), other.recursiveStruct())
                && Objects.equals(polymorphicTypeWithSubTypes(), other.polymorphicTypeWithSubTypes())
                && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
-               && Objects.equals(enumTypeString(), other.enumTypeString());
+               && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
     }
 
     @Override
     public String toString() {
         return ToString.builder("AllTypesResponse").add("StringMember", stringMember()).add("IntegerMember", integerMember())
                        .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
-                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsStrings())
+                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
                        .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
                        .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
-                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumStrings())
-                       .add("MapOfEnumToString", mapOfEnumToStringStrings()).add("MapOfStringToEnum", mapOfStringToEnumStrings())
-                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructStrings()).add("TimestampMember", timestampMember())
+                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
+                       .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
+                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings()).add("TimestampMember", timestampMember())
                        .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
                        .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
                        .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
-                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeString())
+                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
                        .build();
     }
 
@@ -596,7 +596,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
             case "SimpleList":
                 return Optional.of(clazz.cast(simpleList()));
             case "ListOfEnums":
-                return Optional.of(clazz.cast(listOfEnumsStrings()));
+                return Optional.of(clazz.cast(listOfEnumsAsStrings()));
             case "ListOfMaps":
                 return Optional.of(clazz.cast(listOfMaps()));
             case "ListOfStructs":
@@ -608,13 +608,13 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
             case "MapOfStringToSimpleStruct":
                 return Optional.of(clazz.cast(mapOfStringToSimpleStruct()));
             case "MapOfEnumToEnum":
-                return Optional.of(clazz.cast(mapOfEnumToEnumStrings()));
+                return Optional.of(clazz.cast(mapOfEnumToEnumAsStrings()));
             case "MapOfEnumToString":
-                return Optional.of(clazz.cast(mapOfEnumToStringStrings()));
+                return Optional.of(clazz.cast(mapOfEnumToStringAsStrings()));
             case "MapOfStringToEnum":
-                return Optional.of(clazz.cast(mapOfStringToEnumStrings()));
+                return Optional.of(clazz.cast(mapOfStringToEnumAsStrings()));
             case "MapOfEnumToSimpleStruct":
-                return Optional.of(clazz.cast(mapOfEnumToSimpleStructStrings()));
+                return Optional.of(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
             case "TimestampMember":
                 return Optional.of(clazz.cast(timestampMember()));
             case "StructWithNestedTimestampMember":
@@ -634,7 +634,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
             case "PolymorphicTypeWithoutSubTypes":
                 return Optional.of(clazz.cast(polymorphicTypeWithoutSubTypes()));
             case "EnumType":
-                return Optional.of(clazz.cast(enumTypeString()));
+                return Optional.of(clazz.cast(enumTypeAsString()));
             default:
                 return Optional.empty();
         }
@@ -1446,7 +1446,7 @@ public class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                .build() : null;
+                    .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/alltypesrequestmodelmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/alltypesrequestmodelmarshaller.java
@@ -77,15 +77,15 @@ public class AllTypesRequestModelMarshaller {
                                                                                            .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("TimestampMember").isBinary(false).build();
 
     private static final MarshallingInfo<StructuredPojo> STRUCTWITHNESTEDTIMESTAMPMEMBER_BINDING = MarshallingInfo
-        .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
-        .marshallLocationName("StructWithNestedTimestampMember").isBinary(false).build();
+            .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
+            .marshallLocationName("StructWithNestedTimestampMember").isBinary(false).build();
 
     private static final MarshallingInfo<ByteBuffer> BLOBARG_BINDING = MarshallingInfo.builder(MarshallingType.BYTE_BUFFER)
                                                                                       .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("BlobArg").isBinary(false).build();
 
     private static final MarshallingInfo<StructuredPojo> STRUCTWITHNESTEDBLOB_BINDING = MarshallingInfo
-        .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
-        .marshallLocationName("StructWithNestedBlob").isBinary(false).build();
+            .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
+            .marshallLocationName("StructWithNestedBlob").isBinary(false).build();
 
     private static final MarshallingInfo<Map> BLOBMAP_BINDING = MarshallingInfo.builder(MarshallingType.MAP)
                                                                                .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("BlobMap").isBinary(false).build();
@@ -94,16 +94,16 @@ public class AllTypesRequestModelMarshaller {
                                                                                     .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("ListOfBlobs").isBinary(false).build();
 
     private static final MarshallingInfo<StructuredPojo> RECURSIVESTRUCT_BINDING = MarshallingInfo
-        .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
-        .marshallLocationName("RecursiveStruct").isBinary(false).build();
+            .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
+            .marshallLocationName("RecursiveStruct").isBinary(false).build();
 
     private static final MarshallingInfo<StructuredPojo> POLYMORPHICTYPEWITHSUBTYPES_BINDING = MarshallingInfo
-        .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
-        .marshallLocationName("PolymorphicTypeWithSubTypes").isBinary(false).build();
+            .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
+            .marshallLocationName("PolymorphicTypeWithSubTypes").isBinary(false).build();
 
     private static final MarshallingInfo<StructuredPojo> POLYMORPHICTYPEWITHOUTSUBTYPES_BINDING = MarshallingInfo
-        .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
-        .marshallLocationName("PolymorphicTypeWithoutSubTypes").isBinary(false).build();
+            .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
+            .marshallLocationName("PolymorphicTypeWithoutSubTypes").isBinary(false).build();
 
     private static final MarshallingInfo<String> ENUMTYPE_BINDING = MarshallingInfo.builder(MarshallingType.STRING)
                                                                                    .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("EnumType").isBinary(false).build();
@@ -131,16 +131,16 @@ public class AllTypesRequestModelMarshaller {
             protocolMarshaller.marshall(allTypesRequest.doubleMember(), DOUBLEMEMBER_BINDING);
             protocolMarshaller.marshall(allTypesRequest.longMember(), LONGMEMBER_BINDING);
             protocolMarshaller.marshall(allTypesRequest.simpleList(), SIMPLELIST_BINDING);
-            protocolMarshaller.marshall(allTypesRequest.listOfEnumsStrings(), LISTOFENUMS_BINDING);
+            protocolMarshaller.marshall(allTypesRequest.listOfEnumsAsStrings(), LISTOFENUMS_BINDING);
             protocolMarshaller.marshall(allTypesRequest.listOfMaps(), LISTOFMAPS_BINDING);
             protocolMarshaller.marshall(allTypesRequest.listOfStructs(), LISTOFSTRUCTS_BINDING);
             protocolMarshaller.marshall(allTypesRequest.mapOfStringToIntegerList(), MAPOFSTRINGTOINTEGERLIST_BINDING);
             protocolMarshaller.marshall(allTypesRequest.mapOfStringToString(), MAPOFSTRINGTOSTRING_BINDING);
             protocolMarshaller.marshall(allTypesRequest.mapOfStringToSimpleStruct(), MAPOFSTRINGTOSIMPLESTRUCT_BINDING);
-            protocolMarshaller.marshall(allTypesRequest.mapOfEnumToEnumStrings(), MAPOFENUMTOENUM_BINDING);
-            protocolMarshaller.marshall(allTypesRequest.mapOfEnumToStringStrings(), MAPOFENUMTOSTRING_BINDING);
-            protocolMarshaller.marshall(allTypesRequest.mapOfStringToEnumStrings(), MAPOFSTRINGTOENUM_BINDING);
-            protocolMarshaller.marshall(allTypesRequest.mapOfEnumToSimpleStructStrings(), MAPOFENUMTOSIMPLESTRUCT_BINDING);
+            protocolMarshaller.marshall(allTypesRequest.mapOfEnumToEnumAsStrings(), MAPOFENUMTOENUM_BINDING);
+            protocolMarshaller.marshall(allTypesRequest.mapOfEnumToStringAsStrings(), MAPOFENUMTOSTRING_BINDING);
+            protocolMarshaller.marshall(allTypesRequest.mapOfStringToEnumAsStrings(), MAPOFSTRINGTOENUM_BINDING);
+            protocolMarshaller.marshall(allTypesRequest.mapOfEnumToSimpleStructAsStrings(), MAPOFENUMTOSIMPLESTRUCT_BINDING);
             protocolMarshaller.marshall(allTypesRequest.timestampMember(), TIMESTAMPMEMBER_BINDING);
             protocolMarshaller.marshall(allTypesRequest.structWithNestedTimestampMember(),
                                         STRUCTWITHNESTEDTIMESTAMPMEMBER_BINDING);
@@ -151,7 +151,7 @@ public class AllTypesRequestModelMarshaller {
             protocolMarshaller.marshall(allTypesRequest.recursiveStruct(), RECURSIVESTRUCT_BINDING);
             protocolMarshaller.marshall(allTypesRequest.polymorphicTypeWithSubTypes(), POLYMORPHICTYPEWITHSUBTYPES_BINDING);
             protocolMarshaller.marshall(allTypesRequest.polymorphicTypeWithoutSubTypes(), POLYMORPHICTYPEWITHOUTSUBTYPES_BINDING);
-            protocolMarshaller.marshall(allTypesRequest.enumTypeString(), ENUMTYPE_BINDING);
+            protocolMarshaller.marshall(allTypesRequest.enumTypeAsString(), ENUMTYPE_BINDING);
         } catch (Exception e) {
             throw new SdkClientException("Unable to marshall request to JSON: " + e.getMessage(), e);
         }

--- a/services/cloudformation/src/it/java/software/amazon/awssdk/services/cloudformation/StackIntegrationTests.java
+++ b/services/cloudformation/src/it/java/software/amazon/awssdk/services/cloudformation/StackIntegrationTests.java
@@ -281,7 +281,7 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
             assertNotNull(summary);
             assertNotNull(summary.stackStatus());
             assertNotNull(summary.creationTime());
-            if (summary.stackStatusString().contains("DELETE")) {
+            if (summary.stackStatusAsString().contains("DELETE")) {
                 assertNotNull(summary.deletionTime());
             }
             assertNotNull(summary.stackId());
@@ -300,7 +300,7 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
             assertNotNull(summary);
             assertNotNull(summary.stackStatus());
             assertNotNull(summary.creationTime());
-            if (summary.stackStatusString().contains("DELETE")) {
+            if (summary.stackStatusAsString().contains("DELETE")) {
                 assertNotNull(summary.deletionTime());
             }
             assertNotNull(summary.stackId());
@@ -321,10 +321,10 @@ public class StackIntegrationTests extends CloudFormationIntegrationTestBase {
         for (StackSummary summary : listStacksResult.stackSummaries()) {
             assertNotNull(summary);
             assertNotNull(summary.stackStatus());
-            assertTrue(summary.stackStatus().equals("CREATE_COMPLETE")
-                       || summary.stackStatus().equals("DELETE_COMPLETE"));
+            assertTrue(summary.stackStatusAsString().equals("CREATE_COMPLETE")
+                       || summary.stackStatusAsString().equals("DELETE_COMPLETE"));
             assertNotNull(summary.creationTime());
-            if (summary.stackStatusString().contains("DELETE")) {
+            if (summary.stackStatusAsString().contains("DELETE")) {
                 assertNotNull(summary.deletionTime());
             }
             assertNotNull(summary.stackId());

--- a/services/directconnect/src/it/java/software/amazon/awssdk/services/directconnect/ServiceIntegrationTest.java
+++ b/services/directconnect/src/it/java/software/amazon/awssdk/services/directconnect/ServiceIntegrationTest.java
@@ -84,7 +84,7 @@ public class ServiceIntegrationTest extends IntegrationTestBase {
                 .build());
         assertThat(describeConnectionsResult.connections(), hasSize(1));
         assertEquals(connectionId, describeConnectionsResult.connections().get(0).connectionId());
-        assertEquals(EXPECTED_CONNECTION_STATUS, describeConnectionsResult.connections().get(0).connectionStateString());
+        assertEquals(EXPECTED_CONNECTION_STATUS, describeConnectionsResult.connections().get(0).connectionStateAsString());
     }
 
     /**

--- a/services/dynamodb/src/test/java/utils/test/util/DynamoDBTestBase.java
+++ b/services/dynamodb/src/test/java/utils/test/util/DynamoDBTestBase.java
@@ -78,7 +78,7 @@ public class DynamoDBTestBase extends AwsTestBase {
                 DescribeTableRequest request = DescribeTableRequest.builder().tableName(tableName).build();
                 TableDescription table = dynamo.describeTable(request).table();
 
-                log.info(() -> "  - current state: " + table.tableStatusString());
+                log.info(() -> "  - current state: " + table.tableStatusAsString());
                 if (table.tableStatus() == TableStatus.DELETING) {
                     continue;
                 }

--- a/services/inspector/src/test/java/software/amazon/awssdk/services/inspector/InspectorErrorUnmarshallingTest.java
+++ b/services/inspector/src/test/java/software/amazon/awssdk/services/inspector/InspectorErrorUnmarshallingTest.java
@@ -79,7 +79,7 @@ public class InspectorErrorUnmarshallingTest {
             inspector.listRulesPackages(ListRulesPackagesRequest.builder().build());
         } catch (AccessDeniedException e) {
             assertEquals("AccessDeniedException", e.errorCode());
-            assertEquals("ACCESS_DENIED_TO_RULES_PACKAGE", e.inspectorErrorCodeString());
+            assertEquals("ACCESS_DENIED_TO_RULES_PACKAGE", e.inspectorErrorCodeAsString());
         }
     }
 

--- a/services/route53/src/it/java/software/amazon/awssdk/services/route53/Route53IntegrationTest.java
+++ b/services/route53/src/it/java/software/amazon/awssdk/services/route53/Route53IntegrationTest.java
@@ -279,7 +279,7 @@ public class Route53IntegrationTest extends IntegrationTestBase {
         assertNotNull(CALLER_REFERENCE, healthCheck.callerReference());
         assertNotNull(healthCheck.id());
         assertEquals(PORT_NUM, healthCheck.healthCheckConfig().port().intValue());
-        assertEquals(TYPE, healthCheck.healthCheckConfig().typeString());
+        assertEquals(TYPE, healthCheck.healthCheckConfig().typeAsString());
         assertEquals(IP_ADDRESS, healthCheck.healthCheckConfig().ipAddress());
     }
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketAccelerateIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketAccelerateIntegrationTest.java
@@ -25,8 +25,8 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.AccelerateConfiguration;
 import software.amazon.awssdk.services.s3.model.BucketAccelerateStatus;
 import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
@@ -132,7 +132,7 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
         String status = s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
                                                                                                    .bucket(US_BUCKET_NAME)
                                                                                                    .build())
-                          .statusString();
+                          .statusAsString();
 
         if (status == null || !status.equals("Enabled")) {
             enableAccelerateOnBucket();
@@ -159,7 +159,7 @@ public class BucketAccelerateIntegrationTest extends S3IntegrationTestBase {
         String status = s3.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
                                                                                                    .bucket(US_BUCKET_NAME)
                                                                                                    .build())
-                          .statusString();
+                          .statusAsString();
 
         if (status == null || !status.equals("Enabled")) {
             enableAccelerateOnBucket();

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketInventoryConfigurationIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketInventoryConfigurationIntegrationTest.java
@@ -183,7 +183,7 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
         assertEquals(accountId, s3BucketDestination.accountId());
         assertEquals(prefix, s3BucketDestination.prefix());
         assertEquals(prefix, config.filter().prefix());
-        assertTrue(config.optionalFieldsStrings().containsAll(optionalFields));
+        assertTrue(config.optionalFieldsAsStrings().containsAll(optionalFields));
 
         s3.deleteBucketInventoryConfiguration(DeleteBucketInventoryConfigurationRequest.builder()
                                                                                        .bucket(BUCKET_NAME)

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/CreateBucketIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/CreateBucketIntegrationTest.java
@@ -37,7 +37,7 @@ public class CreateBucketIntegrationTest extends S3IntegrationTestBase {
         S3Client client = S3Client.builder().region(Region.US_WEST_2).credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).build();
         client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
 
-        String region = client.getBucketLocation(GetBucketLocationRequest.builder().bucket(BUCKET_NAME).build()).locationConstraintString();
+        String region = client.getBucketLocation(GetBucketLocationRequest.builder().bucket(BUCKET_NAME).build()).locationConstraintAsString();
         assertThat(region).isEqualToIgnoringCase("us-west-2");
     }
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3ListObjectsV2IntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3ListObjectsV2IntegrationTest.java
@@ -245,7 +245,7 @@ public class S3ListObjectsV2IntegrationTest extends S3IntegrationTestBase {
         List<S3Object> objects = result.contents();
 
         // EncodingType should be returned in the response.
-        assertEquals(encodingType, result.encodingTypeString());
+        assertEquals(encodingType, result.encodingTypeAsString());
 
         System.out.println(result.contents().get(0).key());
 
@@ -331,7 +331,7 @@ public class S3ListObjectsV2IntegrationTest extends S3IntegrationTestBase {
             long offset = obj.lastModified().toEpochMilli() - Instant.now().toEpochMilli();
             assertTrue(offset < ONE_HOUR_IN_MILLISECONDS);
 
-            assertTrue(obj.storageClassString().length() > 1);
+            assertTrue(obj.storageClassAsString().length() > 1);
 
             if (shouldIncludeOwner) {
                 assertNotNull(obj.owner());

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptorTest.java
@@ -42,7 +42,7 @@ public class CreateBucketInterceptorTest {
                 .putAttribute(AwsExecutionAttributes.AWS_REGION, Region.US_EAST_1);
 
         SdkRequest modifiedRequest = new CreateBucketInterceptor().modifyRequest(context, attributes);
-        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintString();
+        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintAsString();
 
         assertThat(locationConstraint).isEqualToIgnoringCase("us-west-2");
     }
@@ -58,7 +58,7 @@ public class CreateBucketInterceptorTest {
                 .putAttribute(AwsExecutionAttributes.AWS_REGION, Region.US_EAST_2);
 
         SdkRequest modifiedRequest = new CreateBucketInterceptor().modifyRequest(context, attributes);
-        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintString();
+        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintAsString();
 
         assertThat(locationConstraint).isEqualToIgnoringCase("us-east-2");
     }
@@ -76,7 +76,7 @@ public class CreateBucketInterceptorTest {
                 .putAttribute(AwsExecutionAttributes.AWS_REGION, Region.US_WEST_2);
 
         SdkRequest modifiedRequest = new CreateBucketInterceptor().modifyRequest(context, attributes);
-        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintString();
+        String locationConstraint = ((CreateBucketRequest) modifiedRequest).createBucketConfiguration().locationConstraintAsString();
 
         assertThat(locationConstraint).isEqualToIgnoringCase("us-west-2");
     }

--- a/services/sns/src/it/java/software/amazon/awssdk/services/sns/Topics.java
+++ b/services/sns/src/it/java/software/amazon/awssdk/services/sns/Topics.java
@@ -189,7 +189,7 @@ public class Topics {
                         .queueUrl(sqsQueueUrl)
                         .attributeNames(sqsAttrNames)
                         .build())
-                        .attributesStrings();
+                        .attributesAsStrings();
         String sqsQueueArn = sqsAttrs.get(QueueAttributeName.QUEUE_ARN.toString());
 
         String policyJson = sqsAttrs.get(QueueAttributeName.POLICY.toString());

--- a/test/dynamodbdocument-v1/src/it/java/software/amazon/awssdk/services/dynamodb/TableUtilsIntegrationTest.java
+++ b/test/dynamodbdocument-v1/src/it/java/software/amazon/awssdk/services/dynamodb/TableUtilsIntegrationTest.java
@@ -107,7 +107,7 @@ public class TableUtilsIntegrationTest extends AwsIntegrationTestBase {
      */
     private String tableStatus() {
         try {
-            return ddb.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).table().tableStatusString();
+            return ddb.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).table().tableStatusAsString();
         } catch (ResourceNotFoundException e) {
             return null;
         }

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/Index.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/Index.java
@@ -249,7 +249,7 @@ public class Index implements QueryApi, ScanApi {
                                         "Global Secondary Index "
                                         + indexName
                                         + " is not being created or updated (with status="
-                                        + d.indexStatusString() + ")");
+                                        + d.indexStatusAsString() + ")");
                         }
                     }
                 }
@@ -290,7 +290,7 @@ public class Index implements QueryApi, ScanApi {
                         }
                         throw new IllegalArgumentException(
                                 "Global Secondary Index " + indexName
-                                + " is not being deleted (with status=" + d.indexStatusString() + ")");
+                                + " is not being deleted (with status=" + d.indexStatusAsString() + ")");
                     }
                 }
             }

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchGetItemSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchGetItemSpec.java
@@ -62,7 +62,7 @@ public class BatchGetItemSpec extends AbstractSpec<BatchGetItemRequest> {
 
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
 

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchWriteItemSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/BatchWriteItemSpec.java
@@ -63,7 +63,7 @@ public class BatchWriteItemSpec extends AbstractSpec<BatchWriteItemRequest> {
 
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
 

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/DeleteItemSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/DeleteItemSpec.java
@@ -146,7 +146,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperatorString();
+        return getRequest().conditionalOperatorAsString();
     }
 
     public DeleteItemSpec withConditionalOperator(ConditionalOperator conditionalOperator) {
@@ -155,7 +155,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
     public DeleteItemSpec withReturnConsumedCapacity(
@@ -165,7 +165,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getReturnItemCollectionMetrics() {
-        return getRequest().returnItemCollectionMetricsString();
+        return getRequest().returnItemCollectionMetricsAsString();
     }
 
     public DeleteItemSpec withReturnItemCollectionMetrics(
@@ -175,7 +175,7 @@ public class DeleteItemSpec extends AbstractSpecWithPrimaryKey<DeleteItemRequest
     }
 
     public String getReturnValues() {
-        return getRequest().returnValuesString();
+        return getRequest().returnValuesAsString();
     }
 
     public DeleteItemSpec withReturnValues(ReturnValue returnValues) {

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/GetItemSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/GetItemSpec.java
@@ -61,7 +61,7 @@ public class GetItemSpec extends AbstractSpecWithPrimaryKey<GetItemRequest> {
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
     public GetItemSpec withReturnConsumedCapacity(ReturnConsumedCapacity capacity) {

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/PutItemSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/PutItemSpec.java
@@ -129,7 +129,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperatorString();
+        return getRequest().conditionalOperatorAsString();
     }
 
     public PutItemSpec withConditionalOperator(
@@ -139,7 +139,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
     public PutItemSpec withReturnConsumedCapacity(
@@ -149,7 +149,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getReturnItemCollectionMetrics() {
-        return getRequest().returnItemCollectionMetricsString();
+        return getRequest().returnItemCollectionMetricsAsString();
     }
 
     public PutItemSpec withReturnItemCollectionMetrics(
@@ -161,7 +161,7 @@ public class PutItemSpec extends AbstractSpec<PutItemRequest> {
     }
 
     public String getReturnValues() {
-        return getRequest().returnValuesString();
+        return getRequest().returnValuesAsString();
     }
 
     public PutItemSpec withReturnValues(ReturnValue returnValues) {

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/QuerySpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/QuerySpec.java
@@ -102,7 +102,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperatorString();
+        return getRequest().conditionalOperatorAsString();
     }
 
     public QuerySpec withConsistentRead(boolean consistentRead) {
@@ -202,7 +202,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
     public QuerySpec withReturnConsumedCapacity(
@@ -226,7 +226,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
     }
 
     public String select() {
-        return getRequest().selectString();
+        return getRequest().selectAsString();
     }
 
     // Exclusive start key

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/ScanSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/ScanSpec.java
@@ -78,7 +78,7 @@ public class ScanSpec extends AbstractCollectionSpec<ScanRequest> {
      * @see ScanRequest#getConditionalOperator()
      */
     public String getConditionalOperator() {
-        return getRequest().conditionalOperatorString();
+        return getRequest().conditionalOperatorAsString();
     }
 
     /**
@@ -193,7 +193,7 @@ public class ScanSpec extends AbstractCollectionSpec<ScanRequest> {
      * @see ScanRequest#getReturnConsumedCapacity()
      */
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
     /**
@@ -211,7 +211,7 @@ public class ScanSpec extends AbstractCollectionSpec<ScanRequest> {
      */
     // ALL_ATTRIBUTES | ALL_PROJECTED_ATTRIBUTES | SPECIFIC_ATTRIBUTES | COUNT
     public String select() {
-        return getRequest().selectString();
+        return getRequest().selectAsString();
     }
 
     /**

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/UpdateItemSpec.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/spec/UpdateItemSpec.java
@@ -187,11 +187,11 @@ public class UpdateItemSpec extends AbstractSpecWithPrimaryKey<UpdateItemRequest
     }
 
     public String getConditionalOperator() {
-        return getRequest().conditionalOperatorString();
+        return getRequest().conditionalOperatorAsString();
     }
 
     public String getReturnConsumedCapacity() {
-        return getRequest().returnConsumedCapacityString();
+        return getRequest().returnConsumedCapacityAsString();
     }
 
     public UpdateItemSpec withReturnConsumedCapacity(
@@ -207,7 +207,7 @@ public class UpdateItemSpec extends AbstractSpecWithPrimaryKey<UpdateItemRequest
     }
 
     public String getReturnItemCollectionMetrics() {
-        return getRequest().returnItemCollectionMetricsString();
+        return getRequest().returnItemCollectionMetricsAsString();
     }
 
     public UpdateItemSpec withReturnItemCollectionMetrics(
@@ -223,7 +223,7 @@ public class UpdateItemSpec extends AbstractSpecWithPrimaryKey<UpdateItemRequest
     }
 
     public String getReturnValues() {
-        return getRequest().returnValuesString();
+        return getRequest().returnValuesAsString();
     }
 
     public UpdateItemSpec withReturnValues(ReturnValue returnValues) {

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/core/http/TT0035900619IntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/core/http/TT0035900619IntegrationTest.java
@@ -65,8 +65,8 @@ public class TT0035900619IntegrationTest {
             throws InterruptedException {
         DescribeTableResponse result = client.describeTable(DescribeTableRequest.builder().tableName(tableName).build());
         TableDescription desc = result.table();
-        String status = desc.tableStatusString();
-        for (;; status = desc.tableStatusString()) {
+        String status = desc.tableStatusAsString();
+        for (;; status = desc.tableStatusAsString()) {
             if ("ACTIVE".equals(status)) {
                 return desc;
             } else if ("CREATING".equals(status) || "UPDATING".equals(status)) {

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMapper.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMapper.java
@@ -2271,7 +2271,7 @@ public class DynamoDbMapper extends AbstractDynamoDbMapper {
             for (Entry<String, AttributeValueUpdate> entry : putValues.entrySet()) {
                 String attributeName = entry.getKey();
                 AttributeValue attributeValue = entry.getValue().value();
-                String attributeAction = entry.getValue().actionString();
+                String attributeAction = entry.getValue().actionAsString();
 
                 /*
                  * AttributeValueUpdate allows nulls for its values, since they are

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
@@ -62,7 +62,7 @@ public class ResponseTransformerTest {
         stubFor(post(urlPathEqualTo(STREAMING_OUTPUT_PATH)).willReturn(aResponse().withStatus(200).withBody("test \uD83D\uDE02")));
 
         ResponseBytes<StreamingOutputOperationResponse> response =
-                testClient().streamingOutputOperationBytes(StreamingOutputOperationRequest.builder().build());
+                testClient().streamingOutputOperationAsBytes(StreamingOutputOperationRequest.builder().build());
 
         byte[] arrayCopy = response.asByteArray();
         assertThat(arrayCopy).containsExactly('t', 'e', 's', 't', ' ', -16, -97, -104, -126);
@@ -81,7 +81,7 @@ public class ResponseTransformerTest {
         stubForRetries();
 
         ResponseBytes<StreamingOutputOperationResponse> response =
-                testClient().streamingOutputOperationBytes(StreamingOutputOperationRequest.builder().build());
+                testClient().streamingOutputOperationAsBytes(StreamingOutputOperationRequest.builder().build());
 
         assertThat(response.asUtf8String()).isEqualTo("retried");
     }


### PR DESCRIPTION
This makes it more obvious that they are overloads, not separate operations.