### PR TITLE
Make sure each module has a dedicated package root.

### DIFF
--- a/.changes/next-release/feature-AWSWAFRegional-6c8fb6b.json
+++ b/.changes/next-release/feature-AWSWAFRegional-6c8fb6b.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS WAF Regional", 
+    "type": "feature", 
+    "description": "AWS Waf Regional clients are now in `software.amazon.awssdk.services.waf.regional` package."
+}

--- a/.changes/next-release/feature-AmazonDynamoDBStreams-d03b835.json
+++ b/.changes/next-release/feature-AmazonDynamoDBStreams-d03b835.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon DynamoDB Streams", 
+    "type": "feature", 
+    "description": "Dynamodb Streams clients are now in `software.amazon.awssdk.services.dynamodb.streams` package."
+}

--- a/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
+++ b/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
@@ -98,7 +98,7 @@ public class GenerationMojo extends AbstractMojo {
     }
 
     private int modelSharersLast(Path lhs, Path rhs) {
-        return loadCustomizationConfig(lhs).getShareModelsWith() == null ? -1 : 1;
+        return loadCustomizationConfig(lhs).getShareModelConfig() == null ? -1 : 1;
     }
 
     private boolean isModelFile(Path p, BasicFileAttributes a) {
@@ -121,7 +121,7 @@ public class GenerationMojo extends AbstractMojo {
 
     private CustomizationConfig loadCustomizationConfig(Path root) {
         return loadOptionalModel(CustomizationConfig.class, root.resolve(CUSTOMIZATION_CONFIG_FILE))
-                .orElse(CustomizationConfig.DEFAULT);
+                .orElse(CustomizationConfig.create());
     }
 
     private ServiceModel loadServiceModel(Path root) throws MojoExecutionException {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/SharedModelsTaskParamsValidator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/SharedModelsTaskParamsValidator.java
@@ -20,16 +20,17 @@ import java.util.function.Consumer;
 import software.amazon.awssdk.codegen.emitters.CodeWriter;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.config.customization.ShareModelConfig;
 
 /**
- * This validates that services with the {@link CustomizationConfig#shareModelsWith} attribute specified are being generated
+ * This validates that services with the {@link CustomizationConfig#shareModelConfig} attribute specified are being generated
  * after the service they are attempting to share models with. This ensures that the services are kept together in the same
  * module and allows us to verify (in {@link CodeWriter}) that their models are compatible with each other.
  */
 public class SharedModelsTaskParamsValidator implements Consumer<GeneratorTaskParams> {
     @Override
     public void accept(GeneratorTaskParams params) {
-        String sharedModelService = params.getModel().getCustomizationConfig().getShareModelsWith();
+        ShareModelConfig sharedModelService = params.getModel().getCustomizationConfig().getShareModelConfig();
 
         if (sharedModelService != null) {
             // Validate the service we're sharing models with has been generated already.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.codegen.model.config.templates.CodeGenTemplatesCon
 
 public class CustomizationConfig {
 
-    public static final CustomizationConfig DEFAULT = new CustomizationConfig();
     /**
      * List of 'convenience' overloads to generate for model classes. Convenience overloads expose a
      * different type that is adapted to the real type
@@ -97,10 +96,10 @@ public class CustomizationConfig {
     private boolean excludeClientCreateMethod = false;
 
     /**
-     * A service name that this service client should share models with. The models and non-request marshallers will be generated
-     * into the same directory as the provided service's models.
+     * Configurations for the service that share model with other services. The models and non-request marshallers will be
+     * generated into the same directory as the provided service's models.
      */
-    private String shareModelsWith;
+    private ShareModelConfig shareModelConfig;
 
     /**
      * Expression to return a service specific instance of {@link software.amazon.awssdk.http.SdkHttpConfigurationOption}. If
@@ -139,6 +138,10 @@ public class CustomizationConfig {
     private boolean skipSyncClientGeneration;
 
     private CustomizationConfig() {
+    }
+
+    public static CustomizationConfig create() {
+        return new CustomizationConfig();
     }
 
     public String getCustomServiceNameForRequest() {
@@ -282,12 +285,12 @@ public class CustomizationConfig {
         this.excludeClientCreateMethod = excludeClientCreateMethod;
     }
 
-    public String getShareModelsWith() {
-        return shareModelsWith;
+    public ShareModelConfig getShareModelConfig() {
+        return shareModelConfig;
     }
 
-    public void setShareModelsWith(String shareModelsWith) {
-        this.shareModelsWith = shareModelsWith;
+    public void setShareModelConfig(ShareModelConfig shareModelConfig) {
+        this.shareModelConfig = shareModelConfig;
     }
 
     public String getServiceSpecificHttpConfig() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ShareModelConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ShareModelConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+/**
+ * Contains custom properties for services that share models with other services.
+ */
+public class ShareModelConfig {
+
+    /**
+     * A service name that this service client should share models with. The models and non-request marshallers will be generated
+     * into the same directory as the provided service's models.
+     */
+    private String shareModelWith;
+
+    /**
+     * The package name of the provided service. Service name will be used if not provided.
+     */
+    private String packageName;
+
+    public String getShareModelWith() {
+        return shareModelWith;
+    }
+
+    public void setShareModelWith(String shareModelWith) {
+        this.shareModelWith = shareModelWith;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public void setPackageName(String packageName) {
+        this.packageName = packageName;
+    }
+}

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/streams/StreamsIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/streams/StreamsIntegrationTest.java
@@ -13,12 +13,11 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.dynamodb;
+package software.amazon.awssdk.services.dynamodb.streams;
 
 import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.services.dynamodb.model.ListStreamsRequest;
-import software.amazon.awssdk.services.dynamodbstreams.DynamoDbStreamsClient;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 
 public class StreamsIntegrationTest extends AwsTestBase {

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
@@ -29,7 +29,10 @@
             "excludeShape": true
         }
     },
-    "shareModelsWith" : "dynamodb",
+    "shareModelConfig" : {
+        "shareModelWith" : "dynamodb",
+        "packageName" : "streams"
+    },
 
     "skipSmokeTests": "true",
 

--- a/services/waf/src/it/java/software/amazon/awssdk/services/waf/regional/WafRegionalIntegrationTest.java
+++ b/services/waf/src/it/java/software/amazon/awssdk/services/waf/regional/WafRegionalIntegrationTest.java
@@ -13,13 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.waf;
+package software.amazon.awssdk.services.waf.regional;
 
 import org.junit.Test;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.waf.model.ListResourcesForWebACLRequest;
 import software.amazon.awssdk.services.waf.model.WAFNonexistentItemException;
-import software.amazon.awssdk.services.wafregional.WafRegionalClient;
 import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
 
 public class WafRegionalIntegrationTest extends AwsIntegrationTestBase {
@@ -31,9 +30,9 @@ public class WafRegionalIntegrationTest extends AwsIntegrationTestBase {
     @Test(expected = WAFNonexistentItemException.class)
     public void smokeTest() {
         final WafRegionalClient client = WafRegionalClient.builder()
-                                                                 .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
-                                                                 .region(Region.US_WEST_2)
-                                                                 .build();
+                                                          .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                                          .region(Region.US_WEST_2)
+                                                          .build();
 
         client.listResourcesForWebACL(ListResourcesForWebACLRequest.builder().webACLId("foo").build());
     }

--- a/services/waf/src/main/resources/codegen-resources/waf-regional/customization.config
+++ b/services/waf/src/main/resources/codegen-resources/waf-regional/customization.config
@@ -3,7 +3,10 @@
     "authPolicyActions": {
         "fileNamePrefix": "WafRegional"
     },
-    "shareModelsWith": "waf",
+    "shareModelConfig" : {
+        "shareModelWith" : "waf",
+        "packageName" : "regional"
+    },
     "sdkRequestBaseClassName": "WafRequest",
     "sdkResponseBaseClassName": "WafResponse"
 }


### PR DESCRIPTION
Make sure each module has a dedicated package root.

If a service is sharing models with other service, the package root of that service is going to be within that shared service package.
eg:

dynamodb -> `software.amazon.awssdk.services.dynamodb`
dynamodbstreams -> `software.amazon.awssdk.services.dynamodb.dynamodbstreams`

waf -> `software.amazon.awssdk.services.waf`
waf-regional: -> `software.amazon.awssdk.services.waf.wafregional`
