### PR TITLE
Add more logging

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
@@ -91,14 +91,19 @@ public final class AwsCredentialsProviderChain implements AwsCredentialsProvider
             try {
                 AwsCredentials credentials = provider.resolveCredentials();
 
-                log.debug("Loading credentials from {}", provider.toString());
+                if (log.isDebugEnabled()) {
+                    log.debug("Loading credentials from {}", provider);
+                }
 
                 lastUsedProvider = provider;
                 return credentials;
             } catch (RuntimeException e) {
                 // Ignore any exceptions and move onto the next provider
                 String message = provider + ": " + e.getMessage();
-                log.debug("Unable to load credentials from " + message, e);
+                if (log.isDebugEnabled()) {
+                    log.debug("Unable to load credentials from {}", message , e);
+                }
+
                 if (exceptionMessages == null) {
                     exceptionMessages = new ArrayList<>();
                 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -190,7 +190,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
                                         contentSha256;
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("AWS4 Canonical Request: '\"" + canonicalRequest + "\"");
+            LOG.debug("AWS4 Canonical Request: \"{}\"", canonicalRequest);
         }
 
         return canonicalRequest;
@@ -213,7 +213,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
                                     BinaryUtils.toHex(hash(canonicalRequest));
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("AWS4 String to Sign: '\"" + stringToSign + "\"");
+            LOG.debug("AWS4 String to sign: \"{}\"", stringToSign);
         }
 
         return stringToSign;
