### PR TITLE
Update all service models to follow V2 naming convention

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-3867989.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-3867989.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Update all service models to follow V2 naming convention. eg: `WAFException` -> `WafException`"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -22,7 +22,6 @@ import static software.amazon.awssdk.codegen.internal.Constant.FAULT_CLASS_SUFFI
 import static software.amazon.awssdk.codegen.internal.Constant.REQUEST_CLASS_SUFFIX;
 import static software.amazon.awssdk.codegen.internal.Constant.RESPONSE_CLASS_SUFFIX;
 import static software.amazon.awssdk.codegen.internal.Constant.VARIABLE_NAME_SUFFIX;
-import static software.amazon.awssdk.codegen.internal.Utils.capitalize;
 import static software.amazon.awssdk.codegen.internal.Utils.unCapitalize;
 
 import java.util.Arrays;
@@ -157,6 +156,10 @@ public class DefaultNamingStrategy implements NamingStrategy {
         return serviceName;
     }
 
+    private String pascalCase(String word) {
+        return Stream.of(splitOnWordBoundaries(word)).map(StringUtils::lowerCase).map(Utils::capitalize).collect(joining());
+    }
+
     private String pascalCase(String... words) {
         return Stream.of(words).map(StringUtils::lowerCase).map(Utils::capitalize).collect(joining());
     }
