### PR TITLE
Fixing s3 unmarshalling

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
@@ -52,8 +52,6 @@ public abstract class S3ExceptionUnmarshaller extends AbstractErrorUnmarshaller<
 
         AwsServiceException.Builder exception = newException(message).toBuilder();
 
-        AwsErrorDetails awsErrorDetails = exception.awsErrorDetails().toBuilder().errorCode(errorCode).build();
-
-        return exception.requestId(requestId).awsErrorDetails(awsErrorDetails).build();
+        return exception.requestId(requestId).awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build()).build();
     }
 }


### PR DESCRIPTION
AwsErrorDetails is always null so adding in the null check for the S3 exception unmarshaller.