### PR TITLE
Caching XPathFactory

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-deb2963.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-deb2963.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Caching `XPathFactory` to improve performance of exception handling for services using XML protocol"
+}

--- a/core/src/main/java/software/amazon/awssdk/core/util/XpathUtils.java
+++ b/core/src/main/java/software/amazon/awssdk/core/util/XpathUtils.java
@@ -65,6 +65,11 @@ public final class XpathUtils {
 
     private static final Logger log = LoggerFactory.getLogger(XpathUtils.class);
 
+    /**
+     * Shared factory for creating XML Factory
+     */
+    private static final ThreadLocal<XPathFactory> X_PATH_FACTORY = ThreadLocal.withInitial(XPathFactory::newInstance);
+
     private static final ErrorHandler ERROR_HANDLER = new ErrorHandler() {
 
         @Override
@@ -156,7 +161,7 @@ public final class XpathUtils {
      * reentrant.
      */
     public static XPath xpath() {
-        return XPathFactory.newInstance().newXPath();
+        return X_PATH_FACTORY.get().newXPath();
     }
 
     /**


### PR DESCRIPTION
Caching XPathFactory to improve performance of exception handling for services using xml protocol

v1 parity