### PR TITLE
Don't relocate reactivestreams in bundle

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -99,10 +99,6 @@
                             <shadedPattern>software.amazon.awssdk.thirdparty.com.typesafe</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>org.reactivestreams</pattern>
-                            <shadedPattern>software.amazon.awssdk.thirdparty.org.reactivestreams</shadedPattern>
-                        </relocation>
-                        <relocation>
                             <pattern>org.slf4j</pattern>
                             <shadedPattern>software.amazon.awssdk.thirdparty.org.slf4j</shadedPattern>
                         </relocation>


### PR DESCRIPTION
These are part of the public API so if we relocate them it makes it difficult for customers to interop the publishers/subscribers with other libraries like RxJava.
