### PR TITLE
Add MissingSdkAnnotationCheck 

### DIFF
--- a/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/MissingSdkAnnotationCheck.java
+++ b/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/MissingSdkAnnotationCheck.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.buildtools.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtility;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A rule that checks if sdk annotation is missing on any non-test classes. Inner classes are ignored.
+ */
+public class MissingSdkAnnotationCheck extends AbstractCheck {
+
+    private static final List<String> SDK_ANNOTATIONS = Arrays.asList("SdkPublicApi", "SdkInternalApi", "SdkProtectedApi");
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] {
+            TokenTypes.CLASS_DEF
+        };
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (!ScopeUtils.isOuterMostType(ast) || SDK_ANNOTATIONS.stream().anyMatch(a -> AnnotationUtility.containsAnnotation
+            (ast, a))) {
+            return;
+        }
+
+        log(ast, "SDK annotation is missing on this class. eg: @SdkProtectedApi");
+    }
+}

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle-suppressions.xml
@@ -23,8 +23,13 @@
     <suppress checks=".*"
               files=".*[\\/](test|it)[\\/]java[\\/].+\.java$"/>
 
-    <suppress checks=".*"
-              files=".*[\\/]generated-sources[\\/].+\.java$"/>
+    <!-- ignore missing annotation checks under test/codegen directory -->
+    <suppress checks="MissingSdkAnnotationCheck"
+              files=".(codegen|test)[\\/].+\.java$"/>
+
+    <!-- TODO: Remove this once we add the annotations on the services-->
+    <suppress checks="MissingSdkAnnotationCheck"
+              files=".(services)[\\/].+\.java$"/>
 
     <!-- Assumes getter/setter match JSON property -->
     <suppress checks="AbbreviationAsWordInName"

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
@@ -433,5 +433,8 @@
 
         <!-- Checks for utility and constants classes to have private constructor-->
         <module name="HideUtilityClassConstructor"/>
+
+        <!-- Checks that every class is marked with Sdk Annotation -->
+        <module name="software.amazon.awssdk.buildtools.checkstyle.MissingSdkAnnotationCheck" />
     </module>
 </module>

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/UnreliableTestConfig.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/UnreliableTestConfig.java
@@ -16,15 +16,15 @@
 package software.amazon.awssdk.core.internal.http;
 
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
-import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Used to configure the conditions for injecting content input stream failures
  * for testing purposes.
  */
-@SdkTestInternalApi
+@SdkInternalApi
 @ReviewBeforeRelease("Don't like this mixing of test code")
-public class UnreliableTestConfig {
+class UnreliableTestConfig {
     private int maxNumErrors = 1;
     private int bytesReadBeforeException = 100;
     private boolean isFakeIoException;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/CompletableFutures.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/CompletableFutures.java
@@ -16,10 +16,12 @@
 package software.amazon.awssdk.core.util;
 
 import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
  * Utility class for working with {@link CompletableFuture}.
  */
+@SdkProtectedApi
 public final class CompletableFutures {
     private CompletableFutures() {
     }


### PR DESCRIPTION
Add MissingSdkAnnotationCheck to make sure all non-test classes are marked with sdk annotation

## Motivation and Context
Reduce manual review effort
