### PR TITLE
Fix NPE for S3 GET request using http

### DIFF
--- a/.changes/next-release/bugfix-AamazonS3-06ed2a0.json
+++ b/.changes/next-release/bugfix-AamazonS3-06ed2a0.json
@@ -1,0 +1,5 @@
+{
+    "category": "Aamazon S3", 
+    "type": "bugfix", 
+    "description": "Fix NPE for S3 GET request using http protocol. see [#612](https://github.com/aws/aws-sdk-java-v2/issues/612)"
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsS3V4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsS3V4Signer.java
@@ -220,9 +220,9 @@ public final class AwsS3V4Signer extends AbstractAws4Signer<AwsS3V4SignerParams,
      */
     private boolean isPayloadSigningEnabled(SdkHttpFullRequest.Builder request, AwsS3V4SignerParams signerParams) {
         /**
-         * If we aren't using https we should always sign the payload.
+         * If we aren't using https we should always sign the payload unless there is no payload
          */
-        if (!request.protocol().equals("https")) {
+        if (!request.protocol().equals("https") && request.content() != null) {
             return true;
         }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
+import java.net.URI;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+
+public class EndpointOverrideTest {
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(0);
+
+    private S3Client s3Client;
+
+    private S3AsyncClient s3AsyncClient;
+
+    @Before
+    public void setup() {
+        s3Client = S3Client.builder()
+                           .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                           .region(Region.US_WEST_2).endpointOverride(URI.create(getEndpoint()))
+                           .build();
+
+        s3AsyncClient = S3AsyncClient.builder()
+                                     .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                                     .region(Region.US_WEST_2)
+                                     .endpointOverride(URI.create(getEndpoint()))
+                                     .build();
+    }
+
+    private String getEndpoint() {
+        return "http://localhost:" + mockServer.port();
+    }
+
+    //https://github.com/aws/aws-sdk-java-v2/issues/437
+    @Test
+    public void getObjectAsync_shouldNotThrowNPE() throws IOException {
+        stubFor(get(anyUrl())
+                    .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withBody("<?xml version=\"1.0\"?><GetObjectResult xmlns=\"http://s3"
+                                              + ".amazonaws.com/doc/2006-03-01\"></GetObjectResult>")));
+        assertThat(s3AsyncClient.getObject(b -> b.bucket("test").key("test").build(),
+                                           AsyncResponseTransformer.toBytes()).join()).isNotNull();
+    }
+
+    @Test
+    public void getObject_shouldNotThrowNPE() {
+        stubFor(get(anyUrl())
+                    .willReturn(aResponse()
+                                    .withStatus(200).withBody("<?xml version=\"1.0\"?><GetObjectResult xmlns=\"http://s3"
+                                                              + ".amazonaws.com/doc/2006-03-01\"></GetObjectResult>")));
+        assertThat(s3Client.listObjectVersions(b -> b.bucket("test"))).isNotNull();
+    }
+}


### PR DESCRIPTION
## Description
Fix the bug where AwsS34Singer tries to sign the payload when the request doesn't have payload. 

## Motivation and Context
Fix #612 

## Testing
`mvn clean install`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
