### PR TITLE
Various cleanup

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -231,11 +231,10 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
 
         SignerKey signerKey = SIGNER_CACHE.get(cacheKey);
 
-        if (signerKey != null) {
-            if (daysSinceEpochSigningDate == signerKey.getNumberOfDaysSinceEpoch()) {
-                return signerKey.getSigningKey();
-            }
+        if (signerKey != null && daysSinceEpochSigningDate == signerKey.getNumberOfDaysSinceEpoch()) {
+            return signerKey.getSigningKey();
         }
+
         if (LOG.isDebugEnabled()) {
             LOG.debug("Generating a new signing key as the signing key not available in the cache for the date "
                       + TimeUnit.DAYS.toMillis(daysSinceEpochSigningDate));

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsSigner.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsSigner.java
@@ -209,7 +209,7 @@ public abstract class AbstractAwsSigner implements Signer {
      */
     protected String getCanonicalizedQueryString(Map<String, List<String>> parameters) {
 
-        final SortedMap<String, List<String>> sorted = new TreeMap<String, List<String>>();
+        final SortedMap<String, List<String>> sorted = new TreeMap<>();
 
         /**
          * Signing protocol expects the param values also to be sorted after url
@@ -258,7 +258,7 @@ public abstract class AbstractAwsSigner implements Signer {
         }
     }
 
-    protected String getCanonicalizedResourcePath(String resourcePath, boolean urlEncode) {
+    String getCanonicalizedResourcePath(String resourcePath, boolean urlEncode) {
         if (StringUtils.isEmpty(resourcePath)) {
             return "/";
         } else {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/config/AwsClientOption.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/config/AwsClientOption.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.core.client.config.ClientOption;
 import software.amazon.awssdk.regions.Region;
 
 @SdkProtectedApi
-public class AwsClientOption<T> extends ClientOption<T> {
+public final class AwsClientOption<T> extends ClientOption<T> {
     /**
      * @see AwsClientBuilder#credentialsProvider(AwsCredentialsProvider)
      */
@@ -42,7 +42,7 @@ public class AwsClientOption<T> extends ClientOption<T> {
 
     public static final AwsClientOption<String> SERVICE_SIGNING_NAME = new AwsClientOption<>(String.class);
 
-    protected AwsClientOption(Class<T> valueClass) {
+    private AwsClientOption(Class<T> valueClass) {
         super(valueClass);
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsSyncClientHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsSyncClientHandler.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.core.sync.ResponseTransformer;
 @Immutable
 @ReviewBeforeRelease("This looks identical to the Sdk version, revisit when we add APIG back")
 @SdkProtectedApi
-public class AwsSyncClientHandler extends SdkSyncClientHandler implements SyncClientHandler {
+public final class AwsSyncClientHandler extends SdkSyncClientHandler implements SyncClientHandler {
 
     private final SdkClientConfiguration clientConfiguration;
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/AwsJsonErrorResponseHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/AwsJsonErrorResponseHandler.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.core.internal.protocol.json.JsonContent;
  * services and unmarshalls the result using a JSON unmarshaller.
  */
 @SdkInternalApi
-public class AwsJsonErrorResponseHandler extends JsonErrorResponseHandler<AwsServiceException> {
+public final class AwsJsonErrorResponseHandler extends JsonErrorResponseHandler<AwsServiceException> {
 
     private final List<AwsJsonErrorUnmarshaller> unmarshallers;
     private final ErrorCodeParser errorCodeParser;

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/DefaultErrorResponseHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/DefaultErrorResponseHandler.java
@@ -45,7 +45,7 @@ import software.amazon.awssdk.utils.IoUtils;
  * message, AWS error code, AWS request ID, etc).
  */
 @SdkProtectedApi
-public class DefaultErrorResponseHandler implements HttpResponseHandler<AwsServiceException> {
+public final class DefaultErrorResponseHandler implements HttpResponseHandler<AwsServiceException> {
     private static final Logger log = LoggerFactory.getLogger(DefaultErrorResponseHandler.class);
 
     /**

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/StaxResponseHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/http/response/StaxResponseHandler.java
@@ -47,7 +47,7 @@ import software.amazon.awssdk.utils.XmlUtils;
  */
 @SdkProtectedApi
 @ReviewBeforeRelease("ResponseMetadata is currently broken. Revisit when base result types are refactored")
-public class StaxResponseHandler<T> implements HttpResponseHandler<T> {
+public final class StaxResponseHandler<T> implements HttpResponseHandler<T> {
     private static final Logger log = Logger.loggerFor(StaxResponseHandler.class);
 
     /**

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonErrorMessageParser.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/json/AwsJsonErrorMessageParser.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.core.internal.protocol.json.ErrorMessageParser;
 import software.amazon.awssdk.core.protocol.json.SdkJsonErrorMessageParser;
 
 @SdkProtectedApi
-public class AwsJsonErrorMessageParser implements ErrorMessageParser {
+public final class AwsJsonErrorMessageParser implements ErrorMessageParser {
 
     public static final ErrorMessageParser DEFAULT_ERROR_MESSAGE_PARSER =
         new AwsJsonErrorMessageParser(SdkJsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER);

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/LegacyErrorUnmarshaller.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/LegacyErrorUnmarshaller.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.core.util.XpathUtils;
  * optionally, a subclass of SdkServiceException if this class is extended.
  */
 @SdkProtectedApi
-public class LegacyErrorUnmarshaller extends AbstractErrorUnmarshaller<AwsServiceException, Node> {
+public final class LegacyErrorUnmarshaller extends AbstractErrorUnmarshaller<AwsServiceException, Node> {
 
     /**
      * Constructs a new unmarshaller that will unmarshall AWS error responses as

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/StaxUnmarshallerContext.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/StaxUnmarshallerContext.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * from the parser, reading element text, handling attribute XML events, etc.
  */
 @SdkProtectedApi
-public class StaxUnmarshallerContext {
+public final class StaxUnmarshallerContext {
 
     public final Stack<String> stack = new Stack<>();
     private final XMLEventReader eventReader;
@@ -179,7 +179,7 @@ public class StaxUnmarshallerContext {
         }
 
         int index = -1;
-        while ((index = expression.indexOf("/", index + 1)) > -1) {
+        while ((index = expression.indexOf('/', index + 1)) > -1) {
             // Don't consider attributes a new depth level
             if (expression.charAt(index + 1) != '@') {
                 startingStackDepth++;
@@ -298,10 +298,10 @@ public class StaxUnmarshallerContext {
      * Simple container for the details of a metadata expression this
      * unmarshaller context is looking for.
      */
-    private static class MetadataExpression {
-        public String expression;
-        public int targetDepth;
-        public String key;
+    private static final class MetadataExpression {
+        private String expression;
+        private int targetDepth;
+        private String key;
 
         MetadataExpression(String expression, int targetDepth, String key) {
             this.expression = expression;

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/conditions/RetryOnErrorCodeCondition.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/retry/conditions/RetryOnErrorCodeCondition.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.core.retry.conditions.RetryCondition;
  * Retry condition implementation that retries if the exception or the cause of the exception matches the error codes defined.
  */
 @SdkPublicApi
-public class RetryOnErrorCodeCondition implements RetryCondition {
+public final class RetryOnErrorCodeCondition implements RetryCondition {
 
     private final Set<String> retryableErrorCodes;
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/http/StaxResponseHandlerComponentTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/http/StaxResponseHandlerComponentTest.java
@@ -20,8 +20,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -34,6 +32,7 @@ import java.nio.file.Files;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import software.amazon.awssdk.awscore.client.utils.ValidSdkObjects;
 import software.amazon.awssdk.awscore.http.response.StaxResponseHandler;
 import software.amazon.awssdk.awscore.protocol.xml.StaxUnmarshallerContext;
 import software.amazon.awssdk.core.http.HttpResponse;
@@ -69,11 +68,11 @@ public class StaxResponseHandlerComponentTest {
 
         StaxResponseHandler<EmptyAwsResponse> responseHandler = new StaxResponseHandler<>(dummyUnmarshaller());
 
-        HttpResponse response = mock(HttpResponse.class);
-        when(response.getContent()).thenReturn(new ByteArrayInputStream(payload.getBytes(Charset.forName("UTF-8"))));
+        HttpResponse response = new HttpResponse(ValidSdkObjects.sdkHttpFullRequest().build());
+        response.setContent(new ByteArrayInputStream(payload.getBytes(Charset.forName("UTF-8"))));
 
         try {
-            responseHandler.handle(response, mock(ExecutionAttributes.class));
+            responseHandler.handle(response, new ExecutionAttributes());
         } catch (Exception e) {
             //expected
         }

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * A named collection of configuration stored in a {@link ProfileFile}.
- *
+ * <p>
  * Raw property access can be made via {@link #property(String)} and {@link #properties()}.
  *
  * @see ProfileFile
@@ -125,7 +125,7 @@ public final class Profile implements ToCopyableBuilder<Profile.Builder, Profile
     /**
      * A builder for a {@link Profile}. See {@link #builder()}.
      */
-    public static class Builder implements CopyableBuilder<Builder, Profile> {
+    public static final class Builder implements CopyableBuilder<Builder, Profile> {
         private String name;
         private Map<String, String> properties;
 

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.profiles.internal.ProfileFileLocations;
@@ -53,14 +52,13 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
  * default, the SDK will use the {@link #defaultProfileFile()} when that behavior hasn't been explicitly overridden.
  */
 @SdkPublicApi
-public class ProfileFile {
+public final class ProfileFile {
     private final Map<String, Profile> profiles;
 
     /**
      * @see #builder()
      */
-    @SdkInternalApi
-    ProfileFile(Map<String, Map<String, String>> rawProfiles) {
+    private ProfileFile(Map<String, Map<String, String>> rawProfiles) {
         Validate.paramNotNull(rawProfiles, "rawProfiles");
 
         this.profiles = Collections.unmodifiableMap(convertToProfilesMap(rawProfiles));
@@ -99,7 +97,7 @@ public class ProfileFile {
      * @param profileName The name of the profile that should be retrieved from this file.
      * @return The profile, if available.
      */
-    public final Optional<Profile> profile(String profileName) {
+    public Optional<Profile> profile(String profileName) {
         return Optional.ofNullable(profiles.get(profileName));
     }
 
@@ -107,7 +105,7 @@ public class ProfileFile {
      * Retrieve an unmodifiable collection including all of the profiles in this file.
      * @return An unmodifiable collection of the profiles in this file, keyed by profile name.
      */
-    public final Map<String, Profile> profiles() {
+    public Map<String, Profile> profiles() {
         return profiles;
     }
 

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/Region.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/Region.java
@@ -146,9 +146,18 @@ public final class Region {
         return isGlobalRegion;
     }
 
+    @Override
+    public String toString() {
+        return id;
+    }
+
     private static class RegionCache {
 
         private static final ConcurrentHashMap<String, Region> VALUES = new ConcurrentHashMap<>();
+
+        private RegionCache() {
+
+        }
 
         private static Region put(String value, boolean isGlobalRegion) {
             return VALUES.computeIfAbsent(value, v -> new Region(value, isGlobalRegion));

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/PartitionRegionMetadata.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/PartitionRegionMetadata.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.utils.Validate;
  * A region implementation backed by the partition.
  */
 @SdkInternalApi
-public class PartitionRegionMetadata implements RegionMetadata {
+public final class PartitionRegionMetadata implements RegionMetadata {
 
     /**
      * partition where the region is present.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/PartitionServiceMetadata.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/PartitionServiceMetadata.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.regions.internal.model.Partition;
 import software.amazon.awssdk.regions.internal.model.Service;
 
 @SdkInternalApi
-public class PartitionServiceMetadata implements ServiceMetadata {
+public final class PartitionServiceMetadata implements ServiceMetadata {
 
     private static final String SERVICE = "{service}";
     private static final String REGION = "{region}";

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/CredentialScope.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/CredentialScope.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
  * credential scope associated with an endpoint.
  */
 @SdkInternalApi
-public class CredentialScope {
+public final class CredentialScope {
 
     /**
      * region string to be used when signing a request for an endpoint.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Endpoint.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Endpoint.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.core.Protocol;
  * Endpoint configuration.
  */
 @SdkInternalApi
-public class Endpoint implements Cloneable {
+public final class Endpoint implements Cloneable {
 
     /**
      * endpoint string.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Partition.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Partition.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.core.util.ValidationUtils;
  * This class models a AWS partition and contains all metadata about it.
  */
 @SdkInternalApi
-public class Partition {
+public final class Partition {
 
     /**
      * The name of the partition.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/PartitionRegion.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/PartitionRegion.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.utils.Validate;
  * Metadata about a region in partition.
  */
 @SdkInternalApi
-public class PartitionRegion {
+public final class PartitionRegion {
 
     /**
      * description of the region.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Partitions.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Partitions.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.core.util.ValidationUtils;
  * Metadata of all partitions.
  */
 @SdkInternalApi
-public class Partitions {
+public final class Partitions {
 
     /**
      * the version of json schema for the partition metadata.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Service.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Service.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.core.util.ValidationUtils;
  * Endpoint configuration for a service in a partition.
  */
 @SdkInternalApi
-public class Service {
+public final class Service {
 
     /**
      * endpoint configuration for every region in a partition.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/util/ResourcesEndpointRetryParameters.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/util/ResourcesEndpointRetryParameters.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
  * Parameters that are used in {@link ResourcesEndpointRetryPolicy}.
  */
 @SdkInternalApi
-public class ResourcesEndpointRetryParameters {
+public final class ResourcesEndpointRetryParameters {
 
     private final Integer statusCode;
 

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/providers/AwsProfileRegionProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/providers/AwsProfileRegionProvider.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.regions.Region;
  * Loads region information from the {@link ProfileFile#defaultProfileFile()} using the default profile name.
  */
 @SdkProtectedApi
-public class AwsProfileRegionProvider implements AwsRegionProvider {
+public final class AwsProfileRegionProvider implements AwsRegionProvider {
 
     private final String profileName = SdkSystemSetting.AWS_PROFILE.getStringValueOrThrow();
 

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * </ol>
  */
 @SdkProtectedApi
-public class DefaultAwsRegionProviderChain extends AwsRegionProviderChain {
+public final class DefaultAwsRegionProviderChain extends AwsRegionProviderChain {
     public DefaultAwsRegionProviderChain() {
         super(new SystemSettingsRegionProvider(), new AwsProfileRegionProvider(),
               new InstanceProfileRegionProvider());

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/providers/InstanceProfileRegionProvider.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
  * region from EC2 metadata service and will return null.
  */
 @SdkProtectedApi
-public class InstanceProfileRegionProvider implements AwsRegionProvider {
+public final class InstanceProfileRegionProvider implements AwsRegionProvider {
 
     /**
      * Cache region as it will not change during the lifetime of the JVM.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/providers/SystemSettingsRegionProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/providers/SystemSettingsRegionProvider.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.regions.Region;
  * the system property will be used.
  */
 @SdkProtectedApi
-public class SystemSettingsRegionProvider implements AwsRegionProvider {
+public final class SystemSettingsRegionProvider implements AwsRegionProvider {
     @Override
     public Region getRegion() throws SdkClientException {
         return SdkSystemSetting.AWS_REGION.getStringValue()

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StringToByteBufferAdapter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StringToByteBufferAdapter.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 @SdkProtectedApi
-public class StringToByteBufferAdapter implements TypeAdapter<String, ByteBuffer> {
+public final class StringToByteBufferAdapter implements TypeAdapter<String, ByteBuffer> {
 
     @Override
     public ByteBuffer adapt(String source) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StringToInputStreamAdapter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/adapter/StringToInputStreamAdapter.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.util.StringInputStream;
 
 @SdkProtectedApi
-public class StringToInputStreamAdapter implements TypeAdapter<String, InputStream> {
+public final class StringToInputStreamAdapter implements TypeAdapter<String, InputStream> {
     @Override
     public InputStream adapt(String source) {
         if (source == null) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -216,7 +216,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
     private SdkClientConfiguration finalizeAsyncConfiguration(SdkClientConfiguration config) {
         return config.toBuilder()
                      .option(FUTURE_COMPLETION_EXECUTOR, resolveAsyncFutureCompletionExecutor(config))
-                     .option(ASYNC_RETRY_EXECUTOR_SERVICE, resolveAsyncRetryExecutorService(config))
+                     .option(ASYNC_RETRY_EXECUTOR_SERVICE, resolveAsyncRetryExecutorService())
                      .option(ASYNC_HTTP_CLIENT, resolveAsyncHttpClient(config))
                      .build();
     }
@@ -277,7 +277,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
     /**
      * Finalize which async executor service will be used for retries in the created client.
      */
-    private ScheduledExecutorService resolveAsyncRetryExecutorService(SdkClientConfiguration config) {
+    private ScheduledExecutorService resolveAsyncRetryExecutorService() {
         return Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().threadNamePrefix("sdk-retry").build());
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
@@ -31,7 +31,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  * @param <T> The type of value associated with the option.
  */
 @SdkPublicApi
-public class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
+public final class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
     /**
      * Configure the executor that should be used to complete the {@link CompletableFuture} that is returned by the service
      * clients. By default, this is an the {@link ExecutorService} managed by the SDK. {@link Executor#execute(Runnable)} is
@@ -41,7 +41,7 @@ public class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
     public static final SdkAdvancedAsyncClientOption<Executor> FUTURE_COMPLETION_EXECUTOR =
             new SdkAdvancedAsyncClientOption<>(Executor.class);
 
-    protected SdkAdvancedAsyncClientOption(Class<T> valueClass) {
+    private SdkAdvancedAsyncClientOption(Class<T> valueClass) {
         super(valueClass);
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
  * A set of internal options required by the SDK via {@link SdkClientConfiguration}.
  */
 @SdkProtectedApi
-public class SdkClientOption<T> extends ClientOption<T> {
+public final class SdkClientOption<T> extends ClientOption<T> {
     /**
      * @see ClientOverrideConfiguration#additionalHttpHeaders()
      */
@@ -87,11 +87,11 @@ public class SdkClientOption<T> extends ClientOption<T> {
     public static final SdkClientOption<SdkHttpClient> SYNC_HTTP_CLIENT =
             new SdkClientOption<>(SdkHttpClient.class);
 
-    protected SdkClientOption(Class<T> valueClass) {
+    private SdkClientOption(Class<T> valueClass) {
         super(valueClass);
     }
 
-    protected SdkClientOption(UnsafeValueType valueType) {
+    private SdkClientOption(UnsafeValueType valueType) {
         super(valueType);
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
@@ -180,7 +180,7 @@ public abstract class BaseClientHandler {
     /**
      * Decorate response handlers by running after unmarshalling Interceptors and adding http response metadata.
      */
-    static <InputT extends SdkRequest, OutputT extends SdkResponse> HttpResponseHandler<OutputT> decorateResponseHandlers(
+    static <OutputT extends SdkResponse> HttpResponseHandler<OutputT> decorateResponseHandlers(
         HttpResponseHandler<OutputT> delegate, ExecutionContext executionContext) {
         HttpResponseHandler<OutputT> interceptorCallingResponseHandler = interceptorCalling(delegate, executionContext);
         return addHttpResponseMetadataResponseHandler(interceptorCallingResponseHandler);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
@@ -34,7 +34,7 @@ import software.amazon.awssdk.core.runtime.transform.Marshaller;
 @SdkProtectedApi
 @NotThreadSafe
 @ReviewBeforeRelease("Using old style withers/getters")
-public class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
+public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
 
     private InputT input;
     private AsyncRequestBody asyncRequestBody;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/HttpResponse.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/HttpResponse.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
  */
 @SdkProtectedApi
 @ReviewBeforeRelease("Make sure we aren't exposing this anywhere")
-public class HttpResponse implements Abortable {
+public final class HttpResponse implements Abortable {
 
     private final SdkHttpFullRequest request;
     private final Abortable abortable;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/JsonResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/JsonResponseHandler.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.utils.Logger;
  */
 @SdkProtectedApi
 @ReviewBeforeRelease("Metadata in base result has been broken. Fix this and deal with AwsResponseHandlerAdapter")
-public class JsonResponseHandler<T> implements HttpResponseHandler<T> {
+public final class JsonResponseHandler<T> implements HttpResponseHandler<T> {
     private static final Logger log = Logger.loggerFor(JsonResponseHandler.class);
 
     private final JsonFactory jsonFactory;
@@ -73,7 +73,7 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<T> {
          * don't have to do this check here.
          */
         this.responseUnmarshaller =
-                responseUnmarshaller != null ? responseUnmarshaller : new VoidJsonUnmarshaller<T>();
+                responseUnmarshaller != null ? responseUnmarshaller : new VoidJsonUnmarshaller<>();
 
         this.needsConnectionLeftOpen = needsConnectionLeftOpen;
         this.isPayloadJson = isPayloadJson;
@@ -136,6 +136,7 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<T> {
             JsonUnmarshallerContext unmarshallerContext) {
     }
 
+    @Override
     public boolean needsConnectionLeftOpen() {
         return needsConnectionLeftOpen;
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttribute.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  * @param <T> The type of data associated with this attribute.
  */
 @SdkPublicApi
-public class ExecutionAttribute<T> {
+public final class ExecutionAttribute<T> {
 
     private final String name;
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  */
 @SdkPublicApi
 @NotThreadSafe
-public class ExecutionAttributes {
+public final class ExecutionAttributes {
     private final Map<ExecutionAttribute<?>, Object> attributes = new HashMap<>();
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.utils.BinaryUtils;
  * @see AsyncResponseTransformer#toBytes()
  */
 @SdkInternalApi
-public class ByteArrayAsyncResponseTransformer<ResponseT> implements
+public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
         AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> {
 
     private ResponseT response;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBody.java
@@ -157,7 +157,7 @@ public final class FileAsyncRequestBody implements AsyncRequestBody {
     /**
      * Reads the file for one subscriber.
      */
-    private static class FileSubscription implements Subscription {
+    private static final class FileSubscription implements Subscription {
         private final AsynchronousFileChannel inputChannel;
         private final Subscriber<? super ByteBuffer> subscriber;
         private final int chunkSize;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
@@ -52,7 +52,7 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 @ThreadSafe
 @SdkInternalApi
 @ReviewBeforeRelease("come up with better name")
-public class AmazonAsyncHttpClient implements SdkAutoCloseable {
+public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
     private final HttpClientDependencies httpClientDependencies;
 
     public AmazonAsyncHttpClient(SdkClientConfiguration clientConfiguration) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonSyncHttpClient.java
@@ -58,7 +58,7 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 @SdkInternalApi
 @ReviewBeforeRelease("come up with better name, Also this can be moved to an internal package if we "
                      + "deal with HttpTestUtils.")
-public class AmazonSyncHttpClient implements SdkAutoCloseable {
+public final class AmazonSyncHttpClient implements SdkAutoCloseable {
     /**
      * Used for testing via failure injection.
      */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/StreamManagingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/StreamManagingStage.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
  * @param <OutputT> Type of unmarshalled response
  */
 @SdkInternalApi
-public class StreamManagingStage<OutputT> implements RequestPipeline<SdkHttpFullRequest, Response<OutputT>> {
+public final class StreamManagingStage<OutputT> implements RequestPipeline<SdkHttpFullRequest, Response<OutputT>> {
 
     private static final Logger log = LoggerFactory.getLogger(StreamManagingStage.class);
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/pagination/async/EmptySubscription.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/pagination/async/EmptySubscription.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * This subscription calls {@link Subscriber#onComplete()} on first request for data and then terminates the subscription.
  */
 @SdkProtectedApi
-public class EmptySubscription implements Subscription {
+public final class EmptySubscription implements Subscription {
 
     private final AtomicBoolean isTerminated = new AtomicBoolean(false);
     private final Subscriber subscriber;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/JsonUnmarshallerContextImpl.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/JsonUnmarshallerContextImpl.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.core.http.HttpResponse;
 import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
-public class JsonUnmarshallerContextImpl extends JsonUnmarshallerContext {
+public final class JsonUnmarshallerContextImpl extends JsonUnmarshallerContext {
 
     private final JsonParser jsonParser;
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/ListUnmarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/ListUnmarshaller.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * control of the context.
  */
 @SdkProtectedApi
-public class ListUnmarshaller<T> implements
+public final class ListUnmarshaller<T> implements
                                  Unmarshaller<List<T>, JsonUnmarshallerContext> {
 
     private final Unmarshaller<T, JsonUnmarshallerContext> itemUnmarshaller;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/MapUnmarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/MapUnmarshaller.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 @SdkProtectedApi
-public class MapUnmarshaller<K, V> implements Unmarshaller<Map<K, V>, JsonUnmarshallerContext> {
+public final class MapUnmarshaller<K, V> implements Unmarshaller<Map<K, V>, JsonUnmarshallerContext> {
 
     private final Unmarshaller<K, JsonUnmarshallerContext> keyUnmarshaller;
     private final Unmarshaller<V, JsonUnmarshallerContext> valueUnmarshaller;
@@ -37,7 +37,7 @@ public class MapUnmarshaller<K, V> implements Unmarshaller<Map<K, V>, JsonUnmars
     }
 
     public Map<K, V> unmarshall(JsonUnmarshallerContext context) throws Exception {
-        Map<K, V> map = new HashMap<K, V>();
+        Map<K, V> map = new HashMap<>();
         int originalDepth = context.getCurrentDepth();
 
         if (context.getCurrentToken() == JsonToken.VALUE_NULL) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/SimpleTypeJsonUnmarshallers.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/SimpleTypeJsonUnmarshallers.java
@@ -21,13 +21,14 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.runtime.transform.JsonUnmarshallerContext;
-import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 import software.amazon.awssdk.core.util.DateUtils;
 import software.amazon.awssdk.utils.Base64Utils;
 
 @SdkProtectedApi
-public class SimpleTypeJsonUnmarshallers {
+public final class SimpleTypeJsonUnmarshallers {
+    private SimpleTypeJsonUnmarshallers() {
+    }
+
     /**
      * Unmarshaller for String values.
      */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/StreamingRequestMarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/StreamingRequestMarshaller.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
  * @param <T> Type of POJO being marshalled.
  */
 @SdkProtectedApi
-public class StreamingRequestMarshaller<T> implements Marshaller<Request<T>, T> {
+public final class StreamingRequestMarshaller<T> implements Marshaller<Request<T>, T> {
 
     private final Marshaller<Request<T>, T> delegate;
     private final RequestBody requestBody;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/signer/NoOpSigner.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/signer/NoOpSigner.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
  * input {@link SdkHttpFullRequest} without modifications.
  */
 @SdkPublicApi
-public class NoOpSigner implements Signer, Presigner {
+public final class NoOpSigner implements Signer, Presigner {
 
     @Override
     public SdkHttpFullRequest presign(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/ImmutableMapParameter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/ImmutableMapParameter.java
@@ -56,7 +56,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  *            Class of the value for the map.
  */
 @SdkProtectedApi
-public class ImmutableMapParameter<K, V> implements Map<K, V> {
+public final class ImmutableMapParameter<K, V> implements Map<K, V> {
 
     private static final String UNMODIFIABLE_MESSAGE = "This is an immutable map.";
     private static final String DUPLICATED_KEY_MESSAGE = "Duplicate keys are provided.";

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/JavaVersionParser.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/JavaVersionParser.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.utils.JavaSystemSetting;
  *     </a>
  */
 @SdkInternalApi
-public class JavaVersionParser {
+public final class JavaVersionParser {
 
     public static final String JAVA_VERSION_PROPERTY = "java.version";
 


### PR DESCRIPTION
- Add `final` on classes that are not expected to be extended to prohibit inheritance.

Following `Effective Java`
> Item 17 - Design and document for inheritance or else prohibit it


- Other smaller fixes