### PR TITLE
Fix changelog sorting issue with preview versions

### DIFF
--- a/scripts/changelog/model.py
+++ b/scripts/changelog/model.py
@@ -22,3 +22,13 @@ class Version(object):
         if self.prerelease != "":
             s = "%s-%s" % (s, self.prerelease)
         return s
+
+    # TODO Remove it when we remove "preview" from the version number
+    # Returns the prerelease version number
+    # Example: Version is "preview-11", this method returns "11" as integer
+    def prerelease_version_number(self):
+        if self.prerelease != "":
+            preview_prefix_len = len("preview-")
+            prerelease_version = self.prerelease[preview_prefix_len:]
+            if prerelease_version != "":
+                return int(prerelease_version)

--- a/scripts/changelog/util.py
+++ b/scripts/changelog/util.py
@@ -4,8 +4,8 @@ import json
 from model import ReleaseChanges, ChangelogEntry, Version
 
 def version_cmp(a,b):
-    aa = [a.major, a.minor, a.patch, a.prerelease]
-    bb = [b.major, b.minor, b.patch, b.prerelease]
+    aa = [a.major, a.minor, a.patch, a.prerelease_version_number()]
+    bb = [b.major, b.minor, b.patch, b.prerelease_version_number()]
     return cmp(bb,aa)
 
 def load_all_released_changes(d):


### PR DESCRIPTION
Issue was comparing preview version strings 

In old code,
preview-2 > preview-10 as cmp() functions checks one character at a time. So checks 2 > 1 and decides preview-2 is greater. This PR fixes it by parsing the "preview-" string and comparing the integer values

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