@@ -238,8 +238,8 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Generating a new signing key as the signing key not available in the cache for the date "
-                      + TimeUnit.DAYS.toMillis(daysSinceEpochSigningDate));
+            LOG.debug("Generating a new signing key as the signing key not available in the cache for the date: {}",
+                      TimeUnit.DAYS.toMillis(daysSinceEpochSigningDate));
         }
         byte[] signingKey = newSigningKey(credentials,
                                           signerRequestParams.getFormattedSigningDate(),

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkStandardLogger.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkStandardLogger.java
@@ -30,5 +30,11 @@ public final class SdkStandardLogger {
      */
     public static final Logger REQUEST_LOGGER = Logger.loggerFor("software.amazon.awssdk.request");
 
+    /**
+     * Logger used for the purpose of logging the request id extracted either from the
+     * http response header or from the response body.
+     */
+    public static final Logger REQUEST_ID_LOGGER = Logger.loggerFor("software.amazon.awssdk.requestId");
+
     private SdkStandardLogger() {}
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/JsonResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/JsonResponseHandler.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkStandardLogger;
@@ -88,6 +89,9 @@ public final class JsonResponseHandler<T> implements HttpResponseHandler<T> {
      */
     public T handle(HttpResponse response, ExecutionAttributes executionAttributes) throws Exception {
         SdkStandardLogger.REQUEST_LOGGER.trace(() -> "Parsing service response JSON.");
+        SdkStandardLogger.REQUEST_ID_LOGGER.debug(() -> X_AMZN_REQUEST_ID_HEADER + " : " +
+                                                        Optional.ofNullable(response.getHeader(X_AMZN_REQUEST_ID_HEADER))
+                                                                .orElse("not available"));
 
         JsonParser jsonParser = null;
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
@@ -142,10 +142,8 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
             final int retriesAttempted = requestCount - 2;
             Duration delay = retryHandler.computeDelayBeforeNextRetry();
 
-            if (log.isDebugEnabled()) {
-                log.debug("Retryable error detected, will retry in " + delay + "ms, attempt number: " +
-                          retriesAttempted);
-            }
+            SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Retryable error detected, will retry in " + delay.toMillis() + "ms,"
+                                                         + " attempt number " + retriesAttempted);
             retrySubmitter.schedule(() -> {
                 execute(future);
                 return null;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HandleResponseStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HandleResponseStage.java
@@ -83,10 +83,10 @@ public class HandleResponseStage<OutputT> implements RequestPipeline<HttpRespons
      * @throws IOException If any problems were encountered reading the response contents from
      *                     the HTTP method object.
      */
-    @SuppressWarnings("deprecation")
     private OutputT handleSuccessResponse(HttpResponse httpResponse, RequestExecutionContext context)
             throws IOException, InterruptedException {
         try {
+            SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Received successful response: " + httpResponse.getStatusCode());
             return successResponseHandler.handle(httpResponse, context.executionAttributes());
         } catch (IOException | InterruptedException | RetryableException e) {
             throw e;
@@ -138,5 +138,4 @@ public class HandleResponseStage<OutputT> implements RequestPipeline<HttpRespons
                     .ifPresent(s -> IoUtils.closeQuietly(s, log));
         }
     }
-
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
@@ -206,9 +206,8 @@ public final class RetryableStage<OutputT> implements RequestToResponsePipeline<
             final int retriesAttempted = requestCount - 2;
             Duration delay = retryHandler.computeDelayBeforeNextRetry();
 
-            if (log.isDebugEnabled()) {
-                log.debug("Retriable error detected, " + "will retry in " + delay + "ms, attempt number: " + retriesAttempted);
-            }
+            SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Retryable error detected, will retry in " + delay.toMillis() + "ms,"
+                                                         + " attempt number " + retriesAttempted);
             TimeUnit.MILLISECONDS.sleep(delay.toMillis());
         }
     }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullRequest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
@@ -147,6 +148,19 @@ final class DefaultSdkHttpFullRequest implements SdkHttpFullRequest {
                 .method(httpMethod)
                 .headers(headers)
                 .content(content);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("DefaultSdkHttpFullRequest")
+                       .add("httpMethod", httpMethod)
+                       .add("protocol", protocol)
+                       .add("host", host)
+                       .add("port", port)
+                       .add("encodedPath", path)
+                       .add("queryParameters", queryParameters)
+                       .add("headers", headers)
+                       .build();
     }
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
@@ -37,9 +37,9 @@ import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
-public class EndpointAddressInterceptor implements ExecutionInterceptor {
+public final class EndpointAddressInterceptor implements ExecutionInterceptor {
 
-    private static List<Class<?>> ACCELERATE_DISABLED_OPERATIONS = Arrays.asList(
+    private static final List<Class<?>> ACCELERATE_DISABLED_OPERATIONS = Arrays.asList(
             ListBucketsRequest.class, CreateBucketRequest.class, DeleteBucketRequest.class);
 
     @Override

--- a/services/s3/src/test/resources/log4j.properties
+++ b/services/s3/src/test/resources/log4j.properties
@@ -27,9 +27,7 @@ log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 #log4j.logger.httpclient.wire=DEBUG
 
 # HttpClient 4 Wire Logging
-log4j.logger.org.apache.http.wire=DEBUG
+#log4j.logger.org.apache.http.wire=DEBUG
 #log4j.logger.org.apache.http=DEBUG
 #log4j.logger.org.apache.http.wire=WARN
-
-#log4j.logger.com.amazonaws=DEBUG
-log4j.logger.com.amazonaws.services.s3.internal.Mimetypes=WARN
+log4j.logger.software.amazon.awssdk.request=DEBUG

--- a/test/protocol-tests/src/test/resources/log4j.properties
+++ b/test/protocol-tests/src/test/resources/log4j.properties
@@ -30,6 +30,6 @@ log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 # log4j.logger.org.apache.http.wire=INFO
 # log4j.logger.org.apache.http=DEBUG
 # log4j.logger.org.apache.http.wire=DEBUG
-# log4j.logger.software.amazon.awssdk=DEBUG
-
-
+#log4j.logger.software.amazon.awssdk=DEBUG
+#log4j.logger.software.amazon.awssdk.request=DEBUG
+log4j.logger.software.amazon.awssdk.requestId=DEBUG


### PR DESCRIPTION
Add more logging to be consistent with V1.
RequestLogger: `log4j.logger.software.amazon.awssdk.request=DEBUG`

```
2018-07-30 12:13:35,949 [main] DEBUG software.amazon.awssdk.request - Sending Request: DefaultSdkHttpFullRequest(httpMethod=POST, protocol=http, host=localhost, port=61908, encodedPath=/, queryParameters={}, headers={amz-sdk-invocation-id=[fd14a7a6-d533-b26c-a12a-c813b891ef7e], Content-Length=[2], Content-Type=[application/x-amz-json-1.1], User-Agent=[aws-sdk-java/2.0.0-preview-11-SNAPSHOT Mac_OS_X/10.11.6 Java_HotSpot_TM__64-Bit_Server_VM/10.0.1+10 Java/10.0.1], X-Amz-Target=[ProtocolTestsJsonRpcService.AllTypes]})
2018-07-30 12:13:36,026 [main] DEBUG software.amazon.awssdk.request - Received error response: software.amazon.awssdk.services.protocoljsonrpc.model.ProtocolJsonRpcException: null (Service: AmazonProtocolJsonRpc, Status Code: 500, Request ID: null)
2018-07-30 12:13:36,032 [main] DEBUG software.amazon.awssdk.request - Retryable error detected, will retry in 57ms, attempt number 0
2018-07-30 12:13:36,092 [main] DEBUG software.amazon.awssdk.request - Retrying Request: DefaultSdkHttpFullRequest(httpMethod=POST, protocol=http, host=localhost, port=61908, encodedPath=/, queryParameters={}, headers={amz-sdk-invocation-id=[fd14a7a6-d533-b26c-a12a-c813b891ef7e], Content-Length=[2], Content-Type=[application/x-amz-json-1.1], User-Agent=[aws-sdk-java/2.0.0-preview-11-SNAPSHOT Mac_OS_X/10.11.6 Java_HotSpot_TM__64-Bit_Server_VM/10.0.1+10 Java/10.0.1], X-Amz-Target=[ProtocolTestsJsonRpcService.AllTypes]})
2018-07-30 12:13:36,106 [main] DEBUG software.amazon.awssdk.request - Received successful response: 200
```