### PR TITLE
Models that take and return `ByteBuffer` now take and return `SdkBytes` instead.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-0468abe.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-0468abe.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Accept `SdkBytes` and `byte[]` instead of `ByteBuffer` in generated setters."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-80cb557.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-80cb557.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Return `SdkBytes` instead of `ByteBuffer` from generated getters."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/TypeUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/TypeUtils.java
@@ -22,7 +22,6 @@ import static software.amazon.awssdk.codegen.model.service.ShapeType.Structure;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,6 +30,7 @@ import java.util.Map;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.service.Shape;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
+import software.amazon.awssdk.core.SdkBytes;
 
 /**
  * Used to determine the Java types for the service model.
@@ -62,7 +62,7 @@ public class TypeUtils {
         DATA_TYPE_MAPPINGS.put("float", Float.class.getSimpleName());
         DATA_TYPE_MAPPINGS.put("byte", Byte.class.getSimpleName());
         DATA_TYPE_MAPPINGS.put("timestamp", Instant.class.getName());
-        DATA_TYPE_MAPPINGS.put("blob", ByteBuffer.class.getName());
+        DATA_TYPE_MAPPINGS.put("blob", SdkBytes.class.getName());
         DATA_TYPE_MAPPINGS.put("stream", InputStream.class.getName());
         DATA_TYPE_MAPPINGS.put("bigdecimal", BigDecimal.class.getName());
         DATA_TYPE_MAPPINGS.put("biginteger", BigInteger.class.getName());
@@ -79,7 +79,7 @@ public class TypeUtils {
         MARSHALLING_TYPE_MAPPINGS.put("Float", "FLOAT");
         MARSHALLING_TYPE_MAPPINGS.put("Double", "DOUBLE");
         MARSHALLING_TYPE_MAPPINGS.put("Instant", "INSTANT");
-        MARSHALLING_TYPE_MAPPINGS.put("ByteBuffer", "BYTE_BUFFER");
+        MARSHALLING_TYPE_MAPPINGS.put("SdkBytes", "SDK_BYTES");
         MARSHALLING_TYPE_MAPPINGS.put("Boolean", "BOOLEAN");
         MARSHALLING_TYPE_MAPPINGS.put("BigDecimal", "BIG_DECIMAL");
         MARSHALLING_TYPE_MAPPINGS.put("InputStream", "STREAM");

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ConvenienceTypeOverload.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ConvenienceTypeOverload.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 /**
  * Customization to allow generation of additional setter overloads for a 'convenience' type (i.e. a
  * different type then what the member actually is but a more convenient representation to work
- * with, I.E. String rather than ByteBuffer). Customization is configured with an adapter that knows
+ * with, I.E. String rather than SdkBytes). Customization is configured with an adapter that knows
  * how to convert the 'convenience' type to the actual member type
  * <p>
  * Note - This customization is not directly exposed through {@link CustomizationConfig} at the

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -217,12 +217,12 @@ public class CustomizationConfig {
 
     /**
      * Customization to generate a method overload for a member setter that takes a string rather
-     * than an ByteBuffer. Currently only used by Lambda
+     * than an SdkBytes. Currently only used by Lambda
      */
