### PR TITLE
Add bundle relocation fixes

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -72,7 +72,7 @@
                             <include>org.reactivestreams:*</include>
                             <include>org.slf4j:*</include>
                             <include>commons-codec:commons-codec</include>
-                            <include>software.amazon.awssdk.ion:ion-java</include>
+                            <include>software.amazon.ion:ion-java</include>
                             <include>software.amazon.awssdk:*</include>
                             <include>commons-logging:*</include>
                         </includes>
@@ -80,23 +80,31 @@
                     <relocations>
                         <relocation>
                             <pattern>com.fasterxml.jackson</pattern>
-                            <shadedPattern>software.amazon.awssdk.thirdparty.jackson</shadedPattern>
+                            <shadedPattern>software.amazon.awssdk.thirdparty.com.fasterxml.jackson</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>org.apache.http</pattern>
-                            <shadedPattern>software.amazon.awssdk.thirdparty.apache.http</shadedPattern>
+                            <pattern>org.apache</pattern>
+                            <shadedPattern>software.amazon.awssdk.thirdparty.org.apache</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>org.apache.commons.codec</pattern>
-                            <shadedPattern>software.amazon.awssdk.thirdparty.apache.codec</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>software.amazon.awssdk.ion</pattern>
+                            <pattern>software.amazon.ion</pattern>
                             <shadedPattern>software.amazon.awssdk.thirdparty.ion</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>org.apache.commons.logging</pattern>
-                            <shadedPattern>software.amazon.awssdk.thirdparty.apache.logging</shadedPattern>
+                            <pattern>io.netty</pattern>
+                            <shadedPattern>software.amazon.awssdk.thirdparty.io.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.typesafe</pattern>
+                            <shadedPattern>software.amazon.awssdk.thirdparty.com.typesafe</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.reactivestreams</pattern>
+                            <shadedPattern>software.amazon.awssdk.thirdparty.org.reactivestreams</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.slf4j</pattern>
+                            <shadedPattern>software.amazon.awssdk.thirdparty.org.slf4j</shadedPattern>
                         </relocation>
                     </relocations>
                     <shadedArtifactAttached>false</shadedArtifactAttached>


### PR DESCRIPTION
 - Relocate Netty
 - Correctly include and relocate Ion

I also changed the naming conventions a little to just prepend `software.amazon.awssdk.thirdparty` to the original package name. This results in slightly longer package names but is more predictable.