### PR TITLE
Fix retrypolicy bug, see issue #646

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-b093be5.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-b093be5.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "RetryPolicy bug fix: adding throttlingBackoffStrategy to `RetryPolicy.Builder`. see [#646](https://github.com/aws/aws-sdk-java-v2/issues/646)"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Random;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -121,5 +122,37 @@ public final class EqualJitterBackoffStrategy implements BackoffStrategy,
         public EqualJitterBackoffStrategy build() {
             return new EqualJitterBackoffStrategy(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final EqualJitterBackoffStrategy that = (EqualJitterBackoffStrategy) o;
+
+        if (!baseDelay.equals(that.baseDelay)) {
+            return false;
+        }
+        return maxBackoffTime.equals(that.maxBackoffTime);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = baseDelay.hashCode();
+        result = 31 * result + maxBackoffTime.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("EqualJitterBackoffStrategy")
+                       .add("baseDelay", baseDelay)
+                       .add("maxBackoffTime", maxBackoffTime)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FixedDelayBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FixedDelayBackoffStrategy.java
@@ -20,6 +20,7 @@ import static software.amazon.awssdk.utils.Validate.isNotNegative;
 import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 
 /**
  * Simple backoff strategy that always uses a fixed delay for the delay before the next retry attempt.
@@ -40,5 +41,31 @@ public final class FixedDelayBackoffStrategy implements BackoffStrategy {
 
     public static FixedDelayBackoffStrategy create(Duration fixedBackoff) {
         return new FixedDelayBackoffStrategy(fixedBackoff);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final FixedDelayBackoffStrategy that = (FixedDelayBackoffStrategy) o;
+
+        return fixedBackoff.equals(that.fixedBackoff);
+    }
+
+    @Override
+    public int hashCode() {
+        return fixedBackoff.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("FixedDelayBackoffStrategy")
+                       .add("fixedBackoff", fixedBackoff)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategy.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Random;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -118,5 +119,37 @@ public final class FullJitterBackoffStrategy implements BackoffStrategy,
         public FullJitterBackoffStrategy build() {
             return new FullJitterBackoffStrategy(this);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final FullJitterBackoffStrategy that = (FullJitterBackoffStrategy) o;
+
+        if (!baseDelay.equals(that.baseDelay)) {
+            return false;
+        }
+        return maxBackoffTime.equals(that.maxBackoffTime);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = baseDelay.hashCode();
+        result = 31 * result + maxBackoffTime.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("FullJitterBackoffStrategy")
+                       .add("baseDelay", baseDelay)
+                       .add("maxBackoffTime", maxBackoffTime)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/AndRetryCondition.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/AndRetryCondition.java
@@ -15,11 +15,12 @@
 
 package software.amazon.awssdk.core.retry.conditions;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -28,7 +29,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkPublicApi
 public final class AndRetryCondition implements RetryCondition {
 
-    private List<RetryCondition> conditions = new ArrayList<>();
+    private Set<RetryCondition> conditions = new HashSet<>();
 
     private AndRetryCondition(RetryCondition... conditions) {
         Collections.addAll(this.conditions, Validate.notEmpty(conditions, "%s cannot be empty.", "conditions"));
@@ -44,5 +45,31 @@ public final class AndRetryCondition implements RetryCondition {
 
     public static AndRetryCondition create(RetryCondition... conditions) {
         return new AndRetryCondition(conditions);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final AndRetryCondition that = (AndRetryCondition) o;
+
+        return conditions != null ? conditions.equals(that.conditions) : that.conditions == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return conditions != null ? conditions.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("AndRetryCondition")
+                       .add("conditions", conditions)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/MaxNumberOfRetriesCondition.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/MaxNumberOfRetriesCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.retry.conditions;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -38,5 +39,31 @@ public final class MaxNumberOfRetriesCondition implements RetryCondition {
 
     public static MaxNumberOfRetriesCondition create(int maxNumberOfRetries) {
         return new MaxNumberOfRetriesCondition(maxNumberOfRetries);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final MaxNumberOfRetriesCondition that = (MaxNumberOfRetriesCondition) o;
+
+        return maxNumberOfRetries == that.maxNumberOfRetries;
+    }
+
+    @Override
+    public int hashCode() {
+        return maxNumberOfRetries;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("MaxNumberOfRetriesCondition")
+                       .add("maxNumberOfRetries", maxNumberOfRetries)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/OrRetryCondition.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/OrRetryCondition.java
@@ -15,11 +15,12 @@
 
 package software.amazon.awssdk.core.retry.conditions;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 
 /**
  * Composite retry condition that evaluates to true if any containing condition evaluates to true.
@@ -27,7 +28,7 @@ import software.amazon.awssdk.core.retry.RetryPolicyContext;
 @SdkPublicApi
 public final class OrRetryCondition implements RetryCondition {
 
-    private List<RetryCondition> conditions = new ArrayList<>();
+    private Set<RetryCondition> conditions = new HashSet<>();
 
     private OrRetryCondition(RetryCondition... conditions) {
         Collections.addAll(this.conditions, conditions);
@@ -43,5 +44,31 @@ public final class OrRetryCondition implements RetryCondition {
 
     public static OrRetryCondition create(RetryCondition... conditions) {
         return new OrRetryCondition(conditions);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final OrRetryCondition that = (OrRetryCondition) o;
+
+        return conditions.equals(that.conditions);
+    }
+
+    @Override
+    public int hashCode() {
+        return conditions.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("OrRetryCondition")
+                       .add("conditions", conditions)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnExceptionsCondition.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnExceptionsCondition.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 
 /**
  * Retry condition implementation that retries if the exception or the cause of the exception matches the classes defined.
@@ -73,5 +74,31 @@ public final class RetryOnExceptionsCondition implements RetryCondition {
      */
     public static RetryOnExceptionsCondition create(Class<? extends Exception>... exceptionsToRetryOn) {
         return new RetryOnExceptionsCondition(Arrays.stream(exceptionsToRetryOn).collect(Collectors.toSet()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final RetryOnExceptionsCondition that = (RetryOnExceptionsCondition) o;
+
+        return exceptionsToRetryOn.equals(that.exceptionsToRetryOn);
+    }
+
+    @Override
+    public int hashCode() {
+        return exceptionsToRetryOn.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("RetryOnExceptionsCondition")
+                       .add("exceptionsToRetryOn", exceptionsToRetryOn)
+                       .build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnStatusCodeCondition.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/conditions/RetryOnStatusCodeCondition.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -54,5 +55,31 @@ public final class RetryOnStatusCodeCondition implements RetryCondition {
 
     public static RetryOnStatusCodeCondition create(Integer... statusCodesToRetryOn) {
         return new RetryOnStatusCodeCondition(Arrays.stream(statusCodesToRetryOn).collect(Collectors.toSet()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final RetryOnStatusCodeCondition that = (RetryOnStatusCodeCondition) o;
+
+        return statusCodesToRetryOn.equals(that.statusCodesToRetryOn);
+    }
+
+    @Override
+    public int hashCode() {
+        return statusCodesToRetryOn.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("RetryOnStatusCodeCondition")
+                       .add("statusCodesToRetryOn", statusCodesToRetryOn)
+                       .build();
     }
 }


### PR DESCRIPTION
- fix #646 
- added `toString()`, `hashcode`, `equals` methods to retry policy related classes.
- Make `RetryPolicy.none()` truly none retry policy. 
   Currently, `RetryPolicy.none().retryCondition().toString()` resolves to: 
```
AndRetryCondition(conditions=[MaxNumberOfRetriesCondition(maxNumberOfRetries=3), MaxNumberOfRetriesCondition(maxNumberOfRetries=0)])
```
 and it should be 
```
MaxNumberOfRetriesCondition(maxNumberOfRetries=0)
```

- added more tests.
