### PR TITLE
Stop publishing after Content-Length bytes

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-2a5d0da.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-2a5d0da.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Async HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fix the Netty async client to stop publishing to the request stream once `Content-Length` is reached."
+}

--- a/http-clients/netty-nio-client/pom.xml
+++ b/http-clients/netty-nio-client/pom.xml
@@ -95,11 +95,20 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams-tck</artifactId>
             <version>${reactive-streams.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -39,11 +39,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 
+import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+
+import java.io.IOException;
+import java.net.Socket;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,11 +56,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import org.assertj.core.api.Condition;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,14 +84,23 @@ import software.amazon.awssdk.utils.AttributeMap;
 @RunWith(MockitoJUnitRunner.class)
 public class NettyNioAsyncHttpClientWireMockTest {
 
+    private final RecordingNetworkTrafficListener wiremockTrafficListener = new RecordingNetworkTrafficListener();
+
     @Rule
-    public WireMockRule mockServer = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort()
+            .networkTrafficListener(wiremockTrafficListener));
 
     @Mock
     private SdkRequestContext requestContext;
 
-    private static SdkAsyncHttpClient client = NettyNioAsyncHttpClient.builder()
-                                                                      .buildWithDefaults(mapWithTrustAllCerts());
+    private static SdkAsyncHttpClient client = NettyNioAsyncHttpClient.builder().buildWithDefaults(mapWithTrustAllCerts());
+
+    @Before
+    public void methodSetup() {
+        wiremockTrafficListener.reset();
+    }
 
     @AfterClass
     public static void tearDown() throws Exception {
@@ -227,6 +244,30 @@ public class NettyNioAsyncHttpClientWireMockTest {
         assertThat(recorder.fullResponseAsString()).isEqualTo(reverse(body));
     }
 
+    @Test
+    public void requestContentOnlyEqualToContentLengthHeaderFromProvider() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        final String content = randomAlphabetic(32);
+        final String streamContent = content + reverse(content);
+        stubFor(any(urlEqualTo("/echo?reversed=true"))
+                .withRequestBody(equalTo(content))
+                .willReturn(aResponse().withBody(reverse(content))));
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+
+        SdkHttpFullRequest request = createRequest(uri, "/echo", streamContent, SdkHttpMethod.POST, singletonMap("reversed", "true"));
+        request = request.toBuilder().header("Content-Length", Integer.toString(content.length())).build();
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+
+        client.prepareRequest(request, requestContext, createProvider(streamContent), recorder).run();
+
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+
+        // HTTP servers will stop processing the request as soon as it reads
+        // bytes equal to 'Content-Length' so we need to inspect the raw
+        // traffic to ensure that there wasn't anything after that.
+        assertThat(wiremockTrafficListener.requests.toString()).endsWith(content);
+    }
+
     private void assertCanReceiveBasicRequest(URI uri, String body) throws Exception {
         stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withHeader("Some-Header", "With Value").withBody(body)));
 
@@ -275,11 +316,11 @@ public class NettyNioAsyncHttpClientWireMockTest {
         };
     }
 
-    private SdkHttpRequest createRequest(URI uri) {
+    private SdkHttpFullRequest createRequest(URI uri) {
         return createRequest(uri, "/", null, SdkHttpMethod.GET, emptyMap());
     }
 
-    private SdkHttpRequest createRequest(URI uri,
+    private SdkHttpFullRequest createRequest(URI uri,
                                          String resourcePath,
                                          String body,
                                          SdkHttpMethod method,
@@ -378,5 +419,34 @@ public class NettyNioAsyncHttpClientWireMockTest {
         return AttributeMap.builder()
                            .put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true)
                            .build();
+    }
+
+    private static class RecordingNetworkTrafficListener implements WiremockNetworkTrafficListener {
+        private final StringBuilder requests = new StringBuilder();
+
+
+        @Override
+        public void opened(Socket socket) {
+
+        }
+
+        @Override
+        public void incoming(Socket socket, ByteBuffer byteBuffer) {
+            requests.append(StandardCharsets.UTF_8.decode(byteBuffer));
+        }
+
+        @Override
+        public void outgoing(Socket socket, ByteBuffer byteBuffer) {
+
+        }
+
+        @Override
+        public void closed(Socket socket) {
+
+        }
+
+        public void reset() {
+            requests.setLength(0);
+        }
     }
 }


### PR DESCRIPTION
Stop publishing after Content-Length bytes

Fixes #460

## Description
Stop publishing after Content-Length bytes

Fixes #460

## Motivation and Context
Fix #460

## Testing
`mvn clean install` with new unit test.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
