### PR TITLE
Don't use proxy password in toString method

### DIFF
--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -145,7 +145,6 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         return ToString.builder("ProxyConfiguration")
                        .add("endpoint", endpoint)
                        .add("username", username)
-                       .add("password", password)
                        .add("ntlmDomain", ntlmDomain)
                        .add("ntlmWorkstation", ntlmWorkstation)
                        .add("nonProxyHosts", nonProxyHosts)


### PR DESCRIPTION
Removing password from toString method. (Similar to what we do for Credentials classes where we don't use secret key in toString).