### PR TITLE
aws credentials cleanup

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-758c891.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-758c891.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "- Updated `AwsCredentials` to interface implemented by `AwsBasicCredentials` and `AwsSessionCredentials` - Renamed `AwsCredentialsProvider.getCredentials()` to `AwsCredentialsProvider.resolveCredentials()`."
+}

--- a/auth/src/it/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderIntegrationTest.java
+++ b/auth/src/it/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderIntegrationTest.java
@@ -54,7 +54,7 @@ public class InstanceProfileCredentialsProviderIntegrationTest extends LogCaptor
         mockServer.setAvailableSecurityCredentials("aws-dr-tools-test");
 
         InstanceProfileCredentialsProvider credentialsProvider = InstanceProfileCredentialsProvider.create();
-        AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.getCredentials();
+        AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
 
         assertEquals("ACCESS_KEY_ID", credentials.accessKeyId());
         assertEquals("SECRET_ACCESS_KEY", credentials.secretAccessKey());
@@ -72,7 +72,7 @@ public class InstanceProfileCredentialsProviderIntegrationTest extends LogCaptor
 
         AwsSessionCredentials credentials;
         try (InstanceProfileCredentialsProvider credentialsProvider = InstanceProfileCredentialsProvider.create()) {
-            credentials = (AwsSessionCredentials) credentialsProvider.getCredentials();
+            credentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
         }
 
         assertEquals("ACCESS_KEY_ID", credentials.accessKeyId());
@@ -92,7 +92,7 @@ public class InstanceProfileCredentialsProviderIntegrationTest extends LogCaptor
         try (InstanceProfileCredentialsProvider credentialsProvider = InstanceProfileCredentialsProvider.create()) {
 
             try {
-                credentialsProvider.getCredentials();
+                credentialsProvider.resolveCredentials();
                 fail("Expected an SdkClientException, but wasn't thrown");
             } catch (SdkClientException ace) {
                 assertNotNull(ace.getMessage());
@@ -107,7 +107,7 @@ public class InstanceProfileCredentialsProviderIntegrationTest extends LogCaptor
 
         try (InstanceProfileCredentialsProvider credentialsProvider = InstanceProfileCredentialsProvider.create()) {
             System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property(), "true");
-            credentialsProvider.getCredentials();
+            credentialsProvider.resolveCredentials();
         } finally {
             System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_DISABLED.property());
         }

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/AnonymousCredentialsProvider.java
@@ -33,8 +33,8 @@ public final class AnonymousCredentialsProvider implements AwsCredentialsProvide
     }
 
     @Override
