### PR TITLE
Expose option to trust all certs in Apache client

### DIFF
--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.http;
 
 import java.time.Duration;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -67,14 +66,9 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
             new SdkHttpConfigurationOption<>("MaxConnectionAcquires", Integer.class);
 
     /**
-     * Whether or not to use strict hostname verification when establishing the SSL connection. For almost all services this
-     * should be true. S3 however uses wildcard certificates for virtual bucket address (bucketname.s3.amazonaws.com) and
-     * needs to disable strict hostname verification to allow for wildcard certs.
+     * Option to disable SSL cert validation and SSL host name verification. By default, this option is off.
+     * Only enable this option for testing purposes.
      */
-    @ReviewBeforeRelease("This does not appear to be needed anymore for S3")
-    public static final SdkHttpConfigurationOption<Boolean> USE_STRICT_HOSTNAME_VERIFICATION =
-            new SdkHttpConfigurationOption<>("UseStrictHostnameVerification", Boolean.class);
-
     public static final SdkHttpConfigurationOption<Boolean> TRUST_ALL_CERTIFICATES =
             new SdkHttpConfigurationOption<>("TrustAllCertificates", Boolean.class);
 
@@ -84,7 +78,6 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
     private static final Duration DEFAULT_CONNECTION_ACQUIRE_TIMEOUT = Duration.ofSeconds(10);
     private static final int DEFAULT_MAX_CONNECTIONS = 50;
     private static final int DEFAULT_MAX_CONNECTION_ACQUIRES = 10_000;
-    private static final Boolean DEFAULT_USE_STRICT_HOSTNAME_VERIFICATION = Boolean.TRUE;
     private static final Boolean DEFAULT_TRUST_ALL_CERTIFICATES = Boolean.FALSE;
 
     public static final AttributeMap GLOBAL_HTTP_DEFAULTS = AttributeMap
@@ -95,7 +88,6 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
             .put(CONNECTION_ACQUIRE_TIMEOUT, DEFAULT_CONNECTION_ACQUIRE_TIMEOUT)
             .put(MAX_CONNECTIONS, DEFAULT_MAX_CONNECTIONS)
             .put(MAX_PENDING_CONNECTION_ACQUIRES, DEFAULT_MAX_CONNECTION_ACQUIRES)
-            .put(USE_STRICT_HOSTNAME_VERIFICATION, DEFAULT_USE_STRICT_HOSTNAME_VERIFICATION)
             .put(TRUST_ALL_CERTIFICATES, DEFAULT_TRUST_ALL_CERTIFICATES)
             .build();
 

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +39,8 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -48,6 +52,7 @@ import org.apache.http.conn.ConnectionKeepAliveStrategy;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLInitializationException;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -55,7 +60,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.DefaultSchemePortResolver;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpRequestExecutor;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.AbortableCallable;
 import software.amazon.awssdk.http.AbortableInputStream;
@@ -430,19 +434,55 @@ public final class ApacheHttpClient implements SdkHttpClient {
 
         private ConnectionSocketFactory getPreferredSocketFactory(AttributeMap standardOptions) {
             // TODO v2 custom socket factory
-            return new SdkTlsSocketFactory(getPreferredSslContext(),
-                                           getHostNameVerifier(standardOptions));
+            return new SdkTlsSocketFactory(getSslContext(standardOptions), getHostNameVerifier(standardOptions));
         }
 
-        private static SSLContext getPreferredSslContext() {
+        private HostnameVerifier getHostNameVerifier(AttributeMap standardOptions) {
+            return standardOptions.get(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES)
+                   ? NoopHostnameVerifier.INSTANCE
+                   : SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+        }
+
+        private SSLContext getSslContext(AttributeMap standardOptions) {
+            TrustManager[] trustManagers = null;
+            if (standardOptions.get(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES)) {
+                log.warn(() -> "SSL Certificate verification is disabled. This is not a safe setting and should only be "
+                               + "used for testing.");
+                trustManagers = trustAllTrustManager();
+            }
+
             try {
                 final SSLContext sslcontext = SSLContext.getInstance("TLS");
                 // http://download.java.net/jdk9/docs/technotes/guides/security/jsse/JSSERefGuide.html
-                sslcontext.init(null, null, null);
+                sslcontext.init(null, trustManagers, null);
                 return sslcontext;
             } catch (final NoSuchAlgorithmException | KeyManagementException ex) {
                 throw new SSLInitializationException(ex.getMessage(), ex);
             }
+        }
+
+        /**
+         * Insecure trust manager to trust all certs. Should only be used for testing.
+         */
+        private static TrustManager[] trustAllTrustManager() {
+            return new TrustManager[] {
+                new X509TrustManager() {
+                    @Override
+                    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+                        log.debug(() -> "Accepting a client certificate: " + x509Certificates[0].getSubjectDN());
+                    }
+
+                    @Override
+                    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+                        log.debug(() -> "Accepting a client certificate: " + x509Certificates[0].getSubjectDN());
+                    }
+
+                    @Override
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return new X509Certificate[0];
+                    }
+                }
+            };
         }
 
         private SocketConfig buildSocketConfig(AttributeMap standardOptions) {
@@ -456,23 +496,11 @@ public final class ApacheHttpClient implements SdkHttpClient {
                                .build();
         }
 
-        @ReviewBeforeRelease("Need to have a way to communicate with HTTP impl supports disabling of strict" +
-                             "hostname verification. If it doesn't we either need to fail in S3 or switch to path style" +
-                             "addressing.")
-        private HostnameVerifier getHostNameVerifier(AttributeMap standardOptions) {
-            // TODO Need to find a better way to handle these deprecations.
-            return standardOptions.get(SdkHttpConfigurationOption.USE_STRICT_HOSTNAME_VERIFICATION)
-                   ? SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER
-                   : SSLConnectionSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER;
-        }
-
         private Registry<ConnectionSocketFactory> createSocketFactoryRegistry(ConnectionSocketFactory sslSocketFactory) {
-            // TODO v2 disable cert checking
             return RegistryBuilder.<ConnectionSocketFactory>create()
                     .register("http", PlainConnectionSocketFactory.getSocketFactory())
                     .register("https", sslSocketFactory)
                     .build();
         }
-
     }
 }

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientWireMockTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientWireMockTest.java
@@ -15,12 +15,30 @@
 
 package software.amazon.awssdk.http.apache;
 
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+
+import java.net.HttpURLConnection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpClientTestSuite;
+import software.amazon.awssdk.utils.AttributeMap;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ApacheHttpClientWireMockTest extends SdkHttpClientTestSuite {
     @Override
     protected SdkHttpClient createSdkHttpClient(SdkHttpClientOptions options) {
         return ApacheHttpClient.builder().build();
+    }
+
+    @Test
+    public void noSslException_WhenCertCheckingDisabled() throws Exception {
+        SdkHttpClient client = ApacheHttpClient.builder()
+                                               .buildWithDefaults(AttributeMap.builder()
+                                                                              .put(TRUST_ALL_CERTIFICATES, Boolean.TRUE)
+                                                                              .build());
+
+        testForResponseCodeUsingHttps(client, HttpURLConnection.HTTP_OK);
     }
 }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -64,12 +64,14 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkRequestContext;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
