### PR TITLE
Avoid path.toFile calls

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/async/FileAsyncRequestBody.java
+++ b/core/src/main/java/software/amazon/awssdk/core/async/FileAsyncRequestBody.java
@@ -16,9 +16,11 @@
 package software.amazon.awssdk.core.async;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.CompletionHandler;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicLong;
@@ -57,7 +59,11 @@ final class FileAsyncRequestBody implements AsyncRequestBody {
 
     @Override
     public long contentLength() {
-        return path.toFile().length();
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/core/src/main/java/software/amazon/awssdk/core/util/Mimetype.java
+++ b/core/src/main/java/software/amazon/awssdk/core/util/Mimetype.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -114,12 +115,30 @@ public final class Mimetype {
      * If a file has no extension,
      * Guesses the mimetype of file data based on the file's extension.
      *
+     * @param path the file whose extension may match a known mimetype.
+     * @return the file's mimetype based on its extension, or a default value of
+     * <code>application/octet-stream</code> if a mime type value cannot be found.
+     */
+    public String getMimetype(Path path) {
+        return getMimetype(path.getFileName().toString());
+    }
+
+    /**
+     * Determines the mimetype of a file by looking up the file's extension in an internal listing
+     * to find the corresponding mime type. If the file has no extension, or the extension is not
+     * available in the listing contained in this class, the default mimetype
+     * <code>application/octet-stream</code> is returned.
+     * <p>
+     * A file extension is one or more characters that occur after the last period (.) in the file's name.
+     * If a file has no extension,
+     * Guesses the mimetype of file data based on the file's extension.
+     *
      * @param file the file whose extension may match a known mimetype.
      * @return the file's mimetype based on its extension, or a default value of
      * <code>application/octet-stream</code> if a mime type value cannot be found.
      */
     public String getMimetype(File file) {
-        return getMimetype(file.getName());
+        return getMimetype(file.toPath());
     }
 
     /**

--- a/core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/async/AsyncRequestBodyTest.java
@@ -16,36 +16,81 @@
 package software.amazon.awssdk.core.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.http.async.SimpleSubscriber;
 
+@RunWith(Parameterized.class)
 public class AsyncRequestBodyTest {
+    private final static String testString = "Hello!";
+    private final static Path path;
+
+    static {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        path = fs.getPath("./test");
+        try {
+            Files.write(path, testString.getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Parameterized.Parameters
+    public static AsyncRequestBody[] data() {
+        return new AsyncRequestBody[]{
+                AsyncRequestBody.fromString(testString),
+                AsyncRequestBody.fromFile(path)
+        };
+    }
+
+    private AsyncRequestBody provider;
+
+    public AsyncRequestBodyTest(AsyncRequestBody provider) {
+        this.provider = provider;
+    }
 
     @Test
-    public void canCreateAStringRequestBody() {
-        AsyncRequestBody provider = AsyncRequestBody.fromString("Hello!");
-        StringBuilder sb = new StringBuilder();
-        boolean done = false;
+    public void hasCorrectLength() {
+        assertThat(provider.contentLength()).isEqualTo(testString.length());
+    }
 
-        Subscriber<ByteBuffer> subscriber = spy(new SimpleSubscriber(buffer -> {
-                byte[] bytes = new byte[buffer.remaining()];
-                buffer.get(bytes);
-                sb.append(new String(bytes, StandardCharsets.UTF_8));
-            }));
+    @Test
+    public void hasCorrectContent() throws InterruptedException {
+        StringBuilder sb = new StringBuilder();
+        CountDownLatch done = new CountDownLatch(1);
+
+        Subscriber<ByteBuffer> subscriber = new SimpleSubscriber(buffer -> {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            sb.append(new String(bytes, StandardCharsets.UTF_8));
+        }) {
+            @Override
+            public void onError(Throwable t) {
+                super.onError(t);
+                done.countDown();
+            }
+
+            @Override
+            public void onComplete() {
+                super.onComplete();
+                done.countDown();
+            }
+        };
 
         provider.subscribe(subscriber);
-
-        assertThat(sb.toString()).isEqualTo("Hello!");
-        assertThat(provider.contentLength()).isEqualTo(6);
-        verify(subscriber).onComplete();
-        verify(subscriber, times(0)).onError(any(Throwable.class));
+        done.await();
+        assertThat(sb.toString()).isEqualTo(testString);
     }
 }

--- a/core/src/test/java/software/amazon/awssdk/core/sync/RequestBodyTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/sync/RequestBodyTest.java
@@ -17,7 +17,14 @@ package software.amazon.awssdk.core.sync;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.Test;
 import software.amazon.awssdk.core.util.Mimetype;
 import software.amazon.awssdk.core.util.StringInputStream;
@@ -38,6 +45,15 @@ public class RequestBodyTest {
     public void stringConstructorHasCorrectContentType() {
         RequestBody requestBody = RequestBody.fromString("hello world");
         assertThat(requestBody.contentType()).isEqualTo(Mimetype.MIMETYPE_TEXT_PLAIN);
+    }
+
+    @Test
+    public void fileConstructorHasCorrectContentType() throws IOException {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        Path path = fs.getPath("./test");
+        Files.write(path, "hello world".getBytes());
+        RequestBody requestBody = RequestBody.fromFile(path);
+        assertThat(requestBody.contentType()).isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
     }
 
     @Test


### PR DESCRIPTION
## Description
There are several places in public API of aws-sdk where both `java.io.File` and `java.nio.file.Path` are supported. Usually only the variant that accepts `Path` contains concrete implementation and the other calls `method(file.toPath(), ...)`, but there are few places where things are done the other way around (and thus `path.toFile()` is called). Unfortunately `path -> file` conversion is not possible for paths that exist on non-default filesystem (like already used here in tests in-memory [Jimfs](https://github.com/google/jimfs) filesystem). Avoiding `path -> file` conversion makes API more test friendly (among other things).

## Motivation and Context
- It makes possible to create request body from files from non-default filesystem.
- It makes API more test friendly.

## Testing
I extended existing tests so that methods that were previously performing `path -> file` conversion are called with `Path` instance from Jimfs (that does not support conversion to `File`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