-    public AwsCredentials getCredentials() {
-        return AwsCredentials.ANONYMOUS_CREDENTIALS;
+    public AwsCredentials resolveCredentials() {
+        return AwsBasicCredentials.ANONYMOUS_CREDENTIALS;
     }
 
     @Override

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials;
+
+import static software.amazon.awssdk.utils.StringUtils.trimToNull;
+
+import java.util.Objects;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Provides access to the AWS credentials used for accessing AWS services: AWS access key ID and secret access key. These
+ * credentials are used to securely sign requests to AWS services.
+ *
+ * <p>For more details on AWS access keys, see:
+ * <a href="http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys">
+ *     http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys</a></p>
+ *
+ * @see AwsCredentialsProvider
+ */
+@Immutable
+@SdkPublicApi
+public final class AwsBasicCredentials implements AwsCredentials {
+    /**
+     * A set of AWS credentials without an access key or secret access key, indicating that anonymous access should be used.
+     *
+     * This should be accessed via {@link AnonymousCredentialsProvider#resolveCredentials()}.
+     */
+    @SdkInternalApi
+    static final AwsBasicCredentials ANONYMOUS_CREDENTIALS = new AwsBasicCredentials(null, null, false);
+
+    private final String accessKeyId;
+    private final String secretAccessKey;
+
+    /**
+     * Constructs a new credentials object, with the specified AWS access key, AWS secret key and AWS session token.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
+     */
+    protected AwsBasicCredentials(String accessKeyId, String secretAccessKey) {
+        this(accessKeyId, secretAccessKey, true);
+    }
+
+    private AwsBasicCredentials(String accessKeyId, String secretAccessKey, boolean validateCredentials) {
+        this.accessKeyId = trimToNull(accessKeyId);
+        this.secretAccessKey = trimToNull(secretAccessKey);
+
+        if (validateCredentials) {
+            Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
+            Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
+        }
+    }
+
+    /**
+     * Constructs a new credentials object, with the specified AWS access key, AWS secret key and AWS session token.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
+     * */
+    public static AwsBasicCredentials create(String accessKeyId, String secretAccessKey) {
+        return new AwsBasicCredentials(accessKeyId, secretAccessKey);
+    }
+
+    /**
+     * Retrieve the AWS access key, used to identify the user interacting with AWS.
+     */
+    public String accessKeyId() {
+        return accessKeyId;
+    }
+
+    /**
+     * Retrieve the AWS secret access key, used to authenticate the user interacting with AWS.
+     */
+    public String secretAccessKey() {
+        return secretAccessKey;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("AwsCredentials")
+                       .add("accessKeyId", accessKeyId)
+                       .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final AwsBasicCredentials that = (AwsBasicCredentials) o;
+        return Objects.equals(accessKeyId, that.accessKeyId) &&
+               Objects.equals(secretAccessKey, that.secretAccessKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
+        hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
+        return hashCode;
+    }
+}

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentials.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentials.java
@@ -15,14 +15,7 @@
 
 package software.amazon.awssdk.auth.credentials;
 
-import static software.amazon.awssdk.utils.StringUtils.trimToNull;
-
-import java.util.Objects;
-import software.amazon.awssdk.annotations.Immutable;
-import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.utils.ToString;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * Provides access to the AWS credentials used for accessing AWS services: AWS access key ID and secret access key. These
@@ -30,90 +23,20 @@ import software.amazon.awssdk.utils.Validate;
  *
  * <p>For more details on AWS access keys, see:
  * <a href="http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys">
- *     http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys</a></p>
+ * http://docs.amazonwebservices.com/AWSSecurityCredentials/1.0/AboutAWSCredentials.html#AccessKeys</a></p>
  *
  * @see AwsCredentialsProvider
  */
-@Immutable
 @SdkPublicApi
-public class AwsCredentials {
-    /**
-     * A set of AWS credentials without an access key or secret access key, indicating that anonymous access should be used.
-     *
-     * This should be accessed via {@link AnonymousCredentialsProvider#getCredentials()}.
-     */
-    @SdkInternalApi
-    static final AwsCredentials ANONYMOUS_CREDENTIALS = new AwsCredentials(null, null, false);
-
-    private final String accessKeyId;
-    private final String secretAccessKey;
-
-    /**
-     * Constructs a new credentials object, with the specified AWS access key, AWS secret key and AWS session token.
-     *
-     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
-     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
-     */
-    protected AwsCredentials(String accessKeyId, String secretAccessKey) {
-        this(accessKeyId, secretAccessKey, true);
-    }
-
-    private AwsCredentials(String accessKeyId, String secretAccessKey, boolean validateCredentials) {
-        this.accessKeyId = trimToNull(accessKeyId);
-        this.secretAccessKey = trimToNull(secretAccessKey);
-
-        if (validateCredentials) {
-            Validate.notNull(this.accessKeyId, "Access key ID cannot be blank.");
-            Validate.notNull(this.secretAccessKey, "Secret access key cannot be blank.");
-        }
-    }
-
-    /**
-     * Constructs a new credentials object, with the specified AWS access key, AWS secret key and AWS session token.
-     *
-     * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
-     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
-     * */
-    public static AwsCredentials create(String accessKeyId, String secretAccessKey) {
-        return new AwsCredentials(accessKeyId, secretAccessKey);
-    }
+public interface AwsCredentials {
 
     /**
      * Retrieve the AWS access key, used to identify the user interacting with AWS.
      */
-    public final String accessKeyId() {
-        return accessKeyId;
-    }
+    String accessKeyId();
 
     /**
      * Retrieve the AWS secret access key, used to authenticate the user interacting with AWS.
      */
-    public final String secretAccessKey() {
-        return secretAccessKey;
-    }
-
-    @Override
-    public String toString() {
-        return ToString.builder("AwsCredentials")
-                       .add("accessKeyId", accessKeyId)
-                       .build();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final AwsCredentials that = (AwsCredentials) o;
-        return Objects.equals(accessKeyId, that.accessKeyId) &&
-               Objects.equals(secretAccessKey, that.secretAccessKey);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(accessKeyId, secretAccessKey);
-    }
+    String secretAccessKey();
 }

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProvider.java
@@ -38,5 +38,5 @@ public interface AwsCredentialsProvider {
      *
      * @return AwsCredentials which the caller can use to authorize an AWS request.
      */
-    AwsCredentials getCredentials();
+    AwsCredentials resolveCredentials();
 }

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
@@ -81,15 +81,15 @@ public final class AwsCredentialsProviderChain implements AwsCredentialsProvider
     }
 
     @Override
-    public AwsCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         if (reuseLastProviderEnabled && lastUsedProvider != null) {
-            return lastUsedProvider.getCredentials();
+            return lastUsedProvider.resolveCredentials();
         }
 
         List<String> exceptionMessages = null;
         for (AwsCredentialsProvider provider : credentialsProviders) {
             try {
-                AwsCredentials credentials = provider.getCredentials();
+                AwsCredentials credentials = provider.resolveCredentials();
 
                 log.debug("Loading credentials from {}", provider.toString());
 

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsSessionCredentials.java
@@ -16,22 +16,28 @@
 package software.amazon.awssdk.auth.credentials;
 
 import java.util.Objects;
+import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * A special type of {@link AwsCredentials} that also provides a session token to be used in service authentication. Session
+ * A special type of {@link AwsCredentials} that provides a session token to be used in service authentication. Session
  * tokens are typically provided by a token broker service, like AWS Security Token Service, and provide temporary access to an
  * AWS service.
  */
+@Immutable
 @SdkPublicApi
-public final class AwsSessionCredentials extends AwsCredentials {
+public final class AwsSessionCredentials implements AwsCredentials {
+
+    private final String accessKeyId;
+    private final String secretAccessKey;
     private final String sessionToken;
 
     private AwsSessionCredentials(String accessKey, String secretKey, String sessionToken) {
-        super(accessKey, secretKey);
-        this.sessionToken = Validate.notNull(sessionToken, "Session token cannot be null.");
+        this.accessKeyId = Validate.paramNotNull(accessKey, "accessKey");
+        this.secretAccessKey = Validate.paramNotNull(secretKey, "secretKey");
+        this.sessionToken = Validate.paramNotNull(sessionToken, "sessionToken");
     }
 
     /**
@@ -40,10 +46,26 @@ public final class AwsSessionCredentials extends AwsCredentials {
      * @param accessKey The AWS access key, used to identify the user interacting with AWS.
      * @param secretKey The AWS secret access key, used to authenticate the user interacting with AWS.
      * @param sessionToken The AWS session token, retrieved from an AWS token service, used for authenticating that this user has
-     *                     received temporary permission to access some resource.
+     * received temporary permission to access some resource.
      */
     public static AwsSessionCredentials create(String accessKey, String secretKey, String sessionToken) {
         return new AwsSessionCredentials(accessKey, secretKey, sessionToken);
+    }
+
+    /**
+     * Retrieve the AWS access key, used to identify the user interacting with AWS.
+     */
+    @Override
+    public String accessKeyId() {
+        return accessKeyId;
+    }
+
+    /**
+     * Retrieve the AWS secret access key, used to authenticate the user interacting with AWS.
+     */
+    @Override
+    public String secretAccessKey() {
+        return secretAccessKey;
     }
 
     /**
@@ -73,11 +95,17 @@ public final class AwsSessionCredentials extends AwsCredentials {
             return false;
         }
         final AwsSessionCredentials that = (AwsSessionCredentials) o;
-        return Objects.equals(sessionToken, that.sessionToken);
+        return Objects.equals(accessKeyId, that.accessKeyId) &&
+               Objects.equals(secretAccessKey, that.secretAccessKey) &&
+               Objects.equals(sessionToken, that.sessionToken);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), sessionToken);
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
+        hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
+        hashCode = 31 * hashCode + Objects.hashCode(sessionToken());
+        return hashCode;
     }
 }

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -88,8 +88,8 @@ public final class DefaultCredentialsProvider implements AwsCredentialsProvider,
     }
 
     @Override
-    public AwsCredentials getCredentials() {
-        return providerChain.getCredentials();
+    public AwsCredentials resolveCredentials() {
+        return providerChain.resolveCredentials();
     }
 
     @Override
@@ -129,7 +129,7 @@ public final class DefaultCredentialsProvider implements AwsCredentialsProvider,
 
         /**
          * Configure whether this provider should fetch credentials asynchronously in the background. If this is true, threads are
-         * less likely to block when {@link #getCredentials()} is called, but additional resources are used to maintain the
+         * less likely to block when {@link #resolveCredentials()} is called, but additional resources are used to maintain the
          * provider.
          *
          * <p>By default, this is disabled.</p>

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -36,7 +36,6 @@ import software.amazon.awssdk.utils.ToString;
 @SdkPublicApi
 public final class InstanceProfileCredentialsProvider extends HttpCredentialsProvider {
 
-    //TODO: make this private
     private static final String SECURITY_CREDENTIALS_RESOURCE = "/latest/meta-data/iam/security-credentials/";
     private final ResourcesEndpointProvider credentialsEndpointProvider = new InstanceProviderCredentialsEndpointProvider();
 

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProvider.java
@@ -102,11 +102,11 @@ public final class ProfileCredentialsProvider implements AwsCredentialsProvider,
     }
 
     @Override
-    public AwsCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         if (loadException != null) {
             throw loadException;
         }
-        return credentialsProvider.getCredentials();
+        return credentialsProvider.resolveCredentials();
     }
 
     @Override

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProvider.java
@@ -38,7 +38,7 @@ public final class StaticCredentialsProvider implements AwsCredentialsProvider {
     }
 
     @Override
-    public AwsCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         return credentials;
     }
 

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/HttpCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/HttpCredentialsProvider.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -87,7 +88,7 @@ public abstract class HttpCredentialsProvider implements AwsCredentialsProvider,
             Validate.notNull(secretKey, "Failed to load secret key.");
 
             AwsCredentials credentials =
-                token == null ? AwsCredentials.create(accessKey.asText(), secretKey.asText())
+                token == null ? AwsBasicCredentials.create(accessKey.asText(), secretKey.asText())
                               : AwsSessionCredentials.create(accessKey.asText(), secretKey.asText(), token.asText());
 
             Instant expiration = getExpiration(expirationNode).orElse(null);
@@ -132,7 +133,7 @@ public abstract class HttpCredentialsProvider implements AwsCredentialsProvider,
     }
 
     @Override
-    public AwsCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         if (isLocalCredentialLoadingDisabled()) {
             throw new SdkClientException("Loading credentials from local endpoint is disabled. Unable to load credentials from "
                                          + "service endpoint.");
@@ -158,7 +159,7 @@ public abstract class HttpCredentialsProvider implements AwsCredentialsProvider,
 
         /**
          * Configure whether this provider should fetch credentials asynchronously in the background. If this is true, threads are
-         * less likely to block when {@link #getCredentials()} is called, but additional resources are used to maintain the
+         * less likely to block when {@link #resolveCredentials()} is called, but additional resources are used to maintain the
          * provider.
          *
          * <p>By default, this is disabled.</p>

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -106,8 +107,8 @@ public final class ProfileCredentialsUtils {
     private AwsCredentialsProvider basicProfileCredentialsProvider() {
         requireProperties(ProfileProperty.AWS_ACCESS_KEY_ID,
                           ProfileProperty.AWS_SECRET_ACCESS_KEY);
-        AwsCredentials credentials = AwsCredentials.create(properties.get(ProfileProperty.AWS_ACCESS_KEY_ID),
-                                                           properties.get(ProfileProperty.AWS_SECRET_ACCESS_KEY));
+        AwsCredentials credentials = AwsBasicCredentials.create(properties.get(ProfileProperty.AWS_ACCESS_KEY_ID),
+                                                                     properties.get(ProfileProperty.AWS_SECRET_ACCESS_KEY));
         return StaticCredentialsProvider.create(credentials);
     }
 

--- a/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
@@ -19,6 +19,7 @@ import static software.amazon.awssdk.utils.StringUtils.trim;
 
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -43,7 +44,7 @@ import software.amazon.awssdk.utils.SystemSetting;
 @SdkInternalApi
 public abstract class SystemSettingsCredentialsProvider implements AwsCredentialsProvider {
     @Override
-    public AwsCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         String accessKey = trim(loadSetting(SdkSystemSetting.AWS_ACCESS_KEY_ID).orElse(null));
         String secretKey = trim(loadSetting(SdkSystemSetting.AWS_SECRET_ACCESS_KEY).orElse(null));
         String sessionToken = trim(loadSetting(SdkSystemSetting.AWS_SESSION_TOKEN).orElse(null));
@@ -64,7 +65,7 @@ public abstract class SystemSettingsCredentialsProvider implements AwsCredential
                                   SdkSystemSetting.AWS_SECRET_ACCESS_KEY.property()));
         }
 
-        return sessionToken == null ? AwsCredentials.create(accessKey, secretKey)
+        return sessionToken == null ? AwsBasicCredentials.create(accessKey, secretKey)
                                     : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
     }
 

--- a/auth/src/main/java/software/amazon/awssdk/auth/signer/AbstractAws4Signer.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/signer/AbstractAws4Signer.java
@@ -314,7 +314,6 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
         final List<String> sortedHeaders = new ArrayList<>(headers.keySet());
         sortedHeaders.sort(String.CASE_INSENSITIVE_ORDER);
 
-        final Map<String, List<String>> requestHeaders = headers;
         StringBuilder buffer = new StringBuilder();
         for (String header : sortedHeaders) {
             if (shouldExcludeHeaderFromSigning(header)) {
@@ -322,7 +321,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
             }
             String key = lowerCase(header);
 
-            for (String headerValue : requestHeaders.get(header)) {
+            for (String headerValue : headers.get(header)) {
                 StringUtils.appendCompactedString(buffer, key);
                 buffer.append(":");
                 if (headerValue != null) {

--- a/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsSigner.java
+++ b/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsSigner.java
@@ -31,6 +31,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.signer.SigningAlgorithm;
@@ -287,7 +288,7 @@ public abstract class AbstractAwsSigner implements Signer {
      * Loads the individual access key ID and secret key from the specified credentials, trimming any extra whitespace from the
      * credentials.
      *
-     * <p>Returns either a {@link AwsSessionCredentials} or a {@link AwsCredentials} object, depending on the input type.
+     * <p>Returns either a {@link AwsSessionCredentials} or a {@link AwsBasicCredentials} object, depending on the input type.
      *
      * @return A new credentials object with the sanitized credentials.
      */
@@ -302,7 +303,7 @@ public abstract class AbstractAwsSigner implements Signer {
                                                 StringUtils.trim(sessionCredentials.sessionToken()));
         }
 
-        return AwsCredentials.create(accessKeyId, secretKey);
+        return AwsBasicCredentials.create(accessKeyId, secretKey);
     }
 
     /**

--- a/auth/src/test/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChainTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChainTest.java
@@ -45,15 +45,15 @@ public class AwsCredentialsProviderChainTest {
         assertEquals(0, provider1.getCredentialsCallCount);
         assertEquals(0, provider2.getCredentialsCallCount);
 
-        chain.getCredentials();
+        chain.resolveCredentials();
         assertEquals(1, provider1.getCredentialsCallCount);
         assertEquals(1, provider2.getCredentialsCallCount);
 
-        chain.getCredentials();
+        chain.resolveCredentials();
         assertEquals(1, provider1.getCredentialsCallCount);
         assertEquals(2, provider2.getCredentialsCallCount);
 
-        chain.getCredentials();
+        chain.resolveCredentials();
         assertEquals(1, provider1.getCredentialsCallCount);
         assertEquals(3, provider2.getCredentialsCallCount);
     }
@@ -75,11 +75,11 @@ public class AwsCredentialsProviderChainTest {
         assertEquals(0, provider1.getCredentialsCallCount);
         assertEquals(0, provider2.getCredentialsCallCount);
 
-        chain.getCredentials();
+        chain.resolveCredentials();
         assertEquals(1, provider1.getCredentialsCallCount);
         assertEquals(1, provider2.getCredentialsCallCount);
 
-        chain.getCredentials();
+        chain.resolveCredentials();
         assertEquals(2, provider1.getCredentialsCallCount);
         assertEquals(2, provider2.getCredentialsCallCount);
     }
@@ -98,7 +98,7 @@ public class AwsCredentialsProviderChainTest {
 
         AwsCredentialsProviderChain chain = AwsCredentialsProviderChain.builder().credentialsProviders(provider, provider2).build();
 
-        chain.getCredentials();
+        chain.resolveCredentials();
         assertEquals(1, provider2.getCredentialsCallCount);
     }
 
@@ -118,7 +118,7 @@ public class AwsCredentialsProviderChainTest {
         thrown.expectMessage(provider1.exceptionMessage);
         thrown.expectMessage(provider2.exceptionMessage);
 
-        chain.getCredentials();
+        chain.resolveCredentials();
     }
 
 
@@ -132,18 +132,18 @@ public class AwsCredentialsProviderChainTest {
         }
 
         private MockCredentialsProvider(String exceptionMessage) {
-            staticCredentialsProvider = StaticCredentialsProvider.create(AwsCredentials.create("accessKey", "secretKey"));
+            staticCredentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("accessKey", "secretKey"));
             this.exceptionMessage = exceptionMessage;
         }
 
         @Override
-        public AwsCredentials getCredentials() {
+        public AwsCredentials resolveCredentials() {
             getCredentialsCallCount++;
 
             if (exceptionMessage != null) {
                 throw new RuntimeException(exceptionMessage);
             } else {
-                return staticCredentialsProvider.getCredentials();
+                return staticCredentialsProvider.resolveCredentials();
             }
         }
     }

--- a/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
@@ -70,7 +70,7 @@ public class ContainerCredentialsProviderTest {
         helper.remove(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
         ContainerCredentialsProvider.builder()
                                     .build()
-                                    .getCredentials();
+                                    .resolveCredentials();
     }
 
     /**
@@ -82,7 +82,7 @@ public class ContainerCredentialsProviderTest {
 
         stubForSuccessResponse();
 
-        AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.getCredentials();
+        AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
 
         assertThat(credentials).isNotNull();
         assertThat(credentials.accessKeyId()).isEqualTo(ACCESS_KEY_ID);

--- a/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
@@ -37,7 +37,7 @@ public class ProfileCredentialsProviderTest {
                                                                                      .build())
                                           .build();
 
-        assertThatThrownBy(provider::getCredentials).isInstanceOf(SdkClientException.class);
+        assertThatThrownBy(provider::resolveCredentials).isInstanceOf(SdkClientException.class);
     }
 
     @Test
@@ -49,7 +49,7 @@ public class ProfileCredentialsProviderTest {
         ProfileCredentialsProvider provider =
                 ProfileCredentialsProvider.builder().profileFile(file).profileName("foo").build();
 
-        assertThatThrownBy(provider::getCredentials).isInstanceOf(SdkClientException.class);
+        assertThatThrownBy(provider::resolveCredentials).isInstanceOf(SdkClientException.class);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class ProfileCredentialsProviderTest {
         ProfileCredentialsProvider provider =
                 ProfileCredentialsProvider.builder().profileFile(file).profileName("default").build();
 
-        assertThatThrownBy(provider::getCredentials).isInstanceOf(SdkClientException.class);
+        assertThatThrownBy(provider::resolveCredentials).isInstanceOf(SdkClientException.class);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ProfileCredentialsProviderTest {
         ProfileCredentialsProvider provider =
                 ProfileCredentialsProvider.builder().profileFile(file).profileName("default").build();
 
-        assertThat(provider.getCredentials()).satisfies(credentials -> {
+        assertThat(provider.resolveCredentials()).satisfies(credentials -> {
             assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
             assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
         });

--- a/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProviderTest.java
@@ -22,16 +22,16 @@ import org.junit.Test;
 public class StaticCredentialsProviderTest {
     @Test
     public void getAwsCredentials_ReturnsSameCredentials() throws Exception {
-        final AwsCredentials credentials = new AwsCredentials("akid", "skid");
+        final AwsCredentials credentials = new AwsBasicCredentials("akid", "skid");
         final AwsCredentials actualCredentials =
-                StaticCredentialsProvider.create(credentials).getCredentials();
+                StaticCredentialsProvider.create(credentials).resolveCredentials();
         assertEquals(credentials, actualCredentials);
     }
 
     @Test
     public void getSessionAwsCredentials_ReturnsSameCredentials() throws Exception {
         final AwsSessionCredentials credentials = AwsSessionCredentials.create("akid", "skid", "token");
-        final AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).getCredentials();
+        final AwsCredentials actualCredentials = StaticCredentialsProvider.create(credentials).resolveCredentials();
         assertEquals(credentials, actualCredentials);
     }
 

--- a/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/HttpCredentialsProviderTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/HttpCredentialsProviderTest.java
@@ -69,7 +69,7 @@ public class HttpCredentialsProviderTest {
         stubForSuccessResponseWithCustomBody(successResponse);
 
         HttpCredentialsProvider credentialsProvider = testCredentialsProvider();
-        AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.getCredentials();
+        AwsSessionCredentials credentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
 
         assertThat(credentials.accessKeyId()).isEqualTo("ACCESS_KEY_ID");
         assertThat(credentials.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY");
@@ -87,7 +87,7 @@ public class HttpCredentialsProviderTest {
 
         HttpCredentialsProvider credentialsProvider = testCredentialsProvider();
 
-        assertThatExceptionOfType(SdkClientException.class).isThrownBy(credentialsProvider::getCredentials)
+        assertThatExceptionOfType(SdkClientException.class).isThrownBy(credentialsProvider::resolveCredentials)
                                                            .withMessage("Unable to load credentials from service endpoint.");
     }
 
@@ -102,15 +102,15 @@ public class HttpCredentialsProviderTest {
         HttpCredentialsProvider credentialsProvider = testCredentialsProvider();
 
         // When there are no credentials, the provider should throw an exception if we can't connect
-        assertThatExceptionOfType(SdkClientException.class).isThrownBy(credentialsProvider::getCredentials);
+        assertThatExceptionOfType(SdkClientException.class).isThrownBy(credentialsProvider::resolveCredentials);
 
         // When there are valid credentials (but need to be refreshed) and the endpoint returns 404 status,
         // the provider should throw an exception.
         stubForSuccessResonseWithCustomExpirationDate(new Date(System.currentTimeMillis() + ONE_MINUTE * 4));
-        credentialsProvider.getCredentials(); // loads the credentials that will be expired soon
+        credentialsProvider.resolveCredentials(); // loads the credentials that will be expired soon
 
         stubForErrorResponse();  // Behaves as if server is unavailable.
-        assertThatExceptionOfType(SdkClientException.class).isThrownBy(credentialsProvider::getCredentials);
+        assertThatExceptionOfType(SdkClientException.class).isThrownBy(credentialsProvider::resolveCredentials);
     }
 
     @Test
@@ -119,13 +119,13 @@ public class HttpCredentialsProviderTest {
 
         // Successful load
         stubForSuccessResonseWithCustomExpirationDate(Date.from(Instant.now().plus(Duration.ofDays(10))));
-        assertThat(credentialsProvider.getCredentials()).isNotNull();
+        assertThat(credentialsProvider.resolveCredentials()).isNotNull();
 
         // Break the server
         stubForErrorResponse();
 
         // Still successful load
-        assertThat(credentialsProvider.getCredentials()).isNotNull();
+        assertThat(credentialsProvider.resolveCredentials()).isNotNull();
     }
 
     private void stubForSuccessResponseWithCustomBody(String body) {

--- a/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
@@ -94,7 +94,7 @@ public class ProfileCredentialsUtilsTest {
             assertThat(profile.toString()).contains("default");
             assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
             assertThat(new ProfileCredentialsUtils(profile, profileFile::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
-                assertThat(credentialsProvider.getCredentials()).satisfies(credentials -> {
+                assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
                     assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
                     assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");
                 });
@@ -108,7 +108,7 @@ public class ProfileCredentialsUtilsTest {
         assertThat(profileFile.profile("profile-with-session-token")).hasValueSatisfying(profile -> {
             assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
             assertThat(new ProfileCredentialsUtils(profile, profileFile::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
-                assertThat(credentialsProvider.getCredentials()).satisfies(credentials -> {
+                assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
                     assertThat(credentials).isInstanceOf(AwsSessionCredentials.class);
                     assertThat(credentials.accessKeyId()).isEqualTo("defaultAccessKey");
                     assertThat(credentials.secretAccessKey()).isEqualTo("defaultSecretAccessKey");

--- a/auth/src/test/java/software/amazon/awssdk/auth/signer/Aws4SignerTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/signer/Aws4SignerTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.signer.internal.Aws4SignerUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -68,7 +69,7 @@ public class Aws4SignerTest {
                 "Signature=e73e20539446307a5dc71252dbd5b97e861f1d1267456abda3ebd8d57e519951";
 
 
-        AwsCredentials credentials = AwsCredentials.create("access", "secret");
+        AwsBasicCredentials credentials = AwsBasicCredentials.create("access", "secret");
         // Test request without 'x-amz-sha256' header
         SdkHttpFullRequest.Builder request = generateBasicRequest();
 
@@ -93,7 +94,7 @@ public class Aws4SignerTest {
                 "SignedHeaders=host;x-amz-archive-description;x-amz-date, " +
                 "Signature=c45a3ff1f028e83017f3812c06b4440f0b3240264258f6e18cd683b816990ba4";
 
-        AwsCredentials credentials = AwsCredentials.create("access", "secret");
+        AwsBasicCredentials credentials = AwsBasicCredentials.create("access", "secret");
         // Test request without 'x-amz-sha256' header
         SdkHttpFullRequest.Builder request = generateBasicRequest().rawQueryParameter("Foo", (String) null);
 
@@ -110,7 +111,7 @@ public class Aws4SignerTest {
         final String expectedAmzHeader = "19810216T063000Z";
         final String expectedAmzExpires = "604800";
 
-        AwsCredentials credentials = AwsCredentials.create("access", "secret");
+        AwsBasicCredentials credentials = AwsBasicCredentials.create("access", "secret");
         // Test request without 'x-amz-sha256' header
 
         SdkHttpFullRequest request = generateBasicRequest().build();
@@ -128,7 +129,7 @@ public class Aws4SignerTest {
      */
     @Test
     public void testAnonymous() throws Exception {
-        AwsCredentials credentials = AnonymousCredentialsProvider.create().getCredentials();
+        AwsCredentials credentials = AnonymousCredentialsProvider.create().resolveCredentials();
         SdkHttpFullRequest request = generateBasicRequest().build();
 
         SignerTestUtils.signRequest(signer, request, credentials, "demo", signingOverrideClock, "us-east-1");
@@ -141,7 +142,7 @@ public class Aws4SignerTest {
      */
     @Test
     public void xAmznTraceId_NotSigned() throws Exception {
-        AwsCredentials credentials = AwsCredentials.create("akid", "skid");
+        AwsBasicCredentials credentials = AwsBasicCredentials.create("akid", "skid");
         SdkHttpFullRequest.Builder request = generateBasicRequest();
         request.header("X-Amzn-Trace-Id", " Root=1-584b150a-708479cb060007ffbf3ee1da;Parent=36d3dbcfd150aac9;Sampled=1");
 

--- a/auth/src/test/java/software/amazon/awssdk/auth/signer/QueryStringSignerTest.java
+++ b/auth/src/test/java/software/amazon/awssdk/auth/signer/QueryStringSignerTest.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -34,7 +35,7 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 
 public class QueryStringSignerTest {
 
-    private static final AwsCredentials credentials = AwsCredentials.create("123456789", "123456789");
+    private static final AwsBasicCredentials credentials = AwsBasicCredentials.create("123456789", "123456789");
     private static final String EXPECTED_SIGNATURE = "VjYMhf9TWp08zAxXbKDAvUhW9GjJ56QjAuSj3LBsfjM=";
 
     private static QueryStringSigner signer;
@@ -75,7 +76,7 @@ public class QueryStringSignerTest {
                                                        .rawQueryParameter("foo", "bar")
                                                        .build();
 
-        request = signer.sign(request, constructAttributes(AnonymousCredentialsProvider.create().getCredentials()));
+        request = signer.sign(request, constructAttributes(AnonymousCredentialsProvider.create().resolveCredentials()));
 
         assertNull(request.rawQueryParameters().get("Signature"));
     }

--- a/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/client/handler/AwsClientHandlerUtils.java
+++ b/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/client/handler/AwsClientHandlerUtils.java
@@ -50,7 +50,7 @@ public final class AwsClientHandlerUtils {
                                                                     .flatMap(AwsRequestOverrideConfiguration::credentialsProvider)
                                                                     .orElse(clientCredentials);
 
-        AwsCredentials credentials = credentialsProvider.getCredentials();
+        AwsCredentials credentials = credentialsProvider.resolveCredentials();
 
         Validate.validState(credentials != null, "Credential providers must never return null.");
 

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
@@ -410,6 +410,14 @@
             <property name="ignoreComments" value="true"/>
         </module>
 
+        <!-- Checks that we don't use Objects.hash. Objects.hashCode is preferred-->
+        <module name="Regexp">
+            <property name="format" value="\bObjects.hash\b"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="message" value="Don't use Objects.hashCode, use Objects.hash instead"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
         <!-- Checks that we don't use plural enum names -->
         <module name="software.amazon.awssdk.buildtools.checkstyle.PluralEnumNames"/>
 

--- a/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
+++ b/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
@@ -116,7 +116,10 @@ public final class Profile implements ToCopyableBuilder<Profile.Builder, Profile
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, properties);
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(name());
+        hashCode = 31 * hashCode + Objects.hashCode(properties());
+        return hashCode;
     }
 
     /**

--- a/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
+++ b/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
@@ -132,7 +132,7 @@ public class ProfileFile {
 
     @Override
     public int hashCode() {
-        return Objects.hash(profiles);
+        return Objects.hashCode(profiles());
     }
 
     private static void addCredentialsFile(ProfileFile.Aggregator builder) {

--- a/services/cloudsearchdomain/src/test/java/software/amazon/awssdk/cloudsearchdomain/SearchRequestUnitTest.java
+++ b/services/cloudsearchdomain/src/test/java/software/amazon/awssdk/cloudsearchdomain/SearchRequestUnitTest.java
@@ -30,7 +30,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudsearchdomain.CloudSearchDomainClient;
@@ -40,7 +40,7 @@ import software.amazon.awssdk.services.cloudsearchdomain.model.SearchRequest;
  * Unit tests for {@link SearchRequest}.
  */
 public class SearchRequestUnitTest {
-    private static final AwsCredentials CREDENTIALS = AwsCredentials.create("access", "secret");
+    private static final AwsBasicCredentials CREDENTIALS = AwsBasicCredentials.create("access", "secret");
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(new WireMockConfiguration().port(0).notifier(new ConsoleNotifier(true)));

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/SignersIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/SignersIntegrationTest.java
@@ -61,7 +61,7 @@ public class SignersIntegrationTest extends DynamoDBTestBase {
     private static final String HASH_KEY_VALUE = "123789";
     private static final String ATTRIBUTE_FOO = "foo";
     private static final String ATTRIBUTE_FOO_VALUE = "bar";
-    private static final AwsCredentials awsCredentials = CREDENTIALS_PROVIDER_CHAIN.getCredentials();
+    private static final AwsCredentials awsCredentials = CREDENTIALS_PROVIDER_CHAIN.resolveCredentials();
     private static final String SIGNING_NAME = "dynamodb";
 
     @BeforeClass

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/GlobalRequestHandlerTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/GlobalRequestHandlerTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.global.handlers.TestGlobalExecutionInterceptor;
@@ -40,7 +40,7 @@ public class GlobalRequestHandlerTest {
     public void clientCreatedWithConstructor_RegistersGlobalHandlers() {
         assertFalse(TestGlobalExecutionInterceptor.wasCalled());
         DynamoDbClient client = DynamoDbClient.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                 .region(Region.US_WEST_2)
                 .build();
         callApi(client);
@@ -52,7 +52,7 @@ public class GlobalRequestHandlerTest {
     public void clientCreatedWithBuilder_RegistersGlobalHandlers() {
         assertFalse(TestGlobalExecutionInterceptor.wasCalled());
         DynamoDbClient client = DynamoDbClient.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                 .region(Region.US_WEST_2)
                 .build();
         callApi(client);

--- a/services/glacier/src/test/java/software/amazon/awssdk/services/glacier/AccountIdDefaultValueTest.java
+++ b/services/glacier/src/test/java/software/amazon/awssdk/services/glacier/AccountIdDefaultValueTest.java
@@ -28,7 +28,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.glacier.model.ListVaultsRequest;
@@ -46,7 +46,7 @@ public class AccountIdDefaultValueTest {
     @Before
     public void setup() {
         glacier = GlacierClient.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                 .region(Region.US_WEST_2).endpointOverride(URI.create(getEndpoint()))
                 .build();
     }

--- a/services/glacier/src/test/java/software/amazon/awssdk/services/glacier/UploadArchiveHeaderTest.java
+++ b/services/glacier/src/test/java/software/amazon/awssdk/services/glacier/UploadArchiveHeaderTest.java
@@ -32,7 +32,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.util.Mimetype;
@@ -52,7 +52,7 @@ public class UploadArchiveHeaderTest {
     @Before
     public void setup() {
         glacier = GlacierClient.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                 .region(Region.US_WEST_2).endpointOverride(URI.create(getEndpoint()))
                 .build();
         request = UploadArchiveRequest.builder().vaultName("test").build();

--- a/services/inspector/src/test/java/software/amazon/awssdk/services/inspector/InspectorErrorUnmarshallingTest.java
+++ b/services/inspector/src/test/java/software/amazon/awssdk/services/inspector/InspectorErrorUnmarshallingTest.java
@@ -39,7 +39,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.regions.Region;
@@ -55,7 +55,7 @@ public class InspectorErrorUnmarshallingTest {
 
     @Before
     public void setup() {
-        StaticCredentialsProvider credsProvider = StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid"));
+        StaticCredentialsProvider credsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
         inspector = InspectorClient.builder()
                                    .credentialsProvider(credsProvider)
                                    .region(Region.US_EAST_1)

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/PresignRequestHandlerTest.java
@@ -30,7 +30,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import org.junit.Test;
 import org.mockito.Mockito;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
@@ -51,7 +51,7 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
  * Unit Tests for {@link RdsPresignInterceptor}
  */
 public class PresignRequestHandlerTest {
-    private static final AwsCredentials CREDENTIALS = AwsCredentials.create("foo", "bar");
+    private static final AwsBasicCredentials CREDENTIALS = AwsBasicCredentials.create("foo", "bar");
     private static final Region DESTINATION_REGION = Region.of("us-west-2");
 
     private static RdsPresignInterceptor<CopyDBSnapshotRequest> presignInterceptor = new CopyDbSnapshotPresignInterceptor();

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/signer/AwsS3V4SignerIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/signer/AwsS3V4SignerIntegrationTest.java
@@ -54,7 +54,7 @@ import software.amazon.awssdk.utils.IoUtils;
 
 public class AwsS3V4SignerIntegrationTest extends S3IntegrationTestBase {
 
-    private static final AwsCredentials awsCredentials = CREDENTIALS_PROVIDER_CHAIN.getCredentials();
+    private static final AwsCredentials awsCredentials = CREDENTIALS_PROVIDER_CHAIN.resolveCredentials();
     private static final String SIGNING_NAME = "s3";
     private static final String BUCKET_NAME = temporaryBucketName("s3-signer-integ-test");
     private static final String KEY = "test-key";

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/bucketaddressingsep/VirtualHostAddressingSepTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/bucketaddressingsep/VirtualHostAddressingSepTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -77,7 +77,7 @@ public class VirtualHostAddressingSepTest {
 
     private S3Client constructClient(TestCaseModel testCaseModel) {
         return S3Client.builder()
-                       .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                        .httpClient(mockHttpClient)
                        .region(Region.of(testCaseModel.getRegion()))
                        .serviceConfiguration(c -> c.pathStyleAccessEnabled(testCaseModel.isPathStyle())

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/PutObjectHeaderTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/PutObjectHeaderTest.java
@@ -32,7 +32,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.util.Mimetype;
@@ -53,7 +53,7 @@ public class PutObjectHeaderTest {
     @Before
     public void setup() {
         s3Client = S3Client.builder()
-                           .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                           .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                            .region(Region.US_WEST_2).endpointOverride(URI.create(getEndpoint()))
                            .build();
         putObjectRequest = PutObjectRequest.builder().bucket("test").key("test").build();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/S3EndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/handlers/S3EndpointResolutionTest.java
@@ -24,7 +24,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
@@ -315,7 +315,7 @@ public class S3EndpointResolutionTest {
      */
     private S3ClientBuilder clientBuilder() {
         return S3Client.builder()
-                       .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                        .region(Region.AP_SOUTH_1)
                        .httpClient(mockHttpClient);
     }
@@ -327,7 +327,7 @@ public class S3EndpointResolutionTest {
      */
     private S3ClientBuilder clientBuilderWithMockSigner() {
         return S3Client.builder()
-                       .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                        .region(Region.AP_SOUTH_1)
                        .overrideConfiguration(ClientOverrideConfiguration.builder()
                                                                          .advancedOption(SdkAdvancedClientOption.SIGNER,

--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.internal.ProfileCredentialsUtils;
@@ -75,8 +76,8 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
         // Create credentials for that user
         CreateAccessKeyResponse createAccessKeyResult =
                 iam.createAccessKey(CreateAccessKeyRequest.builder().userName(USER_NAME).build());
-        userCredentials = AwsCredentials.create(createAccessKeyResult.accessKey().accessKeyId(),
-                                                createAccessKeyResult.accessKey().secretAccessKey());
+        userCredentials = AwsBasicCredentials.create(createAccessKeyResult.accessKey().accessKeyId(),
+                                                     createAccessKeyResult.accessKey().secretAccessKey());
 
         // Allow the user to assume roles
         String policyDoc = new Policy()
@@ -190,7 +191,7 @@ public class AssumeRoleIntegrationTest extends IntegrationTestBaseWithIAM {
 
         assertThat(profiles.profile("test")).hasValueSatisfying(profile -> {
             assertThat(new ProfileCredentialsUtils(profile, profiles::profile).credentialsProvider()).hasValueSatisfying(credentialsProvider -> {
-                assertThat(credentialsProvider.getCredentials()).satisfies(credentials -> {
+                assertThat(credentialsProvider.resolveCredentials()).satisfies(credentials -> {
                     assertThat(credentials.accessKeyId()).isNotBlank();
                     assertThat(credentials.secretAccessKey()).isNotBlank();
                     ((SdkAutoCloseable) credentialsProvider).close();

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.utils.Validate;
  * An implementation of {@link AwsCredentialsProvider} that periodically sends an {@link AssumeRoleRequest} to the AWS
  * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated asynchronously
  * in the background as they get close to expiring. If the credentials are not successfully updated asynchronously in the
- * background, calls to {@link #getCredentials()} will begin to block in an attempt to update the credentials synchronously.
+ * background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials synchronously.
  *
  * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
  * the background thread can be shut down using {@link #close()}.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.utils.Validate;
  * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link AssumeRoleWithSAMLRequest}
  * to the AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
  * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
- * in the background, calls to {@link #getCredentials()} will begin to block in an attempt to update the credentials
+ * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
  * synchronously.
  *
  * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.utils.Validate;
  * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link AssumeRoleWithWebIdentityRequest}
  * to the AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
  * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
- * in the background, calls to {@link #getCredentials()} will begin to block in an attempt to update the credentials
+ * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
  * synchronously.
  *
  * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
  * An implementation of {@link AwsCredentialsProvider} that is extended within this package to provide support for periodically-
  * updating session credentials. When credentials get close to expiration, this class will attempt to update them asynchronously
  * using {@link #getUpdatedCredentials(StsClient)}. If the credentials end up expiring, this class will block all calls to
- * {@link #getCredentials()} until the credentials can be updated.
+ * {@link #resolveCredentials()} until the credentials can be updated.
  */
 @ThreadSafe
 @SdkInternalApi
@@ -74,7 +74,7 @@ abstract class StsCredentialsProvider implements AwsCredentialsProvider, SdkAuto
     }
 
     @Override
-    public AwsCredentials getCredentials() {
+    public AwsCredentials resolveCredentials() {
         return sessionCache.get().getSessionCredentials();
     }
 

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.utils.Validate;
  * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link GetFederationTokenRequest} to the
  * AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
  * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
- * in the background, calls to {@link #getCredentials()} will begin to block in an attempt to update the credentials
+ * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
  * synchronously.
  *
  * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.utils.Validate;
  * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link GetSessionTokenRequest} to the AWS
  * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated asynchronously
  * in the background as they get close to expiring. If the credentials are not successfully updated asynchronously in the
- * background, calls to {@link #getCredentials()} will begin to block in an attempt to update the credentials synchronously.
+ * background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials synchronously.
  *
  * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
  * the background thread can be shut down using {@link #close()}.

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsProfileCredentialsProviderFactory.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsProfileCredentialsProviderFactory.java
@@ -89,8 +89,8 @@ public final class StsProfileCredentialsProviderFactory implements ChildProfileC
         }
 
         @Override
-        public AwsCredentials getCredentials() {
-            return this.credentialsProvider.getCredentials();
+        public AwsCredentials resolveCredentials() {
+            return this.credentialsProvider.resolveCredentials();
         }
 
         @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -81,7 +81,7 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
 
         try (StsCredentialsProvider credentialsProvider = createCredentialsProviderBuilder(request).stsClient(stsClient).build()) {
             for(int i = 0; i < numTimesInvokeCredentialsProvider; ++i) {
-                AwsSessionCredentials providedCredentials = (AwsSessionCredentials) credentialsProvider.getCredentials();
+                AwsSessionCredentials providedCredentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
                 assertThat(providedCredentials.accessKeyId()).isEqualTo("a");
                 assertThat(providedCredentials.secretAccessKey()).isEqualTo("b");
                 assertThat(providedCredentials.sessionToken()).isEqualTo("c");

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/core/internal/http/TT0035900619IntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/core/internal/http/TT0035900619IntegrationTest.java
@@ -143,7 +143,7 @@ public class TT0035900619IntegrationTest {
 
     protected static AwsCredentials awsTestCredentials() {
         try {
-            return AwsIntegrationTestBase.CREDENTIALS_PROVIDER_CHAIN.getCredentials();
+            return AwsIntegrationTestBase.CREDENTIALS_PROVIDER_CHAIN.resolveCredentials();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/S3ClientCacheIntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/S3ClientCacheIntegrationTest.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -31,11 +31,11 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Ignore
 // FIXME: Depends on S3 properly parsing region information from the endpoint (see AmazonS3#getRegionName())
 public class S3ClientCacheIntegrationTest {
-    private AwsCredentials credentials;
+    private AwsBasicCredentials credentials;
 
     @Before
     public void setUp() {
-        credentials = AwsCredentials.create("mock", "mock");
+        credentials = AwsBasicCredentials.create("mock", "mock");
     }
 
     @Test

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/ConfigureS3LinksTest.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/ConfigureS3LinksTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertSame;
 
 import org.junit.Before;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.regions.Region;
 
 public class ConfigureS3LinksTest {
@@ -31,7 +31,7 @@ public class ConfigureS3LinksTest {
 
     @Before
     public void setUp() throws Exception {
-        s3cc = new S3ClientCache(AwsCredentials.create("mock", "mock"));
+        s3cc = new S3ClientCache(AwsBasicCredentials.create("mock", "mock"));
     }
 
     @Test

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/S3LinkTest.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/S3LinkTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -31,7 +32,7 @@ public class S3LinkTest {
 
     @Before
     public void setUp() {
-        AwsCredentials credentials = AwsCredentials.create("mock", "mock");
+        AwsCredentials credentials = AwsBasicCredentials.create("mock", "mock");
         DynamoDbClient db = DynamoDbClient.builder()
                                           .credentialsProvider(StaticCredentialsProvider.create(credentials))
                                           .region(Region.US_WEST_2)

--- a/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/reflect/ClientReflector.java
+++ b/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/reflect/ClientReflector.java
@@ -19,7 +19,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.stream.Stream;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
@@ -107,7 +107,7 @@ public class ClientReflector {
      * @return Dummy credentials to create client with.
      */
     private StaticCredentialsProvider getMockCredentials() {
-        return StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid"));
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
     }
 
     /**

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Executor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.regions.Region;
@@ -54,7 +54,7 @@ public class AsyncResponseThreadingTest {
                 ProtocolRestJsonAsyncClient.builder()
                                            .region(Region.US_WEST_1)
                                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                           .credentialsProvider(() -> AwsCredentials.create("akid", "skid"))
+                                           .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                            .asyncConfiguration(c -> c.advancedOption(FUTURE_COMPLETION_EXECUTOR, mockExecutor))
                                            .build();
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
@@ -48,7 +48,7 @@ import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.core.SdkRequest;
@@ -468,7 +468,7 @@ public class ExecutionInterceptorTest {
     private <T extends AwsClientBuilder<?, U>, U> U initializeAndBuild(T builder, ExecutionInterceptor interceptor) {
         return builder.region(Region.US_WEST_1)
                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                      .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                       .overrideConfiguration(ClientOverrideConfiguration.builder()
                                                                         .addExecutionInterceptor(interceptor)
                                                                         .build())

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
@@ -35,7 +35,7 @@ import java.time.Duration;
 import java.util.UUID;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
@@ -125,7 +125,7 @@ public class ResponseTransformerTest {
         return ProtocolRestJsonClient.builder()
                                      .region(Region.US_WEST_1)
                                      .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
-                                     .credentialsProvider(() -> AwsCredentials.create("akid", "skid"))
+                                     .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                      .httpClientBuilder(ApacheHttpClient.builder().socketTimeout(Duration.ofSeconds(1)))
                                      .build();
     }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/SdkHttpResponseTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/SdkHttpResponseTest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -72,14 +72,14 @@ public class SdkHttpResponseTest {
                                        .region(Region.US_WEST_1)
                                        .endpointOverride(URI.create("http://localhost:"
                                                                     + wireMock.port()))
-                                       .credentialsProvider(() -> AwsCredentials.create("akid", "skid"))
+                                       .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                        .build();
 
         asyncClient = ProtocolRestJsonAsyncClient.builder()
                                                  .region(Region.US_WEST_1)
                                                  .endpointOverride(URI.create("http://localhost:"
                                                                               + wireMock.port()))
-                                                 .credentialsProvider(() -> AwsCredentials.create("akid", "skid"))
+                                                 .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
                                                  .build();
     }
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/AwsJsonCrc32ChecksumTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/AwsJsonCrc32ChecksumTests.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -53,7 +53,7 @@ public class AwsJsonCrc32ChecksumTests {
     private static final String JSON_BODY_EXTRA_DATA_GZIP_Crc32_CHECKSUM = "1561543715";
 
     private static final StaticCredentialsProvider FAKE_CREDENTIALS_PROVIDER =
-            StaticCredentialsProvider.create(AwsCredentials.create("foo", "bar"));
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar"));
 
     @Test
     public void clientCalculatesCrc32FromCompressedData_WhenCrc32IsValid() {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/RestJsonCrc32ChecksumTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/crc32/RestJsonCrc32ChecksumTests.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -47,7 +47,7 @@ public class RestJsonCrc32ChecksumTests {
     private static final String JSON_BODY_GZIP_Crc32_CHECKSUM = "3023995622";
     private static final String RESOURCE_PATH = "/2016-03-11/allTypes";
     private static final AwsCredentialsProvider FAKE_CREDENTIALS_PROVIDER = StaticCredentialsProvider.create(
-            AwsCredentials.create("foo", "bar"));
+        AwsBasicCredentials.create("foo", "bar"));
     @Rule
     public WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
             .port(0)

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcClient;
@@ -45,7 +45,7 @@ public class AwsJsonExceptionTest {
     @Before
     public void setupClient() {
         client = ProtocolJsonRpcClient.builder()
-                                      .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                                      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                       .region(Region.US_EAST_1)
                                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                       .build();

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/Ec2ExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/Ec2ExceptionTests.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolec2.ProtocolEc2Client;
@@ -41,7 +41,7 @@ public class Ec2ExceptionTests {
     @Before
     public void setupClient() {
         client = ProtocolEc2Client.builder()
-                                  .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                                  .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                   .region(Region.US_EAST_1)
                                   .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                   .build();

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
@@ -26,7 +26,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.ErrorType;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -48,7 +48,7 @@ public class QueryExceptionTests {
     @Before
     public void setupClient() {
         client = ProtocolQueryClient.builder()
-                                    .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                     .region(Region.US_EAST_1)
                                     .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                     .build();

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestJsonExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestJsonExceptionTests.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -53,7 +53,7 @@ public class RestJsonExceptionTests {
     @Before
     public void setupClient() {
         client = ProtocolRestJsonClient.builder()
-                                       .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                        .region(Region.US_EAST_1)
                                        .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                        .build();

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestXmlExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestXmlExceptionTests.java
@@ -25,7 +25,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
@@ -46,7 +46,7 @@ public class RestXmlExceptionTests {
     @Before
     public void setupClient() {
         client = ProtocolRestXmlClient.builder()
-                                  .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                                  .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                   .region(Region.US_EAST_1)
                                   .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                   .build();

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AwsJsonRetryTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AwsJsonRetryTest.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcClient;
@@ -47,7 +47,7 @@ public class AwsJsonRetryTest {
     @Before
     public void setupClient() {
         client = ProtocolJsonRpcClient.builder()
-                                      .credentialsProvider(StaticCredentialsProvider.create(AwsCredentials.create("akid", "skid")))
+                                      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                                       .region(Region.US_EAST_1)
                                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                       .build();

--- a/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/AwsIntegrationTestBase.java
+++ b/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/AwsIntegrationTestBase.java
@@ -44,7 +44,7 @@ public abstract class AwsIntegrationTestBase {
     /**
      * Shared AWS credentials, loaded from a properties file.
      */
-    private static final AwsCredentials CREDENTIALS = CREDENTIALS_PROVIDER_CHAIN.getCredentials();
+    private static final AwsCredentials CREDENTIALS = CREDENTIALS_PROVIDER_CHAIN.resolveCredentials();
 
     /**
      * @return AWSCredentials to use during tests. Setup by base fixture


### PR DESCRIPTION
Currently, `AwsSessionCredentials` extends `AwsCredentials`, but it's really not a is-a relation and the inheritance has many issues/limitations, eg: inherited static factory methods.

- Updated `AwsCredentials` to interface
  - `AwsSessionCredentials` implements `AwsCredentials`
  - `AwsBasicCredentials` implements `AwsCredentials`

`AwsBasicCredentials` class is named `BasicAwsCredentials` in v1. I named it this way to match AwsSessionCredentials, but this is open to discussion.

- renamed `getCredentials()` to `resolveCredentials()` as we discussed.

will create changelog entry before merge