### PR TITLE
Make paginator resume method private

### DIFF
--- a/.changes/next-release/removal-AWSSDKforJavav2-3225a54.json
+++ b/.changes/next-release/removal-AWSSDKforJavav2-3225a54.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2",
+    "type": "removal", 
+    "description": "Make paginators resume method private.(We will re-add the feature in the future)"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/AsyncResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/AsyncResponseClassSpec.java
@@ -114,8 +114,8 @@ public class AsyncResponseClassSpec extends PaginatorsClassSpec {
     private MethodSpec publicConstructor() {
         return MethodSpec.constructorBuilder()
                          .addModifiers(Modifier.PUBLIC)
-                         .addParameter(getAsyncClientInterfaceName(), CLIENT_MEMBER, Modifier.FINAL)
-                         .addParameter(requestType(), REQUEST_MEMBER, Modifier.FINAL)
+                         .addParameter(getAsyncClientInterfaceName(), CLIENT_MEMBER)
+                         .addParameter(requestType(), REQUEST_MEMBER)
                          .addStatement("this($L, $L, false)", CLIENT_MEMBER, REQUEST_MEMBER)
                          .build();
     }
@@ -123,9 +123,9 @@ public class AsyncResponseClassSpec extends PaginatorsClassSpec {
     private MethodSpec privateConstructor() {
         return MethodSpec.constructorBuilder()
                          .addModifiers(Modifier.PRIVATE)
-                         .addParameter(getAsyncClientInterfaceName(), CLIENT_MEMBER, Modifier.FINAL)
-                         .addParameter(requestType(), REQUEST_MEMBER, Modifier.FINAL)
-                         .addParameter(boolean.class, LAST_PAGE_FIELD, Modifier.FINAL)
+                         .addParameter(getAsyncClientInterfaceName(), CLIENT_MEMBER)
+                         .addParameter(requestType(), REQUEST_MEMBER)
+                         .addParameter(boolean.class, LAST_PAGE_FIELD)
                          .addStatement("this.$L = $L", CLIENT_MEMBER, CLIENT_MEMBER)
                          .addStatement("this.$L = $L", REQUEST_MEMBER, REQUEST_MEMBER)
                          .addStatement("this.$L = $L", LAST_PAGE_FIELD, LAST_PAGE_FIELD)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpec.java
@@ -95,8 +95,8 @@ public abstract class PaginatorsClassSpec implements ClassSpec {
 
     protected MethodSpec.Builder resumeMethodBuilder() {
         return MethodSpec.methodBuilder(RESUME_METHOD)
-                         .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                         .addParameter(responseType(), LAST_SUCCESSFUL_PAGE_LITERAL, Modifier.FINAL)
+                         .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                         .addParameter(responseType(), LAST_SUCCESSFUL_PAGE_LITERAL)
                          .returns(className())
                          .addCode(CodeBlock.builder()
                                            .beginControlFlow("if ($L.$L($L))", NEXT_PAGE_FETCHER_MEMBER,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/SyncResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/SyncResponseClassSpec.java
@@ -100,8 +100,8 @@ public class SyncResponseClassSpec extends PaginatorsClassSpec {
     private MethodSpec constructor() {
         return MethodSpec.constructorBuilder()
                          .addModifiers(Modifier.PUBLIC)
-                         .addParameter(getClientInterfaceName(), CLIENT_MEMBER, Modifier.FINAL)
-                         .addParameter(requestType(), REQUEST_MEMBER, Modifier.FINAL)
+                         .addParameter(getClientInterfaceName(), CLIENT_MEMBER)
+                         .addParameter(requestType(), REQUEST_MEMBER)
                          .addStatement("this.$L = $L", CLIENT_MEMBER, CLIENT_MEMBER)
                          .addStatement("this.$L = $L", REQUEST_MEMBER, REQUEST_MEMBER)
                          .addStatement("this.$L = new $L()", NEXT_PAGE_FETCHER_MEMBER, nextPageFetcherClassName())

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyIterable.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyIterable.java
@@ -75,8 +75,8 @@ public class PaginatedOperationWithResultKeyIterable implements SdkIterable<Pagi
 
     private final SyncPageFetcher nextPageFetcher;
 
-    public PaginatedOperationWithResultKeyIterable(final JsonProtocolTestsClient client,
-                                                   final PaginatedOperationWithResultKeyRequest firstRequest) {
+    public PaginatedOperationWithResultKeyIterable(JsonProtocolTestsClient client,
+                                                   PaginatedOperationWithResultKeyRequest firstRequest) {
         this.client = client;
         this.firstRequest = firstRequest;
         this.nextPageFetcher = new PaginatedOperationWithResultKeyResponseFetcher();
@@ -113,7 +113,7 @@ public class PaginatedOperationWithResultKeyIterable implements SdkIterable<Pagi
      * retrieve the consecutive pages that follows the input page.
      * </p>
      */
-    public final PaginatedOperationWithResultKeyIterable resume(final PaginatedOperationWithResultKeyResponse lastSuccessfulPage) {
+    private final PaginatedOperationWithResultKeyIterable resume(PaginatedOperationWithResultKeyResponse lastSuccessfulPage) {
         if (nextPageFetcher.hasNextPage(lastSuccessfulPage)) {
             return new PaginatedOperationWithResultKeyIterable(client, firstRequest.toBuilder()
                                                                                    .nextToken(lastSuccessfulPage.nextToken()).build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPublisher.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPublisher.java
@@ -78,13 +78,13 @@ public class PaginatedOperationWithResultKeyPublisher implements SdkPublisher<Pa
 
     private boolean isLastPage;
 
-    public PaginatedOperationWithResultKeyPublisher(final JsonProtocolTestsAsyncClient client,
-                                                    final PaginatedOperationWithResultKeyRequest firstRequest) {
+    public PaginatedOperationWithResultKeyPublisher(JsonProtocolTestsAsyncClient client,
+                                                    PaginatedOperationWithResultKeyRequest firstRequest) {
         this(client, firstRequest, false);
     }
 
-    private PaginatedOperationWithResultKeyPublisher(final JsonProtocolTestsAsyncClient client,
-                                                     final PaginatedOperationWithResultKeyRequest firstRequest, final boolean isLastPage) {
+    private PaginatedOperationWithResultKeyPublisher(JsonProtocolTestsAsyncClient client,
+                                                     PaginatedOperationWithResultKeyRequest firstRequest, boolean isLastPage) {
         this.client = client;
         this.firstRequest = firstRequest;
         this.isLastPage = isLastPage;
@@ -118,7 +118,7 @@ public class PaginatedOperationWithResultKeyPublisher implements SdkPublisher<Pa
      * retrieve the consecutive pages that follows the input page.
      * </p>
      */
-    public final PaginatedOperationWithResultKeyPublisher resume(final PaginatedOperationWithResultKeyResponse lastSuccessfulPage) {
+    private final PaginatedOperationWithResultKeyPublisher resume(PaginatedOperationWithResultKeyResponse lastSuccessfulPage) {
         if (nextPageFetcher.hasNextPage(lastSuccessfulPage)) {
             return new PaginatedOperationWithResultKeyPublisher(client, firstRequest.toBuilder()
                                                                                     .nextToken(lastSuccessfulPage.nextToken()).build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyIterable.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyIterable.java
@@ -72,8 +72,8 @@ public class PaginatedOperationWithoutResultKeyIterable implements SdkIterable<P
 
     private final SyncPageFetcher nextPageFetcher;
 
-    public PaginatedOperationWithoutResultKeyIterable(final JsonProtocolTestsClient client,
-                                                      final PaginatedOperationWithoutResultKeyRequest firstRequest) {
+    public PaginatedOperationWithoutResultKeyIterable(JsonProtocolTestsClient client,
+                                                      PaginatedOperationWithoutResultKeyRequest firstRequest) {
         this.client = client;
         this.firstRequest = firstRequest;
         this.nextPageFetcher = new PaginatedOperationWithoutResultKeyResponseFetcher();
@@ -91,8 +91,8 @@ public class PaginatedOperationWithoutResultKeyIterable implements SdkIterable<P
      * retrieve the consecutive pages that follows the input page.
      * </p>
      */
-    public final PaginatedOperationWithoutResultKeyIterable resume(
-        final PaginatedOperationWithoutResultKeyResponse lastSuccessfulPage) {
+    private final PaginatedOperationWithoutResultKeyIterable resume(
+        PaginatedOperationWithoutResultKeyResponse lastSuccessfulPage) {
         if (nextPageFetcher.hasNextPage(lastSuccessfulPage)) {
             return new PaginatedOperationWithoutResultKeyIterable(client, firstRequest.toBuilder()
                                                                                       .nextToken(lastSuccessfulPage.nextToken()).build());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPublisher.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPublisher.java
@@ -73,13 +73,13 @@ public class PaginatedOperationWithoutResultKeyPublisher implements SdkPublisher
 
     private boolean isLastPage;
 
-    public PaginatedOperationWithoutResultKeyPublisher(final JsonProtocolTestsAsyncClient client,
-                                                       final PaginatedOperationWithoutResultKeyRequest firstRequest) {
+    public PaginatedOperationWithoutResultKeyPublisher(JsonProtocolTestsAsyncClient client,
+                                                       PaginatedOperationWithoutResultKeyRequest firstRequest) {
         this(client, firstRequest, false);
     }
 
-    private PaginatedOperationWithoutResultKeyPublisher(final JsonProtocolTestsAsyncClient client,
-                                                        final PaginatedOperationWithoutResultKeyRequest firstRequest, final boolean isLastPage) {
+    private PaginatedOperationWithoutResultKeyPublisher(JsonProtocolTestsAsyncClient client,
+                                                        PaginatedOperationWithoutResultKeyRequest firstRequest, boolean isLastPage) {
         this.client = client;
         this.firstRequest = firstRequest;
         this.isLastPage = isLastPage;
@@ -98,8 +98,8 @@ public class PaginatedOperationWithoutResultKeyPublisher implements SdkPublisher
      * retrieve the consecutive pages that follows the input page.
      * </p>
      */
-    public final PaginatedOperationWithoutResultKeyPublisher resume(
-        final PaginatedOperationWithoutResultKeyResponse lastSuccessfulPage) {
+    private final PaginatedOperationWithoutResultKeyPublisher resume(
+        PaginatedOperationWithoutResultKeyResponse lastSuccessfulPage) {
         if (nextPageFetcher.hasNextPage(lastSuccessfulPage)) {
             return new PaginatedOperationWithoutResultKeyPublisher(client, firstRequest.toBuilder()
                                                                                        .nextToken(lastSuccessfulPage.nextToken()).build());

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/ScanPaginatorIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/ScanPaginatorIntegrationTest.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.services.dynamodb;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -183,44 +182,6 @@ public class ScanPaginatorIntegrationTest extends DynamoDBTestBase {
             count += response.count();
         }
         assertEquals(ITEM_COUNT, count);
-    }
-
-    @Test
-    public void test_resume_On_IntermediatePage() {
-        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(5).build();
-        ScanIterable scanResponses = dynamo.scanPaginator(request);
-
-        Iterator<ScanResponse> scanResponsesIterator = scanResponses.iterator();
-
-        int scannedCount = 0;
-        scannedCount += scanResponsesIterator.next().count();
-
-        ScanResponse lastResponse = scanResponsesIterator.next();
-        scannedCount += lastResponse.count();
-
-        // Resume from last page
-        assertEquals(ITEM_COUNT, scannedCount + scanResponses.resume(lastResponse).stream()
-                                                                    .flatMap(r -> r.items().stream())
-                                                                    .count());
-
-
-        assertEquals(ITEM_COUNT, scannedCount + scanResponses.resume(lastResponse).items().stream().count());
-    }
-
-
-    @Test
-    public void test_resume_On_LastPage() {
-        ScanRequest request = ScanRequest.builder().tableName(TABLE_NAME).limit(5).build();
-        ScanIterable scanResponses = dynamo.scanPaginator(request);
-
-        ScanResponse lastPage = scanResponses.stream().reduce((first, second) -> second).get();
-
-        // Resume from last page
-        assertEquals(0, scanResponses.resume(lastPage).stream()
-                                     .flatMap(r -> r.items().stream())
-                                     .count());
-
-        assertEquals(0, scanResponses.resume(lastPage).items().stream().count());
     }
 
     private static void putTestData() {


### PR DESCRIPTION
- Updated `resume` methods to private.
- removed `final` modifier from methods parameters to be consistent with other generated methods.