### PR TITLE
Add fixes for FullResponseContentPublisher

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -245,14 +245,14 @@ class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                 @Override
                 public void request(long l) {
                     if (l <= 0 && running) {
-                        subscriber.onError(new IllegalArgumentException("Demand must be positive!"));
                         running = false;
+                        subscriber.onError(new IllegalArgumentException("Demand must be positive!"));
                     } else if (running) {
+                        running = false;
                         subscriber.onNext(fullContent);
                         subscriber.onComplete();
                         channelContext.channel().attr(ChannelAttributeKeys.SUBSCRIBER_KEY)
                             .set(subscriber);
-                        running = false;
                     }
                 }
 


### PR DESCRIPTION
 - Allow multiple subscribers

 - Flip to done before signaling onError/onComplete to prevent infinite
   recursion if the subscription is called again synchronously from
   within those methods
