### PR TITLE
Fix #585 RetryOnExceptions should consider subclasses of exceptions.

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseSyncClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseSyncClientHandler.java
@@ -122,7 +122,7 @@ public abstract class BaseSyncClientHandler extends BaseClientHandler implements
         @Override
         public ReturnT handle(HttpResponse response, ExecutionAttributes executionAttributes) throws Exception {
             OutputT resp = httpResponseHandler.handle(response, executionAttributes);
-            return responseTransformer.transform(resp, new AbortableInputStream(response.getContent(), response));
+            return responseTransformer.apply(resp, new AbortableInputStream(response.getContent(), response));
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
@@ -31,6 +31,14 @@ public final class NonRetryableException extends SdkException {
         super(message);
     }
 
+    public NonRetryableException(Throwable t) {
+        super(t);
+    }
+
+    public NonRetryableException(String message, Throwable t) {
+        super(message, t);
+    }
+
     @Override
     public boolean retryable() {
         return false;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnExceptionsCondition.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnExceptionsCondition.java
@@ -52,12 +52,11 @@ public final class RetryOnExceptionsCondition implements RetryCondition {
             return false;
         }
 
-        //TODO: update equals to isAssignableFrom to match all sub classes of IOException
         Predicate<Class<? extends Exception>> isRetryableException =
-            ex -> ex.equals(exception.getClass());
+            ex -> ex.isAssignableFrom(exception.getClass());
 
         Predicate<Class<? extends Exception>> hasRetrableCause =
-            ex -> exception.getCause() != null && ex.equals(exception.getCause().getClass());
+            ex -> exception.getCause() != null && ex.isAssignableFrom(exception.getCause().getClass());
 
         return exceptionsToRetryOn.stream().anyMatch(isRetryableException.or(hasRetrableCause));
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -46,7 +47,7 @@ import software.amazon.awssdk.utils.Logger;
  * the connection pool (if applicable).
  * <h3>Retries</h3>
  * <p>
- * Exceptions thrown from the transformer's {@link #transform(Object, AbortableInputStream)} method are not automatically retried
+ * Exceptions thrown from the transformer's {@link #apply(Object, AbortableInputStream)} method are not automatically retried
  * by the RetryPolicy of the client. Since we can't know if a transformer implementation is idempotent or safe to retry, if you
  * wish to retry on the event of a failure you must throw a {@link SdkException} with retryable set to true from the transformer.
  * This exception can wrap the original exception that was thrown. Note that throwing a {@link
@@ -59,11 +60,11 @@ import software.amazon.awssdk.utils.Logger;
  * Implementations should have proper handling of Thread interrupts. For long running, non-interruptible tasks, it is recommended
  * to check the thread interrupt status periodically and throw an {@link InterruptedException} if set. When an {@link
  * InterruptedException} is thrown from a interruptible task, you should either re-interrupt the current thread or throw that
- * {@link InterruptedException} from the {@link #transform(Object, AbortableInputStream)} method. Failure to do these things may
+ * {@link InterruptedException} from the {@link #apply(Object, AbortableInputStream)} method. Failure to do these things may
  * prevent the SDK from stopping the request in a timely manner in the event the thread is interrupted externally.
  *
  * @param <ResponseT> Type of unmarshalled POJO response.
- * @param <ReturnT>   Return type of the {@link #transform(Object, AbortableInputStream)} method. Implementations are free to
+ * @param <ReturnT>   Return type of the {@link #apply(Object, AbortableInputStream)} method. Implementations are free to
  * perform whatever transformations are appropriate.
  */
 @FunctionalInterface
@@ -78,6 +79,16 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
      * @throws Exception if any error occurs during processing of the response. This will be re-thrown by the SDK, possibly
      *                   wrapped in an {@link SdkClientException}.
      */
+    default ReturnT apply(ResponseT response, AbortableInputStream inputStream) throws Exception {
+        try {
+            return transform(response, inputStream);
+        } catch (RetryableException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new NonRetryableException(e);
+        }
+    }
+
     ReturnT transform(ResponseT response, AbortableInputStream inputStream) throws Exception;
 
     /**
@@ -204,7 +215,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
         return new ResponseTransformer<ResponseT, ReturnT>() {
             @Override
             public ReturnT transform(ResponseT response, AbortableInputStream inputStream) throws Exception {
-                return transformer.transform(response, inputStream);
+                return transformer.apply(response, inputStream);
             }
 
             @Override

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryOnExceptionsConditionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryOnExceptionsConditionTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Sets;
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.Collections;
@@ -79,6 +80,13 @@ public class RetryOnExceptionsConditionTest {
     @Test
     public void genericBaseException_ReturnsFalse() {
         assertFalse(condition.shouldRetry(RetryPolicyContexts.withException(new SdkException("foo"))));
+    }
+
+    @Test
+    public void subclassOfRetryableWrappedClientException_ReturnsTrue() {
+        final RetryCondition condition = RetryOnExceptionsCondition.create(
+            Collections.singleton(IOException.class));
+        assertTrue(condition.shouldRetry(RetryPolicyContexts.withException(new SdkClientException(new ConnectException("foo")))));
     }
 
     @Test

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -97,6 +98,16 @@ public class ResponseTransformerTest {
         testClient().streamingOutputOperation(StreamingOutputOperationRequest.builder().build(), tmpFile);
 
         assertThat(Files.readAllLines(tmpFile)).containsExactly("retried");
+    }
+
+    @Test
+    public void downloadToExistingFileDoesNotRetry() throws IOException {
+        stubForRetriesTimeoutReadingFromStreams();
+
+        assertThatThrownBy(() -> testClient().streamingOutputOperation(StreamingOutputOperationRequest.builder().build(),
+            ResponseTransformer
+                .toFile(new File(".."))))
+            .isInstanceOf(SdkClientException.class);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify `RetryOnExceptionsCondition` to consider subclasses of exception defined in `exceptionsToRetryOn`, e.g. `SSLException` will be retried because it's a subclass of `IOException` if `IOException` is in `exceptionsToRetryOn`

## Motivation and Context
#585 

## Testing
Added unit test for this behaviour.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
