### PR TITLE
Add SdkAnnotation to service module and other small fixes

### DIFF
--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle-suppressions.xml
@@ -31,10 +31,6 @@
     <suppress checks="MissingSdkAnnotationCheck"
               files=".(codegen|test)[\\/].+\.java$"/>
 
-    <!-- TODO: Remove this once we add the annotations on the services-->
-    <suppress checks="MissingSdkAnnotationCheck"
-              files=".(services)[\\/].+\.java$"/>
-
     <!-- TODO want to contribute this back to Netty -->
     <suppress checks=".*"
               files=".*BetterFixedChannelPool\.java$"/>

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/GlobalServiceExecutionInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/interceptor/GlobalServiceExecutionInterceptor.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
  * doesn't support non-global regions.
  */
 @SdkProtectedApi
-public class GlobalServiceExecutionInterceptor implements ExecutionInterceptor {
+public final class GlobalServiceExecutionInterceptor implements ExecutionInterceptor {
     @Override
     public void onExecutionFailure(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
         if (hasCause(context.exception(), UnknownHostException.class) &&

--- a/services/apigateway/src/main/java/software/amazon/awssdk/services/apigateway/internal/AcceptJsonInterceptor.java
+++ b/services/apigateway/src/main/java/software/amazon/awssdk/services/apigateway/internal/AcceptJsonInterceptor.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.services.apigateway.internal;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 
+@SdkProtectedApi
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/cloudsearchdomain/src/main/java/software/amazon/awssdk/services/cloudsearchdomain/SwitchToPostInterceptor.java
+++ b/services/cloudsearchdomain/src/main/java/software/amazon/awssdk/services/cloudsearchdomain/SwitchToPostInterceptor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.cloudsearchdomain;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -26,7 +27,8 @@ import software.amazon.awssdk.services.cloudsearchdomain.model.SearchRequest;
 /**
  * Ensures that all SearchRequests use <code>POST</code> instead of <code>GET</code>, moving the query parameters to be form data.
  */
-public class SwitchToPostInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class SwitchToPostInterceptor implements ExecutionInterceptor {
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         SdkHttpFullRequest request = context.httpRequest();

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/Ec2Interceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/Ec2Interceptor.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -41,7 +42,8 @@ import software.amazon.awssdk.services.ec2.model.RunInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.SpotInstanceRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
 
-public class EC2Interceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class Ec2Interceptor implements ExecutionInterceptor {
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         SdkHttpFullRequest request = context.httpRequest();

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/GeneratePreSignUrlInterceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/GeneratePreSignUrlInterceptor.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.ec2.transform;
 import static software.amazon.awssdk.auth.signer.internal.AwsSignerExecutionAttribute.AWS_CREDENTIALS;
 
 import java.net.URI;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
@@ -37,7 +38,8 @@ import software.amazon.awssdk.services.ec2.model.CopySnapshotRequest;
  * ExecutionInterceptor that generates a pre-signed URL for copying encrypted snapshots
  * TODO: Is this actually right? What if a different interceptor modifies the message? Should this be treated as a signer?
  */
-public class GeneratePreSignUrlInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class GeneratePreSignUrlInterceptor implements ExecutionInterceptor {
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/TimestampFormatInterceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/TimestampFormatInterceptor.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.ec2.transform;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.ec2.model.RequestSpotFleetRequest;
  * RequestSpotFleet and DescribeSpotFleetRequestHistory, which don't expect
  * timestamps to be so precise.
  */
+@SdkProtectedApi
 public final class TimestampFormatInterceptor implements ExecutionInterceptor {
 
     private static final Pattern PATTERN = Pattern.compile("\\.\\d\\d\\dZ");

--- a/services/ec2/src/main/resources/software/amazon/awssdk/services/ec2/execution.interceptors
+++ b/services/ec2/src/main/resources/software/amazon/awssdk/services/ec2/execution.interceptors
@@ -1,3 +1,3 @@
 software.amazon.awssdk.services.ec2.transform.GeneratePreSignUrlInterceptor
 software.amazon.awssdk.services.ec2.transform.TimestampFormatInterceptor
-software.amazon.awssdk.services.ec2.transform.EC2Interceptor
+software.amazon.awssdk.services.ec2.transform.Ec2Interceptor

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/AcceptJsonInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/AcceptJsonInterceptor.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.services.glacier.internal;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 
+@SdkProtectedApi
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.glacier.internal;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -23,7 +24,8 @@ import software.amazon.awssdk.services.glacier.model.DescribeJobRequest;
 import software.amazon.awssdk.services.glacier.model.GetJobOutputRequest;
 import software.amazon.awssdk.services.glacier.model.UploadMultipartPartRequest;
 
-public class GlacierExecutionInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class GlacierExecutionInterceptor implements ExecutionInterceptor {
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/transform/DefaultAccountIdSupplier.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/transform/DefaultAccountIdSupplier.java
@@ -16,7 +16,9 @@
 package software.amazon.awssdk.services.glacier.transform;
 
 import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 
+@SdkProtectedApi
 public final class DefaultAccountIdSupplier {
 
     /**

--- a/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/PredictEndpointInterceptor.java
+++ b/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/PredictEndpointInterceptor.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.machinelearning.internal;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -30,7 +31,8 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
  * extracts the PredictRequest's PredictEndpoint "parameter" and swaps it in as
  * the endpoint to send the request to.
  */
-public class PredictEndpointInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class PredictEndpointInterceptor implements ExecutionInterceptor {
 
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {

--- a/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/RandomIdInterceptor.java
+++ b/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/RandomIdInterceptor.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.machinelearning.internal;
 
 import java.util.UUID;
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -32,8 +33,9 @@ import software.amazon.awssdk.services.machinelearning.model.CreateMlModelReques
  * CreateXxx API calls require a unique (for all time!) ID parameter for
  * idempotency. If the user doesn't specify one, fill in a GUID.
  */
+@SdkProtectedApi
 @ReviewBeforeRelease("They should be using the idempotency trait")
-public class RandomIdInterceptor implements ExecutionInterceptor {
+public final class RandomIdInterceptor implements ExecutionInterceptor {
 
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/CopyDbSnapshotPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/CopyDbSnapshotPresignInterceptor.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.rds;
 
 import java.time.Clock;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.Request;
 import software.amazon.awssdk.services.rds.model.CopyDbSnapshotRequest;
@@ -24,7 +25,8 @@ import software.amazon.awssdk.services.rds.transform.CopyDbSnapshotRequestMarsha
 /**
  * Handler for pre-signing {@link CopyDbSnapshotRequest}.
  */
-public class CopyDbSnapshotPresignInterceptor extends RdsPresignInterceptor<CopyDbSnapshotRequest> {
+@SdkProtectedApi
+public final class CopyDbSnapshotPresignInterceptor extends RdsPresignInterceptor<CopyDbSnapshotRequest> {
 
     public CopyDbSnapshotPresignInterceptor() {
         super(CopyDbSnapshotRequest.class);

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/CreateDbInstanceReadReplicaPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/CreateDbInstanceReadReplicaPresignInterceptor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.rds;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.Request;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
 import software.amazon.awssdk.services.rds.transform.CreateDbInstanceReadReplicaRequestMarshaller;
@@ -22,7 +23,9 @@ import software.amazon.awssdk.services.rds.transform.CreateDbInstanceReadReplica
 /**
  * Handler for pre-signing {@link CreateDbInstanceReadReplicaRequest}.
  */
-public class CreateDbInstanceReadReplicaPresignInterceptor extends RdsPresignInterceptor<CreateDbInstanceReadReplicaRequest> {
+@SdkProtectedApi
+public final class CreateDbInstanceReadReplicaPresignInterceptor extends
+                                                                 RdsPresignInterceptor<CreateDbInstanceReadReplicaRequest> {
     public CreateDbInstanceReadReplicaPresignInterceptor() {
         super(CreateDbInstanceReadReplicaRequest.class);
     }

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/RdsPresignInterceptor.java
@@ -19,6 +19,7 @@ import static software.amazon.awssdk.auth.signer.internal.AwsSignerExecutionAttr
 
 import java.net.URI;
 import java.time.Clock;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
@@ -43,13 +44,14 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
  *
  * @param <T> The request type.
  */
-abstract class RdsPresignInterceptor<T extends RdsRequest> implements ExecutionInterceptor {
+@SdkPublicApi
+public abstract class RdsPresignInterceptor<T extends RdsRequest> implements ExecutionInterceptor {
     private static final String SERVICE_NAME = "rds";
     private static final String PARAM_SOURCE_REGION = "SourceRegion";
     private static final String PARAM_DESTINATION_REGION = "DestinationRegion";
     private static final String PARAM_PRESIGNED_URL = "PreSignedUrl";
 
-    protected interface PresignableRequest {
+    public interface PresignableRequest {
         String getSourceRegion();
 
         Request<?> marshall();
@@ -59,17 +61,18 @@ abstract class RdsPresignInterceptor<T extends RdsRequest> implements ExecutionI
 
     private final Clock signingOverrideClock;
 
-    RdsPresignInterceptor(Class<T> requestClassToPreSign) {
+    public RdsPresignInterceptor(Class<T> requestClassToPreSign) {
         this(requestClassToPreSign, null);
     }
 
-    RdsPresignInterceptor(Class<T> requestClassToPreSign, Clock signingOverrideClock) {
+    public RdsPresignInterceptor(Class<T> requestClassToPreSign, Clock signingOverrideClock) {
         this.requestClassToPreSign = requestClassToPreSign;
         this.signingOverrideClock = signingOverrideClock;
     }
 
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    public final SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                                      ExecutionAttributes executionAttributes) {
         SdkHttpFullRequest request = context.httpRequest();
         SdkRequest originalRequest = context.request();
         if (!requestClassToPreSign.isInstance(originalRequest)) {
@@ -115,6 +118,12 @@ abstract class RdsPresignInterceptor<T extends RdsRequest> implements ExecutionI
                       .build();
     }
 
+    /**
+     * Adapts the request to the {@link PresignableRequest}.
+     *
+     * @param originalRequest the original request
+     * @return a PresignableRequest
+     */
     protected abstract PresignableRequest adaptRequest(T originalRequest);
 
     private SdkHttpFullRequest presignRequest(SdkHttpFullRequest request,

--- a/services/route53/src/main/java/software/amazon/awssdk/services/route53/internal/Route53IdInterceptor.java
+++ b/services/route53/src/main/java/software/amazon/awssdk/services/route53/internal/Route53IdInterceptor.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.route53.internal;
 
 import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -46,7 +47,8 @@ import software.amazon.awssdk.services.route53.model.ResourceRecordSet;
  * cannot be included, otherwise requests fail. This handler removes those
  * partial resource path elements from IDs returned by Route 53.
  */
-public class Route53IdInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class Route53IdInterceptor implements ExecutionInterceptor {
     @Override
     public SdkResponse modifyResponse(Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
         SdkResponse response = context.response();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -17,12 +17,14 @@ package software.amazon.awssdk.services.s3;
 
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationRequest;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
+@SdkPublicApi
 @Immutable
 @ThreadSafe
 public final class S3Configuration implements ServiceConfiguration, ToCopyableBuilder<S3Configuration.Builder, S3Configuration> {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/TaggingAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/TaggingAdapter.java
@@ -15,12 +15,14 @@
 
 package software.amazon.awssdk.services.s3;
 
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.adapter.TypeAdapter;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
-public class TaggingAdapter implements TypeAdapter<Tagging, String> {
+@SdkPublicApi
+public final class TaggingAdapter implements TypeAdapter<Tagging, String> {
 
     @Override
     public String adapt(Tagging tagging) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/CreateBucketInterceptor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.handlers;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -25,7 +26,8 @@ import software.amazon.awssdk.services.s3.internal.BucketUtils;
 import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
-public class CreateBucketInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class CreateBucketInterceptor implements ExecutionInterceptor {
 
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/DecodeUrlEncodedResponseInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/DecodeUrlEncodedResponseInterceptor.java
@@ -22,11 +22,13 @@ package software.amazon.awssdk.services.s3.handlers;
 //import software.amazon.awssdk.Response;
 
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 //import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 //import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 //import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 
+@SdkProtectedApi
 @ReviewBeforeRelease("Finish this and hook it up")
 public class DecodeUrlEncodedResponseInterceptor implements ExecutionInterceptor {
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/DisableDoubleUrlEncodingInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/DisableDoubleUrlEncodingInterceptor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.handlers;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.signer.internal.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -24,7 +25,8 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
  * Don't double-url-encode path elements for S3. S3 expects path elements to be encoded only once in
  * the canonical URI.
  */
-public class DisableDoubleUrlEncodingInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class DisableDoubleUrlEncodingInterceptor implements ExecutionInterceptor {
 
     @Override
     public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EnableChunkedEncodingInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EnableChunkedEncodingInterceptor.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.handlers;
 
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -27,10 +28,11 @@ import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 /**
  * Interceptor to enable chunked encoding on specific upload operations.
  */
+@SdkProtectedApi
 @ReviewBeforeRelease("Check if there are other operations that should have chuncked encoding enabled by default."
                      + "Do we even require this? By default chunked encoding is enabled. See AwsS3V4SignerParams class"
                      + "Maybe we need interceptor for payload signing as its disabled by default. See JAVA-2775")
-public class EnableChunkedEncodingInterceptor implements ExecutionInterceptor {
+public final class EnableChunkedEncodingInterceptor implements ExecutionInterceptor {
 
     @Override
     public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/EndpointAddressInterceptor.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.auth.signer.internal.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.core.SdkRequest;
@@ -37,6 +38,7 @@ import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
+@SdkProtectedApi
 public final class EndpointAddressInterceptor implements ExecutionInterceptor {
 
     private static final List<Class<?>> ACCELERATE_DISABLED_OPERATIONS = Arrays.asList(

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/PutObjectInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/PutObjectInterceptor.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.handlers;
 
 import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -25,8 +26,9 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 /**
  * Interceptor to add an 'Expect: 100-continue' header to the HTTP Request if it represents a PUT Object request.
  */
+@SdkProtectedApi
 @ReviewBeforeRelease("This should be generalized for all streaming requests when we refactor the marshallers.")
-public class PutObjectInterceptor implements ExecutionInterceptor {
+public final class PutObjectInterceptor implements ExecutionInterceptor {
     @Override
     public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         if (context.request() instanceof PutObjectRequest) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/BucketUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/BucketUtils.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  * checked to see if they are compatible with DNS addressing.
  */
 @SdkProtectedApi
-public class BucketUtils {
+public final class BucketUtils {
 
     private static final int MIN_BUCKET_NAME_LENGTH = 3;
     private static final int MAX_BUCKET_NAME_LENGTH = 63;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/GetBucketPolicyResponseUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/GetBucketPolicyResponseUnmarshaller.java
@@ -15,12 +15,14 @@
 
 package software.amazon.awssdk.services.s3.transform;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.runtime.transform.Unmarshaller;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.services.s3.model.GetBucketPolicyResponse;
 import software.amazon.awssdk.utils.FunctionalUtils;
 import software.amazon.awssdk.utils.IoUtils;
 
+@SdkProtectedApi
 public final class GetBucketPolicyResponseUnmarshaller implements Unmarshaller<GetBucketPolicyResponse, SdkHttpFullResponse> {
     @Override
     public GetBucketPolicyResponse unmarshall(SdkHttpFullResponse response) throws Exception {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/S3ExceptionUnmarshaller.java
@@ -20,6 +20,7 @@ import static software.amazon.awssdk.core.util.xml.XpathUtils.xpath;
 
 import javax.xml.xpath.XPath;
 import org.w3c.dom.Node;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.runtime.transform.AbstractErrorUnmarshaller;
@@ -28,6 +29,7 @@ import software.amazon.awssdk.utils.StringUtils;
 /**
  * Base exception unmarshaller for S3.
  */
+@SdkInternalApi
 public abstract class S3ExceptionUnmarshaller extends AbstractErrorUnmarshaller<AwsServiceException, Node> {
 
     private final String errorCode;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/StandardS3ExceptionUnmarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/StandardS3ExceptionUnmarshaller.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.transform;
 
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.awscore.protocol.xml.StandardErrorUnmarshaller;
 
@@ -22,6 +23,7 @@ import software.amazon.awssdk.awscore.protocol.xml.StandardErrorUnmarshaller;
  * The unmarshaller used to read S3 exceptions when no more-specific exception unmarshaller is found. This is the S3 equivalent
  * of {@link StandardErrorUnmarshaller}.
  */
+@SdkProtectedApi
 public final class StandardS3ExceptionUnmarshaller extends S3ExceptionUnmarshaller {
     public StandardS3ExceptionUnmarshaller(Class<? extends AwsServiceException> exceptionClass) {
         super(exceptionClass, null);

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/ErrorCode.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/ErrorCode.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.sfn.builder;
 
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.states.Catcher;
 import software.amazon.awssdk.services.sfn.builder.states.Retrier;
 
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Retrier;
  *
  * @see <a href="https://states-language.net/spec.html#appendix-a">https://states-language.net/spec.html#appendix-a</a>
  */
+@SdkPublicApi
 public final class ErrorCode {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/StateMachine.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/StateMachine.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.DateModule;
@@ -34,6 +35,7 @@ import software.amazon.awssdk.services.sfn.builder.states.State;
  *
  * @see <a href="https://states-language.net/spec.html#toplevelfields">https://states-language.net/spec.html#toplevelfields</a>
  */
+@SdkPublicApi
 public final class StateMachine {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/StepFunctionBuilder.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/StepFunctionBuilder.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder;
 
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.conditions.AndCondition;
 import software.amazon.awssdk.services.sfn.builder.conditions.BooleanEqualsCondition;
 import software.amazon.awssdk.services.sfn.builder.conditions.Condition;
@@ -59,6 +60,7 @@ import software.amazon.awssdk.services.sfn.builder.states.WaitState;
 /**
  * Fluent API for creating a {@link StateMachine} object.
  */
+@SdkPublicApi
 public final class StepFunctionBuilder {
 
     private StepFunctionBuilder() {

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/AndCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/AndCondition.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sfn.builder.states.ChoiceState;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class AndCondition implements NAryCondition {
 
     @JsonProperty(PropertyName.AND)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/BinaryCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/BinaryCondition.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
 /**
  * Interface for all binary conditions.
  *
@@ -22,6 +24,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
  *
  * @param <T> Type of expected value.
  */
+@SdkPublicApi
 public interface BinaryCondition<T> extends Condition {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/BooleanEqualsCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/BooleanEqualsCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class BooleanEqualsCondition implements BinaryCondition<Boolean> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/Condition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/Condition.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  *
  * <p>This interface should not be implemented outside of the SDK.</p>
  */
+@SdkInternalApi
 public interface Condition {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NAryCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NAryCondition.java
@@ -16,12 +16,14 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Base interface for n-ary conditions like {@link AndCondition}.
  *
  * <p>This interface should not be implemented outside of the SDK.</p>
  */
+@SdkInternalApi
 public interface NAryCondition extends Condition {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NotCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NotCondition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 import software.amazon.awssdk.services.sfn.builder.states.ChoiceState;
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.ChoiceState;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class NotCondition implements Condition {
 
     @JsonProperty(PropertyName.NOT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericEqualsCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericEqualsCondition.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class NumericEqualsCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericGreaterThanCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericGreaterThanCondition.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class NumericGreaterThanCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericGreaterThanOrEqualCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericGreaterThanOrEqualCondition.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class NumericGreaterThanOrEqualCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericLessThanCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericLessThanCondition.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class NumericLessThanCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericLessThanOrEqualCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/NumericLessThanOrEqualCondition.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class NumericLessThanOrEqualCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/OrCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/OrCondition.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sfn.builder.states.ChoiceState;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class OrCondition implements NAryCondition {
 
     @JsonProperty(PropertyName.OR)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringEqualsCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringEqualsCondition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class StringEqualsCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringGreaterThanCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringGreaterThanCondition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class StringGreaterThanCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringGreaterThanOrEqualCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringGreaterThanOrEqualCondition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class StringGreaterThanOrEqualCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringLessThanCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringLessThanCondition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class StringLessThanCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringLessThanOrEqualCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/StringLessThanOrEqualCondition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class StringLessThanOrEqualCondition implements BinaryCondition<String> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampEqualsCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampEqualsCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class TimestampEqualsCondition implements BinaryCondition<Date> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampGreaterThanCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampGreaterThanCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class TimestampGreaterThanCondition implements BinaryCondition<Date> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampGreaterThanOrEqualCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampGreaterThanOrEqualCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class TimestampGreaterThanOrEqualCondition implements BinaryCondition<Date> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampLessThanCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampLessThanCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class TimestampLessThanCondition implements BinaryCondition<Date> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampLessThanOrEqualCondition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/conditions/TimestampLessThanOrEqualCondition.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.conditions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.services.sfn.builder.states.Choice;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.states.Choice;
  * @see <a href="https://states-language.net/spec.html#choice-state">https://states-language.net/spec.html#choice-state</a>
  * @see Choice
  */
+@SdkPublicApi
 public final class TimestampLessThanOrEqualCondition implements BinaryCondition<Date> {
 
     @JsonProperty(PropertyName.VARIABLE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/Buildable.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/Buildable.java
@@ -20,12 +20,14 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Interface to build a particular type.
  *
  * @param <T> Type to build.
  */
+@SdkInternalApi
 public interface Buildable<T> {
 
     T build();

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/DateModule.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/DateModule.java
@@ -27,10 +27,12 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Contains Jackson module for serializing dates to ISO8601 format per the <a href="https://states-language.net/spec.html#timestamps">spec</a>.
  */
+@SdkInternalApi
 public final class DateModule {
 
     public static final SimpleModule INSTANCE = new SimpleModule();

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/PropertyName.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/PropertyName.java
@@ -15,9 +15,12 @@
 
 package software.amazon.awssdk.services.sfn.builder.internal;
 
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
 /**
  * JSON property names used for serialization/deserialization.
  */
+@SdkInternalApi
 public class PropertyName {
 
     // Common property names

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/Location.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/Location.java
@@ -15,9 +15,12 @@
 
 package software.amazon.awssdk.services.sfn.builder.internal.validation;
 
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
 /**
  * Enum indicating the location of a validation problem.
  */
+@SdkInternalApi
 enum Location {
     StateMachine,
     State,

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/ProblemReporter.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/ProblemReporter.java
@@ -17,10 +17,12 @@ package software.amazon.awssdk.services.sfn.builder.internal.validation;
 
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
  * Captures reported problems and creates appropriate exception with all problems identified via {@link #getException()}.
  */
+@SdkInternalApi
 final class ProblemReporter {
 
     private final List<Problem> problems = new ArrayList<Problem>();

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/StateMachineValidator.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/StateMachineValidator.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.services.sfn.builder.ErrorCode;
 import software.amazon.awssdk.services.sfn.builder.StateMachine;
 import software.amazon.awssdk.services.sfn.builder.conditions.BinaryCondition;
@@ -53,6 +54,7 @@ import software.amazon.awssdk.services.sfn.builder.states.WaitState;
  * // TODO Does not check max nesting.
  * // TODO Does not validate ARNs against a regex
  */
+@SdkInternalApi
 public class StateMachineValidator {
 
     private final ProblemReporter problemReporter = new ProblemReporter();

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/ValidationContext.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/ValidationContext.java
@@ -19,6 +19,7 @@ import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import java.util.Collection;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.StringUtils;
@@ -27,6 +28,7 @@ import software.amazon.awssdk.utils.StringUtils;
  * Contains context about the current validation scope and factory methods
  * for new sub-contexts and for reporting various common problems.
  */
+@SdkInternalApi
 final class ValidationContext {
 
     private final ValidationContext parentContext;

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/ValidationException.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/internal/validation/ValidationException.java
@@ -15,9 +15,12 @@
 
 package software.amazon.awssdk.services.sfn.builder.internal.validation;
 
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
 /**
  * Thrown if the state machine is invalid. Details about violations are in the exception message.
  */
+@SdkInternalApi
 public final class ValidationException extends RuntimeException {
 
     ValidationException(String message) {

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Branch.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Branch.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.sfn.builder.states;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#parallel-state">https://states-language.net/spec.html#parallel-state</a>
  */
+@SdkPublicApi
 public final class Branch {
 
     @JsonProperty(PropertyName.START_AT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Catcher.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Catcher.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.ErrorCode;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#errors">https://states-language.net/spec.html#errors</a>
  */
+@SdkPublicApi
 public final class Catcher {
 
     @JsonProperty(PropertyName.ERROR_EQUALS)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Choice.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Choice.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.conditions.Condition;
 import software.amazon.awssdk.services.sfn.builder.conditions.ConditionDeserializer;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
@@ -35,6 +36,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#choice-state>https://states-language.net/spec.html#choice-state</a>
  */
+@SdkPublicApi
 public final class Choice {
 
     @JsonUnwrapped

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/ChoiceState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/ChoiceState.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.sfn.builder.states;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.ErrorCode;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#choice-state>https://states-language.net/spec.html#choice-state</a>
  */
+@SdkPublicApi
 public final class ChoiceState implements State {
 
     @JsonProperty(PropertyName.COMMENT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/EndTransition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/EndTransition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -23,6 +24,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#transition">https://states-language.net/spec.html#transition</a>
  */
+@SdkPublicApi
 public final class EndTransition implements Transition {
 
     // Required for proper serialization

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/FailState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/FailState.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -23,6 +24,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#fail-state">https://states-language.net/spec.html#fail-state</a>
  */
+@SdkPublicApi
 public final class FailState implements State {
 
     @JsonProperty(PropertyName.COMMENT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/NextStateTransition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/NextStateTransition.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -23,6 +24,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#transition">https://states-language.net/spec.html#transition</a>
  */
+@SdkPublicApi
 public final class NextStateTransition implements Transition {
 
     @JsonProperty(PropertyName.NEXT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/ParallelState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/ParallelState.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#parallel-state">https://states-language.net/spec.html#parallel-state</a>
  */
+@SdkPublicApi
 public final class ParallelState extends TransitionState {
 
     @JsonProperty(PropertyName.COMMENT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/PassState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/PassState.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
@@ -35,6 +36,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#pass-state">https://states-language.net/spec.html#pass-state</a>
  */
+@SdkPublicApi
 public final class PassState extends TransitionState {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Retrier.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Retrier.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.ErrorCode;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#errors">https://states-language.net/spec.html#errors</a>
  */
+@SdkPublicApi
 public final class Retrier {
 
     @JsonProperty(PropertyName.ERROR_EQUALS)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/State.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/State.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.services.sfn.builder.StateMachine;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * <p>This interface should not be implemented outside the SDK.</p>
  */
+@SdkInternalApi
 public interface State {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/StateVisitor.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/StateVisitor.java
@@ -15,11 +15,14 @@
 
 package software.amazon.awssdk.services.sfn.builder.states;
 
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
 /**
  * Visitor interface for {@link State} inheritance hierarchy. Extend and override to provide your own visitor logic.
  *
  * @param <T> Return type of visit methods (May be {@link Void}).
  */
+@SdkPublicApi
 public abstract class StateVisitor<T> {
 
     public T visit(ChoiceState choiceState) {

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/SucceedState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/SucceedState.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -24,6 +25,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#succeed-state">https://states-language.net/spec.html#succeed-state</a>
  */
+@SdkPublicApi
 public final class SucceedState implements State {
 
     @JsonProperty(PropertyName.COMMENT)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/TaskState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/TaskState.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.ArrayList;
 import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.ErrorCode;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#task-state">https://states-language.net/spec.html#task-state</a>
  */
+@SdkPublicApi
 public final class TaskState extends TransitionState {
 
     @JsonProperty(PropertyName.RESOURCE)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Transition.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/Transition.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
  *
  * <p>This interface should not be implemented outside the SDK.</p>
  */
+@SdkInternalApi
 public interface Transition {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitFor.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitFor.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.sfn.builder.states;
 
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
 
 /**
@@ -22,6 +23,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.Buildable;
  *
  * <p>This interface should not be implemented outside the SDK.</p>
  */
+@SdkInternalApi
 public interface WaitFor {
 
     /**

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForSeconds.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForSeconds.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -24,6 +25,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#wait-state">https://states-language.net/spec.html#wait-state</a>
  */
+@SdkPublicApi
 public final class WaitForSeconds implements WaitFor {
 
     @JsonProperty(PropertyName.SECONDS)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForSecondsPath.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForSecondsPath.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -24,6 +25,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#wait-state">https://states-language.net/spec.html#wait-state</a>
  */
+@SdkPublicApi
 public final class WaitForSecondsPath implements WaitFor {
 
     @JsonProperty(PropertyName.SECONDS_PATH)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForTimestamp.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForTimestamp.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -25,6 +26,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#wait-state">https://states-language.net/spec.html#wait-state</a>
  */
+@SdkPublicApi
 public final class WaitForTimestamp implements WaitFor {
 
     @JsonProperty(PropertyName.TIMESTAMP)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForTimestampPath.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitForTimestampPath.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sfn.builder.states;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -24,6 +25,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#wait-state">https://states-language.net/spec.html#wait-state</a>
  */
+@SdkPublicApi
 public final class WaitForTimestampPath implements WaitFor {
 
     @JsonProperty(PropertyName.TIMESTAMP_PATH)

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitState.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/builder/states/WaitState.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.Date;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
 
 /**
@@ -28,6 +29,7 @@ import software.amazon.awssdk.services.sfn.builder.internal.PropertyName;
  *
  * @see <a href="https://states-language.net/spec.html#wait-state">https://states-language.net/spec.html#wait-state</a>
  */
+@SdkPublicApi
 public final class WaitState extends TransitionState {
 
     @JsonProperty(PropertyName.COMMENT)

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptor.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/MessageMD5ChecksumInterceptor.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
@@ -49,7 +50,8 @@ import software.amazon.awssdk.utils.Md5Utils;
  * This custom request handler will verify that the message is correctly received by SQS, by
  * comparing the returned MD5 with the calculation according to the original request.
  */
-public class MessageMD5ChecksumInterceptor implements ExecutionInterceptor {
+@SdkProtectedApi
+public final class MessageMD5ChecksumInterceptor implements ExecutionInterceptor {
 
     private static final int INTEGER_SIZE_IN_BYTES = 4;
     private static final byte STRING_TYPE_FIELD_INDEX = 1;

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/SessionCredentialsHolder.java
@@ -24,8 +24,8 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 /**
  * Holder class used to atomically store a session with its expiration time.
  */
-@ThreadSafe
 @SdkInternalApi
+@ThreadSafe
 final class SessionCredentialsHolder {
 
     private final AwsSessionCredentials sessionCredentials;

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -38,8 +39,9 @@ import software.amazon.awssdk.utils.Validate;
  *
  * This is created using {@link StsAssumeRoleCredentialsProvider#builder()}.
  */
+@SdkPublicApi
 @ThreadSafe
-public class StsAssumeRoleCredentialsProvider extends StsCredentialsProvider {
+public final class StsAssumeRoleCredentialsProvider extends StsCredentialsProvider {
     private Supplier<AssumeRoleRequest> assumeRoleRequestSupplier;
 
     /**

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sts.auth;
 
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -37,8 +38,9 @@ import software.amazon.awssdk.utils.Validate;
  *
  * This is created using {@link StsAssumeRoleWithSamlCredentialsProvider#builder()}.
  */
+@SdkPublicApi
 @ThreadSafe
-public class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentialsProvider {
+public final class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentialsProvider {
     private final AssumeRoleWithSamlRequest assumeRoleWithSamlRequest;
 
     /**

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sts.auth;
 
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -37,8 +38,9 @@ import software.amazon.awssdk.utils.Validate;
  *
  * This is created using {@link StsAssumeRoleWithWebIdentityCredentialsProvider#builder()}.
  */
+@SdkPublicApi
 @ThreadSafe
-public class StsAssumeRoleWithWebIdentityCredentialsProvider extends StsCredentialsProvider {
+public final class StsAssumeRoleWithWebIdentityCredentialsProvider extends StsCredentialsProvider {
     private final AssumeRoleWithWebIdentityRequest assumeRoleWithWebIdentityRequest;
 
     /**

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sts.auth;
 
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -37,6 +38,7 @@ import software.amazon.awssdk.utils.Validate;
  *
  * This is created using {@link StsGetFederationTokenCredentialsProvider#builder()}.
  */
+@SdkPublicApi
 @ThreadSafe
 public class StsGetFederationTokenCredentialsProvider extends StsCredentialsProvider {
     private final GetFederationTokenRequest getFederationTokenRequest;

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.sts.auth;
 
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -36,6 +37,7 @@ import software.amazon.awssdk.utils.Validate;
  *
  * This is created using {@link StsGetSessionTokenCredentialsProvider#builder()}.
  */
+@SdkPublicApi
 @ThreadSafe
 public class StsGetSessionTokenCredentialsProvider extends StsCredentialsProvider {
     private final GetSessionTokenRequest getSessionTokenRequest;


### PR DESCRIPTION
- Add Sdk annotation to classes in service modules and removed the MissingSdkAnnotationCheck suppressions.
   - Most of the classes are marked with `SdkProtectedApi` as they are interceptors and are used in the generated classes. One service I'm not 100% sure is the stepFunction and I marked some of those classes with`SdkPublicApi`. Let me know if that's not correct.

- Renamed `EC2Interceptor` to `Ec2Interceptor`

- Make classes that are not intended to be extended `final`