### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/.changes/2.0.0-preview-2.json
+++ b/.changes/2.0.0-preview-2.json
@@ -5,7 +5,7 @@
         {
             "category": "AWS SDK for Java v2",
             "type": "feature",
-            "description": "Substantial improvments to start up time and cold start latencies"
+            "description": "Substantial improvements to start up time and cold start latencies"
         },
         {
             "category": "AWS SDK for Java v2",

--- a/.changes/2.0.0-preview-4.json
+++ b/.changes/2.0.0-preview-4.json
@@ -35,7 +35,7 @@
         {
             "category": "AWS SDK for Java v2",
             "type": "bugfix",
-            "description": "Many improvments and fixes to the Netty NIO based transport."
+            "description": "Many improvements and fixes to the Netty NIO based transport."
         },
         {
             "category": "AWS SDK for Java v2",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,7 +306,7 @@
 
   - ### Bugfixes
     - Fixed a bug in default credential provider chain where it would erroneously abort at the ProfileCredentialsProvider. See [Issue #135](https://github.com/aws/aws-sdk-java-v2/issues/135)
-    - Many improvments and fixes to the Netty NIO based transport.
+    - Many improvements and fixes to the Netty NIO based transport.
     - Several fixes around S3's endpoint resolution, particularly with advanced options like path style addressing and accelerate mode. See [Issue #130](https://github.com/aws/aws-sdk-java-v2/issues/130)
     - Several fixes around serialization and deserialization of immutable objects. See [Issue #122](https://github.com/aws/aws-sdk-java-v2/issues/122)
     - Type parameters are now correctly included for [StreamingResponseHandler](https://github.com/aws/aws-sdk-java-v2/blob/master/core/src/main/java/software/amazon/awssdk/sync/StreamingResponseHandler.java) on the client interface.
@@ -321,7 +321,7 @@
   - ### Features
     - New pluggable HTTP implementation built on top of Java's HttpUrlConnection. Good choice for simple applications with low throughput requirements. Better cold start latency than the default Apache implementation.
     - Simple convenience methods have been added for operations that require no input parameters.
-    - Substantial improvments to start up time and cold start latencies
+    - Substantial improvements to start up time and cold start latencies
     - The Netty NIO HTTP client now uses a shared event loop group for better resource management. More options for customizing the event loop group are now available.
     - Using java.time instead of the legacy java.util.Date in generated model classes.
     - Various improvements to the immutability of model POJOs. ByteBuffers are now copied and collections are returned as unmodifiable.

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/DocumentationBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/DocumentationBuilder.java
@@ -208,7 +208,7 @@ public final class DocumentationBuilder {
     }
 
     /**
-     * Builds the Javadoc string with the current configuraton.
+     * Builds the Javadoc string with the current configuration.
      *
      * @return Formatted Javadoc string.
      */

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -134,7 +134,7 @@ public final class ContainerCredentialsProvider extends HttpCredentialsProvider 
             if (!ALLOWED_HOSTS.contains(uri.getHost())) {
 
                 throw SdkClientException.builder()
-                                        .message(String.format("The full URI (%s) contained withing environment " +
+                                        .message(String.format("The full URI (%s) contained within environment " +
                                                  "variable %s has an invalid host. Host can only be one of [%s].",
                                                  uri,
                                                  SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/StaxUnmarshallerContext.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/StaxUnmarshallerContext.java
@@ -148,7 +148,7 @@ public final class StaxUnmarshallerContext {
      * document being parsed.
      *
      * @param expression
-     *            The psuedo-xpath expression to test.
+     *            The pseudo-xpath expression to test.
      * @return True if the expression matches the current document position,
      *         otherwise false.
      */
@@ -165,7 +165,7 @@ public final class StaxUnmarshallerContext {
      * specified stack depth.
      *
      * @param expression
-     *            The psuedo-xpath expression to test.
+     *            The pseudo-xpath expression to test.
      * @param startingStackDepth
      *            The depth in the stack representing where the expression must
      *            start matching in order for this method to return true.

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Service.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Service.java
@@ -112,7 +112,7 @@ public final class Service {
     }
 
     /**
-     * A convienient method that returns true if a service has a partition
+     * A convenient method that returns true if a service has a partition
      * wide endpoint available.
      */
     public boolean isPartitionWideEndpointAvailable() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkCborGenerator.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkCborGenerator.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.core.protocol.json.StructuredJsonGenerator;
 @SdkInternalApi
 public final class SdkCborGenerator extends SdkJsonGenerator {
 
-    private static final int CBOR_TAG_TIMESTAP = 1;
+    private static final int CBOR_TAG_TIMESTAMP = 1;
 
     public SdkCborGenerator(JsonFactory factory, String contentType) {
         super(factory, contentType);
@@ -47,7 +47,7 @@ public final class SdkCborGenerator extends SdkJsonGenerator {
 
         CBORGenerator generator = (CBORGenerator) getGenerator();
         try {
-            generator.writeTag(CBOR_TAG_TIMESTAP);
+            generator.writeTag(CBOR_TAG_TIMESTAMP);
             generator.writeNumber(instant.toEpochMilli());
         } catch (IOException e) {
             throw new JsonGenerationException(e);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java
@@ -202,12 +202,12 @@ public class XpathUtilsTest {
     public void testMissingNodes() throws Exception {
         Document document = documentFrom(DOCUMENT);
         XPath xpath = XpathUtils.xpath();
-        assertNull(asDouble("non-existant-node/name", document, xpath));
-        assertNull(asLong("non-existant-node/name", document, xpath));
-        assertNull(asInteger("non-existant-node/name", document, xpath));
-        assertNull(asDate("non-existant-node/name", document, xpath));
-        assertNull(asFloat("non-existant-node/name", document, xpath));
-        assertNull(asString("non-existant-node/name", document, xpath));
+        assertNull(asDouble("non-existent-node/name", document, xpath));
+        assertNull(asLong("non-existent-node/name", document, xpath));
+        assertNull(asInteger("non-existent-node/name", document, xpath));
+        assertNull(asDate("non-existent-node/name", document, xpath));
+        assertNull(asFloat("non-existent-node/name", document, xpath));
+        assertNull(asString("non-existent-node/name", document, xpath));
     }
 
     /**

--- a/docs/UseOfCompletableFuture.md
+++ b/docs/UseOfCompletableFuture.md
@@ -2,7 +2,7 @@
 
 Operations on the asynchronous clients return [`CompleteableFuture<T>`][1] where `T` is the response type for the operation. This is somewhat curious in that [`CompleteableFuture`][1] is a concrete implementation rather than an interface. The alternative to returning a [`CompleteableFuture`][1] would be to return a [`CompletionStage`][2], an interface intended to allow chaining of asynchronous operations.
 
-The key advantage of [`CompleteableFuture`][1] is that it implements both the [`CompletionStage`][2] and [`Future`][3] interfaces - giving users of the SDK maximum flexibilty when it comes to handling responses from their asynchronous calls.
+The key advantage of [`CompleteableFuture`][1] is that it implements both the [`CompletionStage`][2] and [`Future`][3] interfaces - giving users of the SDK maximum flexibility when it comes to handling responses from their asynchronous calls.
 
 Currently [`CompleteableFuture`][1] is the only implementation of [`CompletionStage`][2] that ships with the JDK. Whilst it's possible that future implementations will be added  [`CompletionStage`][2] will always be tied to [`CompleteableFuture`][1] via the  [`#toCompletableFuture`][4] method. Additionally, [`CompleteableFuture`][1] is not a `final` class and thus could be extended if there was a requirement to do so.
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/SdkEventLoopGroup.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/SdkEventLoopGroup.java
@@ -118,7 +118,7 @@ public final class SdkEventLoopGroup {
                                                                                 .build());
         return new NioEventLoopGroup(numThreads, threadFactory);
         /*
-        Need to investigate why epoll is raising channel inactive after succesful response that causes
+        Need to investigate why epoll is raising channel inactive after successful response that causes
         problems with retries.
 
         if (Epoll.isAvailable() && isNotAwsLambda()) {

--- a/services/appsync/src/main/resources/codegen-resources/service-2.json
+++ b/services/appsync/src/main/resources/codegen-resources/service-2.json
@@ -1624,7 +1624,7 @@
       "members":{
         "graphqlApi":{
           "shape":"GraphqlApi",
-          "documentation":"<p>The udpated <code>GraphqlApi</code> object.</p>"
+          "documentation":"<p>The updated <code>GraphqlApi</code> object.</p>"
         }
       }
     },

--- a/services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/AutoScalingIntegrationTest.java
@@ -502,7 +502,7 @@ public class AutoScalingIntegrationTest extends IntegrationTestBase {
 
 
     /**
-     * Tests that we can invoke the notificaiton related operations correctly.
+     * Tests that we can invoke the notification related operations correctly.
      */
 
     @Test

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java
@@ -148,7 +148,7 @@ public class DynamoServiceIntegrationTest extends DynamoDBTestBase {
     @Test
     public void testErrorHandling() throws Exception {
 
-        DeleteTableRequest request = DeleteTableRequest.builder().tableName("non-existant-table").build();
+        DeleteTableRequest request = DeleteTableRequest.builder().tableName("non-existent-table").build();
         try {
             dynamo.deleteTable(request);
             fail("Expected an exception to be thrown");

--- a/services/stepfunctions/src/main/java/software/amazon/awssdk/services/stepfunctions/builder/internal/validation/Problem.java
+++ b/services/stepfunctions/src/main/java/software/amazon/awssdk/services/stepfunctions/builder/internal/validation/Problem.java
@@ -32,7 +32,7 @@ final class Problem {
     }
 
     /**
-     * @return Context of where this violation occured.
+     * @return Context of where this violation occurred.
      */
     public ValidationContext getContext() {
         return context;

--- a/test/dynamodbdocument-v1/src/it/java/software/amazon/awssdk/services/dynamodb/document/UpdateItemIntegrationTest.java
+++ b/test/dynamodbdocument-v1/src/it/java/software/amazon/awssdk/services/dynamodb/document/UpdateItemIntegrationTest.java
@@ -266,7 +266,7 @@ public class UpdateItemIntegrationTest {
                             // leading to an intentional failure in the update condition
                             .withString(":zipcode", "98104")
                             );
-            fail("Update Should fail as the zip code mentioned in the conditon expression doesn't match");
+            fail("Update Should fail as the zip code mentioned in the condition expression doesn't match");
         } catch (SdkServiceException e) {
             assertTrue(e.getMessage().contains("conditional request failed"));
         }

--- a/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/BatchLoadIntegrationTest.java
+++ b/test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/BatchLoadIntegrationTest.java
@@ -162,7 +162,7 @@ public class BatchLoadIntegrationTest extends DynamoDBMapperIntegrationTestBase 
         // The request only contains invalid key pairs
         List<KeyPair> keyPairs = new LinkedList<KeyPair>();
         Class<?> clazz = getUniqueNumericObject().getClass();
-        keyPairs.add(new KeyPair().withHashKey("non-existant-key"));
+        keyPairs.add(new KeyPair().withHashKey("non-existent-key"));
         itemsToGet.clear();
         itemsToGet.put(clazz, keyPairs);
         response = mapper.batchLoad(itemsToGet);
@@ -203,7 +203,7 @@ public class BatchLoadIntegrationTest extends DynamoDBMapperIntegrationTestBase 
         DynamoDbMapper mapper = new DynamoDbMapper(mockClient);
         try {
             mapper.batchLoad(objs);
-            fail("Expecting an expection due to exceed of number of retries.");
+            fail("Expecting an exception due to exceed of number of retries.");
         } catch (Exception e) {
             e.printStackTrace();
             long endTime = System.currentTimeMillis();

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMappingException.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMappingException.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.services.dynamodb.datamodeling;
 
 /**
- * Generic exception for problems occuring when mapping DynamoDB items to Java
+ * Generic exception for problems occurring when mapping DynamoDB items to Java
  * objects or vice versa. Excludes service exceptions.
  */
 public class DynamoDbMappingException extends RuntimeException {

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMarshaller.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMarshaller.java
@@ -28,7 +28,7 @@ package software.amazon.awssdk.services.dynamodb.datamodeling;
  * {@link DynamoDbTypeConverted} is created per field/attribute. In the old,
  * an new instance of the marshaller was created for each call to
  * {@code marshall} and {@code unmarshall}. If your marshaller/converter is not
- * thread safe, it is recomended to specify a converter which will instantiate
+ * thread safe, it is recommended to specify a converter which will instantiate
  * a new marshaller per call.</p>
  *
  * <pre class="brush: java">

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMarshalling.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMarshalling.java
@@ -42,7 +42,7 @@ import java.util.Set;
  * {@link DynamoDbTypeConverted} is created per field/attribute. In the old,
  * an new instance of the marshaller was created for each call to
  * {@code marshall} and {@code unmarshall}. If your marshaller/converter is not
- * thread safe, it is recomended to specify a converter which will instantiate
+ * thread safe, it is recommended to specify a converter which will instantiate
  * a new marshaller per call.</p>
  *
  * <pre class="brush: java">

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbScalarAttribute.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbScalarAttribute.java
@@ -37,7 +37,7 @@ public @interface DynamoDbScalarAttribute {
     String attributeName() default "";
 
     /**
-     * The scalar attirbute type.
+     * The scalar attribute type.
      * @see software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
      */
     ScalarAttributeType type();

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTypeConverterFactory.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTypeConverterFactory.java
@@ -109,7 +109,7 @@ public abstract class DynamoDbTypeConverterFactory {
     }
 
     /**
-     * Delegate factory to allow selected types to be overriden.
+     * Delegate factory to allow selected types to be overridden.
      */
     private static class OverrideFactory extends DelegateFactory {
         private final ConverterMap overrides;

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTyped.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTyped.java
@@ -78,13 +78,13 @@ import software.amazon.awssdk.services.dynamodb.datamodeling.DynamoDbMapperField
  * <p>If the converter being applied is already a supported data type and
  * the conversion is of the same attribute type, for instance,
  * {@link java.util.Date} to {@link String} to {@code S},
- * the annotation may be omited. The annotation is require for all non-standard
- * types or if the attribute type binding is being overriden.</p>
+ * the annotation may be omitted. The annotation is require for all non-standard
+ * types or if the attribute type binding is being overridden.</p>
  *
  * <p><b>{@link software.amazon.awssdk.services.dynamodb.model.AttributeValue}</b></p>
  * <p>Direct native conversion is supported by default in all schemas.
  * If the attribute is a primary or index key, it must specify either
- * {@code B}, {@code N}, or {@code S}, otherwise, it may be omited.</p>
+ * {@code B}, {@code N}, or {@code S}, otherwise, it may be omitted.</p>
  *
  * <p><b>{@link Boolean} to {@code BOOL}</b></p>
  * <p>The standard V2 conversion schema will by default serialize booleans

--- a/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesTest.java
+++ b/test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesTest.java
@@ -1616,7 +1616,7 @@ public class StandardModelFactoriesTest {
     }
 
     /**
-     * Pojo field assersions.
+     * Pojo field assertions.
      */
     private static enum PojoAsserts {
         hashKey(KeyType.HASH, null),

--- a/test/test-utils/src/main/java/software/amazon/awssdk/core/auth/policy/internal/JsonPolicyReader.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/core/auth/policy/internal/JsonPolicyReader.java
@@ -37,7 +37,7 @@ public class JsonPolicyReader {
 
     private static final String PRINCIPAL_SCHEMA_SERVICE = "Service";
 
-    private static final String PRINICIPAL_SCHEMA_FEDERATED = "Federated";
+    private static final String PRINCIPAL_SCHEMA_FEDERATED = "Federated";
 
     /**
      * Converts the specified JSON string to an AWS policy object.
@@ -247,12 +247,12 @@ public class JsonPolicyReader {
             return new Principal(principalNode.asText());
         } else if (schema.equalsIgnoreCase(PRINCIPAL_SCHEMA_SERVICE)) {
             return new Principal(schema, principalNode.asText());
-        } else if (schema.equalsIgnoreCase(PRINICIPAL_SCHEMA_FEDERATED)) {
+        } else if (schema.equalsIgnoreCase(PRINCIPAL_SCHEMA_FEDERATED)) {
             if (Principal.WebIdentityProvider.fromString(principalNode.asText()) != null) {
                 return new Principal(
                         Principal.WebIdentityProvider.fromString(principalNode.asText()));
             } else {
-                return new Principal(PRINICIPAL_SCHEMA_FEDERATED, principalNode.asText());
+                return new Principal(PRINCIPAL_SCHEMA_FEDERATED, principalNode.asText());
             }
         }
         throw new IllegalArgumentException("Schema " + schema + " is not a valid value for the principal.");

--- a/test/test-utils/src/main/java/software/amazon/awssdk/core/waiters/WaiterAcceptor.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/core/waiters/WaiterAcceptor.java
@@ -23,11 +23,11 @@ public abstract class WaiterAcceptor<OutputT, ErrorT extends RuntimeException> {
     /**
      * Default method definition that matches the response
      * state with the expected state defined by the acceptor.
-     * Overriden by each acceptor definition of matches.
+     * Overridden by each acceptor definition of matches.
      *
      * @param output Response got by the execution of the operation
      * @return False by default.
-     *     When overriden, returns True if it matches, False
+     *     When overridden, returns True if it matches, False
      *     otherwise
      */
     public boolean matches(OutputT output) {
@@ -37,11 +37,11 @@ public abstract class WaiterAcceptor<OutputT, ErrorT extends RuntimeException> {
     /**
      * Default method definition that matches the exception
      * with the expected state defined by the acceptor.
-     * Overriden by each acceptor definition of matches.
+     * Overridden by each acceptor definition of matches.
      *
      * @param output Exception thrown by the execution of the operation
      * @return False by default.
-     *     When overriden, returns True if it matches, False otherwise
+     *     When overridden, returns True if it matches, False otherwise
      */
     public boolean matches(ErrorT output) {
         return false;


### PR DESCRIPTION
## Description

This pull request fixes typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

## Motivation and Context

```
$ find . -name *.java | xargs misspell
./http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/SdkEventLoopGroup.java:121:72: "succesful" is a misspelling of "successful"
./core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/StaxUnmarshallerContext.java:151:22: "psuedo" is a misspelling of "pseudo"
./core/aws-core/src/main/java/software/amazon/awssdk/awscore/protocol/xml/StaxUnmarshallerContext.java:168:22: "psuedo" is a misspelling of "pseudo"
./core/regions/src/main/java/software/amazon/awssdk/regions/internal/model/Service.java:115:9: "convienient" is a misspelling of "convenient"
./core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java:137:92: "withing" is a misspelling of "within"
./core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java:205:33: "existant" is a misspelling of "existent"
./core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java:206:31: "existant" is a misspelling of "existent"
./core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java:207:34: "existant" is a misspelling of "existent"
./core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java:208:31: "existant" is a misspelling of "existent"
./core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java:209:32: "existant" is a misspelling of "existent"
./core/sdk-core/src/test/java/software/amazon/awssdk/core/util/XpathUtilsTest.java:210:33: "existant" is a misspelling of "existent"
./core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkCborGenerator.java:31:38: "TIMESTAP" is a misspelling of "TIMESTAMP"
./core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/protocol/json/SdkCborGenerator.java:50:40: "TIMESTAP" is a misspelling of "TIMESTAMP"
./test/test-utils/src/main/java/software/amazon/awssdk/core/auth/policy/internal/JsonPolicyReader.java:40:32: "PRINICIPAL" is a misspelling of "PRINCIPAL"
./test/test-utils/src/main/java/software/amazon/awssdk/core/auth/policy/internal/JsonPolicyReader.java:250:43: "PRINICIPAL" is a misspelling of "PRINCIPAL"
./test/test-utils/src/main/java/software/amazon/awssdk/core/auth/policy/internal/JsonPolicyReader.java:255:37: "PRINICIPAL" is a misspelling of "PRINCIPAL"
./test/test-utils/src/main/java/software/amazon/awssdk/core/waiters/WaiterAcceptor.java:26:7: "Overriden" is a misspelling of "Overridden"
./test/test-utils/src/main/java/software/amazon/awssdk/core/waiters/WaiterAcceptor.java:30:16: "overriden" is a misspelling of "overridden"
./test/test-utils/src/main/java/software/amazon/awssdk/core/waiters/WaiterAcceptor.java:40:7: "Overriden" is a misspelling of "Overridden"
./test/test-utils/src/main/java/software/amazon/awssdk/core/waiters/WaiterAcceptor.java:44:16: "overriden" is a misspelling of "overridden"
./test/dynamodbdocument-v1/src/it/java/software/amazon/awssdk/services/dynamodb/document/UpdateItemIntegrationTest.java:269:70: "conditon" is a misspelling of "condition"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTyped.java:81:25: "omited" is a misspelling of "omitted"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTyped.java:82:51: "overriden" is a misspelling of "overridden"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTyped.java:87:60: "omited" is a misspelling of "omitted"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMarshaller.java:31:22: "recomended" is a misspelling of "recommended"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbTypeConverterFactory.java:112:54: "overriden" is a misspelling of "overridden"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMarshalling.java:45:22: "recomended" is a misspelling of "recommended"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/StandardModelFactoriesTest.java:1619:18: "assersions" is a misspelling of "assertions"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbScalarAttribute.java:40:18: "attirbute" is a misspelling of "attribute"
./test/dynamodbmapper-v1/src/test/java/software/amazon/awssdk/services/dynamodb/datamodeling/DynamoDbMappingException.java:19:34: "occuring" is a misspelling of "occurring"
./test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/BatchLoadIntegrationTest.java:165:52: "existant" is a misspelling of "existent"
./test/dynamodbmapper-v1/src/it/java/software/amazon/awssdk/services/dynamodb/datamodeling/BatchLoadIntegrationTest.java:206:31: "expection" is a misspelling of "exception"
./codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java:49:34: "strat" is a misspelling of "start"
./codegen/src/main/java/software/amazon/awssdk/codegen/docs/DocumentationBuilder.java:211:50: "configuraton" is a misspelling of "configuration"
./services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoServiceIntegrationTest.java:151:81: "existant" is a misspelling of "existent"
./services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/AutoScalingIntegrationTest.java:505:36: "notificaiton" is a misspelling of "notification"
./services/stepfunctions/src/main/java/software/amazon/awssdk/services/stepfunctions/builder/internal/validation/Problem.java:35:47: "occured" is a misspelling of "occurred"
```

## Testing

This pull request should never bring any changes to the behavior of the library.

## Screenshots (if appropriate)

None.

## Types of changes

Fixing the wordings mainly in comments.

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
