### PR TITLE
Remove gzipEnabled and other small fixes

### DIFF
--- a/.changes/next-release/deprecation-AWSSDKforJavav2-991380e.json
+++ b/.changes/next-release/deprecation-AWSSDKforJavav2-991380e.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "deprecation", 
+    "description": "Deprecating `QueryStringSigner` in favor of `Aws4Signer`."
+}

--- a/.changes/next-release/removal-AWSSDKforJavav2-56e58aa.json
+++ b/.changes/next-release/removal-AWSSDKforJavav2-56e58aa.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "removal", 
+    "description": "Removing gzipEnabled client configuration."
+}

--- a/auth/src/main/java/software/amazon/awssdk/auth/signer/Aws4Signer.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/signer/Aws4Signer.java
@@ -29,15 +29,11 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 @SdkPublicApi
 public final class Aws4Signer extends AbstractAws4Signer<Aws4SignerParams, Aws4PresignerParams> {
 
-    private Aws4Signer(Builder builder) {
-    }
-
-    public static Builder builder() {
-        return new Builder();
+    private Aws4Signer() {
     }
 
     public static Aws4Signer create() {
-        return builder().build();
+        return new Aws4Signer();
     }
 
     @Override
@@ -104,11 +100,5 @@ public final class Aws4Signer extends AbstractAws4Signer<Aws4SignerParams, Aws4P
     protected String calculateContentHashPresign(SdkHttpFullRequest.Builder mutableRequest,
                                                  Aws4PresignerParams signerParams) {
         return calculateContentHash(mutableRequest, signerParams);
-    }
-
-    public static final class Builder  {
-        public Aws4Signer build() {
-            return new Aws4Signer(this);
-        }
     }
 }

--- a/auth/src/main/java/software/amazon/awssdk/auth/signer/QueryStringSigner.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/signer/QueryStringSigner.java
@@ -19,7 +19,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.TimeZone;
-import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.AwsExecutionAttribute;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -33,8 +33,11 @@ import software.amazon.awssdk.utils.StringUtils;
 /**
  * Signer implementation responsible for signing an AWS query string request
  * according to the various signature versions and hashing algorithms.
+ *
+ * @deprecated in favor of {@link Aws4Signer}
  */
-@SdkPublicApi
+@SdkProtectedApi
+@Deprecated
 public final class QueryStringSigner extends AbstractAwsSigner {
     /**
      * Date override for testing only.

--- a/aws-core/src/test/java/software/amazon/awssdk/awscore/client/utils/HttpTestUtils.java
+++ b/aws-core/src/test/java/software/amazon/awssdk/awscore/client/utils/HttpTestUtils.java
@@ -50,7 +50,6 @@ public class HttpTestUtils {
                                      .option(SdkClientOption.EXECUTION_INTERCEPTORS, new ArrayList<>())
                                      .option(SdkClientOption.ENDPOINT, URI.create("http://localhost:8080"))
                                      .option(SdkClientOption.RETRY_POLICY, RetryPolicy.DEFAULT)
-                                     .option(SdkClientOption.GZIP_ENABLED, false)
                                      .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, new HashMap<>())
                                      .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
                                      .option(SdkAdvancedClientOption.SIGNER, new NoOpSigner())

--- a/core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -24,7 +24,6 @@ import static software.amazon.awssdk.core.client.config.SdkClientOption.ASYNC_HT
 import static software.amazon.awssdk.core.client.config.SdkClientOption.ASYNC_RETRY_EXECUTOR_SERVICE;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.EXECUTION_INTERCEPTORS;
-import static software.amazon.awssdk.core.client.config.SdkClientOption.GZIP_ENABLED;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_POLICY;
 import static software.amazon.awssdk.utils.CollectionUtils.mergeLists;
 import static software.amazon.awssdk.utils.Validate.paramNotNull;
@@ -186,8 +185,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
      * Apply global default configuration
      */
     private SdkClientConfiguration mergeGlobalDefaults(SdkClientConfiguration configuration) {
-        return configuration.merge(c -> c.option(GZIP_ENABLED, false)
-                                         .option(EXECUTION_INTERCEPTORS, new ArrayList<>())
+        return configuration.merge(c -> c.option(EXECUTION_INTERCEPTORS, new ArrayList<>())
                                          .option(ADDITIONAL_HTTP_HEADERS, new LinkedHashMap<>())
                                          .option(RETRY_POLICY, RetryPolicy.DEFAULT)
                                          .option(USER_AGENT_PREFIX, UserAgentUtils.getUserAgent())
@@ -315,7 +313,6 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         clientConfiguration.option(EXECUTION_INTERCEPTORS, overrideConfig.executionInterceptors());
         clientConfiguration.option(RETRY_POLICY, overrideConfig.retryPolicy().orElse(null));
         clientConfiguration.option(ADDITIONAL_HTTP_HEADERS, overrideConfig.additionalHttpHeaders());
-        clientConfiguration.option(GZIP_ENABLED, overrideConfig.gzipEnabled().orElse(null));
         clientConfiguration.option(SIGNER, overrideConfig.advancedOption(SIGNER).orElse(null));
         clientConfiguration.option(USER_AGENT_SUFFIX, overrideConfig.advancedOption(USER_AGENT_SUFFIX).orElse(null));
         clientConfiguration.option(USER_AGENT_PREFIX, overrideConfig.advancedOption(USER_AGENT_PREFIX).orElse(null));

--- a/core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -42,7 +42,6 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 public final class ClientOverrideConfiguration
     implements ToCopyableBuilder<ClientOverrideConfiguration.Builder, ClientOverrideConfiguration> {
     private final Map<String, List<String>> additionalHttpHeaders;
-    private final Boolean gzipEnabled;
     private final RetryPolicy retryPolicy;
     private final List<ExecutionInterceptor> executionInterceptors;
     private final AttributeMap advancedOptions;
@@ -52,7 +51,6 @@ public final class ClientOverrideConfiguration
      */
     private ClientOverrideConfiguration(DefaultClientOverrideConfigurationBuilder builder) {
         this.additionalHttpHeaders = CollectionUtils.deepUnmodifiableMap(builder.additionalHttpHeaders);
-        this.gzipEnabled = builder.gzipEnabled;
         this.retryPolicy = builder.retryPolicy;
         this.executionInterceptors = Collections.unmodifiableList(new ArrayList<>(builder.executionInterceptors));
         this.advancedOptions = builder.advancedOptions.build();
@@ -62,7 +60,6 @@ public final class ClientOverrideConfiguration
     public Builder toBuilder() {
         return new DefaultClientOverrideConfigurationBuilder().advancedOptions(advancedOptions.toBuilder())
                                                               .additionalHttpHeaders(additionalHttpHeaders)
-                                                              .gzipEnabled(gzipEnabled)
                                                               .retryPolicy(retryPolicy)
                                                               .executionInterceptors(executionInterceptors);
     }
@@ -82,15 +79,6 @@ public final class ClientOverrideConfiguration
      */
     public Map<String, List<String>> additionalHttpHeaders() {
         return additionalHttpHeaders;
-    }
-
-    /**
-     * Whether GZIP should be used when communication with AWS.
-     *
-     * @see Builder#gzipEnabled(Boolean)
-     */
-    public Optional<Boolean> gzipEnabled() {
-        return Optional.ofNullable(gzipEnabled);
     }
 
     /**
@@ -125,7 +113,6 @@ public final class ClientOverrideConfiguration
     public String toString() {
         return ToString.builder("ClientOverrideConfiguration")
                        .add("additionalHttpHeaders", additionalHttpHeaders)
-                       .add("gzipEnabled", gzipEnabled)
                        .add("retryPolicy", retryPolicy)
                        .add("executionInterceptors", executionInterceptors)
                        .add("advancedOptions", advancedOptions)
@@ -160,14 +147,6 @@ public final class ClientOverrideConfiguration
          * @see ClientOverrideConfiguration#additionalHttpHeaders()
          */
         Builder addAdditionalHttpHeader(String header, String... values);
-
-        /**
-         * Configure whether GZIP should be used when communicating with AWS. Enabling GZIP increases CPU utilization and memory
-         * usage, while decreasing the amount of data sent over the network.
-         *
-         * @see ClientOverrideConfiguration#gzipEnabled()
-         */
-        Builder gzipEnabled(Boolean gzipEnabled);
 
         /**
          * Configure the retry policy that should be used when handling failure cases.
@@ -235,7 +214,6 @@ public final class ClientOverrideConfiguration
      */
     private static final class DefaultClientOverrideConfigurationBuilder implements Builder {
         private Map<String, List<String>> additionalHttpHeaders = new HashMap<>();
-        private Boolean gzipEnabled;
         private RetryPolicy retryPolicy;
         private List<ExecutionInterceptor> executionInterceptors = new ArrayList<>();
         private AttributeMap.Builder advancedOptions = AttributeMap.builder();
@@ -255,16 +233,6 @@ public final class ClientOverrideConfiguration
 
         public void setAdditionalHttpHeaders(Map<String, List<String>> additionalHttpHeaders) {
             additionalHttpHeaders(additionalHttpHeaders);
-        }
-
-        @Override
-        public Builder gzipEnabled(Boolean gzipEnabled) {
-            this.gzipEnabled = gzipEnabled;
-            return this;
-        }
-
-        public void setGzipEnabled(Boolean gzipEnabled) {
-            gzipEnabled(gzipEnabled);
         }
 
         @Override

--- a/core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -41,11 +41,6 @@ public class SdkClientOption<T> extends ClientOption<T> {
             new SdkClientOption<>(new UnsafeValueType(Map.class));
 
     /**
-     * @see ClientOverrideConfiguration#gzipEnabled()
-     */
-    public static final SdkClientOption<Boolean> GZIP_ENABLED = new SdkClientOption<>(Boolean.class);
-
-    /**
      * @see ClientOverrideConfiguration#retryPolicy()
      */
     public static final SdkClientOption<RetryPolicy> RETRY_POLICY = new SdkClientOption<>(RetryPolicy.class);

--- a/core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOptionValidation.java
+++ b/core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOptionValidation.java
@@ -46,7 +46,6 @@ public class SdkClientOptionValidation {
 
         require("overrideConfiguration.additionalHttpHeaders", c.option(SdkClientOption.ADDITIONAL_HTTP_HEADERS));
         require("overrideConfiguration.executionInterceptors", c.option(SdkClientOption.EXECUTION_INTERCEPTORS));
-        require("overrideConfiguration.gzipEnabled", c.option(SdkClientOption.GZIP_ENABLED));
         require("overrideConfiguration.retryPolicy", c.option(SdkClientOption.RETRY_POLICY));
 
         require("overrideConfiguration.advancedOption[SIGNER]", c.option(SdkAdvancedClientOption.SIGNER));

--- a/core/src/test/java/utils/HttpTestUtils.java
+++ b/core/src/test/java/utils/HttpTestUtils.java
@@ -54,7 +54,6 @@ public class HttpTestUtils {
                                      .option(SdkClientOption.EXECUTION_INTERCEPTORS, new ArrayList<>())
                                      .option(SdkClientOption.ENDPOINT, URI.create("http://localhost:8080"))
                                      .option(SdkClientOption.RETRY_POLICY, RetryPolicy.DEFAULT)
-                                     .option(SdkClientOption.GZIP_ENABLED, false)
                                      .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, new HashMap<>())
                                      .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
                                      .option(SdkAdvancedClientOption.SIGNER, new NoOpSigner())

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/AwsS3V4Signer.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/AwsS3V4Signer.java
@@ -50,11 +50,7 @@ public final class AwsS3V4Signer extends AbstractAws4Signer<AwsS3V4SignerParams,
     }
 
     public static AwsS3V4Signer create() {
-        return builder().build();
-    }
-
-    public static Builder builder() {
-        return new Builder();
+        return new AwsS3V4Signer();
     }
 
     @Override
@@ -253,11 +249,5 @@ public final class AwsS3V4Signer extends AbstractAws4Signer<AwsS3V4SignerParams,
             throw new ResetException("Failed to reset the input stream", ex);
         }
         return contentLength;
-    }
-
-    public static final class Builder {
-        public AwsS3V4Signer build() {
-            return new AwsS3V4Signer();
-        }
     }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/AwsJsonCrc32ChecksumTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/AwsJsonCrc32ChecksumTests.java
@@ -29,7 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcClient;
@@ -68,7 +67,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         SimpleResponse result = jsonRpc.simple(SimpleRequest.builder().build());
@@ -93,7 +91,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         SimpleResponse result = jsonRpc.simple(SimpleRequest.builder().build());
@@ -112,7 +109,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         jsonRpc.simple(SimpleRequest.builder().build());
@@ -130,7 +126,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         AllTypesResponse result =
@@ -150,7 +145,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         jsonRpc.allTypes(AllTypesRequest.builder().build());
@@ -167,7 +161,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         AllTypesResponse result =
@@ -186,7 +179,6 @@ public class AwsJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         jsonRpc.allTypes(AllTypesRequest.builder().build());

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/RestJsonCrc32ChecksumTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/RestJsonCrc32ChecksumTests.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
@@ -66,7 +65,6 @@ public class RestJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         SimpleResponse result = client.simple(SimpleRequest.builder().build());
@@ -84,7 +82,6 @@ public class RestJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         client.simple(SimpleRequest.builder().build());
@@ -101,7 +98,6 @@ public class RestJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         AllTypesResponse result =
@@ -120,7 +116,6 @@ public class RestJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         client.allTypes(AllTypesRequest.builder().build());
@@ -136,7 +131,6 @@ public class RestJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         AllTypesResponse result =
@@ -155,7 +149,6 @@ public class RestJsonCrc32ChecksumTests {
                 .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
                 .region(Region.US_EAST_1)
                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
-                .overrideConfiguration(ClientOverrideConfiguration.builder().gzipEnabled(true).build())
                 .build();
 
         client.allTypes(AllTypesRequest.builder().build());


### PR DESCRIPTION
A bunch of small fixes:

- Remove gzipEnabled configuration since it's not being used
- deprecated QueryStringSigner
- remove unnecessary builders in some Signer classes

