### PR TITLE
Move ImmutableObjectUtils to mapper module

### DIFF
--- a/core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/JsonErrorUnmarshaller.java
+++ b/core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/JsonErrorUnmarshaller.java
@@ -39,10 +39,10 @@ public abstract class JsonErrorUnmarshaller<T extends SdkServiceException> exten
 
     @Override
     @ReviewBeforeRelease("Figure out a better way to go from exception class to it's builder class in order to perform the " +
-                         "deserialization")
+                         "deserialization.")
     @SuppressWarnings("unchecked")
     public T unmarshall(JsonNode jsonContent) throws Exception {
-        // FIXME: dirty hack below
+        // FIXME: Generate Unmarshallers for each type instead of using reflection
         try {
             Method builderClassGetter = exceptionClass.getDeclaredMethod("serializableBuilderClass");
             makeAccessible(builderClassGetter);

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/CopyDbSnapshotPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/CopyDbSnapshotPresignInterceptor.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.services.rds;
 import java.time.Clock;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.Request;
-import software.amazon.awssdk.core.util.ImmutableObjectUtils;
 import software.amazon.awssdk.services.rds.model.CopyDBSnapshotRequest;
 import software.amazon.awssdk.services.rds.transform.CopyDBSnapshotRequestMarshaller;
 
@@ -39,11 +38,6 @@ public class CopyDbSnapshotPresignInterceptor extends RdsPresignInterceptor<Copy
     @Override
     protected PresignableRequest adaptRequest(final CopyDBSnapshotRequest originalRequest) {
         return new PresignableRequest() {
-            @Override
-            public void setPreSignedUrl(String preSignedUrl) {
-                ImmutableObjectUtils.setObjectMember(originalRequest, "preSignedUrl", preSignedUrl);
-            }
-
             @Override
             public String getSourceRegion() {
                 return originalRequest.sourceRegion();

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/CreateDbInstanceReadReplicaPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/CreateDbInstanceReadReplicaPresignInterceptor.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.services.rds;
 
 import software.amazon.awssdk.core.Request;
-import software.amazon.awssdk.core.util.ImmutableObjectUtils;
 import software.amazon.awssdk.services.rds.model.CreateDBInstanceReadReplicaRequest;
 import software.amazon.awssdk.services.rds.transform.CreateDBInstanceReadReplicaRequestMarshaller;
 
@@ -31,11 +30,6 @@ public class CreateDbInstanceReadReplicaPresignInterceptor extends RdsPresignInt
     @Override
     protected PresignableRequest adaptRequest(final CreateDBInstanceReadReplicaRequest originalRequest) {
         return new PresignableRequest() {
-            @Override
-            public void setPreSignedUrl(String preSignedUrl) {
-                ImmutableObjectUtils.setObjectMember(originalRequest, "preSignedUrl", preSignedUrl);
-            }
-
             @Override
             public String getSourceRegion() {
                 return originalRequest.sourceRegion();

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/RdsPresignInterceptor.java
@@ -50,8 +50,6 @@ abstract class RdsPresignInterceptor<T extends RdsRequest> implements ExecutionI
     private static final String PARAM_PRESIGNED_URL = "PreSignedUrl";
 
     protected interface PresignableRequest {
-        void setPreSignedUrl(String preSignedUrl);
-
         String getSourceRegion();
 
         Request<?> marshall();
@@ -105,8 +103,6 @@ abstract class RdsPresignInterceptor<T extends RdsRequest> implements ExecutionI
         requestToPresign = presignRequest(requestToPresign, executionAttributes, sourceRegion);
 
         final String presignedUrl = requestToPresign.getUri().toString();
-
-        presignableRequest.setPreSignedUrl(presignedUrl);
 
         return request.toBuilder()
                       .rawQueryParameter(PARAM_PRESIGNED_URL, presignedUrl)

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/mapper/GenerateCreateTableRequestIntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/mapper/GenerateCreateTableRequestIntegrationTest.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import software.amazon.awssdk.core.util.ImmutableObjectUtils;
+import software.amazon.awssdk.services.dynamodb.ImmutableObjectUtils;
 import software.amazon.awssdk.services.dynamodb.TableUtils;
 import software.amazon.awssdk.services.dynamodb.datamodeling.DynamoDbMapper;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/ImmutableObjectUtils.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/ImmutableObjectUtils.java
@@ -13,13 +13,11 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.util;
+package software.amazon.awssdk.services.dynamodb;
 
 import java.util.Arrays;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
-@ReviewBeforeRelease("Remove before GA")
 @SdkProtectedApi
 public final class ImmutableObjectUtils {
 
@@ -28,15 +26,15 @@ public final class ImmutableObjectUtils {
 
     public static <T> void setObjectMember(Object o, String memberName, T value) {
         Arrays.stream(o.getClass().getDeclaredFields())
-                .filter(f -> f.getName().equals(memberName))
-                .findFirst()
-                .ifPresent(f -> {
-                    f.setAccessible(true);
-                    try {
-                        f.set(o, value);
-                    } catch (IllegalAccessException e) {
-                        throw new RuntimeException("Unable to reflectively set member " + memberName);
-                    }
-                });
+              .filter(f -> f.getName().equals(memberName))
+              .findFirst()
+              .ifPresent(f -> {
+                  f.setAccessible(true);
+                  try {
+                      f.set(o, value);
+                  } catch (IllegalAccessException e) {
+                      throw new RuntimeException("Unable to reflectively set member " + memberName);
+                  }
+              });
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactories.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactories.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.util.ImmutableObjectUtils;
+import software.amazon.awssdk.services.dynamodb.ImmutableObjectUtils;
 import software.amazon.awssdk.services.dynamodb.datamodeling.DynamoDbMapperFieldModel.DynamoDbAttributeType;
 import software.amazon.awssdk.services.dynamodb.datamodeling.DynamoDbMapperFieldModel.Reflect;
 import software.amazon.awssdk.services.dynamodb.datamodeling.DynamoDbMapperModelFactory.TableFactory;


### PR DESCRIPTION
* Move ImmutableObjectUtils to test/dynamodbmapper module as it uses reflection to set object values. I don't think we want to expose it (yet)
* **Main change:** 
We don't modify the RDS original requests anymore to set the preSignedUrl parameter. Presigning still works as we send the value correctly to the service. I think this is acceptable change as it is not mentioned in the SEP that we need to modify the original request.