### PR TITLE
Return new instance for newChannel

### DIFF
--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -73,6 +73,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
@@ -181,7 +182,7 @@ public class NettyNioAsyncHttpClientWireMockTest {
 
         ChannelFactory channelFactory = mock(ChannelFactory.class);
 
-        when(channelFactory.newChannel()).thenReturn(new NioSocketChannel());
+        when(channelFactory.newChannel()).thenAnswer((Answer<NioSocketChannel>) invocationOnMock -> new NioSocketChannel());
 
         SdkAsyncHttpClient customClient =
             NettyNioAsyncHttpClient.builder()


### PR DESCRIPTION
We should be returning a new instance rather than the same instance from
the mock to comply with the interface.