### PR TITLE
Updating DDB tests to assert on correct value. Adding in getMessage o…

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -54,6 +54,18 @@ public class AwsServiceException extends SdkServiceException {
     }
 
     @Override
+    public String getMessage() {
+        if (awsErrorDetails != null) {
+            return awsErrorDetails().errorMessage() +
+                    " (Service: " + awsErrorDetails().serviceName() +
+                    ", Status Code: " + statusCode() +
+                    ", Request ID: " + requestId() + ")";
+        }
+
+        return super.getMessage();
+    }
+
+    @Override
     public boolean isClockSkewException() {
         return Optional.ofNullable(awsErrorDetails)
                 .map(a -> AwsErrorCode.CLOCK_SKEW_ERROR_CODES.contains(a.errorCode()))

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoDbJavaClientExceptionIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoDbJavaClientExceptionIntegrationTest.java
@@ -52,7 +52,7 @@ public class DynamoDbJavaClientExceptionIntegrationTest extends AwsTestBase {
             Assert.fail("ResourceNotFoundException is expected.");
         } catch (ResourceNotFoundException e) {
             Assert.assertNotNull(e.awsErrorDetails().errorCode());
-            Assert.assertNotNull(e.getMessage());
+            Assert.assertNotNull(e.awsErrorDetails().errorMessage());
             Assert.assertNotNull(e.awsErrorDetails().rawResponse());
         }
     }

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java
@@ -154,7 +154,7 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
             fail("Expected an exception to be thrown");
         } catch (AwsServiceException exception) {
             assertNotEmpty(exception.awsErrorDetails().errorCode());
-            assertNotEmpty(exception.getMessage());
+            assertNotEmpty(exception.awsErrorDetails().errorMessage());
             assertNotEmpty(exception.requestId());
             assertNotEmpty(exception.awsErrorDetails().serviceName());
             assertTrue(exception.statusCode() >= 400);
@@ -209,7 +209,7 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
             dynamo.batchWriteItem(BatchWriteItemRequest.builder().requestItems(requestItems).build());
         } catch (AwsServiceException exception) {
             assertEquals("ValidationException", exception.awsErrorDetails().errorCode());
-            assertNotEmpty(exception.getMessage());
+            assertNotEmpty(exception.awsErrorDetails().errorMessage());
             assertNotEmpty(exception.requestId());
             assertNotEmpty(exception.awsErrorDetails().serviceName());
             assertEquals(400, exception.statusCode());


### PR DESCRIPTION
…verride on AwsServiceException

Updating the tests to assert on the presence of the errorMessage in AwsErrorDetails rather than the message on the exception.

Also adding in override for getMessage() in AwsServiceException to return a detailed message as we do in v1.