@@ -168,22 +171,22 @@ public class DefaultNamingStrategy implements NamingStrategy {
     @Override
     public String getExceptionName(String errorShapeName) {
         if (errorShapeName.endsWith(FAULT_CLASS_SUFFIX)) {
-            return capitalize(errorShapeName.substring(0, errorShapeName.length() - FAULT_CLASS_SUFFIX.length()) +
-                              EXCEPTION_CLASS_SUFFIX);
+            return pascalCase(errorShapeName.substring(0, errorShapeName.length() - FAULT_CLASS_SUFFIX.length())) +
+                              EXCEPTION_CLASS_SUFFIX;
         } else if (errorShapeName.endsWith(EXCEPTION_CLASS_SUFFIX)) {
-            return capitalize(errorShapeName);
+            return pascalCase(errorShapeName);
         }
-        return capitalize(errorShapeName + EXCEPTION_CLASS_SUFFIX);
+        return pascalCase(errorShapeName) + EXCEPTION_CLASS_SUFFIX;
     }
 
     @Override
     public String getRequestClassName(String operationName) {
-        return capitalize(operationName + REQUEST_CLASS_SUFFIX);
+        return pascalCase(operationName) + REQUEST_CLASS_SUFFIX;
     }
 
     @Override
     public String getResponseClassName(String operationName) {
-        return capitalize(operationName + RESPONSE_CLASS_SUFFIX);
+        return pascalCase(operationName) + RESPONSE_CLASS_SUFFIX;
     }
 
     @Override
@@ -303,7 +306,7 @@ public class DefaultNamingStrategy implements NamingStrategy {
                        .replaceAll("([^A-Z]{2,})V([0-9]+)", "$1 V$2 "); // TestV4 -> "Test V4 "
 
         // Add a space between camelCased words
-        result = result.replaceAll("([a-z])([A-Z][a-zA-Z])", "$1 $2"); // AcmSuccess -> "Acm Success"
+        result = String.join(" ", result.split("(?<=[a-z])(?=[A-Z]([a-zA-Z]|[0-9]))")); // AcmSuccess -> "Acm Success"
 
         // Add a space after acronyms
         result = result.replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2"); // ACMSuccess -> "ACM Success"

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
@@ -218,6 +218,16 @@ public class DefaultNamingStrategyTest {
         assertThat(customizedModel.getTransformPackageName(serviceName)).isEqualTo("foo.transform");
     }
 
+    @Test
+    public void modelNameShouldHavePascalCase() {
+        assertThat(strat.getRequestClassName("CAPSTest")).isEqualTo("CapsTestRequest");
+        assertThat(strat.getExceptionName("CAPSTest")).isEqualTo("CapsTestException");
+        assertThat(strat.getResponseClassName("CAPSTest")).isEqualTo("CapsTestResponse");
+        assertThat(strat.getResponseClassName("CAPSByIndex")).isEqualTo("CapsByIndexResponse");
+
+        assertThat(strat.getRequestClassName("FollowedByS3")).isEqualTo("FollowedByS3Request");
+    }
+
     private void validateConversion(String input, String expectedOutput) {
         assertThat(strat.getEnumValueName(input)).isEqualTo(expectedOutput);
     }

--- a/services/elasticloadbalancing/src/it/java/software/amazon/awssdk/services/elasticloadbalancing/ElbIntegrationTest.java
+++ b/services/elasticloadbalancing/src/it/java/software/amazon/awssdk/services/elasticloadbalancing/ElbIntegrationTest.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest;
 import software.amazon.awssdk.services.elasticloadbalancing.model.ConfigureHealthCheckRequest;
 import software.amazon.awssdk.services.elasticloadbalancing.model.ConnectionDraining;
-import software.amazon.awssdk.services.elasticloadbalancing.model.CreateLBCookieStickinessPolicyRequest;
+import software.amazon.awssdk.services.elasticloadbalancing.model.CreateLbCookieStickinessPolicyRequest;
 import software.amazon.awssdk.services.elasticloadbalancing.model.CreateLoadBalancerListenersRequest;
 import software.amazon.awssdk.services.elasticloadbalancing.model.CreateLoadBalancerRequest;
 import software.amazon.awssdk.services.elasticloadbalancing.model.CrossZoneLoadBalancing;
@@ -64,7 +64,7 @@ import software.amazon.awssdk.services.elasticloadbalancing.model.ModifyLoadBala
 import software.amazon.awssdk.services.elasticloadbalancing.model.PolicyDescription;
 import software.amazon.awssdk.services.elasticloadbalancing.model.PolicyTypeDescription;
 import software.amazon.awssdk.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest;
-import software.amazon.awssdk.services.elasticloadbalancing.model.SetLoadBalancerListenerSSLCertificateRequest;
+import software.amazon.awssdk.services.elasticloadbalancing.model.SetLoadBalancerListenerSslCertificateRequest;
 import software.amazon.awssdk.services.elasticloadbalancing.model.SetLoadBalancerPoliciesOfListenerRequest;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.ListServerCertificatesRequest;
@@ -367,10 +367,10 @@ public class ElbIntegrationTest extends AwsIntegrationTestBase {
 
         if (certificateArn != null) {
             // Set the SSL certificate for an existing listener
-            elb.setLoadBalancerListenerSSLCertificate(SetLoadBalancerListenerSSLCertificateRequest.builder()
-                                                              .loadBalancerName(loadBalancerName)
-                                                              .loadBalancerPort(443)
-                                                              .sslCertificateId(certificateArn).build());
+            elb.setLoadBalancerListenerSSLCertificate(SetLoadBalancerListenerSslCertificateRequest.builder()
+                                                                                                  .loadBalancerName(loadBalancerName)
+                                                                                                  .loadBalancerPort(443)
+                                                                                                  .sslCertificateId(certificateArn).build());
 
             // Delete the SSL listener
             Thread.sleep(1000 * 5);
@@ -461,7 +461,7 @@ public class ElbIntegrationTest extends AwsIntegrationTestBase {
     public void testSetLoadBalancerPoliciesOfListener() {
         // Create LB stickiness policy
         String policyName = "java-sdk-policy-" + System.currentTimeMillis();
-        elb.createLBCookieStickinessPolicy(CreateLBCookieStickinessPolicyRequest.builder().loadBalancerName(
+        elb.createLBCookieStickinessPolicy(CreateLbCookieStickinessPolicyRequest.builder().loadBalancerName(
                 loadBalancerName).policyName(policyName).build());
 
         // Attach the policy to a listener

--- a/services/machinelearning/src/it/java/software/amazon/awssdk/services/machinelearning/AmazonMachineLearningIntegrationTest.java
+++ b/services/machinelearning/src/it/java/software/amazon/awssdk/services/machinelearning/AmazonMachineLearningIntegrationTest.java
@@ -27,11 +27,11 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromS3Request;
 import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromS3Response;
-import software.amazon.awssdk.services.machinelearning.model.CreateMLModelRequest;
-import software.amazon.awssdk.services.machinelearning.model.CreateMLModelResponse;
+import software.amazon.awssdk.services.machinelearning.model.CreateMlModelRequest;
+import software.amazon.awssdk.services.machinelearning.model.CreateMlModelResponse;
 import software.amazon.awssdk.services.machinelearning.model.CreateRealtimeEndpointRequest;
 import software.amazon.awssdk.services.machinelearning.model.DeleteDataSourceRequest;
-import software.amazon.awssdk.services.machinelearning.model.DeleteMLModelRequest;
+import software.amazon.awssdk.services.machinelearning.model.DeleteMlModelRequest;
 import software.amazon.awssdk.services.machinelearning.model.DeleteRealtimeEndpointRequest;
 import software.amazon.awssdk.services.machinelearning.model.EntityStatus;
 import software.amazon.awssdk.services.machinelearning.model.MLModelType;
@@ -131,7 +131,7 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
                 }
 
                 try {
-                    client.deleteMLModel(DeleteMLModelRequest.builder()
+                    client.deleteMLModel(DeleteMlModelRequest.builder()
                                                  .mlModelId(mlModelId).build());
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -179,8 +179,8 @@ public class AmazonMachineLearningIntegrationTest extends AwsTestBase {
 
         waitForDataSource();
 
-        CreateMLModelResponse result2 =
-                client.createMLModel(CreateMLModelRequest.builder()
+        CreateMlModelResponse result2 =
+                client.createMLModel(CreateMlModelRequest.builder()
                         .trainingDataSourceId(dataSourceId)
                         .mlModelType(MLModelType.BINARY)
                         .mlModelId("mlid_" + System.currentTimeMillis())

--- a/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/RandomIdInterceptor.java
+++ b/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/RandomIdInterceptor.java
@@ -22,11 +22,11 @@ import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.services.machinelearning.model.CreateBatchPredictionRequest;
-import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromRDSRequest;
+import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromRdsRequest;
 import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromRedshiftRequest;
 import software.amazon.awssdk.services.machinelearning.model.CreateDataSourceFromS3Request;
 import software.amazon.awssdk.services.machinelearning.model.CreateEvaluationRequest;
-import software.amazon.awssdk.services.machinelearning.model.CreateMLModelRequest;
+import software.amazon.awssdk.services.machinelearning.model.CreateMlModelRequest;
 
 /**
  * CreateXxx API calls require a unique (for all time!) ID parameter for
@@ -47,9 +47,9 @@ public class RandomIdInterceptor implements ExecutionInterceptor {
             }
 
             return copy;
-        } else if (request instanceof CreateDataSourceFromRDSRequest) {
-            CreateDataSourceFromRDSRequest copy =
-                    (CreateDataSourceFromRDSRequest) request;
+        } else if (request instanceof CreateDataSourceFromRdsRequest) {
+            CreateDataSourceFromRdsRequest copy =
+                    (CreateDataSourceFromRdsRequest) request;
 
             if (copy.dataSourceId() == null) {
                 copy = copy.toBuilder().dataSourceId(UUID.randomUUID().toString()).build();
@@ -66,8 +66,7 @@ public class RandomIdInterceptor implements ExecutionInterceptor {
 
             return copy;
         } else if (request instanceof CreateDataSourceFromS3Request) {
-            CreateDataSourceFromS3Request copy =
-                    (CreateDataSourceFromS3Request) request;
+            CreateDataSourceFromS3Request copy = (CreateDataSourceFromS3Request) request;
 
             if (copy.dataSourceId() == null) {
                 copy = copy.toBuilder().dataSourceId(UUID.randomUUID().toString()).build();
@@ -83,8 +82,8 @@ public class RandomIdInterceptor implements ExecutionInterceptor {
             }
 
             return copy;
-        } else if (request instanceof CreateMLModelRequest) {
-            CreateMLModelRequest copy = (CreateMLModelRequest) request;
+        } else if (request instanceof CreateMlModelRequest) {
+            CreateMlModelRequest copy = (CreateMlModelRequest) request;
 
             if (copy.mlModelId() == null) {
                 copy = copy.toBuilder().mlModelId(UUID.randomUUID().toString()).build();

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/CopyDbSnapshotPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/CopyDbSnapshotPresignInterceptor.java
@@ -18,25 +18,25 @@ package software.amazon.awssdk.services.rds;
 import java.time.Clock;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.Request;
-import software.amazon.awssdk.services.rds.model.CopyDBSnapshotRequest;
-import software.amazon.awssdk.services.rds.transform.CopyDBSnapshotRequestMarshaller;
+import software.amazon.awssdk.services.rds.model.CopyDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.transform.CopyDbSnapshotRequestMarshaller;
 
 /**
- * Handler for pre-signing {@link CopyDBSnapshotRequest}.
+ * Handler for pre-signing {@link CopyDbSnapshotRequest}.
  */
-public class CopyDbSnapshotPresignInterceptor extends RdsPresignInterceptor<CopyDBSnapshotRequest> {
+public class CopyDbSnapshotPresignInterceptor extends RdsPresignInterceptor<CopyDbSnapshotRequest> {
 
     public CopyDbSnapshotPresignInterceptor() {
-        super(CopyDBSnapshotRequest.class);
+        super(CopyDbSnapshotRequest.class);
     }
 
     @SdkTestInternalApi
     CopyDbSnapshotPresignInterceptor(Clock signingOverrideClock) {
-        super(CopyDBSnapshotRequest.class, signingOverrideClock);
+        super(CopyDbSnapshotRequest.class, signingOverrideClock);
     }
 
     @Override
-    protected PresignableRequest adaptRequest(final CopyDBSnapshotRequest originalRequest) {
+    protected PresignableRequest adaptRequest(final CopyDbSnapshotRequest originalRequest) {
         return new PresignableRequest() {
             @Override
             public String getSourceRegion() {
@@ -45,7 +45,7 @@ public class CopyDbSnapshotPresignInterceptor extends RdsPresignInterceptor<Copy
 
             @Override
             public Request<?> marshall() {
-                return new CopyDBSnapshotRequestMarshaller().marshall(originalRequest);
+                return new CopyDbSnapshotRequestMarshaller().marshall(originalRequest);
             }
         };
     }

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/CreateDbInstanceReadReplicaPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/CreateDbInstanceReadReplicaPresignInterceptor.java
@@ -16,19 +16,19 @@
 package software.amazon.awssdk.services.rds;
 
 import software.amazon.awssdk.core.Request;
-import software.amazon.awssdk.services.rds.model.CreateDBInstanceReadReplicaRequest;
-import software.amazon.awssdk.services.rds.transform.CreateDBInstanceReadReplicaRequestMarshaller;
+import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
+import software.amazon.awssdk.services.rds.transform.CreateDbInstanceReadReplicaRequestMarshaller;
 
 /**
- * Handler for pre-signing {@link CreateDBInstanceReadReplicaRequest}.
+ * Handler for pre-signing {@link CreateDbInstanceReadReplicaRequest}.
  */
-public class CreateDbInstanceReadReplicaPresignInterceptor extends RdsPresignInterceptor<CreateDBInstanceReadReplicaRequest> {
+public class CreateDbInstanceReadReplicaPresignInterceptor extends RdsPresignInterceptor<CreateDbInstanceReadReplicaRequest> {
     public CreateDbInstanceReadReplicaPresignInterceptor() {
-        super(CreateDBInstanceReadReplicaRequest.class);
+        super(CreateDbInstanceReadReplicaRequest.class);
     }
 
     @Override
-    protected PresignableRequest adaptRequest(final CreateDBInstanceReadReplicaRequest originalRequest) {
+    protected PresignableRequest adaptRequest(final CreateDbInstanceReadReplicaRequest originalRequest) {
         return new PresignableRequest() {
             @Override
             public String getSourceRegion() {
@@ -37,7 +37,7 @@ public class CreateDbInstanceReadReplicaPresignInterceptor extends RdsPresignInt
 
             @Override
             public Request<?> marshall() {
-                return new CreateDBInstanceReadReplicaRequestMarshaller().marshall(originalRequest);
+                return new CreateDbInstanceReadReplicaRequestMarshaller().marshall(originalRequest);
             }
         };
     }

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/PresignRequestHandlerTest.java
@@ -42,9 +42,9 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.internal.interceptor.InterceptorContext;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.rds.model.CopyDBSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.CopyDbSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.RdsRequest;
-import software.amazon.awssdk.services.rds.transform.CopyDBSnapshotRequestMarshaller;
+import software.amazon.awssdk.services.rds.transform.CopyDbSnapshotRequestMarshaller;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
@@ -54,12 +54,12 @@ public class PresignRequestHandlerTest {
     private static final AwsBasicCredentials CREDENTIALS = AwsBasicCredentials.create("foo", "bar");
     private static final Region DESTINATION_REGION = Region.of("us-west-2");
 
-    private static RdsPresignInterceptor<CopyDBSnapshotRequest> presignInterceptor = new CopyDbSnapshotPresignInterceptor();
-    private final CopyDBSnapshotRequestMarshaller marshaller = new CopyDBSnapshotRequestMarshaller();
+    private static RdsPresignInterceptor<CopyDbSnapshotRequest> presignInterceptor = new CopyDbSnapshotPresignInterceptor();
+    private final CopyDbSnapshotRequestMarshaller marshaller = new CopyDbSnapshotRequestMarshaller();
 
     @Test
     public void testSetsPresignedUrl() throws URISyntaxException {
-        CopyDBSnapshotRequest request = makeTestRequest();
+        CopyDbSnapshotRequest request = makeTestRequest();
         SdkHttpFullRequest presignedRequest = modifyHttpRequest(presignInterceptor, request, marshallRequest(request));
 
         assertNotNull(presignedRequest.rawQueryParameters().get("PreSignedUrl").get(0));
@@ -71,7 +71,7 @@ public class PresignRequestHandlerTest {
         // credentials to RDS and checking that they succeeded. Then the
         // request was recreated with all the same parameters but with test
         // credentials.
-        final CopyDBSnapshotRequest request = CopyDBSnapshotRequest.builder()
+        final CopyDbSnapshotRequest request = CopyDbSnapshotRequest.builder()
                 .sourceDBSnapshotIdentifier("arn:aws:rds:us-east-1:123456789012:snapshot:rds:test-instance-ss-2016-12-20-23-19")
                 .targetDBSnapshotIdentifier("test-instance-ss-copy-2")
                 .sourceRegion("us-east-1")
@@ -87,7 +87,7 @@ public class PresignRequestHandlerTest {
         Clock signingDateOverride = Mockito.mock(Clock.class);
         when(signingDateOverride.millis()).thenReturn(c.getTimeInMillis());
 
-        RdsPresignInterceptor<CopyDBSnapshotRequest> interceptor = new CopyDbSnapshotPresignInterceptor(signingDateOverride);
+        RdsPresignInterceptor<CopyDbSnapshotRequest> interceptor = new CopyDbSnapshotPresignInterceptor(signingDateOverride);
 
         SdkHttpFullRequest presignedRequest = modifyHttpRequest(interceptor, request, marshallRequest(request));
 
@@ -110,7 +110,7 @@ public class PresignRequestHandlerTest {
 
     @Test
     public void testSkipsPresigningIfUrlSet() throws URISyntaxException {
-        CopyDBSnapshotRequest request = CopyDBSnapshotRequest.builder()
+        CopyDbSnapshotRequest request = CopyDbSnapshotRequest.builder()
                 .sourceRegion("us-west-2")
                 .preSignedUrl("PRESIGNED")
                 .build();
@@ -123,7 +123,7 @@ public class PresignRequestHandlerTest {
 
     @Test
     public void testSkipsPresigningIfSourceRegionNotSet() throws URISyntaxException {
-        CopyDBSnapshotRequest request = CopyDBSnapshotRequest.builder().build();
+        CopyDbSnapshotRequest request = CopyDbSnapshotRequest.builder().build();
 
         SdkHttpFullRequest presignedRequest = modifyHttpRequest(presignInterceptor, request, marshallRequest(request));
 
@@ -132,7 +132,7 @@ public class PresignRequestHandlerTest {
 
     @Test
     public void testParsesDestinationRegionfromRequestEndpoint() throws URISyntaxException {
-        CopyDBSnapshotRequest request = CopyDBSnapshotRequest.builder()
+        CopyDbSnapshotRequest request = CopyDbSnapshotRequest.builder()
                 .sourceRegion("us-east-1")
                 .build();
         Region destination = Region.of("us-west-2");
@@ -146,15 +146,15 @@ public class PresignRequestHandlerTest {
 
     @Test
     public void testSourceRegionRemovedFromOriginalRequest() throws URISyntaxException {
-        CopyDBSnapshotRequest request = makeTestRequest();
+        CopyDbSnapshotRequest request = makeTestRequest();
         SdkHttpFullRequest marshalled = marshallRequest(request);
         SdkHttpFullRequest actual = modifyHttpRequest(presignInterceptor, request, marshalled);
 
         assertFalse(actual.rawQueryParameters().containsKey("SourceRegion"));
     }
 
-    private SdkHttpFullRequest marshallRequest(CopyDBSnapshotRequest request) throws URISyntaxException {
-        Request<CopyDBSnapshotRequest> legacyMarshalled = marshaller.marshall(request);
+    private SdkHttpFullRequest marshallRequest(CopyDbSnapshotRequest request) throws URISyntaxException {
+        Request<CopyDbSnapshotRequest> legacyMarshalled = marshaller.marshall(request);
         legacyMarshalled.setEndpoint(URI.create("https://example.com"));
 
         SdkHttpFullRequest marshalled = SdkHttpFullRequestAdapter.toHttpFullRequest(legacyMarshalled);
@@ -175,8 +175,8 @@ public class PresignRequestHandlerTest {
                                                                                                          .orElse(AwsRequestOverrideConfiguration.builder().build()));
     }
 
-    private CopyDBSnapshotRequest makeTestRequest() {
-        return CopyDBSnapshotRequest.builder()
+    private CopyDbSnapshotRequest makeTestRequest() {
+        return CopyDbSnapshotRequest.builder()
                 .sourceDBSnapshotIdentifier("arn:aws:rds:us-east-1:123456789012:snapshot:rds:test-instance-ss-2016-12-20-23-19")
                 .targetDBSnapshotIdentifier("test-instance-ss-copy-2")
                 .sourceRegion("us-east-1")

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -20,13 +20,13 @@ import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.model.AssumeRoleWithSAMLRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 import software.amazon.awssdk.services.sts.model.Credentials;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link AssumeRoleWithSAMLRequest}
+ * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link AssumeRoleWithSamlRequest}
  * to the AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
  * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
  * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
@@ -39,7 +39,7 @@ import software.amazon.awssdk.utils.Validate;
  */
 @ThreadSafe
 public class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentialsProvider {
-    private final AssumeRoleWithSAMLRequest assumeRoleWithSamlRequest;
+    private final AssumeRoleWithSamlRequest assumeRoleWithSamlRequest;
 
     /**
      * @see #builder()
@@ -76,31 +76,31 @@ public class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentialsProv
      */
     @NotThreadSafe
     public static final class Builder extends BaseBuilder<Builder, StsAssumeRoleWithSamlCredentialsProvider> {
-        private AssumeRoleWithSAMLRequest assumeRoleWithSamlRequest;
+        private AssumeRoleWithSamlRequest assumeRoleWithSamlRequest;
 
         private Builder() {
             super(StsAssumeRoleWithSamlCredentialsProvider::new);
         }
 
         /**
-         * Configure the {@link AssumeRoleWithSAMLRequest} that should be periodically sent to the STS service to update
+         * Configure the {@link AssumeRoleWithSamlRequest} that should be periodically sent to the STS service to update
          * the session token when it gets close to expiring.
          *
          * @param assumeRoleWithSamlRequest The request to send to STS whenever the assumed session expires.
          * @return This object for chained calls.
          */
-        public Builder refreshRequest(AssumeRoleWithSAMLRequest assumeRoleWithSamlRequest) {
+        public Builder refreshRequest(AssumeRoleWithSamlRequest assumeRoleWithSamlRequest) {
             this.assumeRoleWithSamlRequest = assumeRoleWithSamlRequest;
             return this;
         }
 
         /**
-         * Similar to {@link #refreshRequest(AssumeRoleWithSAMLRequest)}, but takes a lambda to configure a new
-         * {@link AssumeRoleWithSAMLRequest.Builder}. This removes the need to called {@link AssumeRoleWithSAMLRequest#builder()}
-         * and {@link AssumeRoleWithSAMLRequest.Builder#build()}.
+         * Similar to {@link #refreshRequest(AssumeRoleWithSamlRequest)}, but takes a lambda to configure a new
+         * {@link AssumeRoleWithSamlRequest.Builder}. This removes the need to called {@link AssumeRoleWithSamlRequest#builder()}
+         * and {@link AssumeRoleWithSamlRequest.Builder#build()}.
          */
-        public Builder refreshRequest(Consumer<AssumeRoleWithSAMLRequest.Builder> assumeRoleWithSamlRequest) {
-            return refreshRequest(AssumeRoleWithSAMLRequest.builder().applyMutation(assumeRoleWithSamlRequest).build());
+        public Builder refreshRequest(Consumer<AssumeRoleWithSamlRequest.Builder> assumeRoleWithSamlRequest) {
+            return refreshRequest(AssumeRoleWithSamlRequest.builder().applyMutation(assumeRoleWithSamlRequest).build());
         }
     }
 }

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
@@ -17,8 +17,8 @@ package software.amazon.awssdk.services.sts.auth;
 
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithSamlCredentialsProvider.Builder;
-import software.amazon.awssdk.services.sts.model.AssumeRoleWithSAMLRequest;
-import software.amazon.awssdk.services.sts.model.AssumeRoleWithSAMLResponse;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 /**
@@ -26,24 +26,24 @@ import software.amazon.awssdk.services.sts.model.Credentials;
  * Inherits tests from {@link StsCredentialsProviderTestBase}.
  */
 public class StsAssumeRoleWithSamlCredentialsProviderTest
-        extends StsCredentialsProviderTestBase<AssumeRoleWithSAMLRequest, AssumeRoleWithSAMLResponse> {
+        extends StsCredentialsProviderTestBase<AssumeRoleWithSamlRequest, AssumeRoleWithSamlResponse> {
     @Override
-    protected AssumeRoleWithSAMLRequest getRequest() {
-        return AssumeRoleWithSAMLRequest.builder().build();
+    protected AssumeRoleWithSamlRequest getRequest() {
+        return AssumeRoleWithSamlRequest.builder().build();
     }
 
     @Override
-    protected AssumeRoleWithSAMLResponse getResponse(Credentials credentials) {
-        return AssumeRoleWithSAMLResponse.builder().credentials(credentials).build();
+    protected AssumeRoleWithSamlResponse getResponse(Credentials credentials) {
+        return AssumeRoleWithSamlResponse.builder().credentials(credentials).build();
     }
 
     @Override
-    protected Builder createCredentialsProviderBuilder(AssumeRoleWithSAMLRequest request) {
+    protected Builder createCredentialsProviderBuilder(AssumeRoleWithSamlRequest request) {
         return StsAssumeRoleWithSamlCredentialsProvider.builder().refreshRequest(request);
     }
 
     @Override
-    protected AssumeRoleWithSAMLResponse callClient(StsClient client, AssumeRoleWithSAMLRequest request) {
+    protected AssumeRoleWithSamlResponse callClient(StsClient client, AssumeRoleWithSamlRequest request) {
         return client.assumeRoleWithSAML(request);
     }
 }

--- a/services/waf/src/it/java/software/amazon/awssdk/services/waf/WafIntegrationTest.java
+++ b/services/waf/src/it/java/software/amazon/awssdk/services/waf/WafIntegrationTest.java
@@ -25,20 +25,20 @@ import org.junit.Test;
 import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.waf.model.ChangeAction;
-import software.amazon.awssdk.services.waf.model.CreateIPSetRequest;
-import software.amazon.awssdk.services.waf.model.CreateIPSetResponse;
+import software.amazon.awssdk.services.waf.model.CreateIpSetRequest;
+import software.amazon.awssdk.services.waf.model.CreateIpSetResponse;
 import software.amazon.awssdk.services.waf.model.GetChangeTokenRequest;
 import software.amazon.awssdk.services.waf.model.GetChangeTokenResponse;
-import software.amazon.awssdk.services.waf.model.GetIPSetRequest;
-import software.amazon.awssdk.services.waf.model.GetIPSetResponse;
+import software.amazon.awssdk.services.waf.model.GetIpSetRequest;
+import software.amazon.awssdk.services.waf.model.GetIpSetResponse;
 import software.amazon.awssdk.services.waf.model.IPSet;
 import software.amazon.awssdk.services.waf.model.IPSetDescriptor;
 import software.amazon.awssdk.services.waf.model.IPSetDescriptorType;
 import software.amazon.awssdk.services.waf.model.IPSetUpdate;
-import software.amazon.awssdk.services.waf.model.ListIPSetsRequest;
-import software.amazon.awssdk.services.waf.model.ListIPSetsResponse;
-import software.amazon.awssdk.services.waf.model.UpdateIPSetRequest;
-import software.amazon.awssdk.services.waf.model.WAFNonEmptyEntityException;
+import software.amazon.awssdk.services.waf.model.ListIpSetsRequest;
+import software.amazon.awssdk.services.waf.model.ListIpSetsResponse;
+import software.amazon.awssdk.services.waf.model.UpdateIpSetRequest;
+import software.amazon.awssdk.services.waf.model.WafNonEmptyEntityException;
 import software.amazon.awssdk.testutils.Waiter;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 
@@ -71,7 +71,7 @@ public class WafIntegrationTest extends AwsTestBase {
     private static void deleteIpSet() {
         if (ipSetId != null) {
             Waiter.run(() -> client.deleteIPSet(r -> r.ipSetId(ipSetId).changeToken(newChangeToken())))
-                  .ignoringException(WAFNonEmptyEntityException.class)
+                  .ignoringException(WafNonEmptyEntityException.class)
                   .orFailAfter(Duration.ofMinutes(1));
         }
     }
@@ -93,9 +93,9 @@ public class WafIntegrationTest extends AwsTestBase {
 
     private String testCreateIpSet() {
         final String changeToken = newChangeToken();
-        CreateIPSetResponse createResult = client.createIPSet(CreateIPSetRequest.builder()
-                .changeToken(changeToken)
-                .name(IP_SET_NAME).build());
+        CreateIpSetResponse createResult = client.createIPSet(CreateIpSetRequest.builder()
+                                                                                .changeToken(changeToken)
+                                                                                .name(IP_SET_NAME).build());
 
         Assert.assertEquals(changeToken, createResult.changeToken());
 
@@ -109,7 +109,7 @@ public class WafIntegrationTest extends AwsTestBase {
     }
 
     private void testGetIpSet() {
-        GetIPSetResponse getResult = client.getIPSet(GetIPSetRequest.builder()
+        GetIpSetResponse getResult = client.getIPSet(GetIpSetRequest.builder()
                 .ipSetId(ipSetId)
                 .build());
         IPSet ipSet = getResult.ipSet();
@@ -119,9 +119,9 @@ public class WafIntegrationTest extends AwsTestBase {
         Assert.assertNotNull(ipSet.ipSetId());
         Assert.assertEquals(ipSetId, ipSet.ipSetId());
 
-        ListIPSetsResponse listResult = client.listIPSets(ListIPSetsRequest.builder()
-                .limit(1)
-                .build());
+        ListIpSetsResponse listResult = client.listIPSets(ListIpSetsRequest.builder()
+                                                                           .limit(1)
+                                                                           .build());
         Assert.assertNotNull(listResult.ipSets());
         Assert.assertFalse(listResult.ipSets().isEmpty());
     }
@@ -137,12 +137,12 @@ public class WafIntegrationTest extends AwsTestBase {
                 .build();
 
 
-        client.updateIPSet(UpdateIPSetRequest.builder()
-                                   .ipSetId(ipSetId)
-                                   .changeToken(newChangeToken())
-                                   .updates(ipToInsert).build());
-        GetIPSetResponse getResult = client.getIPSet(GetIPSetRequest.builder()
-                                                           .ipSetId(ipSetId).build());
+        client.updateIPSet(UpdateIpSetRequest.builder()
+                                             .ipSetId(ipSetId)
+                                             .changeToken(newChangeToken())
+                                             .updates(ipToInsert).build());
+        GetIpSetResponse getResult = client.getIPSet(GetIpSetRequest.builder()
+                                                                    .ipSetId(ipSetId).build());
 
         IPSet ipSet = getResult.ipSet();
         Assert.assertNotNull(ipSet);
@@ -163,7 +163,7 @@ public class WafIntegrationTest extends AwsTestBase {
                 .action(ChangeAction.DELETE)
                 .build();
 
-        client.updateIPSet(UpdateIPSetRequest.builder()
+        client.updateIPSet(UpdateIpSetRequest.builder()
                 .ipSetId(ipSetId)
                 .changeToken(newChangeToken())
                 .updates(ipToDelete)

--- a/services/waf/src/it/java/software/amazon/awssdk/services/waf/regional/WafRegionalIntegrationTest.java
+++ b/services/waf/src/it/java/software/amazon/awssdk/services/waf/regional/WafRegionalIntegrationTest.java
@@ -17,8 +17,8 @@ package software.amazon.awssdk.services.waf.regional;
 
 import org.junit.Test;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.waf.model.ListResourcesForWebACLRequest;
-import software.amazon.awssdk.services.waf.model.WAFNonexistentItemException;
+import software.amazon.awssdk.services.waf.model.ListResourcesForWebAclRequest;
+import software.amazon.awssdk.services.waf.model.WafNonexistentItemException;
 import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
 
 public class WafRegionalIntegrationTest extends AwsIntegrationTestBase {
@@ -27,13 +27,13 @@ public class WafRegionalIntegrationTest extends AwsIntegrationTestBase {
      * Calls an operation specific to WAF Regional. If we get a modeled exception back then we called the
      * right service.
      */
-    @Test(expected = WAFNonexistentItemException.class)
+    @Test(expected = WafNonexistentItemException.class)
     public void smokeTest() {
         final WafRegionalClient client = WafRegionalClient.builder()
                                                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                                           .region(Region.US_WEST_2)
                                                           .build();
 
-        client.listResourcesForWebACL(ListResourcesForWebACLRequest.builder().webACLId("foo").build());
+        client.listResourcesForWebACL(ListResourcesForWebAclRequest.builder().webACLId("foo").build());
     }
 }


### PR DESCRIPTION
- Update all service models to follow V2 naming convention. i.e. `FooBarRequest` rather than `FOOBARRequest`

- Fixed the bug where we adding space between camel cased words when the string is `"TestByIndex"`, it will become `"Test ByIndex"`


