### PR TITLE
Handle autoconstruct lists in non-JSON protocols

### DIFF
--- a/codegen/src/main/resources/macros/marshaller/ec2/MemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/ec2/MemberMarshallerMacro.ftl
@@ -31,7 +31,11 @@
             <#local loopVariable = listVariable + "Value"/>
 
             ${listModel.templateType} ${listVariable} = ${getMember}();
-            if (${listVariable} != null) {
+            <#if customConfig.useAutoConstructList>
+                if (!${listVariable}.isEmpty() || !(${listVariable} instanceof software.amazon.awssdk.core.util.SdkAutoConstructList)) {
+            <#else>
+                if (${listVariable} != null) {
+            </#if>
                 int ${listIndex} = 1;
 
                 for (${listModel.memberType} ${loopVariable} : ${listVariable}) {

--- a/codegen/src/main/resources/macros/marshaller/query/MemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/query/MemberMarshallerMacro.ftl
@@ -56,10 +56,18 @@
         </#if>
     </#if>
 
-    ${listModel.templateType} ${listVariable} = ${getMember}();
-
-    if (${listVariable} != null) {
-        if (!${listVariable}.isEmpty()) {
+    <#if customConfig.useAutoConstructList>
+    if (${getMember}().isEmpty() && !(${getMember}() instanceof software.amazon.awssdk.core.util.SdkAutoConstructList)) {
+            request.addParameter("${parameterRootPath}", "");
+    } else if (!${getMember}().isEmpty() && !(${getMember}() instanceof software.amazon.awssdk.core.util.SdkAutoConstructList)) {
+        ${listModel.templateType} ${listVariable} = ${getMember}();
+    <#else>
+    if (${getMember}() != null) {
+        ${listModel.templateType} ${listVariable} = ${getMember}();
+        if (${listVariable}.isEmpty()) {
+            request.addParameter("${parameterRootPath}", "");
+        } else {
+    </#if>
             int ${listIndex} = 1;
 
             for (${listModel.memberType} ${loopVariable} : ${listVariable}) {
@@ -72,9 +80,9 @@
                 </#if>
                 ${listIndex}++;
             }
-        } else {
-            request.addParameter("${parameterRootPath}", "");
+    <#if !customConfig.useAutoConstructList>
         }
+    </#if>
     }
 <#elseif member.map>
     <#local parameterPath = http.marshallLocationName/>

--- a/codegen/src/main/resources/macros/marshaller/rest-xml/MemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/rest-xml/MemberMarshallerMacro.ftl
@@ -21,8 +21,12 @@
     <#local listVariable = shapeName?uncap_first + member.name + "List"/>
     <#local loopVariable = listVariable + "Value"/>
 
-  ${listModel.templateType} ${listVariable} = ${getMember}();
-  if (${listVariable} != null) {
+      ${listModel.templateType} ${listVariable} = ${getMember}();
+  <#if customConfig.useAutoConstructList>
+      if (!${listVariable}.isEmpty() || !(${listVariable} instanceof software.amazon.awssdk.core.util.SdkAutoConstructList)) {
+  <#else>
+      if (${listVariable} != null) {
+  </#if>
   <#if member.http.flattened>
       for (${listModel.memberType} ${loopVariable} : ${listVariable}) {
           <#local memberLocationName = listModel.memberLocationName!http.marshallLocationName />

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/PresignRequestHandlerTest.java
@@ -97,17 +97,13 @@ public class PresignRequestHandlerTest {
                 "&SourceDBSnapshotIdentifier=arn%3Aaws%3Ards%3Aus-east-1%3A123456789012%3Asnapshot%3Ards%3Atest-instance-ss-2016-12-20-23-19" +
                 "&TargetDBSnapshotIdentifier=test-instance-ss-copy-2" +
                 "&KmsKeyId=arn%3Aaws%3Akms%3Aus-west-2%3A123456789012%3Akey%2F11111111-2222-3333-4444-555555555555" +
-                // FIXME: The empty "Tags" list should not be getting
-                // marshalled, but we need to fix the marshallers to be aware
-                // of auto construct lists
-                "&Tags=" +
                 "&DestinationRegion=us-west-2" +
                 "&X-Amz-Algorithm=AWS4-HMAC-SHA256" +
                 "&X-Amz-Date=20161221T180735Z" +
                 "&X-Amz-SignedHeaders=host" +
                 "&X-Amz-Expires=604800" +
                 "&X-Amz-Credential=foo%2F20161221%2Fus-east-1%2Frds%2Faws4_request" +
-                "&X-Amz-Signature=6a7e40b24c91517a6de0e60bc65a1a812deaa0a0aa3b54ab513bef3ed34f78c9";
+                "&X-Amz-Signature=f839ca3c728dc96e7c978befeac648296b9f778f6724073de4217173859d13d9";
 
         assertEquals(expectedPreSignedUrl, presignedRequest.rawQueryParameters().get("PreSignedUrl").get(0));
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketAnalyticsConfigurationIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketAnalyticsConfigurationIntegrationTest.java
@@ -19,6 +19,7 @@ import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
 import java.util.List;
@@ -144,7 +145,7 @@ public class BucketAnalyticsConfigurationIntegrationTest extends S3IntegrationTe
                 s3.listBucketAnalyticsConfigurations(ListBucketAnalyticsConfigurationsRequest.builder()
                                                                                              .bucket(BUCKET_NAME)
                                                                                              .build());
-        assertNull(result.analyticsConfigurationList());
+        assertTrue(result.analyticsConfigurationList().isEmpty());
     }
 
     @Test

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketInventoryConfigurationIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/BucketInventoryConfigurationIntegrationTest.java
@@ -125,7 +125,7 @@ public class BucketInventoryConfigurationIntegrationTest extends S3IntegrationTe
                                                         .bucket(BUCKET_NAME)
                                                         .build())
                                                         .inventoryConfigurationList();
-        assertNull(configurations);
+        assertTrue(configurations.isEmpty());
     }
 
     @Test

--- a/test/protocol-tests/src/main/resources/codegen-resources/query/customization.config
+++ b/test/protocol-tests/src/main/resources/codegen-resources/query/customization.config
@@ -10,5 +10,7 @@
         "queryParamWithoutValue",
         "idempotentOperation",
         "queryTypes"
-    ]
+    ],
+    // The tests expect non auto construct lists
+    "useAutoConstructList": false
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/restxml/customization.config
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restxml/customization.config
@@ -9,7 +9,5 @@
         "operationWithModeledContentType",
         "queryParamWithoutValue",
         "restXmlTypes"
-    ],
-    // FIXME: RestXml marshallers need to be made auto construct aware
-    "useAutoConstructList": false
+    ]
 }


### PR DESCRIPTION
Correctly handle autoconstruct lists for non-JSON protocol marshallers.

## Description
Correctly handle autoconstruct lists for non-JSON protocol marshallers.

## Motivation and Context

## Testing
Verified:
- `mvn clean install`
- `mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
