### PR TITLE
Fix paginated response iterable hasNextPage

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-532f520.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-532f520.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix Response Fetcher hasNextPage to check if the output token is non null or non empty if it is a collection or map type. Related to [#677](https://github.com/aws/aws-sdk-java-v2/issues/677)"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/PaginatorsClassSpec.java
@@ -34,8 +34,7 @@ import software.amazon.awssdk.codegen.model.service.PaginatorDefinition;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.codegen.poet.model.TypeProvider;
-import software.amazon.awssdk.core.util.SdkAutoConstructList;
-import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.core.util.PaginatorUtils;
 
 public abstract class PaginatorsClassSpec implements ClassSpec {
 
@@ -178,14 +177,11 @@ public abstract class PaginatorsClassSpec implements ClassSpec {
         }
         // If there is no more_results token, then output_token will be a single value
         return CodeBlock.builder()
-                // Auto construct containers are treated as null so terminate
-                // pagination for those cases as well.
-                .add("return $1N.$2L != null && !$3T.class.isInstance($1N.$2L) && !$4T.class.isInstance($1N.$2L)",
-                              PREVIOUS_PAGE_METHOD_ARGUMENT,
-                              fluentGetterMethodsForOutputToken().get(0),
-                              SdkAutoConstructList.class,
-                              SdkAutoConstructMap.class)
-                .build();
+                        .add("return $3T.isOutputTokenAvailable($1N.$2L)",
+                             PREVIOUS_PAGE_METHOD_ARGUMENT,
+                             fluentGetterMethodsForOutputToken().get(0),
+                             PaginatorUtils.class)
+                        .build();
 
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyIterable.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyIterable.java
@@ -8,8 +8,7 @@ import software.amazon.awssdk.core.pagination.sync.PaginatedItemsIterable;
 import software.amazon.awssdk.core.pagination.sync.PaginatedResponsesIterator;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.core.pagination.sync.SyncPageFetcher;
-import software.amazon.awssdk.core.util.SdkAutoConstructList;
-import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse;
@@ -132,8 +131,7 @@ public class PaginatedOperationWithResultKeyIterable implements SdkIterable<Pagi
             SyncPageFetcher<PaginatedOperationWithResultKeyResponse> {
         @Override
         public boolean hasNextPage(PaginatedOperationWithResultKeyResponse previousPage) {
-            return previousPage.nextToken() != null && !SdkAutoConstructList.class.isInstance(previousPage.nextToken())
-                    && !SdkAutoConstructMap.class.isInstance(previousPage.nextToken());
+            return PaginatorUtils.isOutputTokenAvailable(previousPage.nextToken());
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPublisher.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithResultKeyPublisher.java
@@ -11,8 +11,7 @@ import software.amazon.awssdk.core.pagination.async.AsyncPageFetcher;
 import software.amazon.awssdk.core.pagination.async.EmptySubscription;
 import software.amazon.awssdk.core.pagination.async.PaginatedItemsPublisher;
 import software.amazon.awssdk.core.pagination.async.ResponsesSubscription;
-import software.amazon.awssdk.core.util.SdkAutoConstructList;
-import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsAsyncClient;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithResultKeyResponse;
@@ -138,8 +137,7 @@ public class PaginatedOperationWithResultKeyPublisher implements SdkPublisher<Pa
                                                                  AsyncPageFetcher<PaginatedOperationWithResultKeyResponse> {
         @Override
         public boolean hasNextPage(final PaginatedOperationWithResultKeyResponse previousPage) {
-            return previousPage.nextToken() != null && !SdkAutoConstructList.class.isInstance(previousPage.nextToken())
-                   && !SdkAutoConstructMap.class.isInstance(previousPage.nextToken());
+            return PaginatorUtils.isOutputTokenAvailable(previousPage.nextToken());
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyIterable.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyIterable.java
@@ -6,8 +6,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.pagination.sync.PaginatedResponsesIterator;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.core.pagination.sync.SyncPageFetcher;
-import software.amazon.awssdk.core.util.SdkAutoConstructList;
-import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsClient;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse;
@@ -110,8 +109,7 @@ public class PaginatedOperationWithoutResultKeyIterable implements SdkIterable<P
             SyncPageFetcher<PaginatedOperationWithoutResultKeyResponse> {
         @Override
         public boolean hasNextPage(PaginatedOperationWithoutResultKeyResponse previousPage) {
-            return previousPage.nextToken() != null && !SdkAutoConstructList.class.isInstance(previousPage.nextToken())
-                    && !SdkAutoConstructMap.class.isInstance(previousPage.nextToken());
+            return PaginatorUtils.isOutputTokenAvailable(previousPage.nextToken());
         }
 
         @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPublisher.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/paginators/PaginatedOperationWithoutResultKeyPublisher.java
@@ -7,8 +7,7 @@ import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.pagination.async.AsyncPageFetcher;
 import software.amazon.awssdk.core.pagination.async.EmptySubscription;
 import software.amazon.awssdk.core.pagination.async.ResponsesSubscription;
-import software.amazon.awssdk.core.util.SdkAutoConstructList;
-import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.core.util.PaginatorUtils;
 import software.amazon.awssdk.services.jsonprotocoltests.JsonProtocolTestsAsyncClient;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyRequest;
 import software.amazon.awssdk.services.jsonprotocoltests.model.PaginatedOperationWithoutResultKeyResponse;
@@ -117,8 +116,7 @@ public class PaginatedOperationWithoutResultKeyPublisher implements SdkPublisher
                                                                     AsyncPageFetcher<PaginatedOperationWithoutResultKeyResponse> {
         @Override
         public boolean hasNextPage(final PaginatedOperationWithoutResultKeyResponse previousPage) {
-            return previousPage.nextToken() != null && !SdkAutoConstructList.class.isInstance(previousPage.nextToken())
-                   && !SdkAutoConstructMap.class.isInstance(previousPage.nextToken());
+            return PaginatorUtils.isOutputTokenAvailable(previousPage.nextToken());
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/PaginatorUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/util/PaginatorUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.util;
+
+import java.util.Collection;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+@SdkProtectedApi
+public final class PaginatorUtils {
+
+    private PaginatorUtils() {
+    }
+
+
+    /**
+     * Checks if the output token is available.
+     *
+     * @param outputToken the output token to check
+     * @param <T> the type of the output token
+     * @return true if the output token is non-null or non-empty if the output token is a map or Collection type
+     */
+    public static <T> boolean isOutputTokenAvailable(T outputToken) {
+        if (outputToken == null) {
+            return false;
+        }
+
+        if (outputToken instanceof Map) {
+            return !((Map) outputToken).isEmpty();
+        }
+
+        if (outputToken instanceof Collection) {
+            return !((Collection) outputToken).isEmpty();
+        }
+
+        return true;
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/PaginatorUtilsTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/util/PaginatorUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import org.junit.Test;
+
+public class PaginatorUtilsTest {
+
+    @Test
+    public void nullOutputToken_shouldReturnFalse() {
+       assertFalse(PaginatorUtils.isOutputTokenAvailable(null));
+    }
+
+    @Test
+    public void nonNullString_shouldReturnTrue() {
+        assertTrue(PaginatorUtils.isOutputTokenAvailable("next"));
+    }
+
+    @Test
+    public void nonNullInteger_shouldReturnTrue() {
+        assertTrue(PaginatorUtils.isOutputTokenAvailable(12));
+    }
+
+    @Test
+    public void emptyCollection_shouldReturnFalse() {
+        assertFalse(PaginatorUtils.isOutputTokenAvailable(new ArrayList<>()));
+    }
+
+    @Test
+    public void nonEmptyCollection_shouldReturnTrue() {
+        assertTrue(PaginatorUtils.isOutputTokenAvailable(Arrays.asList("foo", "bar")));
+    }
+
+    @Test
+    public void emptyMap_shouldReturnFalse() {
+        assertFalse(PaginatorUtils.isOutputTokenAvailable(new HashMap<>()));
+    }
+
+    @Test
+    public void nonEmptyMap_shouldReturnTrue() {
+        HashMap<String, String> outputTokens = new HashMap<>();
+        outputTokens.put("foo", "bar");
+        assertTrue(PaginatorUtils.isOutputTokenAvailable(outputTokens));
+    }
+
+    @Test
+    public void sdkAutoConstructList_shouldReturnFalse() {
+        assertFalse(PaginatorUtils.isOutputTokenAvailable(DefaultSdkAutoConstructList.getInstance()));
+    }
+
+    @Test
+    public void sdkAutoConstructMap_shouldReturnFalse() {
+        assertFalse(PaginatorUtils.isOutputTokenAvailable(DefaultSdkAutoConstructMap.getInstance()));
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/CollectionUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/CollectionUtilsTest.java
@@ -15,17 +15,12 @@
 
 package software.amazon.awssdk.utils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Test;
 
 public class CollectionUtilsTest {


### PR DESCRIPTION
## Description
Fix paginated response iterable hasNextPage to check if the output token is non null or non empty if it is a collection or map type. 

`Dynamodb.batchGetItem` returns empty `unprocessedKeys` when there is no unprocessedKeys.
 
`"{"Responses":{"zoewang-TestTable":[{"attribute_foo":{"S":"test"},"hash":{"N":"0"}}]},"UnprocessedKeys":{}}"`

So unprocessedKeys is an empty map and not an instance of `SdkAutoConstructMap`. (we only create the `SdkAutoConstructMap` when it is null)

Currently, the `hasNextPage` checks if the output token is not null AND it is not instance of SdkAutoConstructMap AND not an instance of SdkAutoConstructList. So `hasNextPage` will always return true for empty list or map, which is not expected.

## Motivation and Context
Fixes #677

## Testing
`mvn clean install` local integration test.

Note: I didn't create the integration tests for the scenario where dynamodb returns us unprocessedKeys as it takes large load to trigger that scenario and the test might be flaky. I did test it for once and verified it worked.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
