### PR TITLE
Verifying the http default values

### DIFF
--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/config/options/AwsAdvancedClientOption.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/config/options/AwsAdvancedClientOption.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.awscore.config.options;
 
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.core.config.ClientOverrideConfiguration.Builder;
@@ -31,7 +30,6 @@ import software.amazon.awssdk.regions.Region;
  *
  * @param <T> The type of value associated with the option.
  */
-@ReviewBeforeRelease("Ensure that all of these options are actually advanced.")
 @SdkPublicApi
 public final class AwsAdvancedClientOption<T> extends SdkAdvancedClientOption<T> {
 

--- a/core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -76,12 +76,6 @@ public enum SdkSystemSetting implements SystemSetting {
     AWS_REGION("aws.region", null),
 
     /**
-     * Whether the default configuration applied to AWS clients should be optimized for services within the same region.
-     * This will usually include lower request timeouts because requests do not need to travel outside of the AWS network.
-     */
-    AWS_IN_REGION_OPTIMIZATION_ENABLED("aws.inRegionOptimizationEnabled", "false"),
-
-    /**
      * Whether to load information such as credentials, regions from EC2 Metadata instance service.
      */
     AWS_EC2_METADATA_DISABLED("aws.disableEc2Metadata", "false"),

--- a/core/src/main/java/software/amazon/awssdk/core/config/options/SdkAdvancedClientOption.java
+++ b/core/src/main/java/software/amazon/awssdk/core/config/options/SdkAdvancedClientOption.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.core.signer.Signer;
  *
  * @param <T> The type of value associated with the option.
  */
-@ReviewBeforeRelease("Ensure that all of these options are actually advanced.")
 @SdkPublicApi
 public class SdkAdvancedClientOption<T> extends ClientOption<T> {
     /**

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
@@ -87,7 +87,6 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
     private static final Boolean DEFAULT_USE_STRICT_HOSTNAME_VERIFICATION = Boolean.TRUE;
     private static final Boolean DEFAULT_TRUST_ALL_CERTIFICATES = Boolean.FALSE;
 
-    @ReviewBeforeRelease("Confirm defaults")
     public static final AttributeMap GLOBAL_HTTP_DEFAULTS = AttributeMap
             .builder()
             .put(READ_TIMEOUT, DEFAULT_SOCKET_READ_TIMEOUT)

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/Defaults.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/Defaults.java
@@ -16,17 +16,20 @@
 package software.amazon.awssdk.http.apache.internal;
 
 import java.time.Duration;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 
 /**
  * Default configuration values.
  */
-@ReviewBeforeRelease("These values")
 public final class Defaults {
 
+    /**
+     * The default maximum idle time (in milliseconds) for a connection to be idle in the connection pool and
+     * still be eligible for reuse.
+     */
     public static final Duration MAX_IDLE_CONNECTION_TIME = Duration.ofSeconds(60);
 
     /**
+     * The default expiration time for a connection in the connection pool.
      * A value of -1 means infinite TTL in Apache.
      */
     public static final Duration CONNECTION_POOL_TTL = Duration.ofMillis(-1);


### PR DESCRIPTION
**All current options in following classes are advanced**
AwsAdvancedClientOption
SdkAdvancedClientOption
SdkAdvancedAsyncClientOption

**All default values match the values used in v1.** I don't remember any discussion on changing these values.
https://github.com/aws/aws-sdk-java-v2/blob/master/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java#L81-L88

https://github.com/aws/aws-sdk-java-v2/blob/master/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/Defaults.java

**Other Changes**
Removed unused option in SdkSystemSetting class