-    public void setStringOverloadForByteBufferMember(
-        StringOverloadForByteBufferMember stringOverloadForByteBufferMember) {
+    public void setStringOverloadForSdkBytesMember(
+        StringOverloadForSdkBytesMember stringOverloadForSdkBytesMember) {
         this.convenienceTypeOverloads
-            .add(stringOverloadForByteBufferMember.getConvenienceTypeOverload());
+            .add(stringOverloadForSdkBytesMember.getConvenienceTypeOverload());
     }
 
     public List<ConvenienceTypeOverload> getConvenienceTypeOverloads() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/StringOverloadForSdkBytesMember.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/StringOverloadForSdkBytesMember.java
@@ -17,26 +17,26 @@ package software.amazon.awssdk.codegen.model.config.customization;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import software.amazon.awssdk.core.adapter.StringToByteBufferAdapter;
+import software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter;
 
 /**
  * Basically a facade POJO over {@link ConvenienceTypeOverload} that hides (i.e. hard codes) some
  * configuration options
  */
-public class StringOverloadForByteBufferMember {
+public class StringOverloadForSdkBytesMember {
 
-    private static final String STRING_TO_BYTE_BUFFER_ADAPTER = StringToByteBufferAdapter.class.getName();
+    private static final String STRING_TO_SDK_BYTES_ADAPTER = StringToSdkBytesAdapter.class.getName();
 
     private final ConvenienceTypeOverload convenienceTypeOverload;
 
     @JsonCreator
-    public StringOverloadForByteBufferMember(@JsonProperty("shapeName") String shapeName,
+    public StringOverloadForSdkBytesMember(@JsonProperty("shapeName") String shapeName,
                                              @JsonProperty("memberName") String memberName) {
         convenienceTypeOverload = new ConvenienceTypeOverload()
                 .withShapeName(shapeName)
                 .withMemberName(memberName)
                 .withConvenienceType("String")
-                .withTypeAdapterFqcn(STRING_TO_BYTE_BUFFER_ADAPTER);
+                .withTypeAdapterFqcn(STRING_TO_SDK_BYTES_ADAPTER);
     }
 
     public ConvenienceTypeOverload getConvenienceTypeOverload() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
@@ -302,11 +302,6 @@ public class AwsServiceModel implements ClassSpec {
 
     private CodeBlock getterStatement(MemberModel model) {
         VariableModel modelVariable = model.getVariable();
-
-        if ("java.nio.ByteBuffer".equals(modelVariable.getVariableType())) {
-            return CodeBlock.of("return $1N == null ? null : $1N.asReadOnlyBuffer();", modelVariable.getVariableName());
-        }
-
         return CodeBlock.of("return $N;", modelVariable.getVariableName());
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/BeanGetterHelper.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/BeanGetterHelper.java
@@ -20,12 +20,16 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
+import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.utils.CollectionUtils;
 
 public final class BeanGetterHelper {
@@ -44,14 +48,45 @@ public final class BeanGetterHelper {
         if (memberModel.isCollectionWithBuilderMember()) {
             return memberModel.isList() ? listOfBuildersGetter(memberModel) : mapOfBuildersGetter(memberModel);
         }
+        if (memberModel.isSdkBytesType()) {
+            return byteBufferGetter(memberModel);
+        }
+        if (memberModel.isList() && memberModel.getListModel().getListMemberModel().isSdkBytesType()) {
+            return listByteBufferGetter(memberModel);
+        }
+        if (memberModel.isMap() && memberModel.getMapModel().getValueModel().isSdkBytesType()) {
+            return mapByteBufferGetter(memberModel);
+        }
         return regularGetter(memberModel);
+    }
+
+    private MethodSpec byteBufferGetter(MemberModel memberModel) {
+        return basicGetter(memberModel,
+                           ClassName.get(ByteBuffer.class),
+                           CodeBlock.of("return $1N == null ? null : $1N.asByteBuffer()",
+                                        memberModel.getVariable().getVariableName()));
+    }
+
+    private MethodSpec listByteBufferGetter(MemberModel memberModel) {
+        return basicGetter(memberModel,
+                           ParameterizedTypeName.get(List.class, ByteBuffer.class),
+                           CodeBlock.of("return $1N == null ? null : $1N.stream().map($2T::asByteBuffer).collect($3T.toList())",
+                                        memberModel.getVariable().getVariableName(), SdkBytes.class, Collectors.class));
+    }
+
+    private MethodSpec mapByteBufferGetter(MemberModel memberModel) {
+        String body = "return $1N == null ? null : " +
+                      "$1N.entrySet().stream().collect($2T.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()))";
+        String keyType = memberModel.getMapModel().getKeyModel().getVariable().getVariableType();
+        return basicGetter(memberModel,
+                           PoetUtils.createParameterizedTypeName(Map.class, keyType, ByteBuffer.class.getSimpleName()),
+                           CodeBlock.of(body, memberModel.getVariable().getVariableName(), Collectors.class));
     }
 
     private MethodSpec regularGetter(MemberModel memberModel) {
         return basicGetter(memberModel,
                            typeProvider.parameterType(memberModel),
-                           CodeBlock.builder().add("return $N", memberModel.getVariable().getVariableName())
-                                    .build());
+                           CodeBlock.of("return $N", memberModel.getVariable().getVariableName()));
     }
 
     private MethodSpec builderGetter(MemberModel memberModel) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ListSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ListSetters.java
@@ -121,7 +121,7 @@ class ListSetters extends AbstractMemberSetters {
     @Override
     public MethodSpec beanStyle() {
         MethodSpec.Builder builder = beanStyleSetterBuilder()
-            .addCode(memberModel().isCollectionWithBuilderMember() ? copySetterBuilderBody() : copySetterBody());
+            .addCode(memberModel().isCollectionWithBuilderMember() ? copySetterBuilderBody() : beanCopySetterBody());
 
         if (annotateJsonProperty()) {
             builder.addAnnotation(

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MapSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MapSetters.java
@@ -79,7 +79,7 @@ class MapSetters extends AbstractMemberSetters {
     @Override
     public MethodSpec beanStyle() {
         MethodSpec.Builder builder = beanStyleSetterBuilder()
-                .addCode(memberModel().isCollectionWithBuilderMember() ? copySetterBuilderBody() : copySetterBody());
+                .addCode(memberModel().isCollectionWithBuilderMember() ? copySetterBuilderBody() : beanCopySetterBody());
 
         if (annotateJsonProperty()) {
             builder.addAnnotation(

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MemberCopierSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MemberCopierSpec.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.StaticImport;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/NonCollectionSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/NonCollectionSetters.java
@@ -97,7 +97,7 @@ class NonCollectionSetters extends AbstractMemberSetters {
     @Override
     public MethodSpec beanStyle() {
         MethodSpec.Builder builder = beanStyleSetterBuilder()
-            .addCode(copySetterBuilderBody());
+            .addCode(beanCopySetterBody());
 
         if (annotateJsonProperty()) {
             builder.addAnnotation(

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceModelCopiers.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceModelCopiers.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.codegen.model.intermediate.MapModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 
 public class ServiceModelCopiers {
     private final IntermediateModel intermediateModel;
@@ -132,7 +132,7 @@ public class ServiceModelCopiers {
 
         String simpleType = m.getVariable().getSimpleType();
 
-        return "Date".equals(simpleType) || "ByteBuffer".equals(simpleType);
+        return "Date".equals(simpleType) || "SdkBytes".equals(simpleType);
     }
 
     private boolean canCopyReference(MemberModel m) {
@@ -144,7 +144,7 @@ public class ServiceModelCopiers {
             String simpleType = m.getVariable().getSimpleType();
             switch (simpleType) {
                 case "Date":
-                case "ByteBuffer":
+                case "SdkBytes":
                     return false;
                 default:
                     return true;

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/TypeProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/TypeProvider.java
@@ -23,7 +23,6 @@ import com.squareup.javapoet.WildcardTypeName;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +37,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ListModel;
 import software.amazon.awssdk.codegen.model.intermediate.MapModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
+import software.amazon.awssdk.core.SdkBytes;
 
 /**
  * Helper class for resolving Poet {@link TypeName}s for use in model classes.
@@ -68,6 +68,9 @@ public class TypeProvider {
     }
 
     public TypeName returnType(MemberModel memberModel) {
+        if (memberModel.getVariable().getVariableType().endsWith("SdkBytes")) {
+            return TypeName.get(SdkBytes.class);
+        }
         return fieldType(memberModel, false);
     }
 
@@ -171,10 +174,7 @@ public class TypeProvider {
                 Double.class,
                 Float.class,
                 BigDecimal.class,
-                // TODO: Revisit use of this for non-streaming binary blobs
-                // and whether we even make a distinction between streaming
-                // and non-streaming
-                ByteBuffer.class,
+                SdkBytes.class,
                 InputStream.class,
                 Instant.class)
                 .filter(cls -> cls.getName().equals(simpleType) || cls.getSimpleName().equals(simpleType))

--- a/codegen/src/main/resources/macros/marshaller/rest-json/RequestMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/rest-json/RequestMarshallerMacro.ftl
@@ -74,8 +74,8 @@ public class ${shapeName}Marshaller implements Marshaller<Request<${shapeName}>,
                 if (!request.getHeaders().containsKey("Content-Type")) {
                     request.addHeader("Content-Type", protocolFactory.getContentType());
                 }
-                <#elseif (member.http.isPayload) && member.variable.variableType = "java.nio.ByteBuffer">
-                request.setContent(BinaryUtils.toStream(${shape.variable.variableName}.${member.getterMethodName}()));
+                <#elseif (member.http.isPayload) && member.variable.variableType = "software.amazon.awssdk.core.SdkBytes">
+                request.setContent(${shape.variable.variableName}.${member.getterMethodName}().asInputStream());
                 if (!request.getHeaders().containsKey("Content-Type")) {
                     request.addHeader("Content-Type", protocolFactory.getContentType());
                 }

--- a/codegen/src/main/resources/macros/marshaller/rest-xml/MemberMarshallerMacro.ftl
+++ b/codegen/src/main/resources/macros/marshaller/rest-xml/MemberMarshallerMacro.ftl
@@ -10,6 +10,10 @@
 <#if member.simple>
     <#if member.idempotencyToken>
         xmlWriter.startElement("${http.marshallLocationName}").value(<@IdempotencyTokenMacro.content getMember member.variable.simpleType/>).endElement();
+    <#elseif member.sdkBytesType>
+        if(${getMember}() != null) {
+            xmlWriter.startElement("${http.marshallLocationName}").value(${getMember}().asByteBuffer()).endElement();
+        }
     <#else>
         if(${getMember}() != null) {
             xmlWriter.startElement("${http.marshallLocationName}").value(${getMember}()).endElement();
@@ -32,7 +36,11 @@
           <#local memberLocationName = listModel.memberLocationName!http.marshallLocationName />
           xmlWriter.startElement("${memberLocationName}");
           <#if listModel.simple>
-              xmlWriter.value(${loopVariable});
+              <#if listModel.listMemberModel.sdkBytesType>
+                  xmlWriter.value(${loopVariable}.asByteBuffer());
+              <#else>
+                  xmlWriter.value(${loopVariable});
+              </#if>
           <#else>
               <@MemberMarshallerMacro.content customConfig listModel.memberType loopVariable shapes/>
           </#if>
@@ -46,7 +54,11 @@
           <#local memberLocationName = listModel.memberLocationName!"member" />
           xmlWriter.startElement("${memberLocationName}");
           <#if listModel.simple>
-              xmlWriter.value(${loopVariable});
+              <#if listModel.listMemberModel.sdkBytesType>
+                  xmlWriter.value(${loopVariable}.asByteBuffer());
+              <#else>
+                  xmlWriter.value(${loopVariable});
+              </#if>
           <#else>
               <@MemberMarshallerMacro.content customConfig listModel.memberType loopVariable shapes/>
           </#if>
@@ -72,7 +84,11 @@
             xmlWriter.endElement();
             xmlWriter.startElement("${mapModel.valueLocationName}");
             <#if mapModel.valueModel.simple>
-                xmlWriter.value(${loopVariable}.getValue());
+                <#if mapModel.valueModel.sdkBytesType>
+                  xmlWriter.value(${loopVariable}.getValue().asByteBuffer());
+                <#else>
+                  xmlWriter.value(${loopVariable}.getValue());
+                </#if>
             <#else>
                 <@MemberMarshallerMacro.content customConfig mapModel.valueModel.variable.variableType loopVariable shapes/>
             </#if>

--- a/codegen/src/main/resources/templates/json/ModelJsonUnmarshaller.ftl
+++ b/codegen/src/main/resources/templates/json/ModelJsonUnmarshaller.ftl
@@ -4,7 +4,7 @@ package ${transformPackage};
 import java.util.Map;
 import java.util.Map.Entry;
 import java.math.*;
-import java.nio.ByteBuffer;
+import software.amazon.awssdk.core.SdkBytes;
 import javax.annotation.Generated;
 
 import ${metadata.fullModelPackageName}.*;
@@ -52,11 +52,11 @@ public class ${shape.shapeName}Unmarshaller implements Unmarshaller<${shape.shap
     <#assign explicitPayloadMember=shape.payloadMember />
     <#if explicitPayloadMember.http.isStreaming>
         <#-- Intentionally left blank, streaming handled by SyncResponseHandler -->
-    <#elseif explicitPayloadMember.variable.variableType == "java.nio.ByteBuffer">
+    <#elseif explicitPayloadMember.variable.variableType == "software.amazon.awssdk.core.SdkBytes">
         java.io.InputStream is = context.getHttpResponse().getContent();
         if(is != null) {
             try {
-                ${shape.variable.variableName}Builder.${explicitPayloadMember.fluentSetterMethodName}(java.nio.ByteBuffer.wrap(software.amazon.awssdk.utils.IoUtils.toByteArray(is)));
+                ${shape.variable.variableName}Builder.${explicitPayloadMember.fluentSetterMethodName}(software.amazon.awssdk.core.SdkBytes.fromInputStream(is));
             } finally {
                 software.amazon.awssdk.utils.IoUtils.closeQuietly(is, null);
             }

--- a/codegen/src/main/resources/templates/json/ModelMarshaller.ftl
+++ b/codegen/src/main/resources/templates/json/ModelMarshaller.ftl
@@ -66,8 +66,8 @@ public class ${className} {
                 <#assign getter = shape.variable.variableName + "." + member.fluentGetterMethodName + "()" />
 
                 protocolMarshaller.marshall(
-                ${getter},
-                ${member.marshallerBindingFieldName});
+                    ${getter},
+                    ${member.marshallerBindingFieldName});
                 </#list>
             </#if>
         } catch (Exception e) {

--- a/codegen/src/main/resources/templates/rest-xml/request-marshaller.ftl
+++ b/codegen/src/main/resources/templates/rest-xml/request-marshaller.ftl
@@ -75,8 +75,8 @@ public class ${shapeName}Marshaller implements Marshaller<Request<${shapeName}>,
             <#list shape.members as member>
                 <#if (member.http.isStreaming)>
                 <#-- Content is set by StreamingRequestMarshaller -->
-                <#elseif (member.http.isPayload) && member.variable.variableType = "java.nio.ByteBuffer">
-                request.setContent(BinaryUtils.toStream(${shape.variable.variableName}.${member.fluentGetterMethodName}()));
+                <#elseif (member.http.isPayload) && member.variable.variableType = "software.amazon.awssdk.core.SdkBytes">
+                request.setContent(${shape.variable.variableName}.${member.fluentGetterMethodName}().asInputStream());
                 if (!request.getHeaders().containsKey("Content-Type")) {
                     request.addHeader("Content-Type", "binary/octet-stream");
                 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/ModelCopierSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/ModelCopierSpecTest.java
@@ -93,11 +93,11 @@ public class ModelCopierSpecTest {
     public void doesNotReturnACopierForImmutableTypes() {
         ServiceModelCopiers copiers = new ServiceModelCopiers(intermediateModel);
 
-        // Find members that are not Maps, Lists, Dates, or ByteBuffers
+        // Find members that are not Maps, Lists, Dates, or SdkBytes
         List<MemberModel> immutableMembers = testMemberModels.shapeToMemberMap().values().stream()
                 .filter(m -> !(m.isList() || m.isMap()))
                 .filter(m -> !(m.getVariable().getSimpleType().equals("Date")))
-                .filter(m -> !(m.getVariable().getSimpleType().equals("ByteBuffer")))
+                .filter(m -> !(m.getVariable().getSimpleType().equals("SdkBytes")))
                 .collect(Collectors.toList());
 
         // Quick sanity check to ensure we're actually testing something

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -14,8 +14,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
-import software.amazon.awssdk.core.adapter.StringToByteBufferAdapter;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
+import software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter;
 import software.amazon.awssdk.core.runtime.TypeConverter;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -66,13 +67,13 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     private final StructWithTimestamp structWithNestedTimestampMember;
 
-    private final ByteBuffer blobArg;
+    private final SdkBytes blobArg;
 
     private final StructWithNestedBlobType structWithNestedBlob;
 
-    private final Map<String, ByteBuffer> blobMap;
+    private final Map<String, SdkBytes> blobMap;
 
-    private final List<ByteBuffer> listOfBlobs;
+    private final List<SdkBytes> listOfBlobs;
 
     private final RecursiveStructType recursiveStruct;
 
@@ -382,14 +383,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * <p>
-     * This method will return a new read-only {@code ByteBuffer} each time it is invoked.
-     * </p>
      *
      * @return The value of the BlobArg property for this object.
      */
-    public ByteBuffer blobArg() {
-        return blobArg == null ? null : blobArg.asReadOnlyBuffer();
+    public SdkBytes blobArg() {
+        return blobArg;
     }
 
     /**
@@ -409,7 +407,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the BlobMap property for this object.
      */
-    public Map<String, ByteBuffer> blobMap() {
+    public Map<String, SdkBytes> blobMap() {
         return blobMap;
     }
 
@@ -421,7 +419,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the ListOfBlobs property for this object.
      */
-    public List<ByteBuffer> listOfBlobs() {
+    public List<SdkBytes> listOfBlobs() {
         return listOfBlobs;
     }
 
@@ -941,16 +939,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         /**
          * Sets the value of the BlobArg property for this object.
-         * <p>
-         * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
-         * set.
-         * </p>
          *
          * @param blobArg
          *        The new value for the BlobArg property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobArg(ByteBuffer blobArg);
+        Builder blobArg(SdkBytes blobArg);
 
         Builder blobArg(String blobArg);
 
@@ -988,7 +982,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the BlobMap property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobMap(Map<String, ByteBuffer> blobMap);
+        Builder blobMap(Map<String, SdkBytes> blobMap);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -997,7 +991,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs);
+        Builder listOfBlobs(Collection<SdkBytes> listOfBlobs);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -1006,7 +1000,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(ByteBuffer... listOfBlobs);
+        Builder listOfBlobs(SdkBytes... listOfBlobs);
 
         /**
          * Sets the value of the RecursiveStruct property for this object.
@@ -1157,13 +1151,13 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         private StructWithTimestamp structWithNestedTimestampMember;
 
-        private ByteBuffer blobArg;
+        private SdkBytes blobArg;
 
         private StructWithNestedBlobType structWithNestedBlob;
 
-        private Map<String, ByteBuffer> blobMap;
+        private Map<String, SdkBytes> blobMap;
 
-        private List<ByteBuffer> listOfBlobs = DefaultSdkAutoConstructList.getInstance();
+        private List<SdkBytes> listOfBlobs = DefaultSdkAutoConstructList.getInstance();
 
         private RecursiveStructType recursiveStruct;
 
@@ -1551,26 +1545,26 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         public final ByteBuffer getBlobArg() {
-            return blobArg;
+            return blobArg == null ? null : blobArg.asByteBuffer();
         }
 
         @Override
-        public final Builder blobArg(ByteBuffer blobArg) {
+        public final Builder blobArg(SdkBytes blobArg) {
             this.blobArg = StandardMemberCopier.copy(blobArg);
             return this;
         }
 
         public final void setBlobArg(ByteBuffer blobArg) {
-            this.blobArg = StandardMemberCopier.copy(blobArg);
+            blobArg(blobArg == null ? null : SdkBytes.fromByteBuffer(blobArg));
         }
 
         public Builder blobArg(String blobArg) {
-            blobArg(new StringToByteBufferAdapter().adapt(blobArg));
+            blobArg(new StringToSdkBytesAdapter().adapt(blobArg));
             return this;
         }
 
         public void setBlobArg(String blobArg) {
-            this.blobArg = new StringToByteBufferAdapter().adapt(blobArg);
+            this.blobArg = new StringToSdkBytesAdapter().adapt(blobArg);
         }
 
         public final StructWithNestedBlobType.Builder getStructWithNestedBlob() {
@@ -1588,38 +1582,41 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         public final Map<String, ByteBuffer> getBlobMap() {
-            return blobMap;
+            return blobMap == null ? null : blobMap.entrySet().stream()
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
-        public final Builder blobMap(Map<String, ByteBuffer> blobMap) {
+        public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
             return this;
         }
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
-            this.blobMap = BlobMapTypeCopier.copy(blobMap);
+            blobMap(blobMap == null ? null : blobMap.entrySet().stream()
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
-        public final Collection<ByteBuffer> getListOfBlobs() {
-            return listOfBlobs;
+        public final List<ByteBuffer> getListOfBlobs() {
+            return listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::asByteBuffer).collect(Collectors.toList());
         }
 
         @Override
-        public final Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs) {
+        public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
             return this;
         }
 
         @Override
         @SafeVarargs
-        public final Builder listOfBlobs(ByteBuffer... listOfBlobs) {
+        public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
             return this;
         }
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
-            this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
+            listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -13,8 +13,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
-import software.amazon.awssdk.core.adapter.StringToByteBufferAdapter;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
+import software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter;
 import software.amazon.awssdk.core.runtime.TypeConverter;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -65,13 +66,13 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     private final StructWithTimestamp structWithNestedTimestampMember;
 
-    private final ByteBuffer blobArg;
+    private final SdkBytes blobArg;
 
     private final StructWithNestedBlobType structWithNestedBlob;
 
-    private final Map<String, ByteBuffer> blobMap;
+    private final Map<String, SdkBytes> blobMap;
 
-    private final List<ByteBuffer> listOfBlobs;
+    private final List<SdkBytes> listOfBlobs;
 
     private final RecursiveStructType recursiveStruct;
 
@@ -381,14 +382,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * <p>
-     * This method will return a new read-only {@code ByteBuffer} each time it is invoked.
-     * </p>
      *
      * @return The value of the BlobArg property for this object.
      */
-    public ByteBuffer blobArg() {
-        return blobArg == null ? null : blobArg.asReadOnlyBuffer();
+    public SdkBytes blobArg() {
+        return blobArg;
     }
 
     /**
@@ -408,7 +406,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the BlobMap property for this object.
      */
-    public Map<String, ByteBuffer> blobMap() {
+    public Map<String, SdkBytes> blobMap() {
         return blobMap;
     }
 
@@ -420,7 +418,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the ListOfBlobs property for this object.
      */
-    public List<ByteBuffer> listOfBlobs() {
+    public List<SdkBytes> listOfBlobs() {
         return listOfBlobs;
     }
 
@@ -940,16 +938,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         /**
          * Sets the value of the BlobArg property for this object.
-         * <p>
-         * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
-         * set.
-         * </p>
          *
          * @param blobArg
          *        The new value for the BlobArg property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobArg(ByteBuffer blobArg);
+        Builder blobArg(SdkBytes blobArg);
 
         Builder blobArg(String blobArg);
 
@@ -987,7 +981,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the BlobMap property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobMap(Map<String, ByteBuffer> blobMap);
+        Builder blobMap(Map<String, SdkBytes> blobMap);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -996,7 +990,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs);
+        Builder listOfBlobs(Collection<SdkBytes> listOfBlobs);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -1005,7 +999,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(ByteBuffer... listOfBlobs);
+        Builder listOfBlobs(SdkBytes... listOfBlobs);
 
         /**
          * Sets the value of the RecursiveStruct property for this object.
@@ -1150,13 +1144,13 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         private StructWithTimestamp structWithNestedTimestampMember;
 
-        private ByteBuffer blobArg;
+        private SdkBytes blobArg;
 
         private StructWithNestedBlobType structWithNestedBlob;
 
-        private Map<String, ByteBuffer> blobMap;
+        private Map<String, SdkBytes> blobMap;
 
-        private List<ByteBuffer> listOfBlobs = DefaultSdkAutoConstructList.getInstance();
+        private List<SdkBytes> listOfBlobs = DefaultSdkAutoConstructList.getInstance();
 
         private RecursiveStructType recursiveStruct;
 
@@ -1544,26 +1538,26 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         public final ByteBuffer getBlobArg() {
-            return blobArg;
+            return blobArg == null ? null : blobArg.asByteBuffer();
         }
 
         @Override
-        public final Builder blobArg(ByteBuffer blobArg) {
+        public final Builder blobArg(SdkBytes blobArg) {
             this.blobArg = StandardMemberCopier.copy(blobArg);
             return this;
         }
 
         public final void setBlobArg(ByteBuffer blobArg) {
-            this.blobArg = StandardMemberCopier.copy(blobArg);
+            blobArg(blobArg == null ? null : SdkBytes.fromByteBuffer(blobArg));
         }
 
         public Builder blobArg(String blobArg) {
-            blobArg(new StringToByteBufferAdapter().adapt(blobArg));
+            blobArg(new StringToSdkBytesAdapter().adapt(blobArg));
             return this;
         }
 
         public void setBlobArg(String blobArg) {
-            this.blobArg = new StringToByteBufferAdapter().adapt(blobArg);
+            this.blobArg = new StringToSdkBytesAdapter().adapt(blobArg);
         }
 
         public final StructWithNestedBlobType.Builder getStructWithNestedBlob() {
@@ -1581,38 +1575,41 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         public final Map<String, ByteBuffer> getBlobMap() {
-            return blobMap;
+            return blobMap == null ? null : blobMap.entrySet().stream()
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
-        public final Builder blobMap(Map<String, ByteBuffer> blobMap) {
+        public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
             return this;
         }
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
-            this.blobMap = BlobMapTypeCopier.copy(blobMap);
+            blobMap(blobMap == null ? null : blobMap.entrySet().stream()
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
-        public final Collection<ByteBuffer> getListOfBlobs() {
-            return listOfBlobs;
+        public final List<ByteBuffer> getListOfBlobs() {
+            return listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::asByteBuffer).collect(Collectors.toList());
         }
 
         @Override
-        public final Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs) {
+        public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
             return this;
         }
 
         @Override
         @SafeVarargs
-        public final Builder listOfBlobs(ByteBuffer... listOfBlobs) {
+        public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
             return this;
         }
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
-            this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
+            listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
@@ -2,20 +2,20 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class BlobMapTypeCopier {
-    static Map<String, ByteBuffer> copy(Map<String, ByteBuffer> blobMapTypeParam) {
+    static Map<String, SdkBytes> copy(Map<String, SdkBytes> blobMapTypeParam) {
         if (blobMapTypeParam == null) {
             return null;
         }
-        Map<String, ByteBuffer> blobMapTypeParamCopy = blobMapTypeParam.entrySet().stream()
-                                                                       .collect(toMap(Map.Entry::getKey, e -> StandardMemberCopier.copy(e.getValue())));
+        Map<String, SdkBytes> blobMapTypeParamCopy = blobMapTypeParam.entrySet().stream()
+                                                                     .collect(toMap(Map.Entry::getKey, e -> StandardMemberCopier.copy(e.getValue())));
         return Collections.unmodifiableMap(blobMapTypeParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/customization.config
@@ -9,7 +9,7 @@
             "shapeName": "AllTypesStructure",
             "memberName": "BlobArg",
             "convenienceType": "java.lang.String",
-            "typeAdapterFqcn": "software.amazon.awssdk.core.adapter.StringToByteBufferAdapter"
+            "typeAdapterFqcn": "software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter"
         }
     ]
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofblobstypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofblobstypecopier.java
@@ -2,23 +2,22 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfBlobsTypeCopier {
-    static List<ByteBuffer> copy(Collection<ByteBuffer> listOfBlobsTypeParam) {
+    static List<SdkBytes> copy(Collection<SdkBytes> listOfBlobsTypeParam) {
         if (listOfBlobsTypeParam == null || listOfBlobsTypeParam instanceof SdkAutoConstructList) {
             return DefaultSdkAutoConstructList.getInstance();
         }
-        List<ByteBuffer> listOfBlobsTypeParamCopy = listOfBlobsTypeParam.stream().map(StandardMemberCopier::copy)
-                .collect(toList());
+        List<SdkBytes> listOfBlobsTypeParamCopy = listOfBlobsTypeParam.stream().map(StandardMemberCopier::copy).collect(toList());
         return Collections.unmodifiableList(listOfBlobsTypeParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesrequest.java
@@ -14,8 +14,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
-import software.amazon.awssdk.core.adapter.StringToByteBufferAdapter;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
+import software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter;
 import software.amazon.awssdk.core.runtime.TypeConverter;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
@@ -65,13 +66,13 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     private final StructWithTimestamp structWithNestedTimestampMember;
 
-    private final ByteBuffer blobArg;
+    private final SdkBytes blobArg;
 
     private final StructWithNestedBlobType structWithNestedBlob;
 
-    private final Map<String, ByteBuffer> blobMap;
+    private final Map<String, SdkBytes> blobMap;
 
-    private final List<ByteBuffer> listOfBlobs;
+    private final List<SdkBytes> listOfBlobs;
 
     private final RecursiveStructType recursiveStruct;
 
@@ -381,14 +382,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * <p>
-     * This method will return a new read-only {@code ByteBuffer} each time it is invoked.
-     * </p>
      *
      * @return The value of the BlobArg property for this object.
      */
-    public ByteBuffer blobArg() {
-        return blobArg == null ? null : blobArg.asReadOnlyBuffer();
+    public SdkBytes blobArg() {
+        return blobArg;
     }
 
     /**
@@ -408,7 +406,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the BlobMap property for this object.
      */
-    public Map<String, ByteBuffer> blobMap() {
+    public Map<String, SdkBytes> blobMap() {
         return blobMap;
     }
 
@@ -420,7 +418,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      *
      * @return The value of the ListOfBlobs property for this object.
      */
-    public List<ByteBuffer> listOfBlobs() {
+    public List<SdkBytes> listOfBlobs() {
         return listOfBlobs;
     }
 
@@ -940,16 +938,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         /**
          * Sets the value of the BlobArg property for this object.
-         * <p>
-         * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
-         * set.
-         * </p>
          *
          * @param blobArg
          *        The new value for the BlobArg property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobArg(ByteBuffer blobArg);
+        Builder blobArg(SdkBytes blobArg);
 
         Builder blobArg(String blobArg);
 
@@ -987,7 +981,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the BlobMap property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobMap(Map<String, ByteBuffer> blobMap);
+        Builder blobMap(Map<String, SdkBytes> blobMap);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -996,7 +990,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs);
+        Builder listOfBlobs(Collection<SdkBytes> listOfBlobs);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -1005,7 +999,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(ByteBuffer... listOfBlobs);
+        Builder listOfBlobs(SdkBytes... listOfBlobs);
 
         /**
          * Sets the value of the RecursiveStruct property for this object.
@@ -1156,13 +1150,13 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         private StructWithTimestamp structWithNestedTimestampMember;
 
-        private ByteBuffer blobArg;
+        private SdkBytes blobArg;
 
         private StructWithNestedBlobType structWithNestedBlob;
 
-        private Map<String, ByteBuffer> blobMap;
+        private Map<String, SdkBytes> blobMap;
 
-        private List<ByteBuffer> listOfBlobs;
+        private List<SdkBytes> listOfBlobs;
 
         private RecursiveStructType recursiveStruct;
 
@@ -1550,26 +1544,26 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         public final ByteBuffer getBlobArg() {
-            return blobArg;
+            return blobArg == null ? null : blobArg.asByteBuffer();
         }
 
         @Override
-        public final Builder blobArg(ByteBuffer blobArg) {
+        public final Builder blobArg(SdkBytes blobArg) {
             this.blobArg = StandardMemberCopier.copy(blobArg);
             return this;
         }
 
         public final void setBlobArg(ByteBuffer blobArg) {
-            this.blobArg = StandardMemberCopier.copy(blobArg);
+            blobArg(blobArg == null ? null : SdkBytes.fromByteBuffer(blobArg));
         }
 
         public Builder blobArg(String blobArg) {
-            blobArg(new StringToByteBufferAdapter().adapt(blobArg));
+            blobArg(new StringToSdkBytesAdapter().adapt(blobArg));
             return this;
         }
 
         public void setBlobArg(String blobArg) {
-            this.blobArg = new StringToByteBufferAdapter().adapt(blobArg);
+            this.blobArg = new StringToSdkBytesAdapter().adapt(blobArg);
         }
 
         public final StructWithNestedBlobType.Builder getStructWithNestedBlob() {
@@ -1587,38 +1581,41 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         public final Map<String, ByteBuffer> getBlobMap() {
-            return blobMap;
+            return blobMap == null ? null : blobMap.entrySet().stream()
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
-        public final Builder blobMap(Map<String, ByteBuffer> blobMap) {
+        public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
             return this;
         }
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
-            this.blobMap = BlobMapTypeCopier.copy(blobMap);
+            blobMap(blobMap == null ? null : blobMap.entrySet().stream()
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
-        public final Collection<ByteBuffer> getListOfBlobs() {
-            return listOfBlobs;
+        public final List<ByteBuffer> getListOfBlobs() {
+            return listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::asByteBuffer).collect(Collectors.toList());
         }
 
         @Override
-        public final Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs) {
+        public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
             return this;
         }
 
         @Override
         @SafeVarargs
-        public final Builder listOfBlobs(ByteBuffer... listOfBlobs) {
+        public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
             return this;
         }
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
-            this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
+            listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesresponse.java
@@ -13,8 +13,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.Generated;
-import software.amazon.awssdk.core.adapter.StringToByteBufferAdapter;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
+import software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter;
 import software.amazon.awssdk.core.runtime.TypeConverter;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
@@ -64,13 +65,13 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     private final StructWithTimestamp structWithNestedTimestampMember;
 
-    private final ByteBuffer blobArg;
+    private final SdkBytes blobArg;
 
     private final StructWithNestedBlobType structWithNestedBlob;
 
-    private final Map<String, ByteBuffer> blobMap;
+    private final Map<String, SdkBytes> blobMap;
 
-    private final List<ByteBuffer> listOfBlobs;
+    private final List<SdkBytes> listOfBlobs;
 
     private final RecursiveStructType recursiveStruct;
 
@@ -380,14 +381,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * <p>
-     * This method will return a new read-only {@code ByteBuffer} each time it is invoked.
-     * </p>
      *
      * @return The value of the BlobArg property for this object.
      */
-    public ByteBuffer blobArg() {
-        return blobArg == null ? null : blobArg.asReadOnlyBuffer();
+    public SdkBytes blobArg() {
+        return blobArg;
     }
 
     /**
@@ -407,7 +405,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the BlobMap property for this object.
      */
-    public Map<String, ByteBuffer> blobMap() {
+    public Map<String, SdkBytes> blobMap() {
         return blobMap;
     }
 
@@ -419,7 +417,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      *
      * @return The value of the ListOfBlobs property for this object.
      */
-    public List<ByteBuffer> listOfBlobs() {
+    public List<SdkBytes> listOfBlobs() {
         return listOfBlobs;
     }
 
@@ -939,16 +937,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         /**
          * Sets the value of the BlobArg property for this object.
-         * <p>
-         * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
-         * set.
-         * </p>
          *
          * @param blobArg
          *        The new value for the BlobArg property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobArg(ByteBuffer blobArg);
+        Builder blobArg(SdkBytes blobArg);
 
         Builder blobArg(String blobArg);
 
@@ -986,7 +980,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the BlobMap property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder blobMap(Map<String, ByteBuffer> blobMap);
+        Builder blobMap(Map<String, SdkBytes> blobMap);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -995,7 +989,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs);
+        Builder listOfBlobs(Collection<SdkBytes> listOfBlobs);
 
         /**
          * Sets the value of the ListOfBlobs property for this object.
@@ -1004,7 +998,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the ListOfBlobs property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder listOfBlobs(ByteBuffer... listOfBlobs);
+        Builder listOfBlobs(SdkBytes... listOfBlobs);
 
         /**
          * Sets the value of the RecursiveStruct property for this object.
@@ -1149,13 +1143,13 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         private StructWithTimestamp structWithNestedTimestampMember;
 
-        private ByteBuffer blobArg;
+        private SdkBytes blobArg;
 
         private StructWithNestedBlobType structWithNestedBlob;
 
-        private Map<String, ByteBuffer> blobMap;
+        private Map<String, SdkBytes> blobMap;
 
-        private List<ByteBuffer> listOfBlobs;
+        private List<SdkBytes> listOfBlobs;
 
         private RecursiveStructType recursiveStruct;
 
@@ -1543,26 +1537,26 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         public final ByteBuffer getBlobArg() {
-            return blobArg;
+            return blobArg == null ? null : blobArg.asByteBuffer();
         }
 
         @Override
-        public final Builder blobArg(ByteBuffer blobArg) {
+        public final Builder blobArg(SdkBytes blobArg) {
             this.blobArg = StandardMemberCopier.copy(blobArg);
             return this;
         }
 
         public final void setBlobArg(ByteBuffer blobArg) {
-            this.blobArg = StandardMemberCopier.copy(blobArg);
+            blobArg(blobArg == null ? null : SdkBytes.fromByteBuffer(blobArg));
         }
 
         public Builder blobArg(String blobArg) {
-            blobArg(new StringToByteBufferAdapter().adapt(blobArg));
+            blobArg(new StringToSdkBytesAdapter().adapt(blobArg));
             return this;
         }
 
         public void setBlobArg(String blobArg) {
-            this.blobArg = new StringToByteBufferAdapter().adapt(blobArg);
+            this.blobArg = new StringToSdkBytesAdapter().adapt(blobArg);
         }
 
         public final StructWithNestedBlobType.Builder getStructWithNestedBlob() {
@@ -1580,38 +1574,41 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         public final Map<String, ByteBuffer> getBlobMap() {
-            return blobMap;
+            return blobMap == null ? null : blobMap.entrySet().stream()
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
-        public final Builder blobMap(Map<String, ByteBuffer> blobMap) {
+        public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
             return this;
         }
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
-            this.blobMap = BlobMapTypeCopier.copy(blobMap);
+            blobMap(blobMap == null ? null : blobMap.entrySet().stream()
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
-        public final Collection<ByteBuffer> getListOfBlobs() {
-            return listOfBlobs;
+        public final List<ByteBuffer> getListOfBlobs() {
+            return listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::asByteBuffer).collect(Collectors.toList());
         }
 
         @Override
-        public final Builder listOfBlobs(Collection<ByteBuffer> listOfBlobs) {
+        public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
             return this;
         }
 
         @Override
         @SafeVarargs
-        public final Builder listOfBlobs(ByteBuffer... listOfBlobs) {
+        public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
             return this;
         }
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
-            this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
+            listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/listofblobstypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/listofblobstypecopier.java
@@ -2,21 +2,20 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfBlobsTypeCopier {
-    static List<ByteBuffer> copy(Collection<ByteBuffer> listOfBlobsTypeParam) {
+    static List<SdkBytes> copy(Collection<SdkBytes> listOfBlobsTypeParam) {
         if (listOfBlobsTypeParam == null) {
             return null;
         }
-        List<ByteBuffer> listOfBlobsTypeParamCopy = listOfBlobsTypeParam.stream().map(StandardMemberCopier::copy)
-                .collect(toList());
+        List<SdkBytes> listOfBlobsTypeParamCopy = listOfBlobsTypeParam.stream().map(StandardMemberCopier::copy).collect(toList());
         return Collections.unmodifiableList(listOfBlobsTypeParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
@@ -5,7 +5,8 @@ import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.internal.StandardMemberCopier;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.protocol.ProtocolMarshaller;
 import software.amazon.awssdk.core.protocol.StructuredPojo;
 import software.amazon.awssdk.services.jsonprotocoltests.transform.StructWithNestedBlobTypeMarshaller;
@@ -17,9 +18,8 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class StructWithNestedBlobType implements StructuredPojo,
-                                                       ToCopyableBuilder<StructWithNestedBlobType.Builder,
-                                                           StructWithNestedBlobType> {
-    private final ByteBuffer nestedBlob;
+                                                       ToCopyableBuilder<StructWithNestedBlobType.Builder, StructWithNestedBlobType> {
+    private final SdkBytes nestedBlob;
 
     private StructWithNestedBlobType(BuilderImpl builder) {
         this.nestedBlob = builder.nestedBlob;
@@ -27,14 +27,11 @@ public final class StructWithNestedBlobType implements StructuredPojo,
 
     /**
      * Returns the value of the NestedBlob property for this object.
-     * <p>
-     * This method will return a new read-only {@code ByteBuffer} each time it is invoked.
-     * </p>
      *
      * @return The value of the NestedBlob property for this object.
      */
-    public ByteBuffer nestedBlob() {
-        return nestedBlob == null ? null : nestedBlob.asReadOnlyBuffer();
+    public SdkBytes nestedBlob() {
+        return nestedBlob;
     }
 
     @Override
@@ -95,20 +92,16 @@ public final class StructWithNestedBlobType implements StructuredPojo,
     public interface Builder extends CopyableBuilder<Builder, StructWithNestedBlobType> {
         /**
          * Sets the value of the NestedBlob property for this object.
-         * <p>
-         * To preserve immutability, the remaining bytes in the provided buffer will be copied into a new buffer when
-         * set.
-         * </p>
          *
          * @param nestedBlob
          *        The new value for the NestedBlob property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder nestedBlob(ByteBuffer nestedBlob);
+        Builder nestedBlob(SdkBytes nestedBlob);
     }
 
     static final class BuilderImpl implements Builder {
-        private ByteBuffer nestedBlob;
+        private SdkBytes nestedBlob;
 
         private BuilderImpl() {
         }
@@ -118,17 +111,17 @@ public final class StructWithNestedBlobType implements StructuredPojo,
         }
 
         public final ByteBuffer getNestedBlob() {
-            return nestedBlob;
+            return nestedBlob == null ? null : nestedBlob.asByteBuffer();
         }
 
         @Override
-        public final Builder nestedBlob(ByteBuffer nestedBlob) {
+        public final Builder nestedBlob(SdkBytes nestedBlob) {
             this.nestedBlob = StandardMemberCopier.copy(nestedBlob);
             return this;
         }
 
         public final void setNestedBlob(ByteBuffer nestedBlob) {
-            this.nestedBlob = StandardMemberCopier.copy(nestedBlob);
+            nestedBlob(nestedBlob == null ? null : SdkBytes.fromByteBuffer(nestedBlob));
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/alltypesrequestmodelmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/alltypesrequestmodelmarshaller.java
@@ -1,11 +1,11 @@
 package software.amazon.awssdk.services.jsonprotocoltests.transform;
 
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingInfo;
@@ -80,8 +80,8 @@ public class AllTypesRequestModelMarshaller {
             .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)
             .marshallLocationName("StructWithNestedTimestampMember").isBinary(false).build();
 
-    private static final MarshallingInfo<ByteBuffer> BLOBARG_BINDING = MarshallingInfo.builder(MarshallingType.BYTE_BUFFER)
-                                                                                      .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("BlobArg").isBinary(false).build();
+    private static final MarshallingInfo<SdkBytes> BLOBARG_BINDING = MarshallingInfo.builder(MarshallingType.SDK_BYTES)
+                                                                                    .marshallLocation(MarshallLocation.PAYLOAD).marshallLocationName("BlobArg").isBinary(false).build();
 
     private static final MarshallingInfo<StructuredPojo> STRUCTWITHNESTEDBLOB_BINDING = MarshallingInfo
             .builder(MarshallingType.STRUCTURED).marshallLocation(MarshallLocation.PAYLOAD)

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/SimpleTypeStaxUnmarshallers.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/SimpleTypeStaxUnmarshallers.java
@@ -17,11 +17,11 @@ package software.amazon.awssdk.awscore.protocol.xml;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 import software.amazon.awssdk.core.util.DateUtils;
@@ -206,17 +206,17 @@ public final class SimpleTypeStaxUnmarshallers {
     /**
      * Unmarshaller for ByteBuffer values.
      */
-    public static class ByteBufferUnmarshaller implements Unmarshaller<ByteBuffer, StaxUnmarshallerContext> {
-        private static final ByteBufferUnmarshaller INSTANCE = new ByteBufferUnmarshaller();
+    public static class SdkBytesUnmarshaller implements Unmarshaller<SdkBytes, StaxUnmarshallerContext> {
+        private static final SdkBytesUnmarshaller INSTANCE = new SdkBytesUnmarshaller();
 
-        public static ByteBufferUnmarshaller getInstance() {
+        public static SdkBytesUnmarshaller getInstance() {
             return INSTANCE;
         }
 
-        public ByteBuffer unmarshall(StaxUnmarshallerContext unmarshallerContext) throws Exception {
+        public SdkBytes unmarshall(StaxUnmarshallerContext unmarshallerContext) throws Exception {
             String base64EncodedString = unmarshallerContext.readText();
             byte[] decodedBytes = Base64Utils.decode(base64EncodedString);
-            return ByteBuffer.wrap(decodedBytes);
+            return SdkBytes.fromByteArray(decodedBytes);
 
         }
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/BytesWrapper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/BytesWrapper.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+abstract class BytesWrapper {
+    private final byte[] bytes;
+
+    BytesWrapper(byte[] bytes) {
+        this.bytes = Validate.paramNotNull(bytes, "bytes");
+    }
+
+    final byte[] wrappedBytes() {
+        return bytes;
+    }
+
+    /**
+     * @return The output as a read-only byte buffer.
+     */
+    public final ByteBuffer asByteBuffer() {
+        return ByteBuffer.wrap(bytes).asReadOnlyBuffer();
+    }
+
+    /**
+     * @return A copy of the output as a byte array.
+     * @see #asByteBuffer() to prevent creating an additional array copy.
+     */
+    public final byte[] asByteArray() {
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+
+    /**
+     * Retrieve the output as a string.
+     *
+     * @param charset The charset of the string.
+     * @return The output as a string.
+     * @throws UncheckedIOException with a {@link CharacterCodingException} as the cause if the bytes cannot be encoded using the
+     * provided charset
+     */
+    public final String asString(Charset charset) throws UncheckedIOException {
+        return StringUtils.fromBytes(bytes, charset);
+    }
+
+    /**
+     * @return The output as a utf-8 encoded string.
+     * @throws UncheckedIOException with a {@link CharacterCodingException} as the cause if the bytes cannot be encoded as UTF-8.
+     */
+    public final String asUtf8String() throws UncheckedIOException {
+        return asString(UTF_8);
+    }
+
+    /**
+     * @return The output as an input stream. This stream will not need to be closed.
+     */
+    public final InputStream asInputStream() {
+        return new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final BytesWrapper sdkBytes = (BytesWrapper) o;
+
+        return Arrays.equals(bytes, sdkBytes.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes);
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkBytes.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkBytes.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An in-memory representation of data being given to a service or being returned by a service.
+ *
+ * This can be created via static methods, like {@link SdkBytes#fromByteArray(byte[])}. This can be converted to binary types
+ * via instance methods, like {@link SdkBytes#asByteArray()}.
+ */
+@SdkPublicApi
+public final class SdkBytes extends BytesWrapper {
+    /**
+     * @see #fromByteArray(byte[])
+     * @see #fromByteBuffer(ByteBuffer)
+     * @see #fromInputStream(InputStream)
+     * @see #fromUtf8String(String)
+     * @see #fromString(String, Charset)
+     */
+    SdkBytes(byte[] bytes) {
+        super(bytes);
+    }
+
+    /**
+     * Create {@link SdkBytes} from a Byte buffer. This will read the remaining contents of the byte buffer.
+     */
+    public static SdkBytes fromByteBuffer(ByteBuffer byteBuffer) {
+        Validate.paramNotNull(byteBuffer, "byteBuffer");
+        return new SdkBytes(BinaryUtils.copyBytesFrom(byteBuffer));
+    }
+
+    /**
+     * Create {@link SdkBytes} from a Byte array. This will copy the contents of the byte array.
+     */
+    public static SdkBytes fromByteArray(byte[] bytes) {
+        Validate.paramNotNull(bytes, "bytes");
+        return new SdkBytes(Arrays.copyOf(bytes, bytes.length));
+    }
+
+    /**
+     * Create {@link SdkBytes} from a string, using the provided charset.
+     */
+    public static SdkBytes fromString(String string, Charset charset) {
+        Validate.paramNotNull(string, "string");
+        Validate.paramNotNull(string, "charset");
+        return new SdkBytes(string.getBytes(charset));
+    }
+
+    /**
+     * Create {@link SdkBytes} from a string, using the UTF-8 charset.
+     */
+    public static SdkBytes fromUtf8String(String string) {
+        return fromString(string, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Create {@link SdkBytes} from an input stream. This will read all of the remaining contents of the stream, but will not
+     * close it.
+     */
+    public static SdkBytes fromInputStream(InputStream inputStream) {
+        Validate.paramNotNull(inputStream, "inputStream");
+        return new SdkBytes(invokeSafely(() -> IoUtils.toByteArray(inputStream)));
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("SdkBytes")
+                       .add("bytes", wrappedBytes())
+                       .build();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StandardMemberCopier.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StandardMemberCopier.java
@@ -13,20 +13,21 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.internal;
+package software.amazon.awssdk.core.adapter;
 
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
-import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.utils.BinaryUtils;
 
 /**
  * Used in combination with the generated member copiers to implement deep
  * copies of shape members.
  */
-@SdkInternalApi
+@SdkProtectedApi
 public final class StandardMemberCopier {
 
     private StandardMemberCopier() {
@@ -70,6 +71,10 @@ public final class StandardMemberCopier {
 
     public static Instant copy(Instant i) {
         return i;
+    }
+
+    public static SdkBytes copy(SdkBytes bytes) {
+        return bytes;
     }
 
     public static ByteBuffer copy(ByteBuffer bb) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StringToSdkBytesAdapter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StringToSdkBytesAdapter.java
@@ -15,20 +15,18 @@
 
 package software.amazon.awssdk.core.adapter;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 
 @SdkProtectedApi
-public final class StringToByteBufferAdapter implements TypeAdapter<String, ByteBuffer> {
-
+public final class StringToSdkBytesAdapter implements TypeAdapter<String, SdkBytes> {
     @Override
-    public ByteBuffer adapt(String source) {
+    public SdkBytes adapt(String source) {
         if (source == null) {
             return null;
         } else {
-            return ByteBuffer.wrap(source.getBytes(StandardCharsets.UTF_8));
+            return SdkBytes.fromByteArray(source.getBytes(StandardCharsets.UTF_8));
         }
     }
-
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
@@ -62,7 +62,7 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
     @Override
     public ResponseBytes<ResponseT> complete() {
         try {
-            return new ResponseBytes<>(response, baos.toByteArray());
+            return ResponseBytes.fromByteArray(response, baos.toByteArray());
         } finally {
             baos = null;
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/JsonProtocolMarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/JsonProtocolMarshaller.java
@@ -20,10 +20,10 @@ import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.DefaultRequest;
 import software.amazon.awssdk.core.Request;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.protocol.MarshallingInfo;
 import software.amazon.awssdk.core.protocol.MarshallingType;
@@ -31,7 +31,6 @@ import software.amazon.awssdk.core.protocol.OperationInfo;
 import software.amazon.awssdk.core.protocol.ProtocolRequestMarshaller;
 import software.amazon.awssdk.core.protocol.json.StructuredJsonGenerator;
 import software.amazon.awssdk.core.util.UriResourcePathUtils;
-import software.amazon.awssdk.utils.BinaryUtils;
 
 /**
  * Implementation of {@link ProtocolRequestMarshaller} for JSON based services. This includes JSON-RPC and REST-JSON.
@@ -90,7 +89,7 @@ public class JsonProtocolMarshaller<OrigRequestT extends SdkRequest> implements 
                 .payloadMarshaller(MarshallingType.BIG_DECIMAL, SimpleTypeJsonMarshaller.BIG_DECIMAL)
                 .payloadMarshaller(MarshallingType.BOOLEAN, SimpleTypeJsonMarshaller.BOOLEAN)
                 .payloadMarshaller(MarshallingType.INSTANT, SimpleTypeJsonMarshaller.INSTANT)
-                .payloadMarshaller(MarshallingType.BYTE_BUFFER, SimpleTypeJsonMarshaller.BYTE_BUFFER)
+                .payloadMarshaller(MarshallingType.SDK_BYTES, SimpleTypeJsonMarshaller.SDK_BYTES)
                 .payloadMarshaller(MarshallingType.STRUCTURED, SimpleTypeJsonMarshaller.STRUCTURED)
                 .payloadMarshaller(MarshallingType.LIST, SimpleTypeJsonMarshaller.LIST)
                 .payloadMarshaller(MarshallingType.MAP, SimpleTypeJsonMarshaller.MAP)
@@ -163,8 +162,8 @@ public class JsonProtocolMarshaller<OrigRequestT extends SdkRequest> implements 
      * Binary data should be placed as is, directly into the content.
      */
     private void marshallBinaryPayload(Object val) {
-        if (val instanceof ByteBuffer) {
-            request.setContent(BinaryUtils.toStream((ByteBuffer) val));
+        if (val instanceof SdkBytes) {
+            request.setContent(((SdkBytes) val).asInputStream());
         } else if (val instanceof InputStream) {
             request.setContent((InputStream) val);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkStructuredCborFactory.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkStructuredCborFactory.java
@@ -19,12 +19,12 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.function.BiFunction;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.protocol.json.StructuredJsonGenerator;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
@@ -56,7 +56,7 @@ public abstract class SdkStructuredCborFactory {
             .put(Long.class, SimpleTypeCborUnmarshallers.LongCborUnmarshaller.getInstance())
             .put(Byte.class, SimpleTypeCborUnmarshallers.ByteCborUnmarshaller.getInstance())
             .put(Date.class, SimpleTypeCborUnmarshallers.DateCborUnmarshaller.getInstance())
-            .put(ByteBuffer.class, SimpleTypeCborUnmarshallers.ByteBufferCborUnmarshaller.getInstance())
+            .put(SdkBytes.class, SimpleTypeCborUnmarshallers.SdkBytesCborUnmarshaller.getInstance())
             .put(Instant.class, SimpleTypeCborUnmarshallers.InstantCborUnmarshaller.getInstance())
             .put(Short.class, SimpleTypeCborUnmarshallers.ShortCborUnmarshaller.getInstance()).build();
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkStructuredIonFactory.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkStructuredIonFactory.java
@@ -18,11 +18,11 @@ package software.amazon.awssdk.core.internal.protocol.json;
 import com.fasterxml.jackson.core.JsonFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.Map;
 import java.util.function.BiFunction;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.protocol.json.StructuredJsonGenerator;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
@@ -45,7 +45,7 @@ public abstract class SdkStructuredIonFactory {
             .put(BigDecimal.class, SimpleTypeIonUnmarshallers.BigDecimalIonUnmarshaller.getInstance())
             .put(BigInteger.class, SimpleTypeIonUnmarshallers.BigIntegerIonUnmarshaller.getInstance())
             .put(Boolean.class, SimpleTypeIonUnmarshallers.BooleanIonUnmarshaller.getInstance())
-            .put(ByteBuffer.class, SimpleTypeIonUnmarshallers.ByteBufferIonUnmarshaller.getInstance())
+            .put(SdkBytes.class, SimpleTypeIonUnmarshallers.SdkBytesIonUnmarshaller.getInstance())
             .put(Byte.class, SimpleTypeIonUnmarshallers.ByteIonUnmarshaller.getInstance())
             .put(Date.class, SimpleTypeIonUnmarshallers.DateIonUnmarshaller.getInstance())
             .put(Double.class, SimpleTypeIonUnmarshallers.DoubleIonUnmarshaller.getInstance())

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SimpleTypeCborUnmarshallers.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SimpleTypeCborUnmarshallers.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Date;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
@@ -198,15 +198,15 @@ public class SimpleTypeCborUnmarshallers {
     /**
      * Unmarshaller for ByteBuffer values.
      */
-    public static class ByteBufferCborUnmarshaller implements Unmarshaller<ByteBuffer, JsonUnmarshallerContext> {
-        private static final ByteBufferCborUnmarshaller INSTANCE = new ByteBufferCborUnmarshaller();
+    public static class SdkBytesCborUnmarshaller implements Unmarshaller<SdkBytes, JsonUnmarshallerContext> {
+        private static final SdkBytesCborUnmarshaller INSTANCE = new SdkBytesCborUnmarshaller();
 
-        public static ByteBufferCborUnmarshaller getInstance() {
+        public static SdkBytesCborUnmarshaller getInstance() {
             return INSTANCE;
         }
 
-        public ByteBuffer unmarshall(JsonUnmarshallerContext unmarshallerContext) throws Exception {
-            return ByteBuffer.wrap(unmarshallerContext.getJsonParser().getBinaryValue());
+        public SdkBytes unmarshall(JsonUnmarshallerContext unmarshallerContext) throws Exception {
+            return SdkBytes.fromByteArray(unmarshallerContext.getJsonParser().getBinaryValue());
 
         }
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SimpleTypeIonUnmarshallers.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SimpleTypeIonUnmarshallers.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 
@@ -156,16 +157,16 @@ public class SimpleTypeIonUnmarshallers {
         }
     }
 
-    public static class ByteBufferIonUnmarshaller implements Unmarshaller<ByteBuffer, JsonUnmarshallerContext> {
-        private static final ByteBufferIonUnmarshaller INSTANCE = new ByteBufferIonUnmarshaller();
+    public static class SdkBytesIonUnmarshaller implements Unmarshaller<SdkBytes, JsonUnmarshallerContext> {
+        private static final SdkBytesIonUnmarshaller INSTANCE = new SdkBytesIonUnmarshaller();
 
-        public static ByteBufferIonUnmarshaller getInstance() {
+        public static SdkBytesIonUnmarshaller getInstance() {
             return INSTANCE;
         }
 
         @Override
-        public ByteBuffer unmarshall(JsonUnmarshallerContext context) throws Exception {
-            return (ByteBuffer) context.getJsonParser().getEmbeddedObject();
+        public SdkBytes unmarshall(JsonUnmarshallerContext context) throws Exception {
+            return SdkBytes.fromByteBuffer((ByteBuffer) context.getJsonParser().getEmbeddedObject());
         }
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SimpleTypeJsonMarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SimpleTypeJsonMarshaller.java
@@ -16,11 +16,11 @@
 package software.amazon.awssdk.core.internal.protocol.json;
 
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.StructuredPojo;
 import software.amazon.awssdk.core.protocol.json.StructuredJsonGenerator;
@@ -95,10 +95,10 @@ public final class SimpleTypeJsonMarshaller {
         }
     };
 
-    public static final JsonMarshaller<ByteBuffer> BYTE_BUFFER = new BaseJsonMarshaller<ByteBuffer>() {
+    public static final JsonMarshaller<SdkBytes> SDK_BYTES = new BaseJsonMarshaller<SdkBytes>() {
         @Override
-        public void marshall(ByteBuffer val, StructuredJsonGenerator jsonGenerator, JsonMarshallerContext context) {
-            jsonGenerator.writeValue(val);
+        public void marshall(SdkBytes val, StructuredJsonGenerator jsonGenerator, JsonMarshallerContext context) {
+            jsonGenerator.writeValue(val.asByteBuffer());
         }
     };
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingInfo.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingInfo.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.protocol;
 
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 
 /**
  * Metadata about the marshalling requirements of a given member. Includes things like where to put the
@@ -74,7 +75,7 @@ public final class MarshallingInfo<T> {
     }
 
     /**
-     * @return True if the payload member is binary data (i.e. a {@link java.nio.ByteBuffer} or {@link java.io.InputStream} and
+     * @return True if the payload member is binary data (i.e. a {@link SdkBytes} or {@link java.io.InputStream} and
      *     should be sent as the request content. This is not true when binary data is bound to a member of the JSON payload
      *     since it will be base64 encoded as a string.
      */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/MarshallingType.java
@@ -17,11 +17,11 @@ package software.amazon.awssdk.core.protocol;
 
 import java.io.InputStream;
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 
 /**
  * Represents the various types supported for marshalling.
@@ -52,7 +52,7 @@ public interface MarshallingType<T> {
 
     MarshallingType<Instant> INSTANT = () -> Instant.class;
 
-    MarshallingType<ByteBuffer> BYTE_BUFFER = () -> ByteBuffer.class;
+    MarshallingType<SdkBytes> SDK_BYTES = () -> SdkBytes.class;
 
     MarshallingType<InputStream> STREAM = () -> InputStream.class;
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkStructuredPlainJsonFactory.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/protocol/json/SdkStructuredPlainJsonFactory.java
@@ -18,11 +18,11 @@ package software.amazon.awssdk.core.protocol.json;
 import com.fasterxml.jackson.core.JsonFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.internal.protocol.json.BaseSdkStructuredJsonFactory;
 import software.amazon.awssdk.core.internal.protocol.json.SdkJsonGenerator;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
@@ -55,7 +55,7 @@ public abstract class SdkStructuredPlainJsonFactory {
             .put(Long.class, SimpleTypeJsonUnmarshallers.LongJsonUnmarshaller.getInstance())
             .put(Byte.class, SimpleTypeJsonUnmarshallers.ByteJsonUnmarshaller.getInstance())
             .put(Instant.class, SimpleTypeJsonUnmarshallers.InstantJsonUnmarshaller.getInstance())
-            .put(ByteBuffer.class, SimpleTypeJsonUnmarshallers.ByteBufferJsonUnmarshaller.getInstance())
+            .put(SdkBytes.class, SimpleTypeJsonUnmarshallers.SdkBytesJsonUnmarshaller.getInstance())
             .put(Character.class, SimpleTypeJsonUnmarshallers.CharacterJsonUnmarshaller.getInstance())
             .put(Short.class, SimpleTypeJsonUnmarshallers.ShortJsonUnmarshaller.getInstance()).build();
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/SimpleTypeJsonUnmarshallers.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/SimpleTypeJsonUnmarshallers.java
@@ -17,9 +17,9 @@ package software.amazon.awssdk.core.runtime.transform;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.util.DateUtils;
 import software.amazon.awssdk.utils.Base64Utils;
@@ -183,20 +183,20 @@ public final class SimpleTypeJsonUnmarshallers {
     /**
      * Unmarshaller for ByteBuffer values.
      */
-    public static class ByteBufferJsonUnmarshaller implements Unmarshaller<ByteBuffer, JsonUnmarshallerContext> {
-        private static final ByteBufferJsonUnmarshaller INSTANCE = new ByteBufferJsonUnmarshaller();
+    public static class SdkBytesJsonUnmarshaller implements Unmarshaller<SdkBytes, JsonUnmarshallerContext> {
+        private static final SdkBytesJsonUnmarshaller INSTANCE = new SdkBytesJsonUnmarshaller();
 
-        public static ByteBufferJsonUnmarshaller getInstance() {
+        public static SdkBytesJsonUnmarshaller getInstance() {
             return INSTANCE;
         }
 
-        public ByteBuffer unmarshall(JsonUnmarshallerContext unmarshallerContext) throws Exception {
+        public SdkBytes unmarshall(JsonUnmarshallerContext unmarshallerContext) throws Exception {
             String base64EncodedString = unmarshallerContext.readText();
             if (base64EncodedString == null) {
                 return null;
             }
             byte[] decodedBytes = Base64Utils.decode(base64EncodedString);
-            return ByteBuffer.wrap(decodedBytes);
+            return SdkBytes.fromByteArray(decodedBytes);
 
         }
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
@@ -168,7 +168,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
     static <ResponseT> ResponseTransformer<ResponseT, ResponseBytes<ResponseT>> toBytes() {
         return (response, inputStream) -> {
             try {
-                return new ResponseBytes<>(response, IoUtils.toByteArray(inputStream));
+                return ResponseBytes.fromByteArray(response, IoUtils.toByteArray(inputStream));
             } catch (IOException e) {
                 throw new RetryableException("Failed to read response.", e);
             }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/StringUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/StringUtils.java
@@ -22,6 +22,7 @@ import java.text.Collator;
 import java.time.Instant;
 import java.util.Locale;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.utils.Base64Utils;
 
 /**
@@ -117,6 +118,16 @@ public class StringUtils {
      */
     public static String fromByteBuffer(ByteBuffer byteBuffer) {
         return Base64Utils.encodeAsString(copyBytesFrom(byteBuffer));
+    }
+
+    /**
+     * Base64 encodes the data in the specified sdk bytes.
+     *
+     * @param sdkBytes The data to base64 encode and return as a string; must not be null.
+     * @return The base64 encoded contents of the specified bytes.
+     */
+    public static String fromSdkBytes(SdkBytes sdkBytes) {
+        return Base64Utils.encodeAsString(sdkBytes.asByteArray());
     }
 
     public static String replace(String originalString, String partToMatch, String replacement) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/protocol/json/SimpleTypeIonUnmarshallersTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/protocol/json/SimpleTypeIonUnmarshallersTest.java
@@ -20,21 +20,21 @@ import static org.junit.Assert.assertEquals;
 import com.fasterxml.jackson.core.JsonParser;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.util.Calendar;
 import java.util.TimeZone;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.internal.protocol.json.IonFactory;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.BigDecimalIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.BigIntegerIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.BooleanIonUnmarshaller;
-import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.ByteBufferIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.ByteIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.DateIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.DoubleIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.FloatIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.IntegerIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.LongIonUnmarshaller;
+import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.SdkBytesIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.ShortIonUnmarshaller;
 import software.amazon.awssdk.core.internal.protocol.json.SimpleTypeIonUnmarshallers.StringIonUnmarshaller;
 import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
@@ -110,7 +110,7 @@ public class SimpleTypeIonUnmarshallersTest {
     @Test
     public void unmarshalByteBuffer() throws Exception {
         byte[] buffer = new byte[] {1, 2, 3, 4, 5, 6};
-        assertEquals(ByteBuffer.wrap(buffer), ByteBufferIonUnmarshaller.getInstance().unmarshall(context("{{AQIDBAUG}}")));
+        assertEquals(SdkBytes.fromByteArray(buffer), SdkBytesIonUnmarshaller.getInstance().unmarshall(context("{{AQIDBAUG}}")));
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/runtime/adapters/types/StringToSdkBytesAdapterTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/runtime/adapters/types/StringToSdkBytesAdapterTest.java
@@ -21,11 +21,12 @@ import static org.junit.Assert.assertNull;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.junit.Test;
-import software.amazon.awssdk.core.adapter.StringToByteBufferAdapter;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter;
 
-public class StringToByteBufferAdapterTest {
+public class StringToSdkBytesAdapterTest {
 
-    private final StringToByteBufferAdapter adapter = new StringToByteBufferAdapter();
+    private final StringToSdkBytesAdapter adapter = new StringToSdkBytesAdapter();
 
     @Test
     public void nullString_ReturnsNullByteBuffer() {
@@ -34,15 +35,15 @@ public class StringToByteBufferAdapterTest {
 
     @Test
     public void emptyString_ReturnsEmptyByteBuffer() throws IOException {
-        ByteBuffer byteBuffer = adapter.adapt("");
-        assertEquals(0, byteBuffer.remaining());
+        SdkBytes bytes = adapter.adapt("");
+        assertEquals(0, bytes.asByteBuffer().remaining());
     }
 
     @Test
     public void nonEmptyString_ReturnsNonEmptyByteBuffer() throws IOException {
         String source = "foo";
-        ByteBuffer byteBuffer = adapter.adapt(source);
-        assertEquals(new String(byteBuffer.array()), source);
+        SdkBytes bytes = adapter.adapt(source);
+        assertEquals(new String(bytes.asByteArray()), source);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -661,6 +661,7 @@
                                         <include>**/RunCucumberTest.java</include>
                                     </includes>
                                     <trimStackTrace>false</trimStackTrace>
+                                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
                                 </configuration>
                             </execution>
                         </executions>

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.ErrorType;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
@@ -240,9 +241,9 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
 
         // Add some data
         int contentLength = 1 * 1024;
-        Set<ByteBuffer> byteBufferSet = new HashSet<ByteBuffer>();
-        byteBufferSet.add(ByteBuffer.wrap(generateByteArray(contentLength)));
-        byteBufferSet.add(ByteBuffer.wrap(generateByteArray(contentLength + 1)));
+        Set<SdkBytes> byteBufferSet = new HashSet<SdkBytes>();
+        byteBufferSet.add(SdkBytes.fromByteArray(generateByteArray(contentLength)));
+        byteBufferSet.add(SdkBytes.fromByteArray(generateByteArray(contentLength + 1)));
 
         Map<String, AttributeValue> item = new HashMap<String, AttributeValue>();
         item.put(HASH_KEY_NAME, AttributeValue.builder().s("bar").build());
@@ -250,9 +251,9 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
         item.put("bar", AttributeValue.builder().s("" + System.currentTimeMillis()).build());
         item.put("foos", AttributeValue.builder().ss("bleh", "blah").build());
         item.put("S", AttributeValue.builder().ss("ONE", "TWO").build());
-        item.put("blob", AttributeValue.builder().b(ByteBuffer.wrap(generateByteArray(contentLength))).build());
-        item.put("blobs", AttributeValue.builder().bs(ByteBuffer.wrap(generateByteArray(contentLength)),
-                                                      ByteBuffer.wrap(generateByteArray(contentLength + 1))).build());
+        item.put("blob", AttributeValue.builder().b(SdkBytes.fromByteArray(generateByteArray(contentLength))).build());
+        item.put("blobs", AttributeValue.builder().bs(SdkBytes.fromByteArray(generateByteArray(contentLength)),
+                                                      SdkBytes.fromByteArray(generateByteArray(contentLength + 1))).build());
         item.put("BS", AttributeValue.builder().bs(byteBufferSet).build());
 
         PutItemRequest putItemRequest = PutItemRequest.builder().tableName(tableName).item(item).returnValues(ReturnValue.ALL_OLD.toString()).build();
@@ -270,15 +271,15 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
         assertEquals("30", itemResult.item().get("age").n());
         assertNotNull(itemResult.item().get("bar").s());
         assertNotNull(itemResult.item().get("blob").b());
-        assertEquals(0, itemResult.item().get("blob").b().compareTo(ByteBuffer.wrap(generateByteArray(contentLength))));
+        assertTrue(itemResult.item().get("blob").b().equals(SdkBytes.fromByteArray(generateByteArray(contentLength))));
         assertNotNull(itemResult.item().get("blobs").bs());
         assertEquals(2, itemResult.item().get("blobs").bs().size());
-        assertTrue(itemResult.item().get("blobs").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength))));
-        assertTrue(itemResult.item().get("blobs").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength + 1))));
+        assertTrue(itemResult.item().get("blobs").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength))));
+        assertTrue(itemResult.item().get("blobs").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))));
         assertNotNull(itemResult.item().get("BS").bs());
         assertEquals(2, itemResult.item().get("BS").bs().size());
-        assertTrue(itemResult.item().get("BS").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength))));
-        assertTrue(itemResult.item().get("BS").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength + 1))));
+        assertTrue(itemResult.item().get("BS").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength))));
+        assertTrue(itemResult.item().get("BS").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))));
 
         // Pause to try and deal with ProvisionedThroughputExceededExceptions
         Thread.sleep(1000 * 5);
@@ -288,11 +289,11 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
         byteBuffer.put(generateByteArray(contentLength));
         byteBuffer.flip();
         item = new HashMap<String, AttributeValue>();
-        item.put(HASH_KEY_NAME, AttributeValue.builder().b(byteBuffer).build());
+        item.put(HASH_KEY_NAME, AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build());
         // Reuse the byteBuffer
-        item.put("blob", AttributeValue.builder().b(byteBuffer).build());
-        item.put("blobs", AttributeValue.builder().bs(ByteBuffer.wrap(generateByteArray(contentLength)),
-                                                      ByteBuffer.wrap(generateByteArray(contentLength + 1))).build());
+        item.put("blob", AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build());
+        item.put("blobs", AttributeValue.builder().bs(SdkBytes.fromByteArray(generateByteArray(contentLength)),
+                                                      SdkBytes.fromByteArray(generateByteArray(contentLength + 1))).build());
         // Reuse the byteBufferSet
         item.put("BS", AttributeValue.builder().bs(byteBufferSet).build());
 
@@ -301,18 +302,18 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
 
         // Get our new item
         itemResult = dynamo.getItem(GetItemRequest.builder().tableName(binaryKeyTableName).key(mapKey(HASH_KEY_NAME,
-                                                                                        AttributeValue.builder().b(byteBuffer).build()))
+                                                                                        AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build()))
                                                .consistentRead(true).build());
         assertNotNull(itemResult.item().get("blob").b());
-        assertEquals(0, itemResult.item().get("blob").b().compareTo(ByteBuffer.wrap(generateByteArray(contentLength))));
+        assertEquals(itemResult.item().get("blob").b(), SdkBytes.fromByteArray(generateByteArray(contentLength)));
         assertNotNull(itemResult.item().get("blobs").bs());
         assertEquals(2, itemResult.item().get("blobs").bs().size());
-        assertTrue(itemResult.item().get("blobs").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength))));
-        assertTrue(itemResult.item().get("blobs").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength + 1))));
+        assertTrue(itemResult.item().get("blobs").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength))));
+        assertTrue(itemResult.item().get("blobs").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))));
         assertNotNull(itemResult.item().get("BS").bs());
         assertEquals(2, itemResult.item().get("BS").bs().size());
-        assertTrue(itemResult.item().get("BS").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength))));
-        assertTrue(itemResult.item().get("BS").bs().contains(ByteBuffer.wrap(generateByteArray(contentLength + 1))));
+        assertTrue(itemResult.item().get("BS").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength))));
+        assertTrue(itemResult.item().get("BS").bs().contains(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))));
 
         // Pause to try and deal with ProvisionedThroughputExceededExceptions
         Thread.sleep(1000 * 5);
@@ -336,10 +337,10 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
         itemUpdates.put("S", AttributeValueUpdate.builder().value(AttributeValue.builder().ss("THREE").build()).action(AttributeAction.ADD.toString()).build());
         itemUpdates.put("age", AttributeValueUpdate.builder().value(AttributeValue.builder().n("10").build()).action(AttributeAction.ADD.toString()).build());
         itemUpdates.put("blob", AttributeValueUpdate.builder().value(
-                AttributeValue.builder().b(ByteBuffer.wrap(generateByteArray(contentLength + 1))).build()).action(
+                AttributeValue.builder().b(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))).build()).action(
                 AttributeAction.PUT.toString()).build());
         itemUpdates.put("blobs",
-                        AttributeValueUpdate.builder().value(AttributeValue.builder().bs(ByteBuffer.wrap(generateByteArray(contentLength))).build()).action(
+                        AttributeValueUpdate.builder().value(AttributeValue.builder().bs(SdkBytes.fromByteArray(generateByteArray(contentLength))).build()).action(
                                                  AttributeAction.PUT.toString()).build());
         UpdateItemRequest updateItemRequest = UpdateItemRequest.builder().tableName(tableName).key(
                 mapKey(HASH_KEY_NAME, AttributeValue.builder().s("bar").build())).attributeUpdates(
@@ -355,16 +356,15 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
         assertTrue(updateItemResult.attributes().get("S").ss().contains("TWO"));
         assertTrue(updateItemResult.attributes().get("S").ss().contains("THREE"));
         assertEquals(Integer.toString(30 + 10), updateItemResult.attributes().get("age").n());
-        assertEquals(0, updateItemResult.attributes().get("blob").b()
-                                        .compareTo(ByteBuffer.wrap(generateByteArray(contentLength + 1))));
+        assertEquals(updateItemResult.attributes().get("blob").b(), SdkBytes.fromByteArray(generateByteArray(contentLength + 1)));
         assertEquals(1, updateItemResult.attributes().get("blobs").bs().size());
         assertTrue(updateItemResult.attributes().get("blobs").bs()
-                                   .contains(ByteBuffer.wrap(generateByteArray(contentLength))));
+                                   .contains(SdkBytes.fromByteArray(generateByteArray(contentLength))));
 
         itemUpdates.clear();
         itemUpdates.put("age", AttributeValueUpdate.builder().value(AttributeValue.builder().n("30").build()).action(AttributeAction.PUT.toString()).build());
         itemUpdates.put("blobs", AttributeValueUpdate.builder()
-                .value(AttributeValue.builder().bs(ByteBuffer.wrap(generateByteArray(contentLength + 1))).build())
+                .value(AttributeValue.builder().bs(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))).build())
                 .action(AttributeAction.ADD.toString())
                 .build());
         updateItemRequest = UpdateItemRequest.builder()
@@ -379,9 +379,9 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
         assertEquals("30", updateItemResult.attributes().get("age").n());
         assertEquals(2, updateItemResult.attributes().get("blobs").bs().size());
         assertTrue(updateItemResult.attributes().get("blobs").bs()
-                                   .contains(ByteBuffer.wrap(generateByteArray(contentLength))));
+                                   .contains(SdkBytes.fromByteArray(generateByteArray(contentLength))));
         assertTrue(updateItemResult.attributes().get("blobs").bs()
-                                   .contains(ByteBuffer.wrap(generateByteArray(contentLength + 1))));
+                                   .contains(SdkBytes.fromByteArray(generateByteArray(contentLength + 1))));
 
         // Get an item that doesn't exist.
         GetItemRequest itemsRequest = GetItemRequest.builder().tableName(tableName).key(mapKey(HASH_KEY_NAME, AttributeValue.builder().s("3").build()))

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/PutItemRequestMarshallerTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/PutItemRequestMarshallerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.awscore.protocol.json.AwsJsonProtocolMetadata;
 import software.amazon.awssdk.core.Request;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.protocol.json.JsonClientMetadata;
 import software.amazon.awssdk.core.util.ImmutableMapParameter;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -48,7 +49,7 @@ public class PutItemRequestMarshallerTest {
         // Consume some of the byte buffer
         byteBuffer.position(3);
         Request<PutItemRequest> marshalled = marshaller.marshall(PutItemRequest.builder().item(
-                ImmutableMapParameter.of("binaryProp", AttributeValue.builder().b(byteBuffer).build())).build());
+                ImmutableMapParameter.of("binaryProp", AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build())).build());
         JsonNode marshalledContent = MAPPER.readTree(marshalled.getContent());
         String base64Binary = marshalledContent.get("Item").get("binaryProp").get("B").asText();
         // Only the remaining data in the byte buffer should have been read and marshalled.

--- a/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
+++ b/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
@@ -16,12 +16,12 @@
 package software.amazon.awssdk.services.kinesis;
 
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest;
@@ -46,7 +46,6 @@ import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 import software.amazon.awssdk.services.kinesis.model.SplitShardRequest;
 import software.amazon.awssdk.services.kinesis.model.StreamDescription;
 import software.amazon.awssdk.services.kinesis.model.StreamStatus;
-import software.amazon.awssdk.utils.BinaryUtils;
 
 public class KinesisIntegrationTests extends AbstractTestCase {
 
@@ -228,7 +227,7 @@ public class KinesisIntegrationTests extends AbstractTestCase {
         Assert.assertNotNull(record.sequenceNumber());
         new BigInteger(record.sequenceNumber());
 
-        String value = new String(BinaryUtils.copyBytesFrom(record.data()));
+        String value = record.data() == null ? null : record.data().asUtf8String();
         Assert.assertEquals(data, value);
 
         Assert.assertNotNull(record.partitionKey());
@@ -373,7 +372,7 @@ public class KinesisIntegrationTests extends AbstractTestCase {
                 PutRecordRequest.builder()
                                 .streamName(streamName)
                                 .partitionKey("foobar")
-                                .data(ByteBuffer.wrap(data.getBytes()))
+                                .data(SdkBytes.fromUtf8String(data))
                                 .build());
         Assert.assertNotNull(result);
 
@@ -390,7 +389,7 @@ public class KinesisIntegrationTests extends AbstractTestCase {
                                                                   .streamName(streamName)
                                                                   .partitionKey("foobar")
                                                                   .explicitHashKey(hashKey)
-                                                                  .data(ByteBuffer.wrap("Speak No Evil".getBytes()))
+                                                                  .data(SdkBytes.fromUtf8String("Speak No Evil"))
                                                                   .build());
         Assert.assertNotNull(result);
 
@@ -409,7 +408,7 @@ public class KinesisIntegrationTests extends AbstractTestCase {
                                                                   .partitionKey("foobar")
                                                                   .explicitHashKey(hashKey)
                                                                   .sequenceNumberForOrdering(minSQN)
-                                                                  .data(ByteBuffer.wrap("Hear No Evil".getBytes()))
+                                                                  .data(SdkBytes.fromUtf8String("Hear No Evil"))
                                                                   .build());
         Assert.assertNotNull(result);
 

--- a/services/kinesisfirehose/src/it/java/software/amazon/awssdk/services/firehose/ServiceIntegrationTest.java
+++ b/services/kinesisfirehose/src/it/java/software/amazon/awssdk/services/firehose/ServiceIntegrationTest.java
@@ -22,12 +22,12 @@ import static software.amazon.awssdk.testutils.SdkAsserts.assertNotEmpty;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.services.firehose.model.CreateDeliveryStreamRequest;
 import software.amazon.awssdk.services.firehose.model.ListDeliveryStreamsRequest;
@@ -87,7 +87,7 @@ public class ServiceIntegrationTest extends AwsTestBase {
         String recordId = firehose.putRecord(PutRecordRequest.builder()
                                                              .deliveryStreamName(DEVLIVERY_STREAM_NAME)
                                                              .record(Record.builder()
-                                                                           .data(ByteBuffer.wrap(new byte[] {0, 1, 2}))
+                                                                           .data(SdkBytes.fromByteArray(new byte[] {0, 1, 2}))
                                                                            .build())
                                                              .build()
                                             ).recordId();
@@ -97,8 +97,8 @@ public class ServiceIntegrationTest extends AwsTestBase {
         List<PutRecordBatchResponseEntry> entries = firehose.putRecordBatch(
                 PutRecordBatchRequest.builder()
                                      .deliveryStreamName(DEVLIVERY_STREAM_NAME)
-                                     .records(Record.builder().data(ByteBuffer.wrap(new byte[] {0})).build(),
-                                              Record.builder().data(ByteBuffer.wrap(new byte[] {1})).build())
+                                     .records(Record.builder().data(SdkBytes.fromByteArray(new byte[] {0})).build(),
+                                              Record.builder().data(SdkBytes.fromByteArray(new byte[] {1})).build())
                                      .build()
                                                                            ).requestResponses();
         assertEquals(2, entries.size());

--- a/services/lambda/src/main/resources/codegen-resources/customization.config
+++ b/services/lambda/src/main/resources/codegen-resources/customization.config
@@ -7,7 +7,7 @@
             "shapeName": "InvocationRequest",
             "memberName": "Payload",
             "convenienceType": "java.lang.String",
-            "typeAdapterFqcn": "software.amazon.awssdk.core.adapter.StringToByteBufferAdapter"
+            "typeAdapterFqcn": "software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter"
         }
     ]
 }

--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/IntegrationTestBase.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/IntegrationTestBase.java
@@ -15,13 +15,13 @@
 
 package software.amazon.awssdk.services.sqs;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import org.junit.Before;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.util.StringUtils;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.iam.IamClient;
@@ -93,7 +93,7 @@ public class IntegrationTestBase extends AwsIntegrationTestBase {
     protected static MessageAttributeValue createRandomBinaryAttributeValue() {
         byte[] randomBytes = new byte[10];
         random.nextBytes(randomBytes);
-        return MessageAttributeValue.builder().dataType("Binary").binaryValue(ByteBuffer.wrap(randomBytes)).build();
+        return MessageAttributeValue.builder().dataType("Binary").binaryValue(SdkBytes.fromByteArray(randomBytes)).build();
     }
 
     protected static Map<String, MessageAttributeValue> createRandomAttributeValues(int attrNumber) {

--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/MessageAttributesIntegrationTest.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/MessageAttributesIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -119,7 +120,7 @@ public class MessageAttributesIntegrationTest extends IntegrationTestBase {
         byte[] bytes = new byte[]{1, 1, 1, 0, 0, 0};
         String byteBufferAttrName = "byte-buffer-attr";
         Map<String, MessageAttributeValue> attrs = ImmutableMapParameter.of(byteBufferAttrName,
-                MessageAttributeValue.builder().dataType("Binary").binaryValue(ByteBuffer.wrap(bytes)).build());
+                MessageAttributeValue.builder().dataType("Binary").binaryValue(SdkBytes.fromByteArray(bytes)).build());
 
         sqsAsync.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("test")
                 .messageAttributes(attrs)
@@ -129,7 +130,7 @@ public class MessageAttributesIntegrationTest extends IntegrationTestBase {
                 ReceiveMessageRequest.builder().queueUrl(queueUrl).messageAttributeNames("All").waitTimeSeconds(20).build()).join()
                 .messages();
 
-        ByteBuffer actualByteBuffer = messages.get(0).messageAttributes().get(byteBufferAttrName).binaryValue();
+        ByteBuffer actualByteBuffer = messages.get(0).messageAttributes().get(byteBufferAttrName).binaryValue().asByteBuffer();
         assertEquals(bytes.length, actualByteBuffer.remaining());
     }
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptor.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -234,7 +235,7 @@ public class MessageMD5ChecksumInterceptor implements ExecutionInterceptor {
                     updateLengthAndBytes(md5Digest, attrValue.stringValue());
                 } else if (attrValue.binaryValue() != null) {
                     md5Digest.update(BINARY_TYPE_FIELD_INDEX);
-                    updateLengthAndBytes(md5Digest, attrValue.binaryValue());
+                    updateLengthAndBytes(md5Digest, attrValue.binaryValue().asByteBuffer());
                 } else if (attrValue.stringListValues() != null &&
                            attrValue.stringListValues().size() > 0) {
                     md5Digest.update(STRING_LIST_TYPE_FIELD_INDEX);
@@ -244,8 +245,8 @@ public class MessageMD5ChecksumInterceptor implements ExecutionInterceptor {
                 } else if (attrValue.binaryListValues() != null &&
                            attrValue.binaryListValues().size() > 0) {
                     md5Digest.update(BINARY_LIST_TYPE_FIELD_INDEX);
-                    for (ByteBuffer byteListMember : attrValue.binaryListValues()) {
-                        updateLengthAndBytes(md5Digest, byteListMember);
+                    for (SdkBytes byteListMember : attrValue.binaryListValues()) {
+                        updateLengthAndBytes(md5Digest, byteListMember.asByteBuffer());
                     }
                 }
             }

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptorTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptorTest.java
@@ -17,10 +17,10 @@ package software.amazon.awssdk.services.sqs;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -257,7 +257,7 @@ public class MessageMD5ChecksumInterceptorTest {
                                                              .dataType("String")
                                                              .build());
         messageAttributes.put("Binary", MessageAttributeValue.builder()
-                                                             .binaryValue(ByteBuffer.wrap(new byte[] {5 }))
+                                                             .binaryValue(SdkBytes.fromByteArray(new byte[] { 5 }))
                                                              .dataType("Binary")
                                                              .build());
         messageAttributes.put("StringList", MessageAttributeValue.builder()
@@ -265,7 +265,7 @@ public class MessageMD5ChecksumInterceptorTest {
                                                                  .dataType("String")
                                                                  .build());
         messageAttributes.put("ByteList", MessageAttributeValue.builder()
-                                                               .binaryListValues(ByteBuffer.wrap(new byte[] { 3 }))
+                                                               .binaryListValues(SdkBytes.fromByteArray(new byte[] { 3 }))
                                                                .dataType("Binary")
                                                                .build());
         return messageAttributes;

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/autoconstructedlists/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/autoconstructedlists/customization.config
@@ -9,7 +9,7 @@
             "shapeName": "AllTypesStructure",
             "memberName": "BlobArg",
             "convenienceType": "java.lang.String",
-            "typeAdapterFqcn": "software.amazon.awssdk.core.adapter.StringToByteBufferAdapter"
+            "typeAdapterFqcn": "software.amazon.awssdk.core.adapter.StringToSdkBytesAdapter"
         }
     ],
     "useAutoConstructList": true

--- a/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/internal/InternalUtilsTest.java
+++ b/test/dynamodbdocument-v1/src/test/java/software/amazon/awssdk/services/dynamodb/document/internal/InternalUtilsTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.Ignore;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.document.Expected;
 import software.amazon.awssdk.services.dynamodb.document.Item;
 import software.amazon.awssdk.services.dynamodb.document.KeyAttribute;
@@ -63,7 +64,7 @@ public class InternalUtilsTest {
     public void toAttributeValue_ByteBuffer() {
         ByteBuffer bbFrom = ByteBuffer.allocate(10);
         AttributeValue av = InternalUtils.toAttributeValue(bbFrom);
-        ByteBuffer bbTo = av.b();
+        ByteBuffer bbTo = av.b().asByteBuffer();
         assertSame(bbFrom, bbTo);
     }
 
@@ -71,7 +72,7 @@ public class InternalUtilsTest {
     public void toAttributeValue_byteArray() {
         byte[] bytesFrom = {1, 2, 3, 4};
         AttributeValue av = InternalUtils.toAttributeValue(bytesFrom);
-        ByteBuffer bbTo = av.b();
+        ByteBuffer bbTo = av.b().asByteBuffer();
         assertTrue(ByteBuffer.wrap(bytesFrom).compareTo(bbTo) == 0);
     }
 
@@ -137,14 +138,14 @@ public class InternalUtilsTest {
                 .with(ba2From);
         AttributeValue av = InternalUtils.toAttributeValue(nsFrom);
         assertNull(av.ss());
-        List<ByteBuffer> bs = av.bs();
+        List<SdkBytes> bs = av.bs();
         assertTrue(bs.size() == 2);
         boolean bool1 = false;
         boolean bool2 = false;
-        for (ByteBuffer b : bs) {
-            if (ByteBuffer.wrap(ba1From).compareTo(b) == 0) {
+        for (SdkBytes b : bs) {
+            if (ByteBuffer.wrap(ba1From).compareTo(b.asByteBuffer()) == 0) {
                 bool1 = true;
-            } else if (ByteBuffer.wrap(ba2From).compareTo(b) == 0) {
+            } else if (ByteBuffer.wrap(ba2From).compareTo(b.asByteBuffer()) == 0) {
                 bool2 = true;
             }
         }
@@ -161,14 +162,14 @@ public class InternalUtilsTest {
                 .with(ByteBuffer.wrap(ba2From));
         AttributeValue av = InternalUtils.toAttributeValue(nsFrom);
         assertNull(av.ss());
-        List<ByteBuffer> bs = av.bs();
+        List<SdkBytes> bs = av.bs();
         assertTrue(bs.size() == 2);
         boolean bool1 = false;
         boolean bool2 = false;
-        for (ByteBuffer b : bs) {
-            if (ByteBuffer.wrap(ba1From).compareTo(b) == 0) {
+        for (SdkBytes b : bs) {
+            if (ByteBuffer.wrap(ba1From).compareTo(b.asByteBuffer()) == 0) {
                 bool1 = true;
-            } else if (ByteBuffer.wrap(ba2From).compareTo(b) == 0) {
+            } else if (ByteBuffer.wrap(ba2From).compareTo(b.asByteBuffer()) == 0) {
                 bool2 = true;
             }
         }
@@ -293,7 +294,7 @@ public class InternalUtilsTest {
         ByteBuffer byteBufferTo = ByteBuffer.allocate(3).put(bytesFrom);
         byteBufferTo.rewind();
         byte[] bytesTo = toSimpleValue(
-                AttributeValue.builder().b(byteBufferTo).build());
+                AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBufferTo)).build());
         assertTrue(Arrays.equals(bytesTo, bytesFrom));
     }
 
@@ -303,7 +304,7 @@ public class InternalUtilsTest {
         ByteBuffer byteBufferTo = ByteBuffer.allocateDirect(3).put(bytesFrom);
         byteBufferTo.rewind();
         byte[] bytesTo = toSimpleValue(
-                AttributeValue.builder().b(byteBufferTo).build());
+                AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBufferTo)).build());
         assertTrue(Arrays.equals(bytesTo, bytesFrom));
     }
 

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/mapper/BinaryAttributesIntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/mapper/BinaryAttributesIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.DynamoDBMapperIntegrationTestBase;
 import software.amazon.awssdk.services.dynamodb.datamodeling.DynamoDbMapper;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -53,9 +54,9 @@ public class BinaryAttributesIntegrationTest extends DynamoDBMapperIntegrationTe
     static {
         Map<String, AttributeValue> attr = new HashMap<String, AttributeValue>();
         attr.put(KEY_NAME, AttributeValue.builder().s("" + startKey++).build());
-        attr.put(BINARY_ATTRIBUTE, AttributeValue.builder().b(ByteBuffer.wrap(generateByteArray(CONTENT_LENGTH))).build());
-        attr.put(BINARY_SET_ATTRIBUTE, AttributeValue.builder().bs(ByteBuffer.wrap(generateByteArray(CONTENT_LENGTH)),
-                                                                   ByteBuffer.wrap(generateByteArray(CONTENT_LENGTH + 1))).build());
+        attr.put(BINARY_ATTRIBUTE, AttributeValue.builder().b(SdkBytes.fromByteArray(generateByteArray(CONTENT_LENGTH))).build());
+        attr.put(BINARY_SET_ATTRIBUTE, AttributeValue.builder().bs(SdkBytes.fromByteArray(generateByteArray(CONTENT_LENGTH)),
+                                                                   SdkBytes.fromByteArray(generateByteArray(CONTENT_LENGTH + 1))).build());
         ATTRIBUTES.add(attr);
 
     }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV1Test.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV1Test.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.services.dynamodb.pojos.TestClass;
@@ -130,9 +131,9 @@ public class StandardModelFactoriesV1Test {
 
     @Test
     public void testBinary() {
-        ByteBuffer value = ByteBuffer.wrap("value".getBytes());
-        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).b());
-        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).b());
+        SdkBytes value = SdkBytes.fromUtf8String("value");
+        assertEquals(value, convert("getByteArray", value.asByteArray()).b());
+        assertEquals(value, convert("getByteBuffer", value.asByteBuffer()).b());
     }
 
     @Test
@@ -234,21 +235,19 @@ public class StandardModelFactoriesV1Test {
 
     @Test
     public void testBinarySet() {
-        final ByteBuffer test = ByteBuffer.wrap("test".getBytes());
-        final ByteBuffer test2 = ByteBuffer.wrap("test2".getBytes());
+        SdkBytes test = SdkBytes.fromUtf8String("test");
+        SdkBytes test2 = SdkBytes.fromUtf8String("test2");
 
-        assertEquals(Collections.singletonList(test.slice()),
-                     convert("getByteArraySet", Collections.singleton("test".getBytes()))
-                             .bs());
+        assertEquals(Collections.singletonList(test),
+                     convert("getByteArraySet", Collections.singleton(test.asByteArray())).bs());
 
-        assertEquals(Collections.singletonList(test.slice()),
-                     convert("getByteBufferSet", Collections.singleton(test.slice()))
-                             .bs());
+        assertEquals(Collections.singletonList(test),
+                     convert("getByteBufferSet", Collections.singleton(test.asByteBuffer())).bs());
 
-        assertEquals(Arrays.asList(test.slice(), test2.slice()),
+        assertEquals(Arrays.asList(test, test2),
                      convert("getByteBufferSet", new TreeSet<ByteBuffer>() {{
-                         add(test.slice());
-                         add(test2.slice());
+                         add(test.asByteBuffer());
+                         add(test2.asByteBuffer());
                      }}).bs());
     }
 

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV2CompatibleTest.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV2CompatibleTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.services.dynamodb.pojos.TestClass;
@@ -137,9 +138,9 @@ public class StandardModelFactoriesV2CompatibleTest {
 
     @Test
     public void testBinary() {
-        ByteBuffer value = ByteBuffer.wrap("value".getBytes());
-        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).b());
-        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).b());
+        SdkBytes value = SdkBytes.fromUtf8String("value");
+        assertEquals(value, convert("getByteArray", value.asByteArray()).b());
+        assertEquals(value, convert("getByteBuffer", value.asByteBuffer()).b());
     }
 
     @Test
@@ -241,21 +242,19 @@ public class StandardModelFactoriesV2CompatibleTest {
 
     @Test
     public void testBinarySet() {
-        final ByteBuffer test = ByteBuffer.wrap("test".getBytes());
-        final ByteBuffer test2 = ByteBuffer.wrap("test2".getBytes());
+        SdkBytes test = SdkBytes.fromUtf8String("test");
+        SdkBytes test2 = SdkBytes.fromUtf8String("test2");
 
-        assertEquals(Collections.singletonList(test.slice()),
-                     convert("getByteArraySet", Collections.singleton("test".getBytes()))
-                             .bs());
+        assertEquals(Collections.singletonList(test),
+                     convert("getByteArraySet", Collections.singleton(test.asByteArray())).bs());
 
-        assertEquals(Collections.singletonList(test.slice()),
-                     convert("getByteBufferSet", Collections.singleton(test.slice()))
-                             .bs());
+        assertEquals(Collections.singletonList(test),
+                     convert("getByteBufferSet", Collections.singleton(test.asByteBuffer())).bs());
 
-        assertEquals(Arrays.asList(test.slice(), test2.slice()),
+        assertEquals(Arrays.asList(test, test2),
                      convert("getByteBufferSet", new TreeSet<ByteBuffer>() {{
-                         add(test.slice());
-                         add(test2.slice());
+                         add(test.asByteBuffer());
+                         add(test2.asByteBuffer());
                      }}).bs());
     }
 

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV2Test.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV2Test.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.services.dynamodb.pojos.TestClass;
@@ -134,9 +135,9 @@ public class StandardModelFactoriesV2Test {
 
     @Test
     public void testBinary() {
-        ByteBuffer value = ByteBuffer.wrap("value".getBytes());
-        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).b());
-        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).b());
+        SdkBytes value = SdkBytes.fromUtf8String("value");
+        assertEquals(value, convert("getByteArray", value.asByteArray()).b());
+        assertEquals(value, convert("getByteBuffer", value.asByteBuffer()).b());
     }
 
     @Test
@@ -234,21 +235,19 @@ public class StandardModelFactoriesV2Test {
 
     @Test
     public void testBinarySet() {
-        final ByteBuffer test = ByteBuffer.wrap("test".getBytes());
-        final ByteBuffer test2 = ByteBuffer.wrap("test2".getBytes());
+        SdkBytes test = SdkBytes.fromUtf8String("test");
+        SdkBytes test2 = SdkBytes.fromUtf8String("test2");
 
-        assertEquals(Collections.singletonList(test.slice()),
-                     convert("getByteArraySet", Collections.singleton("test".getBytes()))
-                             .bs());
+        assertEquals(Collections.singletonList(test),
+                     convert("getByteArraySet", Collections.singleton(test.asByteArray())).bs());
 
-        assertEquals(Collections.singletonList(test.slice()),
-                     convert("getByteBufferSet", Collections.singleton(test.slice()))
-                             .bs());
+        assertEquals(Collections.singletonList(test),
+                     convert("getByteBufferSet", Collections.singleton(test.asByteBuffer())).bs());
 
-        assertEquals(Arrays.asList(test.slice(), test2.slice()),
+        assertEquals(Arrays.asList(test, test2),
                      convert("getByteBufferSet", new TreeSet<ByteBuffer>() {{
-                         add(test.slice());
-                         add(test2.slice());
+                         add(test.asByteBuffer());
+                         add(test2.asByteBuffer());
                      }}).bs());
     }
 

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV2UnconvertTest.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesV2UnconvertTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.dynamodb.datamodeling;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.Method;
@@ -35,6 +36,7 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.pojos.SubClass;
@@ -156,13 +158,12 @@ public class StandardModelFactoriesV2UnconvertTest {
 
     @Test
     public void testBinary() {
-        ByteBuffer test = ByteBuffer.wrap("test".getBytes());
-        Assert.assertTrue(Arrays.equals("test".getBytes(), (byte[]) unconvert(
-                "getByteArray", "setByteArray",
-                AttributeValue.builder().b(test.slice()).build())));
+        SdkBytes test = SdkBytes.fromUtf8String("test");
+        assertArrayEquals(test.asByteArray(),
+                          (byte[]) unconvert("getByteArray", "setByteArray", AttributeValue.builder().b(test).build()));
 
-        assertEquals(test.slice(), unconvert("getByteBuffer", "setByteBuffer",
-                                             AttributeValue.builder().b(test.slice()).build()));
+        assertEquals(test.asByteBuffer(),
+                     unconvert("getByteBuffer", "setByteBuffer", AttributeValue.builder().b(test).build()));
     }
 
     @Test
@@ -343,7 +344,7 @@ public class StandardModelFactoriesV2UnconvertTest {
 
         Set<byte[]> result = (Set<byte[]>) unconvert(
                 "getByteArraySet", "setByteArraySet",
-                AttributeValue.builder().bs(test.slice()).build());
+                AttributeValue.builder().bs(SdkBytes.fromByteBuffer(test.slice())).build());
 
         assertEquals(1, result.size());
         Assert.assertTrue(Arrays.equals(
@@ -352,7 +353,7 @@ public class StandardModelFactoriesV2UnconvertTest {
 
         Assert.assertEquals(Collections.singleton(test.slice()),
                             unconvert("getByteBufferSet", "setByteBufferSet",
-                                      AttributeValue.builder().bs(test.slice()).build()));
+                                      AttributeValue.builder().bs(SdkBytes.fromByteBuffer(test.slice())).build()));
     }
 
     @Test

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteArraySetToBinarySetMarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteArraySetToBinarySetMarshaller.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.datamodeling.ArgumentMarshaller.BinarySetAttributeMarshaller;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -43,10 +44,10 @@ public class ByteArraySetToBinarySetMarshaller
     public AttributeValue marshall(Object obj) {
         @SuppressWarnings("unchecked")
         Set<byte[]> buffers = (Set<byte[]>) obj;
-        List<ByteBuffer> attributes = new ArrayList<ByteBuffer>(buffers.size());
+        List<SdkBytes> attributes = new ArrayList<>(buffers.size());
 
         for (byte[] b : buffers) {
-            attributes.add(ByteBuffer.wrap(b));
+            attributes.add(SdkBytes.fromByteArray(b));
         }
 
         return AttributeValue.builder().bs(attributes).build();

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteArrayToBinaryMarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteArrayToBinaryMarshaller.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.services.dynamodb.datamodeling.marshallers;
 
-import java.nio.ByteBuffer;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.datamodeling.ArgumentMarshaller.BinaryAttributeMarshaller;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -37,6 +37,6 @@ public class ByteArrayToBinaryMarshaller implements BinaryAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return AttributeValue.builder().b(ByteBuffer.wrap((byte[]) obj)).build();
+        return AttributeValue.builder().b(SdkBytes.fromByteArray((byte[]) obj)).build();
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteBufferSetToBinarySetMarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteBufferSetToBinarySetMarshaller.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.datamodeling.ArgumentMarshaller.BinarySetAttributeMarshaller;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -43,10 +44,10 @@ public class ByteBufferSetToBinarySetMarshaller
     public AttributeValue marshall(Object obj) {
         @SuppressWarnings("unchecked")
         Set<ByteBuffer> buffers = (Set<ByteBuffer>) obj;
-        List<ByteBuffer> attributes = new ArrayList<ByteBuffer>(buffers.size());
+        List<SdkBytes> attributes = new ArrayList<SdkBytes>(buffers.size());
 
         for (ByteBuffer b : buffers) {
-            attributes.add(b);
+            attributes.add(SdkBytes.fromByteBuffer(b));
         }
 
         return AttributeValue.builder().bs(attributes).build();

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteBufferToBinaryMarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/marshallers/ByteBufferToBinaryMarshaller.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.dynamodb.datamodeling.marshallers;
 
 import java.nio.ByteBuffer;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.datamodeling.ArgumentMarshaller.BinaryAttributeMarshaller;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -37,6 +38,6 @@ public class ByteBufferToBinaryMarshaller implements BinaryAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return AttributeValue.builder().b((ByteBuffer) obj).build();
+        return AttributeValue.builder().b(SdkBytes.fromByteBuffer((ByteBuffer) obj)).build();
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteArraySetUnmarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteArraySetUnmarshaller.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.dynamodb.datamodeling.unmarshallers;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -40,7 +41,8 @@ public class ByteArraySetUnmarshaller extends BsUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<byte[]> result = new HashSet<byte[]>();
 
-        for (ByteBuffer buffer : value.bs()) {
+        for (SdkBytes bytesBuffer : value.bs()) {
+            ByteBuffer buffer = bytesBuffer.asByteBuffer();
             if (buffer.hasArray()) {
                 result.add(buffer.array());
             } else {

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteArrayUnmarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteArrayUnmarshaller.java
@@ -35,14 +35,6 @@ public class ByteArrayUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        ByteBuffer buffer = value.b();
-
-        if (buffer.hasArray()) {
-            return buffer.array();
-        }
-
-        byte[] array = new byte[buffer.remaining()];
-        buffer.get(array);
-        return array;
+        return value.b().asByteArray();
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteBufferSetUnmarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteBufferSetUnmarshaller.java
@@ -15,8 +15,8 @@
 
 package software.amazon.awssdk.services.dynamodb.datamodeling.unmarshallers;
 
-import java.nio.ByteBuffer;
-import java.util.HashSet;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -37,6 +37,8 @@ public class ByteBufferSetUnmarshaller extends BsUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return new HashSet<ByteBuffer>(value.bs());
+        return value.bs().stream()
+                    .map(SdkBytes::asByteBuffer)
+                    .collect(Collectors.toSet());
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteBufferUnmarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/unmarshallers/ByteBufferUnmarshaller.java
@@ -34,6 +34,6 @@ public class ByteBufferUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return value.b();
+        return value.b().asByteBuffer();
     }
 }

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/model/Item.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/model/Item.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
 
 /**
@@ -145,7 +146,7 @@ public final class Item extends HashMap<String, AttributeValue> {
          * @return the builder for method chaining
          */
         public Builder attribute(String key, ByteBuffer binaryValue) {
-            item.put(key, AttributeValue.builder().b(binaryValue).build());
+            item.put(key, AttributeValue.builder().b(SdkBytes.fromByteBuffer(binaryValue)).build());
             return this;
         }
 
@@ -316,7 +317,7 @@ public final class Item extends HashMap<String, AttributeValue> {
          * </code></pre>
          *
          * @param key the key of this attribute
-         * @param byteArrays the binary values of the attribute
+         * @param binaryValues the binary values of the attribute
          * @return the builder for method chaining
          */
         public Builder byteBuffers(String key, ByteBuffer... binaryValues) {
@@ -332,11 +333,11 @@ public final class Item extends HashMap<String, AttributeValue> {
          * </code></pre>
          *
          * @param key the key of this attribute
-         * @param byteArrays the binary values of the attribute
+         * @param binaryValues the binary values of the attribute
          * @return the builder for method chaining
          */
         public Builder byteBuffers(String key, Collection<? extends ByteBuffer> binaryValues) {
-            item.put(key, AttributeValue.builder().bs(binaryValues.stream().collect(toList())).build());
+            item.put(key, AttributeValue.builder().bs(binaryValues.stream().map(SdkBytes::fromByteBuffer).collect(toList())).build());
             return this;
         }
 
@@ -351,10 +352,10 @@ public final class Item extends HashMap<String, AttributeValue> {
                 return AttributeValue.builder().n(String.valueOf((Number) object)).build();
             }
             if (object instanceof byte[]) {
-                return AttributeValue.builder().b(ByteBuffer.wrap((byte[]) object)).build();
+                return AttributeValue.builder().b(SdkBytes.fromByteArray((byte[]) object)).build();
             }
             if (object instanceof ByteBuffer) {
-                return AttributeValue.builder().b((ByteBuffer) object).build();
+                return AttributeValue.builder().b(SdkBytes.fromByteBuffer((ByteBuffer) object)).build();
             }
             if (object instanceof Boolean) {
                 return AttributeValue.builder().bool((Boolean) object).build();

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/model/ItemTest.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/model/ItemTest.java
@@ -119,14 +119,14 @@ public class ItemTest {
     }
 
     private static Condition<AttributeValue> bytesMatching(byte[] bytes) {
-        return new Condition<>(item -> byteBufferEquals(item.b(), bytes), "bytes matching");
+        return new Condition<>(item -> byteBufferEquals(item.b().asByteBuffer(), bytes), "bytes matching");
     }
 
     private static Condition<AttributeValue> bytesMatching(byte[] firstByteArray, byte[] secondByteArray) {
         return new Condition<>(item -> {
             return item.bs().size() == 2 &&
-                   byteBufferEquals(item.bs().get(0), firstByteArray) &&
-                   byteBufferEquals(item.bs().get(1), secondByteArray);
+                   byteBufferEquals(item.bs().get(0).asByteBuffer(), firstByteArray) &&
+                   byteBufferEquals(item.bs().get(1).asByteBuffer(), secondByteArray);
         }, "List<" + String.valueOf(firstByteArray) + ", " + String.valueOf(secondByteArray) + ">");
     }
 

--- a/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/asserts/marshalling/XmlAsserts.java
+++ b/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/asserts/marshalling/XmlAsserts.java
@@ -87,7 +87,9 @@ public final class XmlAsserts {
     private static TransformerFactory transformerFactory() throws TransformerConfigurationException {
         TransformerFactory factory = TransformerFactory.newInstance();
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setFeature(XMLConstants.ACCESS_EXTERNAL_DTD, false);
+        if (factory.getFeature(XMLConstants.ACCESS_EXTERNAL_DTD)) {
+            factory.setFeature(XMLConstants.ACCESS_EXTERNAL_DTD, false);
+        }
         return factory;
     }
 }

--- a/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/reflect/ShapeModelReflector.java
+++ b/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/reflect/ShapeModelReflector.java
@@ -19,8 +19,6 @@ import static software.amazon.awssdk.utils.Validate.paramNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,6 +31,7 @@ import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.utils.StringUtils;
 
 /**
@@ -153,7 +152,7 @@ public class ShapeModelReflector {
         if (memberModel.isSimple()) {
             switch (memberModel.getVariable().getSimpleType()) {
                 case "Instant":
-                case "ByteBuffer":
+                case "SdkBytes":
                 case "InputStream":
                     return memberModel.getSetterModel().getVariableSetterType();
                 default:
@@ -229,8 +228,8 @@ public class ShapeModelReflector {
                 return currentNode.asDouble();
             case "Instant":
                 return Instant.ofEpochMilli(currentNode.asLong());
-            case "ByteBuffer":
-                return ByteBuffer.wrap(currentNode.asText().getBytes(StandardCharsets.UTF_8));
+            case "SdkBytes":
+                return SdkBytes.fromUtf8String(currentNode.asText());
             case "Float":
                 return (float) currentNode.asDouble();
             case "Character":

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ImmutableModelTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ImmutableModelTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
 import software.amazon.awssdk.services.protocolrestjson.model.SimpleStruct;
 import software.amazon.awssdk.utils.BinaryUtils;
@@ -84,13 +85,14 @@ public class ImmutableModelTest {
 
         buffer.position(1);
 
-        AllTypesRequest request = AllTypesRequest.builder().blobArg(buffer).build();
+        AllTypesRequest request = AllTypesRequest.builder().blobArg(SdkBytes.fromByteBuffer(buffer)).build();
 
         buffer.array()[1] = ' ';
 
-        assertThat(request.blobArg()).as("Check new read-only blob each time").isNotSameAs(request.blobArg());
-        assertThat(request.blobArg().isReadOnly()).as("Check read-only").isTrue();
-        assertThat(BinaryUtils.copyAllBytesFrom(request.blobArg()))
+        assertThat(request.blobArg().asByteBuffer()).as("Check new read-only blob each time")
+                                                    .isNotSameAs(request.blobArg().asByteBuffer());
+        assertThat(request.blobArg().asByteBuffer().isReadOnly()).as("Check read-only").isTrue();
+        assertThat(BinaryUtils.copyAllBytesFrom(request.blobArg().asByteBuffer()))
                 .as("Check copy contents").containsExactly('e', 'l', 'l', 'o');
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/StringUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/StringUtils.java
@@ -15,6 +15,10 @@
 
 package software.amazon.awssdk.utils;
 
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
 import java.util.Locale;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
@@ -562,5 +566,18 @@ public final class StringUtils {
             inOffset += Character.charCount(codepoint);
         }
         return new String(newCodePoints, 0, outOffset);
+    }
+
+    /**
+     * Encode the given bytes as a string using the given charset
+     * @throws UncheckedIOException with a {@link CharacterCodingException} as the cause if the bytes cannot be encoded using the
+     * provided charset.
+     */
+    public static String fromBytes(byte[] bytes, Charset charset) throws UncheckedIOException {
+        try {
+            return charset.newDecoder().decode(ByteBuffer.wrap(bytes)).toString();
+        } catch (CharacterCodingException e) {
+            throw new UncheckedIOException("Cannot encode string.", e);
+        }
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/ToString.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ToString.java
@@ -65,8 +65,17 @@ public final class ToString {
      */
     public ToString add(String fieldName, Object field) {
         if (field != null) {
-            String value = field.getClass().isArray() ? Arrays.toString((Object[]) field)
-                                                      : String.valueOf(field);
+            String value;
+
+            if (field.getClass().isArray()) {
+                if (field instanceof byte[]) {
+                    value = "0x" + BinaryUtils.toHex((byte[]) field);
+                } else {
+                    value = Arrays.toString((Object[]) field);
+                }
+            } else {
+                value = String.valueOf(field);
+            }
             result.append(fieldName).append("=").append(value).append(", ");
         }
         return this;


### PR DESCRIPTION
`ByteBuffer` is still used by the model builders for marshalling purposes. An overloaded setter was added for byte arrays.