### PR TITLE
Update DDB default max retry count to 8

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDB-d1378b3.json
+++ b/.changes/next-release/feature-AmazonDynamoDB-d1378b3.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon DynamoDB", 
+    "type": "feature", 
+    "description": "Update DynamoDB default max retry count to 8. Related to [#431](https://github.com/aws/aws-sdk-java-v2/issues/431)"
+}

--- a/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicy.java
+++ b/services/dynamodb/src/main/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicy.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.core.retry.backoff.FullJitterBackoffStrategy;
 public final class DynamoDbRetryPolicy {
 
     /** Default max retry count for DynamoDB client **/
-    private static final int DEFAULT_MAX_ERROR_RETRY = 10;
+    private static final int DEFAULT_MAX_ERROR_RETRY = 8;
 
     /**
      * Default base sleep time for DynamoDB.


### PR DESCRIPTION
Update DDB default max retry count to 8

related to #431 