+import software.amazon.awssdk.utils.AttributeMap;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NettyNioAsyncHttpClientWireMockTest {
@@ -81,8 +83,7 @@ public class NettyNioAsyncHttpClientWireMockTest {
     private SdkRequestContext requestContext;
 
     private static SdkAsyncHttpClient client = NettyNioAsyncHttpClient.builder()
-                                                                      .trustAllCertificates(true)
-                                                                      .build();
+                                                                      .buildWithDefaults(mapWithTrustAllCerts());
 
     @AfterClass
     public static void tearDown() throws Exception {
@@ -94,7 +95,6 @@ public class NettyNioAsyncHttpClientWireMockTest {
         ThreadFactory threadFactory = spy(new CustomThreadFactory());
         SdkAsyncHttpClient customClient =
                 NettyNioAsyncHttpClient.builder()
-                                       .trustAllCertificates(true)
                                        .eventLoopGroupFactory(DefaultEventLoopGroupFactory.builder()
                                                                                           .threadFactory(threadFactory)
                                                                                           .build())
@@ -123,7 +123,6 @@ public class NettyNioAsyncHttpClientWireMockTest {
         ThreadFactory threadFactory = spy(new CustomThreadFactory());
         SdkAsyncHttpClient customClient =
                 NettyNioAsyncHttpClient.builder()
-                                       .trustAllCertificates(true)
                                        .eventLoopGroupFactory(DefaultEventLoopGroupFactory.builder()
                                                                                           .threadFactory(threadFactory)
                                                                                           .numberOfThreads(threadCount)
@@ -149,7 +148,6 @@ public class NettyNioAsyncHttpClientWireMockTest {
         EventLoopGroup eventLoopGroup = spy(new NioEventLoopGroup(0, threadFactory));
         SdkAsyncHttpClient customClient =
                 NettyNioAsyncHttpClient.builder()
-                                       .trustAllCertificates(true)
                                        .eventLoopGroup(eventLoopGroup)
                                        .build();
 
@@ -374,5 +372,11 @@ public class NettyNioAsyncHttpClientWireMockTest {
         RecordingResponseHandler recorder = new RecordingResponseHandler();
         client.prepareRequest(request, requestContext, createProvider(""), recorder).run();
         return recorder;
+    }
+
+    private static AttributeMap mapWithTrustAllCerts() {
+        return AttributeMap.builder()
+                           .put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true)
+                           .build();
     }
 }

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
@@ -106,6 +106,15 @@ public abstract class SdkHttpClientTestSuite {
         validateResponse(response, returnCode);
     }
 
+    protected void testForResponseCodeUsingHttps(SdkHttpClient client, int returnCode) throws Exception {
+        stubForMockRequest(returnCode);
+
+        SdkHttpFullRequest request = mockSdkRequest("https://localhost:" + mockServer.httpsPort());
+        SdkHttpFullResponse response = client.prepareRequest(request, requestContext).call();
+
+        validateResponse(response, returnCode);
+    }
+
     private void stubForMockRequest(int returnCode) {
         stubFor(any(urlPathEqualTo("/")).willReturn(
                 aResponse().withStatus(returnCode).withHeader("Some-Header", "With Value").withBody("hello")));
@@ -152,7 +161,6 @@ public abstract class SdkHttpClientTestSuite {
      * The options that should be considered when creating the client via {@link #createSdkHttpClient(SdkHttpClientOptions)}.
      */
     protected static final class SdkHttpClientOptions {
-        // TODO: Add option for disabling certificate validation. This should probably be supported by all HTTP implementations
-        // because it is necessary for testing that HTTPS functions correctly.
+
     }
 }


### PR DESCRIPTION
Using SdkHttpConfigurationOption#TRUST_ALL_CERTIFICATES option to disable cert validation and strict host name verification. This option is disabled by default. Customers can enable it in httpClients by passing it to buildWithDefaults() method

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
