### PR TITLE
Signal exceptions through CompletableFuture

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.client.specs.ProtocolSpec;
 import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.util.CompletableFutures;
 
 public final class AsyncClientClass extends AsyncClientInterface {
     private final IntermediateModel model;
@@ -104,11 +105,15 @@ public final class AsyncClientClass extends AsyncClientInterface {
 
         return builder.addModifiers(Modifier.PUBLIC)
                       .addAnnotation(Override.class)
-                      .addCode(getCustomResponseHandler(opModel, returnType)
-                                   .orElseGet(() -> protocolSpec.responseHandler(opModel)))
-                      .addCode(protocolSpec.errorResponseHandler(opModel))
-                      .addCode(protocolSpec.asyncExecutionHandler(opModel));
-
+                      .beginControlFlow("try")
+                          .addCode(getCustomResponseHandler(opModel, returnType)
+                                       .orElseGet(() -> protocolSpec.responseHandler(opModel)))
+                          .addCode(protocolSpec.errorResponseHandler(opModel))
+                          .addCode(protocolSpec.asyncExecutionHandler(opModel))
+                      .endControlFlow()
+                      .beginControlFlow("catch ($T t)", Throwable.class)
+                          .addStatement("return $T.failedFuture(t)", CompletableFutures.class)
+                      .endControlFlow();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.core.protocol.json.JsonClientMetadata;
 import software.amazon.awssdk.core.protocol.json.JsonErrorResponseMetadata;
 import software.amazon.awssdk.core.protocol.json.JsonErrorShapeMetadata;
 import software.amazon.awssdk.core.protocol.json.JsonOperationMetadata;
+import software.amazon.awssdk.core.util.CompletableFutures;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest;
@@ -97,16 +98,20 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<APostOperationResponse> aPostOperation(APostOperationRequest aPostOperationRequest) {
+        try {
 
-        HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new APostOperationResponseUnmarshaller());
+            HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+                    new APostOperationResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
-                                             .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
-                                             .withErrorResponseHandler(errorResponseHandler).withInput(aPostOperationRequest));
+            return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                    .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
+                    .withErrorResponseHandler(errorResponseHandler).withInput(aPostOperationRequest));
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     /**
@@ -135,18 +140,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<APostOperationWithOutputResponse> aPostOperationWithOutput(
             APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
+        try {
 
-        HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new APostOperationWithOutputResponseUnmarshaller());
+            HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
+                    new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+                    new APostOperationWithOutputResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler
-                .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
-                                 .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(aPostOperationWithOutputRequest));
+            return clientHandler
+                    .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                            .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(aPostOperationWithOutputRequest));
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     /**
@@ -175,18 +184,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<GetWithoutRequiredMembersResponse> getWithoutRequiredMembers(
             GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
+        try {
 
-        HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new GetWithoutRequiredMembersResponseUnmarshaller());
+            HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
+                    new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+                    new GetWithoutRequiredMembersResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler
-                .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
-                                 .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(getWithoutRequiredMembersRequest));
+            return clientHandler
+                    .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                            .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(getWithoutRequiredMembersRequest));
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     /**
@@ -212,18 +225,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
             PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+        try {
 
-        HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new PaginatedOperationWithResultKeyResponseUnmarshaller());
+            HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
+                    new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+                    new PaginatedOperationWithResultKeyResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler
-                .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
-                                 .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(paginatedOperationWithResultKeyRequest));
+            return clientHandler
+                    .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                            .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(paginatedOperationWithResultKeyRequest));
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     /**
@@ -322,18 +339,23 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
             PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+        try {
 
-        HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new PaginatedOperationWithoutResultKeyResponseUnmarshaller());
+            HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory
+                    .createResponseHandler(
+                            new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+                            new PaginatedOperationWithoutResultKeyResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler
-                .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
-                                 .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
-                                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                 .withInput(paginatedOperationWithoutResultKeyRequest));
+            return clientHandler
+                    .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                            .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(paginatedOperationWithoutResultKeyRequest));
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     /**
@@ -436,17 +458,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     @Override
     public CompletableFuture<StreamingInputOperationResponse> streamingInputOperation(
             StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestBody requestBody) {
+        try {
 
-        HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new StreamingInputOperationResponseUnmarshaller());
+            HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
+                    new StreamingInputOperationResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
-                                             .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
-                                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                             .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
+            return clientHandler
+                    .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                            .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     /**
@@ -477,18 +504,22 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     public <ReturnT> CompletableFuture<ReturnT> streamingOutputOperation(
             StreamingOutputOperationRequest streamingOutputOperationRequest,
             AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
+        try {
 
-        HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
-                new StreamingOutputOperationResponseUnmarshaller());
+            HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),
+                    new StreamingOutputOperationResponseUnmarshaller());
 
-        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler();
 
-        return clientHandler.execute(
-                new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
-                        .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
-                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                        .withInput(streamingOutputOperationRequest), asyncResponseTransformer);
+            return clientHandler.execute(
+                    new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                            .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(streamingOutputOperationRequest), asyncResponseTransformer);
+        } catch (Throwable t) {
+            return CompletableFutures.failedFuture(t);
+        }
     }
 
     @Override
@@ -506,7 +537,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                         .addErrorMetadata(
                                 new JsonErrorShapeMetadata().withErrorCode("InvalidInput").withModeledClass(
                                         InvalidInputException.class)), AwsJsonProtocolMetadata.builder().protocolVersion("1.1")
-                                                                                              .protocol(AwsJsonProtocol.REST_JSON).build());
+                        .protocol(AwsJsonProtocol.REST_JSON).build());
     }
 
     private HttpResponseHandler<AwsServiceException> createErrorResponseHandler() {

--- a/core/src/main/java/software/amazon/awssdk/core/client/handler/SdkAsyncClientHandler.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/handler/SdkAsyncClientHandler.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration
 @SdkProtectedApi
 public class SdkAsyncClientHandler extends BaseAsyncClientHandler implements AsyncClientHandler {
 
-    protected SdkAsyncClientHandler(SdkClientConfiguration clientConfiguration) {
+    public SdkAsyncClientHandler(SdkClientConfiguration clientConfiguration) {
         super(clientConfiguration, new AmazonAsyncHttpClient(clientConfiguration));
         SdkClientOptionValidation.validateAsyncClientOptions(clientConfiguration);
     }

--- a/core/src/main/java/software/amazon/awssdk/core/util/CompletableFutures.java
+++ b/core/src/main/java/software/amazon/awssdk/core/util/CompletableFutures.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.util;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Utility class for working with {@link CompletableFuture}.
+ */
+public final class CompletableFutures {
+    private CompletableFutures() {
+    }
+
+    /**
+     * Convenience method for creating a future that is immediately completed
+     * exceptionally with the given {@code Throwable}.
+     * <p />
+     * Similar to {@code CompletableFuture#failedFuture} which was added in
+     * Java 9.
+     *
+     * @param t The failure.
+     * @param <U> The type of the element.
+     * @return The failed future.
+     */
+    public static <U> CompletableFuture<U> failedFuture(Throwable t) {
+        CompletableFuture<U> cf = new CompletableFuture<>();
+        cf.completeExceptionally(t);
+        return cf;
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.core.DefaultRequest;
+import software.amazon.awssdk.core.Request;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.client.handler.SdkAsyncClientHandler;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.http.EmptySdkResponse;
+import software.amazon.awssdk.core.http.HttpResponse;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkRequestContext;
+import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
+import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import utils.HttpTestUtils;
+
+/**
+ * Tests to verify that when exceptions are thrown during various stages of
+ * execution within the handler, they are reported through the returned {@link
+ * java.util.concurrent.CompletableFuture}.
+ *
+ * @see AsyncClientHandlerInterceptorExceptionTest
+ */
+public class AsyncClientHandlerExceptionTest {
+    private final SdkRequest request = mock(SdkRequest.class);
+
+    private final SdkAsyncHttpClient asyncHttpClient = mock(SdkAsyncHttpClient.class);
+
+    private final Marshaller<Request<SdkRequest>, SdkRequest> marshaller = mock(Marshaller.class);
+
+    private final HttpResponseHandler<SdkResponse> responseHandler = mock(HttpResponseHandler.class);
+
+    private final HttpResponseHandler<SdkServiceException> errorResponseHandler = mock(HttpResponseHandler.class);
+
+    private SdkAsyncClientHandler clientHandler;
+
+    private ClientExecutionParams<SdkRequest, SdkResponse> executionParams;
+
+    @Before
+    public void methodSetup() throws Exception {
+        executionParams = new ClientExecutionParams<SdkRequest, SdkResponse>()
+                .withInput(request)
+                .withMarshaller(marshaller)
+                .withResponseHandler(responseHandler)
+                .withErrorResponseHandler(errorResponseHandler);
+
+        SdkClientConfiguration config = HttpTestUtils.testClientConfiguration().toBuilder()
+                .option(SdkClientOption.ASYNC_HTTP_CLIENT, asyncHttpClient)
+                .option(SdkClientOption.RETRY_POLICY, RetryPolicy.NONE)
+                .option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run)
+                .build();
+
+        clientHandler = new SdkAsyncClientHandler(config);
+
+        when(request.overrideConfiguration()).thenReturn(Optional.empty());
+
+        when(marshaller.marshall(eq(request))).thenReturn(new DefaultRequest<>(null));
+
+        when(responseHandler.handle(any(HttpResponse.class), any(ExecutionAttributes.class)))
+                .thenReturn(EmptySdkResponse.builder().build());
+
+        when(asyncHttpClient.prepareRequest(any(SdkHttpRequest.class),
+                                            any(SdkRequestContext.class),
+                                            any(SdkHttpRequestProvider.class),
+                                            any(SdkHttpResponseHandler.class)))
+                                           .thenAnswer((Answer<AbortableRunnable>) invocationOnMock -> {
+                    SdkHttpResponseHandler handler = invocationOnMock.getArgumentAt(3, SdkHttpResponseHandler.class);
+                    return new AbortableRunnable() {
+                        @Override
+                        public void run() {
+                            handler.headersReceived(SdkHttpFullResponse.builder()
+                                    .statusCode(200)
+                                    .build());
+                            handler.complete();
+                        }
+
+                        @Override
+                        public void abort() {
+                        }
+                    };
+                });
+    }
+
+    @Test
+    public void marshallerThrowsReportedThroughFuture() throws ExecutionException, InterruptedException {
+        final RuntimeException e = new RuntimeException("Could not marshall");
+        when(marshaller.marshall(any(SdkRequest.class))).thenThrow(e);
+        doVerify(() -> clientHandler.execute(executionParams), e);
+    }
+
+    @Test
+    public void responseHandlerThrowsReportedThroughFuture() throws Exception {
+        final RuntimeException e = new RuntimeException("Could not handle response");
+        when(responseHandler.handle(any(HttpResponse.class), any(ExecutionAttributes.class))).thenThrow(e);
+        doVerify(() -> clientHandler.execute(executionParams), e);
+    }
+
+    private void doVerify(Supplier<CompletableFuture<?>> s, final Throwable expectedException) {
+        doVerify(s, (thrown) -> thrown.getCause() == expectedException);
+    }
+
+    private void doVerify(Supplier<CompletableFuture<?>> s, Predicate<Throwable> assertFn) {
+        CompletableFuture<?> cf = s.get();
+        try {
+            cf.get();
+            fail("get() method did not fail as expected.");
+        } catch (Throwable t) {
+            assertTrue(assertFn.test(t));
+        }
+    }
+}

--- a/core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
+++ b/core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
@@ -1,0 +1,298 @@
+
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import software.amazon.awssdk.core.DefaultRequest;
+import software.amazon.awssdk.core.Request;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.client.handler.SdkAsyncClientHandler;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.http.EmptySdkResponse;
+import software.amazon.awssdk.core.http.HttpResponse;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkRequestContext;
+import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
+import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import utils.HttpTestUtils;
+
+/**
+ * Tests to ensure that any failures thrown from calling into the {@link
+ * software.amazon.awssdk.core.interceptor.ExecutionInterceptor}s is reported
+ * through the returned {@link java.util.concurrent.CompletableFuture}.
+ */
+@RunWith(Parameterized.class)
+public class AsyncClientHandlerInterceptorExceptionTest {
+    private final SdkRequest request = mock(SdkRequest.class);
+
+    private final SdkAsyncHttpClient asyncHttpClient = mock(SdkAsyncHttpClient.class);
+
+    private final Marshaller<Request<SdkRequest>, SdkRequest> marshaller = mock(Marshaller.class);
+
+    private final HttpResponseHandler<SdkResponse> responseHandler = mock(HttpResponseHandler.class);
+
+    private final HttpResponseHandler<SdkServiceException> errorResponseHandler = mock(HttpResponseHandler.class);
+
+    private final Hook hook;
+
+    private SdkAsyncClientHandler clientHandler;
+
+    private ClientExecutionParams<SdkRequest, SdkResponse> executionParams;
+
+    @Parameterized.Parameters(name = "Interceptor Hook: {0}")
+    public static Collection<Object> data() {
+        return Arrays.asList(Hook.values());
+    }
+
+    public AsyncClientHandlerInterceptorExceptionTest(Hook hook) {
+        this.hook = hook;
+    }
+
+    @Before
+    public void testSetup() throws Exception {
+        executionParams = new ClientExecutionParams<SdkRequest, SdkResponse>()
+                .withInput(request)
+                .withMarshaller(marshaller)
+                .withResponseHandler(responseHandler)
+                .withErrorResponseHandler(errorResponseHandler);
+
+        SdkClientConfiguration config = HttpTestUtils.testClientConfiguration().toBuilder()
+                .option(SdkClientOption.EXECUTION_INTERCEPTORS, Collections.singletonList(hook.interceptor()))
+                .option(SdkClientOption.ASYNC_HTTP_CLIENT, asyncHttpClient)
+                .option(SdkClientOption.RETRY_POLICY, RetryPolicy.NONE)
+                .option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run)
+                .build();
+
+        clientHandler = new SdkAsyncClientHandler(config);
+
+        when(request.overrideConfiguration()).thenReturn(Optional.empty());
+
+        when(marshaller.marshall(eq(request))).thenReturn(new DefaultRequest<>(null));
+
+        when(responseHandler.handle(any(HttpResponse.class), any(ExecutionAttributes.class)))
+                .thenReturn(EmptySdkResponse.builder().build());
+
+        Answer<AbortableRunnable> prepareRequestAnswer;
+        if (hook != Hook.ON_EXECUTION_FAILURE) {
+            prepareRequestAnswer = invocationOnMock -> {
+                SdkHttpResponseHandler handler = invocationOnMock.getArgumentAt(3, SdkHttpResponseHandler.class);
+                return new AbortableRunnable() {
+                    @Override
+                    public void run() {
+                        handler.headersReceived(SdkHttpFullResponse.builder()
+                                .statusCode(200)
+                                .build());
+                        handler.complete();
+                    }
+
+                    @Override
+                    public void abort() {
+                    }
+                };
+            };
+        } else {
+            prepareRequestAnswer = invocationOnMock -> {
+                SdkHttpResponseHandler handler = invocationOnMock.getArgumentAt(3, SdkHttpResponseHandler.class);
+                return new AbortableRunnable() {
+                    @Override
+                    public void run() {
+                        handler.exceptionOccurred(new RuntimeException("Something went horribly wrong!"));
+                    }
+
+                    @Override
+                    public void abort() {
+                    }
+                };
+            };
+        }
+
+        when(asyncHttpClient.prepareRequest(any(SdkHttpRequest.class),
+                                            any(SdkRequestContext.class),
+                                            any(SdkHttpRequestProvider.class),
+                                            any(SdkHttpResponseHandler.class)))
+                                           .thenAnswer(prepareRequestAnswer);
+    }
+
+    @Test
+    public void test() {
+        if (hook != Hook.ON_EXECUTION_FAILURE) {
+            doVerify(() -> clientHandler.execute(executionParams), (t) -> t.getCause().getMessage().equals(hook.name()));
+        } else {
+            // ON_EXECUTION_FAILURE is handled differently because we don't
+            // want an exception thrown from the interceptor to replace the
+            // original exception.
+            doVerify(() -> clientHandler.execute(executionParams),
+                     (t) -> {
+                        for (; t != null; t = t.getCause()) {
+                            if (t.getMessage().equals(Hook.ON_EXECUTION_FAILURE.name())) {
+                                return false;
+                            }
+                        }
+                        return true;
+                     });
+        }
+    }
+
+    private void doVerify(Supplier<CompletableFuture<?>> s, Predicate<Throwable> assertFn) {
+        CompletableFuture<?> cf = s.get();
+        try {
+            cf.get();
+            Assert.fail("get() method did not fail as expected.");
+        } catch (Throwable t) {
+            assertTrue(assertFn.test(t));
+        }
+    }
+
+    public enum Hook {
+        BEFORE_EXECUTION(new ExecutionInterceptor() {
+            @Override
+            public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(BEFORE_EXECUTION.name());
+            }
+        }),
+
+        MODIFY_REQUEST(new ExecutionInterceptor() {
+            @Override
+            public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(MODIFY_REQUEST.name());
+            }
+        }),
+
+        BEFORE_MARSHALLING(new ExecutionInterceptor() {
+            @Override
+            public void beforeMarshalling(Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(BEFORE_MARSHALLING.name());
+            }
+        }),
+
+        AFTER_MARSHALLING(new ExecutionInterceptor() {
+            @Override
+            public void afterMarshalling(Context.AfterMarshalling context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(AFTER_MARSHALLING.name());
+            }
+        }),
+
+        MODIFY_HTTP_REQUEST(new ExecutionInterceptor() {
+            @Override
+            public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(MODIFY_HTTP_REQUEST.name());
+            }
+        }),
+
+        BEFORE_TRANSMISSION(new ExecutionInterceptor() {
+            @Override
+            public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(BEFORE_TRANSMISSION.name());
+            }
+        }),
+
+        AFTER_TRANSMISSION(new ExecutionInterceptor() {
+            @Override
+            public void afterTransmission(Context.AfterTransmission context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(AFTER_TRANSMISSION.name());
+            }
+        }),
+
+        MODIFY_HTTP_RESPONSE(new ExecutionInterceptor() {
+            @Override
+            public SdkHttpFullResponse modifyHttpResponse(Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(MODIFY_HTTP_RESPONSE.name());
+            }
+        }),
+
+        BEFORE_UNMARSHALLING(new ExecutionInterceptor() {
+            @Override
+            public void beforeUnmarshalling(Context.BeforeUnmarshalling context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(BEFORE_UNMARSHALLING.name());
+            }
+        }),
+
+        AFTER_UNMARSHALLING(new ExecutionInterceptor() {
+            @Override
+            public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(AFTER_UNMARSHALLING.name());
+            }
+        }),
+
+        MODIFY_RESPONSE(new ExecutionInterceptor() {
+            @Override
+            public SdkResponse modifyResponse(Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(MODIFY_RESPONSE.name());
+            }
+        }),
+
+        AFTER_EXECUTION(new ExecutionInterceptor() {
+            @Override
+            public void afterExecution(Context.AfterExecution context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(AFTER_EXECUTION.name());
+            }
+        }),
+
+        ON_EXECUTION_FAILURE(new ExecutionInterceptor() {
+            @Override
+            public void onExecutionFailure(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+                throw new RuntimeException(ON_EXECUTION_FAILURE.name());
+            }
+        })
+        ;
+
+        private ExecutionInterceptor interceptor;
+
+        Hook(ExecutionInterceptor interceptor) {
+            this.interceptor = interceptor;
+        }
+
+        public ExecutionInterceptor interceptor() {
+            return interceptor;
+        }
+    }
+}
+


### PR DESCRIPTION
Upon calling BaseAsyncClientHandler#execute, any exceptions that get
thrown over the lifetime of the request are signaled through to
CompletableFuture returned to the caller.

Fixes #436

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
So that users only need to worry about one mechanism for dealing with exceptions on async requests instead of 2.

## Testing
`mvn clean install` with new unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
