### PR TITLE
add method name checkstyle

### DIFF
--- a/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/SdkPublicMethodNameCheck.java
+++ b/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/SdkPublicMethodNameCheck.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.buildtools.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtility;
+
+/**
+ * Sdk Method Name check to check only public methods in the classes with {@code @SdkPublicApi} annotation.
+ */
+public final class SdkPublicMethodNameCheck extends MethodNameCheck {
+
+    /**
+     * {@link Override Override} annotation name.
+     */
+    private static final String OVERRIDE = "Override";
+
+    private static final String SDK_PUBLIC_API = "SdkPublicApi";
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] {
+            TokenTypes.METHOD_DEF
+        };
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        // Get class classDef
+        DetailAST classDef = ast.getParent().getParent();
+
+        try {
+            if (!AnnotationUtility.containsAnnotation(ast, OVERRIDE)
+                && AnnotationUtility.containsAnnotation(classDef, SDK_PUBLIC_API)) {
+                super.visitToken(ast);
+            }
+        } catch (NullPointerException ex) {
+            //If that method is in an anonymous class, it will throw NPE, ignoring those.
+        }
+
+    }
+
+    @Override
+    protected boolean mustCheckName(DetailAST ast) {
+        return ast.findFirstToken(TokenTypes.MODIFIERS)
+                  .findFirstToken(TokenTypes.LITERAL_PUBLIC) != null;
+    }
+}

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
@@ -252,6 +252,13 @@
                      value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
 
+        <!-- Should not use kotlin function name as public method name -->
+        <module name="software.amazon.awssdk.buildtools.checkstyle.SdkPublicMethodNameCheck">
+            <property name="format" value="^(?!(?:apply|let|run|also|with)$).*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' conflicts with kotlin function name"/>
+        </module>
+
         <!-- Finalizers must not be overridden. -->
         <module name="NoFinalizer"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-        <checkstyle.version>7.5.1</checkstyle.version>
+        <checkstyle.version>7.8.2</checkstyle.version>
         <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 

--- a/test/test-utils/src/main/java/software/amazon/awssdk/testutils/retry/RetryRule.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/testutils/retry/RetryRule.java
@@ -48,7 +48,7 @@ public class RetryRule implements TestRule {
                 retry(base, 1);
             }
 
-            public void retry(final Statement base, int attempts) throws Throwable {
+            void retry(final Statement base, int attempts) throws Throwable {
                 try {
                     base.evaluate();
                 } catch (Exception e) {


### PR DESCRIPTION
Add method name checkstyle to make sure we are not using kotlin function names as public method name.

The `SdkPublicMethodNameCheck` will only check against `public` methods within classes annoted with`@SdkPublicApi`