### PR TITLE
Update HTTP Async SPI

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -179,7 +179,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
         if (opModel.hasStreamingOutput() || opModel.hasEventStreamOutput()) {
             String paramName = opModel.hasStreamingOutput() ? "asyncResponseTransformer" : "asyncResponseHandler";
             builder.addStatement("runAndLogError(log, \"Exception thrown in exceptionOccurred callback, ignoring\",\n" +
-                                 "() -> $L.exceptionOccurred(t))", paramName);
+                                 "() -> $N.exceptionOccurred(t))", paramName);
         }
 
         return builder.addStatement("return $T.failedFuture(t)", CompletableFutureUtils.class)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryXmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryXmlProtocolSpec.java
@@ -154,20 +154,14 @@ public class QueryXmlProtocolSpec implements ProtocolSpec {
                                        ".withResponseHandler(responseHandler)" +
                                        ".withErrorResponseHandler($N)\n" +
                                        asyncRequestBody +
-                                       ".withInput($L) $L)$L;",
+                                       ".withInput($L) $L);",
                                        ClientExecutionParams.class,
                                        requestType,
                                        pojoResponseType,
                                        marshaller,
                                        "errorResponseHandler",
                                        opModel.getInput().getVariableName(),
-                                       opModel.hasStreamingOutput() ? ", asyncResponseTransformer" : "",
-                                       // If it's a streaming operation we also need to notify the handler on exception
-                                       opModel.hasStreamingOutput() ? ".whenComplete((r, e) -> {\n"
-                                                                      + "    if (e != null) {\n"
-                                                                      + "        asyncResponseTransformer.exceptionOccurred(e);\n"
-                                                                      + "    }\n"
-                                                                      + "})" : "")
+                                       opModel.hasStreamingOutput() ? ", asyncResponseTransformer" : "")
                         .build();
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -282,8 +282,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             });
             return future;
         } catch (Throwable t) {
-            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
-                           () -> asyncResponseHandler.exceptionOccurred(t));
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring", () -> asyncResponseHandler.exceptionOccurred(t));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -764,7 +763,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             });
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
-                           () -> asyncResponseTransformer.exceptionOccurred(t));
+                    () -> asyncResponseTransformer.exceptionOccurred(t));
             return CompletableFutureUtils.failedFuture(t);
         }
     }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
@@ -46,8 +46,8 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
-import software.amazon.awssdk.core.internal.util.ThrowableUtils;
 import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.SdkCancellationException;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.eventstream.Message;
@@ -115,11 +115,6 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
     private volatile boolean isDone = false;
 
     /**
-     * Holds a reference to any exception delivered to exceptionOccurred.
-     */
-    private final AtomicReference<Throwable> error = new AtomicReference<>();
-
-    /**
      * Executor to deliver events to the subscriber
      */
     private final Executor executor;
@@ -161,6 +156,8 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
      */
     private String requestId = null;
 
+    private volatile CompletableFuture<Void> transformFuture;
+
     @Deprecated
     @ReviewBeforeRelease("Remove this on full GA of 2.0.0")
     public EventStreamAsyncResponseTransformer(
@@ -191,7 +188,16 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
     }
 
     @Override
-    public void responseReceived(SdkResponse response) {
+    public CompletableFuture<Void> prepare() {
+        transformFuture = new CompletableFuture<>();
+        return transformFuture;
+    }
+
+    @Override
+    public void onResponse(SdkResponse response) {
+        // We use a void unmarshaller and unmarshall the actual response in the message
+        // decoder when we receive the initial-response frame. TODO not clear
+        // how we would handle REST protocol which would unmarshall the response from the HTTP headers
         if (response != null && response.sdkHttpResponse() != null) {
             this.requestId = response.sdkHttpResponse()
                                      .firstMatchingHeader(X_AMZN_REQUEST_ID_HEADER)
@@ -223,28 +229,14 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
         synchronized (this) {
             if (!isDone) {
                 isDone = true;
-                error.set(throwable);
                 // If we have a Subscriber at this point notify it as well
-                if (subscriberRef.get() != null) {
+                if (subscriberRef.get() != null && shouldSurfaceErrorToEventSubscriber(throwable)) {
                     runAndLogError(log, "Error thrown from Subscriber#onError, ignoring.",
                         () -> subscriberRef.get().onError(throwable));
                 }
                 eventStreamResponseHandler.exceptionOccurred(throwable);
+                transformFuture.completeExceptionally(throwable);
             }
-        }
-    }
-
-    @Override
-    public Void complete() {
-        if (error.get() == null) {
-            // Add the special on complete event to signal drainEvents to complete the subscriber
-            eventsToDeliver.add(ON_COMPLETE_EVENT);
-            drainEventsIfNotAlready();
-            return null;
-        } else {
-            // Need to propagate the failure up so the future is completed exceptionally. This should only happen
-            // when there is a frame level exception that the upper layers don't know about.
-            throw ThrowableUtils.failure(error.get());
         }
     }
 
@@ -340,6 +332,10 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
                                   .build();
     }
 
+    private static boolean shouldSurfaceErrorToEventSubscriber(Throwable t) {
+        return !(t instanceof SdkCancellationException);
+    }
+
     /**
      * Subscriber for the raw bytes from the stream. Feeds them to the {@link MessageDecoder} as they arrive
      * and will request as much as needed to fulfill any outstanding demand.
@@ -390,8 +386,10 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
 
         @Override
         public void onComplete() {
-            // Notified in onEventComplete method because we have more context on what we've delivered to
-            // the event stream subscriber there.
+            // Add the special on complete event to signal drainEvents to complete the subscriber
+            eventsToDeliver.add(ON_COMPLETE_EVENT);
+            drainEventsIfNotAlready();
+            transformFuture.complete(null);
         }
     }
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/RestEventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/RestEventStreamAsyncResponseTransformer.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.awscore.eventstream;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -43,8 +45,13 @@ public class RestEventStreamAsyncResponseTransformer<ResponseT extends SdkRespon
     }
 
     @Override
-    public void responseReceived(ResponseT response) {
-        delegate.responseReceived(response);
+    public CompletableFuture<Void> prepare() {
+        return delegate.prepare();
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
+        delegate.onResponse(response);
         eventStreamResponseHandler.responseReceived(response);
     }
 
@@ -56,11 +63,6 @@ public class RestEventStreamAsyncResponseTransformer<ResponseT extends SdkRespon
     @Override
     public void exceptionOccurred(Throwable throwable) {
         delegate.exceptionOccurred(throwable);
-    }
-
-    @Override
-    public Void complete() {
-        return delegate.complete();
     }
 
     public static <ResponseT extends SdkResponse, EventT> Builder<ResponseT, EventT> builder() {

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformerTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformerTest.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -123,10 +124,19 @@ public class EventStreamAsyncResponseTransformerTest {
                                                .executor(Executors.newSingleThreadExecutor())
                                                .future(new CompletableFuture<>())
                                                .build();
-        transformer.responseReceived(null);
+        CompletableFuture<Void> cf = transformer.prepare();
+        transformer.onResponse(null);
         transformer.onStream(SdkPublisher.adapt(bytePublisher));
 
-        assertThatThrownBy(transformer::complete).isSameAs(exception);
+        assertThatThrownBy(() -> {
+            try {
+                cf.join();
+            } catch (CompletionException e) {
+                if (e.getCause() instanceof SdkServiceException) {
+                    throw ((SdkServiceException) e.getCause());
+                }
+            }
+        }).isSameAs(exception);
     }
 
     private static class SubscribingResponseHandler implements EventStreamResponseHandler<Object, Object> {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -18,8 +18,8 @@ package software.amazon.awssdk.core.async;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscription;
+import java.util.concurrent.CompletableFuture;
+
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer;
@@ -27,61 +27,83 @@ import software.amazon.awssdk.core.internal.async.FileAsyncResponseTransformer;
 
 /**
  * Callback interface to handle a streaming asynchronous response.
+ * <p>
+ * <h2>Synchronization</h2>
+ * <p>
+ * All operations, including those called on the {@link org.reactivestreams.Subscriber} of the stream are guaranteed to be
+ * synchronized externally; i.e. no two methods on this interface or on the {@link org.reactivestreams.Subscriber} will be
+ * invoked concurrently. It is <b>not</b> guaranteed that the methods will being invoked by the same thread.
+ * <p>
+ * <h2>Invocation Order</h2>
+ * <p>
+ * The methods are called in the following order:
+ * <ul>
+ *     <li>
+ *     {@link #prepare()}: This method is always called first. Implementations should use this to setup or perform any
+ *     cleanup necessary. <b>Note that this will be called upon each request attempt</b>. If the {@link CompletableFuture}
+ *     returned from the previous invocation has already been completed, the implementation should return a new instance.
+ *     </li>
+ *     <li>
+ *     {@link #onResponse}: If the response was received successfully, this method is called next.
+ *     </li>
+ *     <li>
+ *     {@link #onStream(SdkPublisher)}: Called after {@code onResponse}. This is always invoked, even if the service
+ *     operation response does not contain a body. If the response does not have a body, then the {@link SdkPublisher} will
+ *     complete the subscription without signaling any elements.
+ *     </li>
+ *     <li>
+ *     {@link #exceptionOccurred(Throwable)}: If there is an error sending the request. This method is called before {@link
+ *     org.reactivestreams.Subscriber#onError(Throwable)}.
+ *     </li>
+ *     <li>
+ *     {@link org.reactivestreams.Subscriber#onError(Throwable)}: If an error is encountered while the {@code Publisher} is
+ *     publishing to a {@link org.reactivestreams.Subscriber}.
+ *     </li>
+ * </ul>
+ * <p>
+ * <h2>Retries</h2>
+ * <p>
+ * The transformer has the ability to trigger retries at any time by completing the {@link CompletableFuture} with an
+ * exception that is deemed retryable by the configured {@link software.amazon.awssdk.core.retry.RetryPolicy}.
  *
  * @param <ResponseT> POJO response type.
- * @param <ReturnT>   Type this response handler produces. I.E. the type you are transforming the response into.
+ * @param <ResultT>   Type this response handler produces. I.E. the type you are transforming the response into.
  */
 @SdkPublicApi
-public interface AsyncResponseTransformer<ResponseT, ReturnT> {
-
+public interface AsyncResponseTransformer<ResponseT, ResultT> {
     /**
-     * Called when the initial response has been received and the POJO response has
-     * been unmarshalled. This is guaranteed to be called before onStream.
+     * Initial call to enable any setup required before the response is handled.
+     * <p>
+     * Note that this will be called for each request attempt, up to the number of retries allowed by the configured {@link
+     * software.amazon.awssdk.core.retry.RetryPolicy}.
+     * <p>
+     * This method is guaranteed to be called before the request is executed, and before {@link #onResponse(Object)} is
+     * signaled.
      *
-     * <p>In the event of a retryable error, this callback may be called multiple times. It
-     * also may never be invoked if the request never succeeds.</p>
-     *
-     * @param response Unmarshalled POJO containing metadata about the streamed data.
+     * @return The future holding the transformed response.
      */
-    void responseReceived(ResponseT response);
+    CompletableFuture<ResultT> prepare();
 
     /**
-     * Called when events are ready to be streamed. Implementations  must subscribe to the {@link Publisher} and request data via
-     * a {@link org.reactivestreams.Subscription} as they can handle it.
+     * Called when the unmarshalled response object is ready.
      *
-     * <p>
-     * If at any time the subscriber wishes to stop receiving data, it may call {@link Subscription#cancel()}. This
-     * will be treated as a failure of the response and the {@link #exceptionOccurred(Throwable)} callback will be invoked.
-     * </p>
+     * @param response The unmarshalled response.
+     */
+    void onResponse(ResponseT response);
+
+    /**
+     * Called when the response stream is ready.
      *
-     * <p>This callback may never be called if the response has no content or if an error occurs.</p>
-     *
-     * <p>
-     * In the event of a retryable error, this callback may be called multiple times with different Publishers.
-     * If this method is called more than once, implementation must either reset any state to prepare for another
-     * stream of data or must throw an exception indicating they cannot reset. If any exception is thrown then no
-     * automatic retry is performed.
-     * </p>
+     * @param publisher The publisher.
      */
     void onStream(SdkPublisher<ByteBuffer> publisher);
 
     /**
-     * Called when an exception occurs while establishing the connection or streaming the response. Implementations
-     * should free up any resources in this method. This method may be called multiple times during the lifecycle
-     * of a request if automatic retries are enabled.
+     * Called when a error is encountered while making the request or receiving the response.
      *
-     * @param throwable Exception that occurred.
+     * @param error Error that occurred.
      */
-    void exceptionOccurred(Throwable throwable);
-
-    /**
-     * Called when all data has been successfully published to the {@link org.reactivestreams.Subscriber}. This will
-     * only be called once during the lifecycle of the request. Implementors should free up any resources they have
-     * opened and do final transformations to produce the return object.
-     *
-     * @return Transformed object as a result of the streamed data.
-     */
-    ReturnT complete();
+    void exceptionOccurred(Throwable error);
 
     /**
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file. In the event of an error,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/DrainingSubscriber.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/DrainingSubscriber.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Requests elements from a subscriber until the subscription is completed.
+ */
+@SdkProtectedApi
+public class DrainingSubscriber<T> implements Subscriber<T> {
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        subscription.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(T t) {
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+    }
+
+    @Override
+    public void onComplete() {
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/EmptyPublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/EmptyPublisher.java
@@ -13,22 +13,28 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.async;
+package software.amazon.awssdk.core.async;
 
-import java.nio.ByteBuffer;
-import java.util.Optional;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
-/**
- * A {@link Publisher} of HTTP content data that allows streaming operations for asynchronous HTTP clients.
- */
 @SdkProtectedApi
-public interface SdkHttpRequestProvider extends Publisher<ByteBuffer> {
+public class EmptyPublisher<T> implements Publisher<T> {
+    private static final Subscription SUBSCRIPTION = new Subscription() {
+        @Override
+        public void request(long l) {
+        }
 
-    /**
-     * @return The content length of the data being produced.
-     */
-    Optional<Long> contentLength();
+        @Override
+        public void cancel() {
+        }
+    };
 
+    @Override
+    public void subscribe(Subscriber<? super T> subscriber) {
+        subscriber.onSubscribe(SUBSCRIPTION);
+        subscriber.onComplete();
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -59,12 +60,9 @@ import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkRequestContext;
-import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.Either;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
@@ -400,9 +398,8 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         }
 
         @Override
-        public AbortableRunnable prepareRequest(SdkHttpRequest request, SdkRequestContext context,
-                                                SdkHttpRequestProvider requestProvider, SdkHttpResponseHandler handler) {
-            return delegate.prepareRequest(request, context, requestProvider, handler);
+        public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+            return delegate.execute(request);
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncResponseTransformer.java
@@ -19,6 +19,8 @@ import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -40,41 +42,39 @@ import software.amazon.awssdk.utils.BinaryUtils;
 public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
         AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> {
 
-    private ResponseT response;
-    private ByteArrayOutputStream baos;
+    private volatile CompletableFuture<byte[]> cf;
+    private volatile ResponseT response;
 
     @Override
-    public void responseReceived(ResponseT response) {
+    public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
+        cf = new CompletableFuture<>();
+        return cf.thenApply(arr -> ResponseBytes.fromByteArray(response, arr));
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
         this.response = response;
     }
 
     @Override
     public void onStream(SdkPublisher<ByteBuffer> publisher) {
-        baos = new ByteArrayOutputStream();
-        publisher.subscribe(new BaosSubscriber(baos));
+        publisher.subscribe(new BaosSubscriber(cf));
     }
 
     @Override
     public void exceptionOccurred(Throwable throwable) {
-        baos = null;
-    }
-
-    @Override
-    public ResponseBytes<ResponseT> complete() {
-        try {
-            return ResponseBytes.fromByteArray(response, baos.toByteArray());
-        } finally {
-            baos = null;
-        }
+        cf.completeExceptionally(throwable);
     }
 
     static class BaosSubscriber implements Subscriber<ByteBuffer> {
-        private final ByteArrayOutputStream baos;
+        private final CompletableFuture<byte[]> resultFuture;
+
+        private ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         private Subscription subscription;
 
-        BaosSubscriber(ByteArrayOutputStream baos) {
-            this.baos = baos;
+        BaosSubscriber(CompletableFuture<byte[]> resultFuture) {
+            this.resultFuture = resultFuture;
         }
 
         @Override
@@ -84,7 +84,7 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
                 return;
             }
             this.subscription = s;
-            subscription.request(1);
+            subscription.request(Long.MAX_VALUE);
         }
 
         @Override
@@ -95,12 +95,13 @@ public final class ByteArrayAsyncResponseTransformer<ResponseT> implements
 
         @Override
         public void onError(Throwable throwable) {
-            // Handled by response transformer
+            baos = null;
+            resultFuture.completeExceptionally(throwable);
         }
 
         @Override
         public void onComplete() {
-            // Handled by response transformer
+            resultFuture.complete(baos.toByteArray());
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/AmazonAsyncHttpClient.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder
 import software.amazon.awssdk.core.internal.http.pipeline.stages.AfterExecutionInterceptorsStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.ApplyTransactionIdStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.ApplyUserAgentStage;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncApiCallTimeoutTrackingStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncExecutionFailureExceptionReportingStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.BeforeTransmissionExecutionInterceptorsStage;
@@ -43,9 +44,9 @@ import software.amazon.awssdk.core.internal.http.pipeline.stages.SigningStage;
 import software.amazon.awssdk.core.internal.http.pipeline.stages.UnwrapResponseContainer;
 import software.amazon.awssdk.core.internal.retry.SdkDefaultRetrySetting;
 import software.amazon.awssdk.core.internal.util.CapacityManager;
+import software.amazon.awssdk.core.internal.util.ThrowableUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 @ThreadSafe
@@ -91,12 +92,12 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
     public interface RequestExecutionBuilder {
 
         /**
-         * Fluent setter for {@link SdkHttpRequestProvider}
+         * Fluent setter for {@link SdkHttpContentPublisher}
          *
          * @param requestProvider Request provider object
          * @return This builder for method chaining.
          */
-        RequestExecutionBuilder requestProvider(SdkHttpRequestProvider requestProvider);
+        RequestExecutionBuilder requestProvider(SdkHttpContentPublisher requestProvider);
 
         /**
          * Fluent setter for {@link SdkHttpFullRequest}
@@ -113,7 +114,7 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
          * @return This builder for method chaining.
          */
         RequestExecutionBuilder errorResponseHandler(
-                SdkHttpResponseHandler<? extends SdkException> errorResponseHandler);
+                TransformingAsyncResponseHandler<? extends SdkException> errorResponseHandler);
 
         /**
          * Fluent setter for the execution context
@@ -139,19 +140,19 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
          * @param <OutputT>       Result type
          * @return Unmarshalled result type.
          */
-        <OutputT> CompletableFuture<OutputT> execute(SdkHttpResponseHandler<OutputT> responseHandler);
+        <OutputT> CompletableFuture<OutputT> execute(TransformingAsyncResponseHandler<OutputT> responseHandler);
     }
 
     private class RequestExecutionBuilderImpl implements RequestExecutionBuilder {
 
-        private SdkHttpRequestProvider requestProvider;
+        private SdkHttpContentPublisher requestProvider;
         private SdkHttpFullRequest request;
-        private SdkHttpResponseHandler<? extends SdkException> errorResponseHandler;
+        private TransformingAsyncResponseHandler<? extends SdkException> errorResponseHandler;
         private SdkRequest originalRequest;
         private ExecutionContext executionContext;
 
         @Override
-        public RequestExecutionBuilder requestProvider(SdkHttpRequestProvider requestProvider) {
+        public RequestExecutionBuilder requestProvider(SdkHttpContentPublisher requestProvider) {
             this.requestProvider = requestProvider;
             return this;
         }
@@ -164,7 +165,7 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
 
         @Override
         public RequestExecutionBuilder errorResponseHandler(
-                SdkHttpResponseHandler<? extends SdkException> errorResponseHandler) {
+                TransformingAsyncResponseHandler<? extends SdkException> errorResponseHandler) {
             this.errorResponseHandler = errorResponseHandler;
             return this;
         }
@@ -183,31 +184,30 @@ public final class AmazonAsyncHttpClient implements SdkAutoCloseable {
         }
 
         @Override
-        public <OutputT> CompletableFuture<OutputT> execute(SdkHttpResponseHandler<OutputT> responseHandler) {
+        public <OutputT> CompletableFuture<OutputT> execute(TransformingAsyncResponseHandler<OutputT> responseHandler) {
             try {
                 return RequestPipelineBuilder
-                    .first(RequestPipelineBuilder
-                               .first(MakeRequestMutableStage::new)
-                               .then(ApplyTransactionIdStage::new)
-                               .then(ApplyUserAgentStage::new)
-                               .then(MergeCustomHeadersStage::new)
-                               .then(MergeCustomQueryParamsStage::new)
-                               .then(MoveParametersToBodyStage::new)
-                               .then(MakeRequestImmutableStage::new)
-                               .then(RequestPipelineBuilder
-                                         .first(SigningStage::new)
-                                         .then(BeforeTransmissionExecutionInterceptorsStage::new)
-                                         .then(d -> new MakeAsyncHttpRequestStage<>(responseHandler, errorResponseHandler, d))
-                                         .wrappedWith((deps, wrapped) ->
-                                                          new AsyncRetryableStage<>(responseHandler, deps, wrapped))
-                                         ::build)
-                               .then(async(() -> new UnwrapResponseContainer<>()))
-                               .then(async(() -> new AfterExecutionInterceptorsStage<>()))::build)
-                    .wrappedWith(AsyncExecutionFailureExceptionReportingStage::new)
-                    .build(httpClientDependencies)
-                    .execute(request, createRequestExecutionDependencies());
+                        .first(RequestPipelineBuilder
+                                .first(MakeRequestMutableStage::new)
+                                .then(ApplyTransactionIdStage::new)
+                                .then(ApplyUserAgentStage::new)
+                                .then(MergeCustomHeadersStage::new)
+                                .then(MergeCustomQueryParamsStage::new)
+                                .then(MoveParametersToBodyStage::new)
+                                .then(MakeRequestImmutableStage::new)
+                                .then(RequestPipelineBuilder
+                                        .first(SigningStage::new)
+                                        .then(BeforeTransmissionExecutionInterceptorsStage::new)
+                                        .then(d -> new MakeAsyncHttpRequestStage<>(responseHandler, errorResponseHandler, d))
+                                        .wrappedWith(AsyncRetryableStage::new)
+                                        .then(async(() -> new UnwrapResponseContainer<>()))
+                                        .then(async(() -> new AfterExecutionInterceptorsStage<>()))
+                                        .wrappedWith(AsyncExecutionFailureExceptionReportingStage::new)
+                                        .wrappedWith(AsyncApiCallTimeoutTrackingStage::new)::build)::build)
+                        .build(httpClientDependencies)
+                        .execute(request, createRequestExecutionDependencies());
             } catch (RuntimeException e) {
-                throw e;
+                throw ThrowableUtils.asSdkException(e);
             } catch (Exception e) {
                 throw SdkClientException.builder().cause(e).build();
             }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/RequestExecutionContext.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/RequestExecutionContext.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.timers.TimeoutTracker;
 import software.amazon.awssdk.core.internal.interceptor.ExecutionInterceptorChain;
 import software.amazon.awssdk.core.signer.Signer;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -37,7 +37,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public final class RequestExecutionContext {
     private static final RequestOverrideConfiguration EMPTY_CONFIG = SdkRequestOverrideConfiguration.builder().build();
-    private final SdkHttpRequestProvider requestProvider;
+    private final SdkHttpContentPublisher requestProvider;
     private final SdkRequest originalRequest;
     private final ExecutionContext executionContext;
     private TimeoutTracker apiCallTimeoutTracker;
@@ -55,7 +55,7 @@ public final class RequestExecutionContext {
         return new Builder();
     }
 
-    public SdkHttpRequestProvider requestProvider() {
+    public SdkHttpContentPublisher requestProvider() {
         return requestProvider;
     }
 
@@ -115,11 +115,11 @@ public final class RequestExecutionContext {
      */
     public static final class Builder {
 
-        private SdkHttpRequestProvider requestProvider;
+        private SdkHttpContentPublisher requestProvider;
         private SdkRequest originalRequest;
         private ExecutionContext executionContext;
 
-        public Builder requestProvider(SdkHttpRequestProvider requestProvider) {
+        public Builder requestProvider(SdkHttpContentPublisher requestProvider) {
             this.requestProvider = requestProvider;
             return this;
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/TransformingAsyncResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/TransformingAsyncResponseHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+/**
+ * A response handler that returns a transformed response.
+ *
+ * @param <ResultT> The type of the result.
+ */
+public interface TransformingAsyncResponseHandler<ResultT> extends SdkAsyncHttpResponseHandler {
+    /**
+     * Return the future holding the transformed response.
+     * <p>
+     * This method is guaranteed to be called before the request is executed, and before {@link
+     * SdkAsyncHttpResponseHandler#onHeaders(software.amazon.awssdk.http.SdkHttpResponse)} is signaled.
+     *
+     * @return The future holding the transformed response.
+     */
+    CompletableFuture<ResultT> prepare();
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/SimpleHttpContentPublisher.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/SimpleHttpContentPublisher.java
@@ -26,20 +26,20 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.RequestOption;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 import software.amazon.awssdk.utils.IoUtils;
 
 /**
- * Implementation of {@link SdkHttpRequestProvider} that provides all it's data at once. Useful for
+ * Implementation of {@link SdkHttpContentPublisher} that provides all it's data at once. Useful for
  * non streaming operations that are already marshalled into memory.
  */
 @SdkInternalApi
-public final class SimpleRequestProvider implements SdkHttpRequestProvider {
+public final class SimpleHttpContentPublisher implements SdkHttpContentPublisher {
 
     private final byte[] content;
     private final int length;
 
-    public SimpleRequestProvider(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
+    public SimpleHttpContentPublisher(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
         this.content = request.content().map(content -> {
             try {
                 content.mark(getReadLimit(executionAttributes));

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/SyncResponseHandlerAdapter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/SyncResponseHandlerAdapter.java
@@ -18,20 +18,22 @@ package software.amazon.awssdk.core.internal.http.async;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.core.internal.util.ThrowableUtils;
+import software.amazon.awssdk.core.internal.http.TransformingAsyncResponseHandler;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
-import software.amazon.awssdk.http.async.SimpleSubscriber;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Adapts an {@link HttpResponseHandler} to the asynchronous {@link SdkHttpResponseHandler}. Buffers
@@ -41,13 +43,12 @@ import software.amazon.awssdk.utils.BinaryUtils;
  * @param <T> Type that the response handler produces.
  */
 @SdkInternalApi
-public final class SyncResponseHandlerAdapter<T> implements SdkHttpResponseHandler<T> {
-
+public final class SyncResponseHandlerAdapter<T> implements TransformingAsyncResponseHandler<T> {
+    private final CompletableFuture<ByteArrayOutputStream> streamFuture = new CompletableFuture<>();
     private final HttpResponseHandler<T> responseHandler;
-    private ByteArrayOutputStream baos;
     private final ExecutionAttributes executionAttributes;
-    private SdkHttpFullResponse.Builder httpResponse;
     private final Function<SdkHttpFullResponse, SdkHttpFullResponse> crc32Validator;
+    private SdkHttpFullResponse.Builder httpResponse;
 
     public SyncResponseHandlerAdapter(HttpResponseHandler<T> responseHandler,
                                       Function<SdkHttpFullResponse, SdkHttpFullResponse> crc32Validator,
@@ -58,39 +59,71 @@ public final class SyncResponseHandlerAdapter<T> implements SdkHttpResponseHandl
     }
 
     @Override
-    public void headersReceived(SdkHttpResponse response) {
+    public void onHeaders(SdkHttpResponse response) {
         this.httpResponse = ((SdkHttpFullResponse) response).toBuilder();
     }
 
     @Override
     public void onStream(Publisher<ByteBuffer> publisher) {
-        baos = new ByteArrayOutputStream();
-        publisher.subscribe(new SimpleSubscriber(b -> {
+        publisher.subscribe(new BaosSubscriber(streamFuture));
+    }
+
+    @Override
+    public void onError(Throwable err) {
+        streamFuture.completeExceptionally(err);
+    }
+
+    @Override
+    public CompletableFuture<T> prepare() {
+        return streamFuture.thenComposeAsync(baos -> {
+            ByteArrayInputStream content = new ByteArrayInputStream(baos.toByteArray());
+            // Ignore aborts - we already have all of the content.
+            AbortableInputStream abortableContent = AbortableInputStream.create(content);
+            httpResponse.content(abortableContent);
             try {
-                baos.write(BinaryUtils.copyBytesFrom(b));
+                return CompletableFuture.completedFuture(responseHandler.handle(crc32Validator
+                        .apply(httpResponse.build()),
+                        executionAttributes));
+            } catch (Exception e) {
+                return CompletableFutureUtils.failedFuture(e);
+            }
+        });
+    }
+
+    private static class BaosSubscriber implements Subscriber<ByteBuffer> {
+        private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        private final CompletableFuture<ByteArrayOutputStream> streamFuture;
+        private Subscription subscription;
+
+        private BaosSubscriber(CompletableFuture<ByteArrayOutputStream> streamFuture) {
+            this.streamFuture = streamFuture;
+        }
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            try {
+                baos.write(BinaryUtils.copyBytesFrom(byteBuffer));
+                this.subscription.request(Long.MAX_VALUE);
             } catch (IOException e) {
-                throw new UncheckedIOException(e);
+                // Should never happen
+                streamFuture.completeExceptionally(e);
             }
-        }));
-    }
+        }
 
-    @Override
-    public void exceptionOccurred(Throwable throwable) {
-    }
+        @Override
+        public void onError(Throwable throwable) {
+            streamFuture.completeExceptionally(throwable);
+        }
 
-    @Override
-    public T complete() {
-        try {
-            // Once we've buffered all the content we can invoke the response handler
-            if (baos != null) {
-                // Ignore aborts - we already have all of the content.
-                ByteArrayInputStream content = new ByteArrayInputStream(baos.toByteArray());
-                AbortableInputStream abortableContent = AbortableInputStream.create(content);
-                httpResponse.content(abortableContent);
-            }
-            return responseHandler.handle(crc32Validator.apply(httpResponse.build()), executionAttributes);
-        } catch (Exception e) {
-            throw ThrowableUtils.failure(e);
+        @Override
+        public void onComplete() {
+            streamFuture.complete(baos);
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallTimeoutTrackingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallTimeoutTrackingStage.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.timeCompletableFuture;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
+import software.amazon.awssdk.core.internal.http.timers.TimeoutTracker;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.utils.OptionalUtils;
+
+@SdkInternalApi
+public class AsyncApiCallTimeoutTrackingStage<OutputT>
+        implements RequestPipeline<SdkHttpFullRequest, CompletableFuture<OutputT>> {
+    private final RequestPipeline<SdkHttpFullRequest, CompletableFuture<OutputT>> requestPipeline;
+    private final SdkClientConfiguration clientConfig;
+    private final ScheduledExecutorService scheduledExecutor;
+
+    public AsyncApiCallTimeoutTrackingStage(HttpClientDependencies dependencies,
+                                            RequestPipeline<SdkHttpFullRequest, CompletableFuture<OutputT>> requestPipeline) {
+        this.requestPipeline = requestPipeline;
+        this.scheduledExecutor = dependencies.clientConfiguration().option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
+        this.clientConfig = dependencies.clientConfiguration();
+    }
+
+    @Override
+    public CompletableFuture<OutputT> execute(SdkHttpFullRequest input, RequestExecutionContext context) throws Exception {
+        CompletableFuture<OutputT> future = new CompletableFuture<>();
+
+        long apiCallTimeoutInMillis = getApiCallTimeoutInMillis(context.requestConfig());
+
+        TimeoutTracker timeoutTracker = timeCompletableFuture(future,
+                scheduledExecutor,
+                ApiCallTimeoutException.create(apiCallTimeoutInMillis),
+                apiCallTimeoutInMillis);
+        context.apiCallTimeoutTracker(timeoutTracker);
+
+        requestPipeline.execute(input, context).whenComplete((r, t) -> {
+            if (t != null) {
+                future.completeExceptionally(t);
+            } else {
+                future.complete(r);
+            }
+        });
+
+        return future;
+    }
+
+    private long getApiCallTimeoutInMillis(RequestOverrideConfiguration requestConfig) {
+        return OptionalUtils
+                .firstPresent(requestConfig.apiCallTimeout(),
+                    () -> clientConfig.option(SdkClientOption.API_CALL_TIMEOUT))
+                .map(Duration::toMillis)
+                .orElse(0L);
+
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncExecutionFailureExceptionReportingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncExecutionFailureExceptionReportingStage.java
@@ -16,16 +16,22 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.interceptor.DefaultFailedExecutionContext;
+import software.amazon.awssdk.core.internal.util.ThrowableUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Logger;
 
 @SdkInternalApi
 public class AsyncExecutionFailureExceptionReportingStage<OutputT>
     implements RequestPipeline<SdkHttpFullRequest, CompletableFuture<OutputT>> {
+    private static final Logger log = Logger.loggerFor(AsyncExecutionFailureExceptionReportingStage.class);
 
     private final RequestPipeline<SdkHttpFullRequest, CompletableFuture<OutputT>> wrapped;
 
@@ -35,12 +41,36 @@ public class AsyncExecutionFailureExceptionReportingStage<OutputT>
 
     @Override
     public CompletableFuture<OutputT> execute(SdkHttpFullRequest input, RequestExecutionContext context) throws Exception {
-        return wrapped.execute(input, context).whenComplete((o, t) -> {
+        return wrapped.execute(input, context).handle((o, t) -> {
             if (t != null) {
-                Context.FailedExecution failedContext =
-                        new DefaultFailedExecutionContext(context.executionContext().interceptorContext(), t);
-                context.interceptorChain().onExecutionFailure(failedContext, context.executionAttributes());
+                Throwable toReport = t;
+
+                if (toReport instanceof CompletionException) {
+                    toReport = toReport.getCause();
+                }
+                reportFailureToInterceptors(context, toReport);
+
+                throw CompletableFutureUtils.errorAsCompletionException(ThrowableUtils.asSdkException(toReport));
+            } else {
+                return o;
             }
         });
+    }
+
+    /**
+     * Report the failure to the execution interceptors. Swallow any exceptions thrown from the interceptor since we don't
+     * want to replace the execution failure.
+     *
+     * @param context The execution context.
+     * @param failure     The execution failure.
+     */
+    private static void reportFailureToInterceptors(RequestExecutionContext context, Throwable failure) {
+        try {
+            Context.FailedExecution failedContext =
+                    new DefaultFailedExecutionContext(context.executionContext().interceptorContext(), failure);
+            context.interceptorChain().onExecutionFailure(failedContext, context.executionAttributes());
+        } catch (Throwable t) {
+            log.warn(() -> "Interceptor chain threw an error from onExecutionFailure().", t);
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -15,13 +15,10 @@
 
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
-import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.timeCompletableFuture;
-
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -36,20 +33,18 @@ import software.amazon.awssdk.core.internal.Response;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.InterruptMonitor;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
-import software.amazon.awssdk.core.internal.http.async.SimpleRequestProvider;
+import software.amazon.awssdk.core.internal.http.TransformingAsyncResponseHandler;
+import software.amazon.awssdk.core.internal.http.async.SimpleHttpContentPublisher;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
-import software.amazon.awssdk.core.internal.http.timers.TimeoutTracker;
+import software.amazon.awssdk.core.internal.http.timers.TimerUtils;
 import software.amazon.awssdk.core.internal.interceptor.SdkInternalExecutionAttribute;
-import software.amazon.awssdk.http.Abortable;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpResponse;
-import software.amazon.awssdk.http.SdkRequestContext;
-import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.OptionalUtils;
 
@@ -63,14 +58,14 @@ public final class MakeAsyncHttpRequestStage<OutputT>
     private static final Logger log = Logger.loggerFor(MakeAsyncHttpRequestStage.class);
 
     private final SdkAsyncHttpClient sdkAsyncHttpClient;
-    private final SdkHttpResponseHandler<OutputT> responseHandler;
-    private final SdkHttpResponseHandler<? extends SdkException> errorResponseHandler;
+    private final TransformingAsyncResponseHandler<OutputT> responseHandler;
+    private final TransformingAsyncResponseHandler<? extends SdkException> errorResponseHandler;
     private final Executor futureCompletionExecutor;
     private final ScheduledExecutorService timeoutExecutor;
     private final Duration apiCallAttemptTimeout;
 
-    public MakeAsyncHttpRequestStage(SdkHttpResponseHandler<OutputT> responseHandler,
-                                     SdkHttpResponseHandler<? extends SdkException> errorResponseHandler,
+    public MakeAsyncHttpRequestStage(TransformingAsyncResponseHandler<OutputT> responseHandler,
+                                     TransformingAsyncResponseHandler<? extends SdkException> errorResponseHandler,
                                      HttpClientDependencies dependencies) {
         this.responseHandler = responseHandler;
         this.errorResponseHandler = errorResponseHandler;
@@ -81,9 +76,7 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         this.timeoutExecutor = dependencies.clientConfiguration().option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
     }
 
-    /**
-     * Returns the response from executing one httpClientSettings request; or null for retry.
-     */
+    @Override
     public CompletableFuture<Response<OutputT>> execute(SdkHttpFullRequest request,
                                                         RequestExecutionContext context) throws Exception {
         InterruptMonitor.checkInterrupted();
@@ -93,34 +86,52 @@ public final class MakeAsyncHttpRequestStage<OutputT>
     private CompletableFuture<Response<OutputT>> executeHttpRequest(SdkHttpFullRequest request,
                                                                     RequestExecutionContext context) throws Exception {
 
-        long timeout = apiCallAttemptTimeoutInMillis(context.requestConfig());
-        Completable completable = new Completable(timeout);
+        CompletableFuture<? extends SdkException> errorResponseFuture =
+                errorResponseHandler == null ? null : errorResponseHandler.prepare();
 
-        SdkHttpResponseHandler<Response<OutputT>> handler = new ResponseHandler(completable);
+        //FIXME(dongie): We need to be careful to only call responseHandler.prepare() exactly once per execute() call
+        //because it calls prepare() under the hood and we guarantee that we call that once per execution. It would be good
+        //to find a way to prevent multiple calls to prepare() within a single execution to only call prepare() once.
+        final ResponseHandler handler = new ResponseHandler(responseHandler.prepare(), errorResponseFuture);
 
-        SdkHttpRequestProvider requestProvider = context.requestProvider() == null
-                ? new SimpleRequestProvider(request, context.executionAttributes())
+        SdkHttpContentPublisher requestProvider = context.requestProvider() == null
+                ? new SimpleHttpContentPublisher(request, context.executionAttributes())
                 : context.requestProvider();
         // Set content length if it hasn't been set already.
         SdkHttpFullRequest requestWithContentLength = getRequestWithContentLength(request, requestProvider);
 
-        AbortableRunnable abortableRunnable = sdkAsyncHttpClient.prepareRequest(
-            requestWithContentLength,
-            SdkRequestContext.builder()
-                             .fullDuplex(isFullDuplex(context.executionAttributes()))
-                             .build(),
-            requestProvider,
-            handler);
+        AsyncExecuteRequest executeRequest = AsyncExecuteRequest.builder()
+                .request(requestWithContentLength)
+                .requestContentPublisher(requestProvider)
+                .responseHandler(handler)
+                .fullDuplex(isFullDuplex(context.executionAttributes()))
+                .build();
 
-        // Set the abortable so that the abortable request can be aborted after timeout if timeout is enabled
-        completable.abortable(abortableRunnable);
+        CompletableFuture<Void> httpClientFuture = sdkAsyncHttpClient.execute(executeRequest);
 
-        if (context.apiCallTimeoutTracker() != null && context.apiCallTimeoutTracker().isEnabled()) {
-            context.apiCallTimeoutTracker().abortable(abortableRunnable);
-        }
+        CompletableFuture<Response<OutputT>> transformFuture = handler.prepare();
 
-        abortableRunnable.run();
-        return completable.completableFuture;
+        CompletableFuture<Response<OutputT>> responseFuture = new CompletableFuture<>();
+        setupAttemptTimer(responseFuture, context);
+
+        // Forward the cancellation
+        responseFuture.whenComplete((r, t) -> {
+            if (t != null) {
+                httpClientFuture.completeExceptionally(t);
+            }
+        });
+
+        // Offload the completion of the future returned from this stage onto
+        // the future completion executor
+        transformFuture.whenCompleteAsync((r, t) -> {
+            if (t == null) {
+                responseFuture.complete(r);
+            } else {
+                responseFuture.completeExceptionally(t);
+            }
+        }, futureCompletionExecutor);
+
+        return responseFuture;
     }
 
     private boolean isFullDuplex(ExecutionAttributes executionAttributes) {
@@ -128,7 +139,7 @@ public final class MakeAsyncHttpRequestStage<OutputT>
                executionAttributes.getAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX);
     }
 
-    private SdkHttpFullRequest getRequestWithContentLength(SdkHttpFullRequest request, SdkHttpRequestProvider requestProvider) {
+    private SdkHttpFullRequest getRequestWithContentLength(SdkHttpFullRequest request, SdkHttpContentPublisher requestProvider) {
         if (shouldSetContentLength(request, requestProvider)) {
             return request.toBuilder()
                           .putHeader("Content-Length", String.valueOf(requestProvider.contentLength().get()))
@@ -137,7 +148,7 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         return request;
     }
 
-    private boolean shouldSetContentLength(SdkHttpFullRequest request, SdkHttpRequestProvider requestProvider) {
+    private boolean shouldSetContentLength(SdkHttpFullRequest request, SdkHttpContentPublisher requestProvider) {
         return requestProvider != null
                && !request.firstMatchingHeader("Content-Length").isPresent()
                && requestProvider.contentLength().isPresent()
@@ -147,39 +158,62 @@ public final class MakeAsyncHttpRequestStage<OutputT>
 
     }
 
+    private void setupAttemptTimer(CompletableFuture<Response<OutputT>> executeFuture, RequestExecutionContext ctx) {
+        final long timeoutMillis = apiCallAttemptTimeoutInMillis(ctx.requestConfig());
+        TimerUtils.timeCompletableFuture(executeFuture,
+                                         timeoutExecutor,
+                                         ApiCallAttemptTimeoutException.create(timeoutMillis),
+                                         timeoutMillis);
+    }
+
     /**
      * Detects whether the response succeeded or failed and delegates to appropriate response handler.
      */
-    private class ResponseHandler implements SdkHttpResponseHandler<Response<OutputT>> {
-        private final Completable completable;
 
-        private volatile SdkHttpResponse response;
-        private volatile boolean isSuccess = false;
+    private class ResponseHandler implements TransformingAsyncResponseHandler<Response<OutputT>> {
+        private final CompletableFuture<SdkHttpResponse> headersFuture = new CompletableFuture<>();
+        private final CompletableFuture<OutputT> transformFuture;
+        private final CompletableFuture<? extends SdkException> errorTransformFuture;
+        private volatile SdkHttpFullResponse response;
 
-        /**
-         * @param completable   Future to notify when response has been handled.
-         */
-        private ResponseHandler(Completable completable) {
-            this.completable = completable;
+        ResponseHandler(CompletableFuture<OutputT> transformFuture,
+                        CompletableFuture<? extends SdkException> errorTransformFuture) {
+            this.transformFuture = transformFuture;
+            this.errorTransformFuture = errorTransformFuture;
         }
 
         @Override
-        public void headersReceived(SdkHttpResponse response) {
+        public void onHeaders(SdkHttpResponse response) {
+            headersFuture.complete(response);
             if (response.isSuccessful()) {
                 SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Received successful response: " + response.statusCode());
-                isSuccess = true;
-                responseHandler.headersReceived(response);
+                responseHandler.onHeaders(response);
             } else {
                 SdkStandardLogger.REQUEST_LOGGER.debug(() -> "Received error response: " + response.statusCode());
-                errorResponseHandler.headersReceived(response);
+                errorResponseHandler.onHeaders(response);
             }
-            this.response = response;
+            this.response = toFullResponse(response);
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            // If we already have the headers we've chosen one of the two
+            // handlers so notify the correct handler. Otherwise, just complete
+            // the future exceptionally
+            if (response != null) {
+                if (response.isSuccessful()) {
+                    responseHandler.onError(error);
+                } else {
+                    errorResponseHandler.onError(error);
+                }
+            } else {
+                headersFuture.completeExceptionally(error);
+            }
         }
 
         @Override
         public void onStream(Publisher<ByteBuffer> publisher) {
-            if (isSuccess) {
-                // TODO handle exception as non retryable
+            if (response.isSuccessful()) {
                 responseHandler.onStream(publisher);
             } else {
                 errorResponseHandler.onStream(publisher);
@@ -187,79 +221,14 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         }
 
         @Override
-        public void exceptionOccurred(Throwable throwable) {
-            // Note that we don't notify the response handler here, we do that in AsyncRetryableStage where we
-            // have more context of what's going on and can deliver exceptions more reliably.
-            completable.completeExceptionally(throwable);
-        }
-
-        @Override
-        public Response<OutputT> complete() {
-            try {
-                SdkHttpFullResponse httpFullResponse = (SdkHttpFullResponse) this.response;
-                Response<OutputT> toReturn = handleResponse(httpFullResponse);
-                completable.complete(toReturn);
-                return toReturn;
-            } catch (Exception e) {
-                completable.completeExceptionally(e);
-                throw e;
-            }
-        }
-
-        private Response<OutputT> handleResponse(SdkHttpFullResponse httpResponse) {
-            if (isSuccess) {
-                OutputT response = responseHandler.complete();
-                return Response.fromSuccess(response, httpResponse);
-            } else {
-                return Response.fromFailure(errorResponseHandler.complete(), httpResponse);
-            }
-        }
-
-    }
-
-    /**
-     * An interface similar to {@link CompletableFuture} that may or may not dispatch completion of the future to an executor
-     * service, depending on the client's configuration.
-     */
-    private class Completable {
-        private final CompletableFuture<Response<OutputT>> completableFuture = new CompletableFuture<>();
-        private TimeoutTracker timeoutTracker;
-
-        Completable(long timeoutInMills) {
-            timeoutTracker = timeCompletableFuture(completableFuture, timeoutExecutor,
-                                                   ApiCallAttemptTimeoutException.create(timeoutInMills),
-                                                   timeoutInMills);
-        }
-
-        void abortable(Abortable abortable) {
-            if (timeoutTracker != null) {
-                timeoutTracker.abortable(abortable);
-            }
-        }
-
-        void complete(Response<OutputT> result) {
-            try {
-                futureCompletionExecutor.execute(() -> completableFuture.complete(result));
-            } catch (RejectedExecutionException e) {
-                completableFuture.completeExceptionally(explainRejection(e));
-            }
-        }
-
-        void completeExceptionally(Throwable exception) {
-            try {
-                futureCompletionExecutor.execute(() -> completableFuture.completeExceptionally(exception));
-            } catch (RejectedExecutionException e) {
-                completableFuture.completeExceptionally(explainRejection(e));
-            }
-        }
-
-        private RejectedExecutionException explainRejection(RejectedExecutionException e) {
-            return new RejectedExecutionException("The SDK was unable to complete the async future to provide you with a " +
-                                                  "response. This may be caused by too-few threads in the response executor, " +
-                                                  "too-short of a queue or too long of an operation in your future completion " +
-                                                  "chain. You can provide a larger executor service to the SDK via the " +
-                                                  "client's async configuration setting or you can reduce the amount of work " +
-                                                  "performed on the async execution thread.", e);
+        public CompletableFuture<Response<OutputT>> prepare() {
+            return headersFuture.thenCompose(headers -> {
+                if (headers.isSuccessful()) {
+                    return transformFuture.thenApply(r -> Response.fromSuccess(r, response));
+                } else {
+                    return errorTransformFuture.thenApply(e -> Response.fromFailure(e, response));
+                }
+            });
         }
     }
 
@@ -268,5 +237,13 @@ public final class MakeAsyncHttpRequestStage<OutputT>
             requestConfig.apiCallAttemptTimeout(), () -> apiCallAttemptTimeout)
                             .map(Duration::toMillis)
                             .orElse(0L);
+    }
+
+    private static SdkHttpFullResponse toFullResponse(SdkHttpResponse response) {
+        SdkHttpFullResponse.Builder builder = SdkHttpFullResponse.builder()
+                .statusCode(response.statusCode())
+                .headers(response.headers());
+        response.statusText().ifPresent(builder::statusText);
+        return builder.build();
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/NoopSubscription.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/NoopSubscription.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 /** An implementation of {@link org.reactivestreams.Subscription} that does nothing.
  * <p>
  * Useful in situations where a {@link org.reactivestreams.Publisher} needs to
- * signal {@code onError} or {@code onComplete} immediately after
+ * signal {@code exceptionOccurred} or {@code onComplete} immediately after
  * {@code subscribe()} but but it needs to signal{@code onSubscription} first.
  */
 @SdkInternalApi

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/ThrowableUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/ThrowableUtils.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 
 /**
  * Utility for use with errors or exceptions.
@@ -85,5 +86,15 @@ public final class ThrowableUtils {
         return t instanceof InterruptedException
                ? AbortedException.builder().message(errmsg).cause(t).build()
                : SdkClientException.builder().message(errmsg).cause(t).build();
+    }
+
+    /**
+     * Wraps the given {@code Throwable} in {@link SdkException} if necessary.
+     */
+    public static SdkException asSdkException(Throwable t) {
+        if (t instanceof SdkException) {
+            return (SdkException) t;
+        }
+        return SdkClientException.builder().cause(t).build();
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.core.DefaultRequest;
 import software.amazon.awssdk.core.Request;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.EmptyPublisher;
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
@@ -54,12 +55,10 @@ import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
-import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.SdkRequestContext;
-import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import utils.HttpTestUtils;
 
 /**
@@ -118,51 +117,33 @@ public class AsyncClientHandlerInterceptorExceptionTest {
         when(responseHandler.handle(any(SdkHttpFullResponse.class), any(ExecutionAttributes.class)))
                 .thenReturn(EmptySdkResponse.builder().build());
 
-        Answer<AbortableRunnable> prepareRequestAnswer;
+        Answer<CompletableFuture<Void>> prepareRequestAnswer;
         if (hook != Hook.ON_EXECUTION_FAILURE) {
             prepareRequestAnswer = invocationOnMock -> {
-                SdkHttpResponseHandler handler = invocationOnMock.getArgumentAt(3, SdkHttpResponseHandler.class);
-                return new AbortableRunnable() {
-                    @Override
-                    public void run() {
-                        handler.headersReceived(SdkHttpFullResponse.builder()
-                                .statusCode(200)
-                                .build());
-                        handler.complete();
-                    }
-
-                    @Override
-                    public void abort() {
-                    }
-                };
+                SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+                handler.onHeaders(SdkHttpFullResponse.builder()
+                        .statusCode(200)
+                        .build());
+                handler.onStream(new EmptyPublisher<>());
+                return CompletableFuture.completedFuture(null);
             };
         } else {
             prepareRequestAnswer = invocationOnMock -> {
-                SdkHttpResponseHandler handler = invocationOnMock.getArgumentAt(3, SdkHttpResponseHandler.class);
-                return new AbortableRunnable() {
-                    @Override
-                    public void run() {
-                        handler.exceptionOccurred(new RuntimeException("Something went horribly wrong!"));
-                    }
-
-                    @Override
-                    public void abort() {
-                    }
-                };
+                SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+                RuntimeException error = new RuntimeException("Something went horribly wrong!");
+                handler.onError(error);
+                return CompletableFutureUtils.failedFuture(error);
             };
         }
 
-        when(asyncHttpClient.prepareRequest(any(SdkHttpRequest.class),
-                                            any(SdkRequestContext.class),
-                                            any(SdkHttpRequestProvider.class),
-                                            any(SdkHttpResponseHandler.class)))
-                                           .thenAnswer(prepareRequestAnswer);
+        when(asyncHttpClient.execute(any(AsyncExecuteRequest.class)))
+                .thenAnswer(prepareRequestAnswer);
     }
 
     @Test
     public void test() {
         if (hook != Hook.ON_EXECUTION_FAILURE) {
-            doVerify(() -> clientHandler.execute(executionParams), (t) -> t.getCause().getMessage().equals(hook.name()));
+            doVerify(() -> clientHandler.execute(executionParams), (t) -> t.getCause().getCause().getMessage().equals(hook.name()));
         } else {
             // ON_EXECUTION_FAILURE is handled differently because we don't
             // want an exception thrown from the interceptor to replace the
@@ -182,7 +163,7 @@ public class AsyncClientHandlerInterceptorExceptionTest {
     private void doVerify(Supplier<CompletableFuture<?>> s, Predicate<Throwable> assertFn) {
         CompletableFuture<?> cf = s.get();
         try {
-            cf.get();
+            cf.join();
             Assert.fail("get() method did not fail as expected.");
         } catch (Throwable t) {
             assertTrue(assertFn.test(t));

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTest.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.core.client.handler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +38,7 @@ import software.amazon.awssdk.core.DefaultRequest;
 import software.amazon.awssdk.core.Request;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.EmptyPublisher;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.EmptySdkResponse;
@@ -47,9 +47,9 @@ import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
-import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 import utils.HttpTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -67,8 +67,7 @@ public class AsyncClientHandlerTest {
     @Mock
     private SdkAsyncHttpClient httpClient;
 
-    @Mock
-    private AbortableRunnable httpClientCall;
+    private CompletableFuture<Void> httpClientFuture = CompletableFuture.completedFuture(null);
 
     @Mock
     private HttpResponseHandler<SdkResponse> responseHandler;
@@ -88,22 +87,22 @@ public class AsyncClientHandlerTest {
         SdkResponse expected = EmptySdkResponse.builder().build();
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("foo", Arrays.asList("bar"));
-        ArgumentCaptor<SdkHttpResponseHandler> sdkHttpResponseHandler = ArgumentCaptor.forClass(SdkHttpResponseHandler.class);
+        ArgumentCaptor<AsyncExecuteRequest> executeRequest = ArgumentCaptor.forClass(AsyncExecuteRequest.class);
 
         expectRetrievalFromMocks();
-        when(httpClient.prepareRequest(any(), any(), any(), sdkHttpResponseHandler.capture())).thenReturn(httpClientCall);
+        when(httpClient.execute(executeRequest.capture())).thenReturn(httpClientFuture);
         when(responseHandler.handle(any(), any())).thenReturn(expected); // Response handler call
 
         // When
         CompletableFuture<SdkResponse> responseFuture = asyncClientHandler.execute(clientExecutionParams());
-        sdkHttpResponseHandler.getValue().headersReceived(SdkHttpFullResponse.builder().statusCode(200)
+        SdkAsyncHttpResponseHandler capturedHandler = executeRequest.getValue().responseHandler();
+        capturedHandler.onHeaders(SdkHttpFullResponse.builder().statusCode(200)
                                                                              .headers(headers).build());
-        sdkHttpResponseHandler.getValue().complete();
+        capturedHandler.onStream(new EmptyPublisher<>());
         SdkResponse actualResponse = responseFuture.get(1, TimeUnit.SECONDS);
 
         // Then
         verifyNoMoreInteractions(errorResponseHandler); // No error handler calls
-        verify(httpClientCall).run(); // Response handler is invoked
         assertThat(actualResponse.sdkHttpResponse().statusCode()).isEqualTo(200);
         assertThat(actualResponse.sdkHttpResponse().headers()).isEqualTo(headers);
     }
@@ -113,16 +112,17 @@ public class AsyncClientHandlerTest {
         SdkServiceException exception = SdkServiceException.builder().message("Uh oh!").statusCode(500).build();
 
         // Given
-        ArgumentCaptor<SdkHttpResponseHandler> sdkHttpResponseHandler = ArgumentCaptor.forClass(SdkHttpResponseHandler.class);
+        ArgumentCaptor<AsyncExecuteRequest> executeRequest = ArgumentCaptor.forClass(AsyncExecuteRequest.class);
 
         expectRetrievalFromMocks();
-        when(httpClient.prepareRequest(any(), any(), any(), sdkHttpResponseHandler.capture())).thenReturn(httpClientCall);
+        when(httpClient.execute(executeRequest.capture())).thenReturn(httpClientFuture);
         when(errorResponseHandler.handle(any(), any())).thenReturn(exception); // Error response handler call
 
         // When
         CompletableFuture<SdkResponse> responseFuture = asyncClientHandler.execute(clientExecutionParams());
-        sdkHttpResponseHandler.getValue().headersReceived(SdkHttpFullResponse.builder().statusCode(500).build());
-        sdkHttpResponseHandler.getValue().complete();
+        SdkAsyncHttpResponseHandler capturedHandler = executeRequest.getValue().responseHandler();
+        capturedHandler.onHeaders(SdkHttpFullResponse.builder().statusCode(500).build());
+        capturedHandler.onStream(new EmptyPublisher<>());
         assertThatThrownBy(() -> responseFuture.get(1, TimeUnit.SECONDS)).hasCause(exception);
 
         // Then

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTransformerVerificationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTransformerVerificationTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client.handler;
+
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.core.DefaultRequest;
+import software.amazon.awssdk.core.Request;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.DrainingSubscriber;
+import software.amazon.awssdk.core.async.EmptyPublisher;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.http.EmptySdkResponse;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import utils.HttpTestUtils;
+
+/**
+ * Verification tests to ensure that the behavior of {@link SdkAsyncClientHandler} is in line with the
+ * {@link AsyncResponseTransformer} interface.
+ */
+public class AsyncClientHandlerTransformerVerificationTest {
+    private static final RetryPolicy RETRY_POLICY = RetryPolicy.defaultRetryPolicy();
+
+    private final SdkRequest request = mock(SdkRequest.class);
+
+    private final Marshaller<Request<SdkRequest>, SdkRequest> marshaller = mock(Marshaller.class);
+
+    private final HttpResponseHandler<SdkResponse> responseHandler = mock(HttpResponseHandler.class);
+
+    private final HttpResponseHandler<SdkServiceException> errorResponseHandler = mock(HttpResponseHandler.class);
+
+    private SdkAsyncHttpClient mockClient;
+
+    private SdkAsyncClientHandler clientHandler;
+
+    private ClientExecutionParams<SdkRequest, SdkResponse> executionParams;
+
+    @Before
+    public void testSetup() throws Exception {
+        mockClient = mock(SdkAsyncHttpClient.class);
+
+        executionParams = new ClientExecutionParams<SdkRequest, SdkResponse>()
+                .withInput(request)
+                .withMarshaller(marshaller)
+                .withResponseHandler(responseHandler)
+                .withErrorResponseHandler(errorResponseHandler);
+
+        SdkClientConfiguration config = HttpTestUtils.testClientConfiguration().toBuilder()
+                .option(SdkClientOption.ASYNC_HTTP_CLIENT, mockClient)
+                .option(SdkClientOption.RETRY_POLICY, RETRY_POLICY)
+                .option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, Runnable::run)
+                .build();
+
+        clientHandler = new SdkAsyncClientHandler(config);
+
+        when(request.overrideConfiguration()).thenReturn(Optional.empty());
+
+        when(marshaller.marshall(eq(request))).thenReturn(new DefaultRequest<>(null));
+
+        when(responseHandler.handle(any(SdkHttpFullResponse.class), any(ExecutionAttributes.class)))
+                .thenReturn(EmptySdkResponse.builder().build());
+    }
+
+    @Test
+    public void nonRetryableErrorDoesNotTriggerRetry() {
+        mockSuccessfulResponse();
+        AtomicLong prepareCalls = new AtomicLong(0);
+        executeAndWaitError(new TestTransformer<SdkResponse, Void>() {
+            @Override
+            public CompletableFuture<Void> prepare() {
+                prepareCalls.incrementAndGet();
+                return super.prepare();
+            }
+
+            @Override
+            public void onStream(SdkPublisher<ByteBuffer> stream) {
+                super.transformFuture().completeExceptionally(new RuntimeException("some error"));
+            }
+        });
+        assertThat(prepareCalls.get()).isEqualTo(1L);
+    }
+
+    @Test
+    public void prepareCallsEqualToExecuteAttempts() {
+        mockSuccessfulResponse();
+        AtomicLong prepareCalls = new AtomicLong(0);
+        executeAndWaitError(new TestTransformer<SdkResponse, Void>() {
+            @Override
+            public CompletableFuture<Void> prepare() {
+                prepareCalls.incrementAndGet();
+                return super.prepare();
+            }
+
+            @Override
+            public void onStream(SdkPublisher<ByteBuffer> stream) {
+                stream.subscribe(new DrainingSubscriber<ByteBuffer>() {
+                    @Override
+                    public void onComplete() {
+                        transformFuture().completeExceptionally(RetryableException.builder().message("retry me please: " + prepareCalls.get()).build());
+                    }
+                });
+            }
+        });
+        assertThat(prepareCalls.get()).isEqualTo(1 + RETRY_POLICY.numRetries());
+    }
+
+    @Test(timeout = 1000L)
+    public void handlerExecutionCompletesIndependentlyOfRequestExecution_CompleteAfterResponse() {
+        mockSuccessfulResponse_NonSignalingStream();
+
+        // Since we never signal any elements on the response stream, if the async client handler waited for the stream to
+        // finish before completing the future, this would never return.
+        assertThat(execute(new TestTransformer<SdkResponse, SdkResponse>() {
+            @Override
+            public void onResponse(SdkResponse response) {
+                transformFuture().complete(response);
+            }
+        })).isNotNull();
+    }
+
+    @Test(timeout = 1000L)
+    public void handlerExecutionCompletesIndependentlyOfRequestExecution_CompleteAfterStream() {
+        mockSuccessfulResponse_NonSignalingStream();
+        // Since we never signal any elements on the response stream, if the async client handler waited for the stream to
+        // finish before completing the future, this would never return.
+        assertThat(execute(new TestTransformer<SdkResponse, Publisher<ByteBuffer>>() {
+            @Override
+            public void onStream(SdkPublisher<ByteBuffer> stream) {
+                transformFuture().complete(stream);
+            }
+        })).isNotNull();
+    }
+
+    private void mockSuccessfulResponse() {
+        Answer<CompletableFuture<Void>> executeAnswer = invocationOnMock -> {
+            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+            handler.onHeaders(SdkHttpFullResponse.builder()
+                    .statusCode(200)
+                    .build());
+            handler.onStream(new EmptyPublisher<>());
+            return CompletableFuture.completedFuture(null);
+        };
+        reset(mockClient);
+        when(mockClient.execute(any(AsyncExecuteRequest.class))).thenAnswer(executeAnswer);
+    }
+
+    /**
+     * Mock a response with success status (200), but with a stream that never signals anything on the Subscriber. This
+     * roughly emulates a very slow response.
+     */
+    private void mockSuccessfulResponse_NonSignalingStream() {
+        Answer<CompletableFuture<Void>> executeAnswer = invocationOnMock -> {
+            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+            handler.onHeaders(SdkHttpFullResponse.builder()
+                    .statusCode(200)
+                    .build());
+            handler.onStream(subscriber -> {
+                // never signal onSubscribe
+            });
+            return CompletableFuture.completedFuture(null);
+        };
+        reset(mockClient);
+        when(mockClient.execute(any(AsyncExecuteRequest.class))).thenAnswer(executeAnswer);
+    }
+
+    private void executeAndWaitError(AsyncResponseTransformer<SdkResponse, ?> transformer) {
+        try {
+            execute(transformer);
+            fail("Client execution should have completed exceptionally");
+        } catch (CompletionException e) {
+            // ignored
+        }
+    }
+
+    private <ResultT> ResultT execute(AsyncResponseTransformer<SdkResponse, ResultT> transformer) {
+        return clientHandler.execute(executionParams, transformer).join();
+    }
+
+    private static class TestTransformer<ResponseT, ResultT> implements AsyncResponseTransformer<ResponseT, ResultT> {
+        private volatile CompletableFuture<ResultT> transformFuture;
+
+        @Override
+        public CompletableFuture<ResultT> prepare() {
+            this.transformFuture = new CompletableFuture<>();
+            return transformFuture;
+        }
+
+        @Override
+        public void onResponse(ResponseT response) {
+        }
+
+        @Override
+        public void onStream(SdkPublisher<ByteBuffer> publisher) {
+            publisher.subscribe(new DrainingSubscriber<ByteBuffer>() {
+                @Override
+                public void onComplete() {
+                    transformFuture.complete(null);
+                }
+            });
+        }
+
+        @Override
+        public void exceptionOccurred(Throwable error) {
+            transformFuture.completeExceptionally(error);
+        }
+
+        CompletableFuture<ResultT> transformFuture() {
+            return transformFuture;
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/BaosSubscriberTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/BaosSubscriberTckTest.java
@@ -15,8 +15,9 @@
 
 package software.amazon.awssdk.core.internal.async;
 
-import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.SubscriberWhiteboxVerification;
@@ -35,7 +36,7 @@ public class BaosSubscriberTckTest extends SubscriberWhiteboxVerification<ByteBu
 
     @Override
     public Subscriber<ByteBuffer> createSubscriber(WhiteboxSubscriberProbe<ByteBuffer> whiteboxSubscriberProbe) {
-        return new BaosSubscriber(new ByteArrayOutputStream()) {
+        return new BaosSubscriber(new CompletableFuture<>()) {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileSubscriberTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileSubscriberTckTest.java
@@ -25,6 +25,8 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.SubscriberWhiteboxVerification;
@@ -45,8 +47,7 @@ public class FileSubscriberTckTest extends SubscriberWhiteboxVerification<ByteBu
     @Override
     public Subscriber<ByteBuffer> createSubscriber(WhiteboxSubscriberProbe<ByteBuffer> whiteboxSubscriberProbe) {
         Path tempFile = getNewTempFile();
-
-        return new FileSubscriber(openChannel(tempFile), tempFile) {
+        return new FileSubscriber(openChannel(tempFile), tempFile, new CompletableFuture<>()) {
             @Override
             public void onSubscribe(Subscription s) {
                 super.onSubscribe(s);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/async/SimpleRequestProviderTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/async/SimpleRequestProviderTckTest.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 
 /**
- * TCK verification test for {@link SimpleRequestProvider}.
+ * TCK verification test for {@link SimpleHttpContentPublisher}.
  */
 public class SimpleRequestProviderTckTest extends PublisherVerification<ByteBuffer> {
     private static final byte[] CONTENT = new byte[4906];
@@ -20,7 +20,7 @@ public class SimpleRequestProviderTckTest extends PublisherVerification<ByteBuff
 
     @Override
     public Publisher<ByteBuffer> createPublisher(long l) {
-        return new SimpleRequestProvider(makeFullRequest(), new ExecutionAttributes());
+        return new SimpleHttpContentPublisher(makeFullRequest(), new ExecutionAttributes());
     }
 
     @Override

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallTimeoutTrackingStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallTimeoutTrackingStageTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.http.NoopTestRequest;
+import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
+import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils;
+import software.amazon.awssdk.core.internal.util.CapacityManager;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import utils.ValidSdkObjects;
+
+/**
+ * Unit tests for {@link AsyncApiCallTimeoutTrackingStage}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncApiCallTimeoutTrackingStageTest {
+
+    private final long TIMEOUT_MILLIS = 1234;
+
+    @Mock
+    private RequestPipeline<SdkHttpFullRequest, CompletableFuture> requestPipeline;
+
+    @Mock
+    private ScheduledExecutorService executorService;
+
+    private SdkClientConfiguration configuration;
+
+    private HttpClientDependencies dependencies;
+
+    @Mock
+    private CapacityManager capacityManager;
+
+    private SdkHttpFullRequest httpRequest;
+
+    private RequestExecutionContext requestExecutionContext;
+
+    private SdkRequest sdkRequest = NoopTestRequest.builder().build();
+
+    @Before
+    public void methodSetup() throws Exception {
+        configuration = SdkClientConfiguration.builder()
+                .option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE, executorService)
+                .option(SdkClientOption.API_CALL_TIMEOUT, Duration.ofMillis(TIMEOUT_MILLIS))
+                .build();
+
+        dependencies = HttpClientDependencies.builder()
+                .clientConfiguration(configuration)
+                .capacityManager(capacityManager)
+                .build();
+
+        httpRequest = SdkHttpFullRequest.builder()
+                .protocol("https")
+                .host("localhost")
+                .method(SdkHttpMethod.GET)
+                .build();
+
+        requestExecutionContext = RequestExecutionContext.builder()
+                .originalRequest(sdkRequest)
+                .executionContext(ClientExecutionAndRequestTimerTestUtils
+                        .executionContext(ValidSdkObjects.sdkHttpFullRequest().build()))
+                .build();
+
+        when(requestPipeline.execute(any(SdkHttpFullRequest.class), any(RequestExecutionContext.class)))
+                .thenReturn(new CompletableFuture());
+
+        when(executorService.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenReturn(mock(ScheduledFuture.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSchedulesTheTimeoutUsingSuppliedExecutorService() throws Exception {
+        AsyncApiCallTimeoutTrackingStage apiCallTimeoutTrackingStage = new AsyncApiCallTimeoutTrackingStage(dependencies,
+                requestPipeline);
+        apiCallTimeoutTrackingStage.execute(httpRequest, requestExecutionContext);
+        verify(executorService)
+                .schedule(any(Runnable.class), eq(TIMEOUT_MILLIS), eq(TimeUnit.MILLISECONDS));
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/AsyncHttpClientApiCallTimeoutTests.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/AsyncHttpClientApiCallTimeoutTests.java
@@ -33,10 +33,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.ExecutionContext;
 import software.amazon.awssdk.core.http.NoopTestRequest;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -49,7 +51,6 @@ import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.signer.NoOpSigner;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import utils.ValidSdkObjects;
-
 
 public class AsyncHttpClientApiCallTimeoutTests {
 
@@ -108,7 +109,7 @@ public class AsyncHttpClientApiCallTimeoutTests {
         CompletableFuture future = httpClient.requestExecutionBuilder()
                                              .originalRequest(NoopTestRequest.builder().build())
                                              .request(request)
-                                             .errorResponseHandler(noOpResponseHandler())
+                                             .errorResponseHandler(noOpResponseHandler(SdkServiceException.builder().build()))
                                              .executionContext(executionContext)
                                              .execute(noOpResponseHandler());
 
@@ -122,17 +123,6 @@ public class AsyncHttpClientApiCallTimeoutTests {
         ExecutionInterceptor interceptor =
             new SlowExecutionInterceptor().beforeTransmissionWaitInSeconds(SLOW_REQUEST_HANDLER_TIMEOUT);
 
-        CompletableFuture future = requestBuilder().executionContext(withInterceptors(interceptor))
-                                                   .execute(noOpResponseHandler());
-        assertThatThrownBy(future::join).hasCauseInstanceOf(ApiCallTimeoutException.class);
-    }
-
-    @Test
-    public void successfulResponse_SlowAfterResponseRequestHandler_ThrowsApiCallTimeoutException() {
-        stubFor(get(anyUrl())
-                    .willReturn(aResponse().withStatus(200).withBody("{}")));
-        ExecutionInterceptor interceptor =
-            new SlowExecutionInterceptor().afterTransmissionWaitInSeconds(SLOW_REQUEST_HANDLER_TIMEOUT);
         CompletableFuture future = requestBuilder().executionContext(withInterceptors(interceptor))
                                                    .execute(noOpResponseHandler());
         assertThatThrownBy(future::join).hasCauseInstanceOf(ApiCallTimeoutException.class);

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/AsyncExecuteRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/AsyncExecuteRequest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.async;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+/**
+ * Request object containing the parameters necessary to make an asynchronous HTTP request.
+ *
+ * @see SdkAsyncHttpClient
+ */
+@SdkProtectedApi
+public final class AsyncExecuteRequest {
+    private final SdkHttpRequest request;
+    private final SdkHttpContentPublisher requestContentPublisher;
+    private final SdkAsyncHttpResponseHandler responseHandler;
+    private final boolean isFullDuplex;
+
+    private AsyncExecuteRequest(BuilderImpl builder) {
+        this.request = builder.request;
+        this.requestContentPublisher = builder.requestContentPublisher;
+        this.responseHandler = builder.responseHandler;
+        this.isFullDuplex = builder.isFullDuplex;
+    }
+
+    /**
+     * @return The HTTP request.
+     */
+    public SdkHttpRequest request() {
+        return request;
+    }
+
+    /**
+     * @return The publisher of request body.
+     */
+    public SdkHttpContentPublisher requestContentPublisher() {
+        return requestContentPublisher;
+    }
+
+    /**
+     * @return The response handler.
+     */
+    public SdkAsyncHttpResponseHandler responseHandler() {
+        return responseHandler;
+    }
+
+    /**
+     * @return True if the operation this request belongs to is full duplex. Otherwise false.
+     */
+    public boolean fullDuplex() {
+        return isFullDuplex;
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder {
+        /**
+         * Set the HTTP request to be executed by the client.
+         *
+         * @param request The request.
+         * @return This builder for method chaining.
+         */
+        Builder request(SdkHttpRequest request);
+
+        /**
+         * Set the publisher of the request content.
+         *
+         * @param requestContentPublisher The publisher.
+         * @return This builder for method chaining.
+         */
+        Builder requestContentPublisher(SdkHttpContentPublisher requestContentPublisher);
+
+        /**
+         * Set the response handler for the resposne.
+         *
+         * @param responseHandler The response handler.
+         * @return This builder for method chaining.
+         */
+        Builder responseHandler(SdkAsyncHttpResponseHandler responseHandler);
+
+        /**
+         * Option to indicate if the request is for a full duplex operation ie., request and response are sent/received at
+         * the same time.
+         * <p>
+         * This can be used to set http configuration like ReadTimeouts as soon as request has begin sending data instead of
+         * waiting for the entire request to be sent.
+         *
+         * @return True if the operation this request belongs to is full duplex. Otherwise false.
+         */
+        Builder fullDuplex(boolean fullDuplex);
+
+        AsyncExecuteRequest build();
+    }
+
+    private static class BuilderImpl implements Builder {
+        private SdkHttpRequest request;
+        private SdkHttpContentPublisher requestContentPublisher;
+        private SdkAsyncHttpResponseHandler responseHandler;
+        private boolean isFullDuplex;
+
+        @Override
+        public Builder request(SdkHttpRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        @Override
+        public Builder requestContentPublisher(SdkHttpContentPublisher requestContentPublisher) {
+            this.requestContentPublisher = requestContentPublisher;
+            return this;
+        }
+
+        @Override
+        public Builder responseHandler(SdkAsyncHttpResponseHandler responseHandler) {
+            this.responseHandler = responseHandler;
+            return this;
+        }
+
+        @Override
+        public Builder fullDuplex(boolean fullDuplex) {
+            isFullDuplex = fullDuplex;
+            return this;
+        }
+
+        @Override
+        public AsyncExecuteRequest build() {
+            return new AsyncExecuteRequest(this);
+        }
+    }
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
@@ -15,55 +15,44 @@
 
 package software.amazon.awssdk.http.async;
 
+import java.util.concurrent.CompletableFuture;
+
 import software.amazon.awssdk.annotations.Immutable;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.http.ConfigurationProvider;
-import software.amazon.awssdk.http.SdkHttpConfigurationOption;
-import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.SdkRequestContext;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
 
 /**
- * Interface to take a representation of an HTTP request, asynchronously make an HTTP call, and return a representation of an
- * HTTP response.
- *
- * <p>Implementations MUST be thread safe.</p>
- *
- * <p><b><i>Note: This interface will change between SDK versions and should not be implemented by SDK users.</i></b></p>
- */
+* Interface to take a representation of an HTTP request, asynchronously make an HTTP call, and return a representation of an
+* HTTP response.
+*
+* <p>Implementations MUST be thread safe.</p>
+*
+* <p><b><i>Note: This interface will change between SDK versions and should not be implemented by SDK users.</i></b></p>
+*/
 @Immutable
 @ThreadSafe
 @SdkProtectedApi
 public interface SdkAsyncHttpClient extends SdkAutoCloseable, ConfigurationProvider {
-    /**
-     * Create an {@link AbortableRunnable} that can be used to execute the HTTP request.
-     *
-     * @param request         HTTP request (without content).
-     * @param context         Request context containing additional dependencies.
-     * @param requestProvider Representation of an HTTP requestProvider.
-     * @param handler         The handler that will be called when data is received.
-     * @return Task that can execute an HTTP requestProvider and can be aborted.
-     */
-    @ReviewBeforeRelease("Should we wrap this in a container for more flexibility?")
-    AbortableRunnable prepareRequest(SdkHttpRequest request,
-                                     SdkRequestContext context,
-                                     SdkHttpRequestProvider requestProvider,
-                                     SdkHttpResponseHandler handler);
 
     /**
-     * Interface for creating an {@link SdkAsyncHttpClient} with service specific defaults applied.
+     * Execute the request.
      *
-     * <p>Implementations must be thread safe.</p>
+     * @param request The request object.
+     *
+     * @return The future holding the result of the request execution. Upon success execution of the request, the future is
+     * completed with {@code null}, otherwise it is completed exceptionally.
      */
+    CompletableFuture<Void> execute(AsyncExecuteRequest request);
+
     @FunctionalInterface
     interface Builder<T extends SdkAsyncHttpClient.Builder<T>> extends SdkBuilder<T, SdkAsyncHttpClient> {
         /**
-         * Create a {@link SdkAsyncHttpClient} without defaults applied. This is useful for reusing an HTTP client across multiple
-         * services.
+         * Create a {@link SdkAsyncHttpClient} without defaults applied. This is useful for reusing an HTTP client across
+         * multiple services.
          */
         default SdkAsyncHttpClient build() {
             return buildWithDefaults(AttributeMap.empty());
@@ -73,8 +62,8 @@ public interface SdkAsyncHttpClient extends SdkAutoCloseable, ConfigurationProvi
          * Create an {@link SdkAsyncHttpClient} with service specific defaults applied. Applying service defaults is optional
          * and some options may not be supported by a particular implementation.
          *
-         * @param serviceDefaults Service specific defaults. Keys will be one of the constants defined in
-         *                        {@link SdkHttpConfigurationOption}.
+         * @param serviceDefaults Service specific defaults. Keys will be one of the constants defined in {@link
+         *                        SdkHttpConfigurationOption}.
          * @return Created client
          */
         SdkAsyncHttpClient buildWithDefaults(AttributeMap serviceDefaults);

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpResponseHandler.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpResponseHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.async;
+
+import java.nio.ByteBuffer;
+
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+/**
+ * Handles asynchronous HTTP responses.
+ */
+@SdkProtectedApi
+public interface SdkAsyncHttpResponseHandler {
+    /**
+     * Called when the headers have been received.
+     *
+     * @param headers The headers.
+     */
+    void onHeaders(SdkHttpResponse headers);
+
+    /**
+     * Called when the streaming body is ready.
+     * <p>
+     * This method is always called. If the response does not have a body, then the publisher will complete the subscription
+     * without signalling any elements.
+     *
+     * @param stream The streaming body.
+     */
+    void onStream(Publisher<ByteBuffer> stream);
+
+    /**
+     * Called when there is an error making the request or receiving the response. If the error is encountered while
+     * streaming the body, then the error is also delivered to the {@link org.reactivestreams.Subscriber}.
+     *
+     * @param error The error.
+     */
+    void onError(Throwable error);
+
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkHttpContentPublisher.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkHttpContentPublisher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.async;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * A {@link Publisher} of HTTP content data that allows streaming operations for asynchronous HTTP clients.
+ */
+@SdkProtectedApi
+public interface SdkHttpContentPublisher extends Publisher<ByteBuffer> {
+
+    /**
+     * @return The content length of the data being produced.
+     */
+    Optional<Long> contentLength();
+
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -36,6 +36,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
@@ -43,19 +44,15 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.SdkRequestContext;
-import software.amazon.awssdk.http.async.AbortableRunnable;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
 import software.amazon.awssdk.http.nio.netty.internal.ChannelPipelineInitializer;
 import software.amazon.awssdk.http.nio.netty.internal.HandlerRemovingChannelPool;
 import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
+import software.amazon.awssdk.http.nio.netty.internal.NettyRequestExecutor;
 import software.amazon.awssdk.http.nio.netty.internal.NonManagedEventLoopGroup;
 import software.amazon.awssdk.http.nio.netty.internal.ReleaseOnceChannelPool;
-import software.amazon.awssdk.http.nio.netty.internal.RequestAdapter;
 import software.amazon.awssdk.http.nio.netty.internal.RequestContext;
-import software.amazon.awssdk.http.nio.netty.internal.RunnableRequest;
 import software.amazon.awssdk.http.nio.netty.internal.SdkChannelOptions;
 import software.amazon.awssdk.http.nio.netty.internal.SdkChannelPoolMap;
 import software.amazon.awssdk.http.nio.netty.internal.SharedSdkEventLoopGroup;
@@ -71,7 +68,6 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkPublicApi
 public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
-    private final RequestAdapter requestAdapter = new RequestAdapter();
     private final SdkEventLoopGroup sdkEventLoopGroup;
     private final ChannelPoolMap<URI, ChannelPool> pools;
     private final SdkChannelOptions sdkChannelOptions;
@@ -92,29 +88,27 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         return builder.sdkChannelOptions;
     }
 
-    private SdkEventLoopGroup eventLoopGroup(DefaultBuilder builder) {
-        Validate.isTrue(builder.eventLoopGroup == null || builder.eventLoopGroupBuilder == null,
-                        "The eventLoopGroup and the eventLoopGroupFactory can't both be configured.");
-        return Either.fromNullable(builder.eventLoopGroup, builder.eventLoopGroupBuilder)
-                     .map(e -> e.map(this::nonManagedEventLoopGroup, SdkEventLoopGroup.Builder::build))
-                     .orElseGet(SharedSdkEventLoopGroup::get);
+    @Override
+    public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+        RequestContext ctx = createRequestContext(request);
+        return new NettyRequestExecutor(ctx).execute();
     }
 
     public static Builder builder() {
         return new DefaultBuilder();
     }
 
-    @Override
-    public AbortableRunnable prepareRequest(SdkHttpRequest sdkRequest,
-                                            SdkRequestContext sdkRequestContext,
-                                            SdkHttpRequestProvider requestProvider,
-                                            SdkHttpResponseHandler handler) {
-        RequestContext context = new RequestContext(pools.get(poolKey(sdkRequest)),
-                                                    sdkRequest, requestProvider,
-                                                    requestAdapter.adapt(sdkRequest),
-                                                    handler, configuration,
-                                                    sdkRequestContext);
-        return new RunnableRequest(context);
+    private RequestContext createRequestContext(AsyncExecuteRequest request) {
+        ChannelPool pool = pools.get(poolKey(request.request()));
+        return new RequestContext(pool, request, configuration);
+    }
+
+    private SdkEventLoopGroup eventLoopGroup(DefaultBuilder builder) {
+        Validate.isTrue(builder.eventLoopGroup == null || builder.eventLoopGroupBuilder == null,
+                "The eventLoopGroup and the eventLoopGroupFactory can't both be configured.");
+        return Either.fromNullable(builder.eventLoopGroup, builder.eventLoopGroupBuilder)
+                .map(e -> e.map(this::nonManagedEventLoopGroup, SdkEventLoopGroup.Builder::build))
+                .orElseGet(SharedSdkEventLoopGroup::get);
     }
 
     private static URI poolKey(SdkHttpRequest sdkRequest) {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -55,6 +55,12 @@ public final class ChannelAttributeKey {
 
     static final AttributeKey<Boolean> RESPONSE_COMPLETE_KEY = AttributeKey.newInstance("responseComplete");
 
+    static final AttributeKey<CompletableFuture<Void>> EXECUTE_FUTURE_KEY = AttributeKey.newInstance(
+            "aws.http.nio.netty.async.executeFuture");
+
+    static final AttributeKey<Long> EXECUTION_ID_KEY = AttributeKey.newInstance(
+            "aws.http.nio.netty.async.executionId");
+
     private ChannelAttributeKey() {
     }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
@@ -73,6 +73,8 @@ public class ChannelPipelineInitializer extends AbstractChannelPoolHandler {
         } else {
             configureHttp11(ch, pipeline);
         }
+
+        pipeline.addLast(new FutureCancelHandler());
     }
 
     private void configureHttp2(Channel ch, ChannelPipeline pipeline) {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTION_ID_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.util.ReferenceCountUtil;
+import java.io.IOException;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Closes the channel if the execution future has been cancelled.
+ */
+@SdkInternalApi
+public class FutureCancelHandler extends SimpleChannelInboundHandler {
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Object o) throws Exception {
+        ReferenceCountUtil.retain(o);
+        ctx.fireChannelRead(o);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable e) {
+        if (cancelled(ctx, e)) {
+            RequestContext requestContext = ctx.channel().attr(REQUEST_CONTEXT_KEY).get();
+            requestContext.handler().onError(e);
+            ctx.fireExceptionCaught(new IOException("Request cancelled"));
+            ctx.close();
+            requestContext.channelPool().release(ctx.channel());
+        } else {
+            ctx.fireExceptionCaught(e);
+        }
+    }
+
+    private boolean cancelled(ChannelHandlerContext ctx, Throwable t) {
+        if (!(t instanceof FutureCancelledException)) {
+            return false;
+        }
+
+        FutureCancelledException e = (FutureCancelledException) t;
+
+        return e.getExecutionId() == ctx.channel().attr(EXECUTION_ID_KEY).get();
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelledException.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelledException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+final class FutureCancelledException extends RuntimeException {
+    private final long executionId;
+
+    FutureCancelledException(long executionId, Throwable cause) {
+        super(cause);
+        this.executionId = executionId;
+    }
+
+    long getExecutionId() {
+        return executionId;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestContext.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestContext.java
@@ -16,65 +16,42 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import io.netty.channel.pool.ChannelPool;
-import io.netty.handler.codec.http.HttpRequest;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.http.SdkHttpRequest;
-import software.amazon.awssdk.http.SdkRequestContext;
-import software.amazon.awssdk.http.async.SdkHttpRequestProvider;
-import software.amazon.awssdk.http.async.SdkHttpResponseHandler;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 
 @SdkInternalApi
 public final class RequestContext {
 
     private final ChannelPool channelPool;
-    private final SdkHttpRequest sdkRequest;
-    private final SdkHttpRequestProvider requestProvider;
-    private final HttpRequest nettyRequest;
-    private final SdkHttpResponseHandler handler;
+    private final AsyncExecuteRequest executeRequest;
     private final NettyConfiguration configuration;
-    private final SdkRequestContext sdkRequestContext;
 
-    public RequestContext(ChannelPool channelPool,
-                          SdkHttpRequest sdkRequest,
-                          SdkHttpRequestProvider requestProvider,
-                          HttpRequest nettyRequest,
-                          SdkHttpResponseHandler handler,
-                          NettyConfiguration configuration,
-                          SdkRequestContext sdkRequestContext) {
+    public RequestContext(ChannelPool channelPool, AsyncExecuteRequest executeRequest, NettyConfiguration configuration) {
         this.channelPool = channelPool;
-        this.sdkRequest = sdkRequest;
-        this.requestProvider = requestProvider;
-        this.nettyRequest = nettyRequest;
-        this.handler = handler;
+        this.executeRequest = executeRequest;
         this.configuration = configuration;
-        this.sdkRequestContext = sdkRequestContext;
-    }
-
-    public SdkHttpResponseHandler handler() {
-        return handler;
     }
 
     public ChannelPool channelPool() {
         return channelPool;
     }
 
-    public SdkHttpRequest sdkRequest() {
-        return this.sdkRequest;
+    public AsyncExecuteRequest executeRequest() {
+        return executeRequest;
     }
 
-    public SdkHttpRequestProvider sdkRequestProvider() {
-        return requestProvider;
+    /**
+     * Convenience method to retrieve the {@link SdkAsyncHttpResponseHandler} contained in the {@link AsyncExecuteRequest}
+     * returned by {@link #executeRequest}.
+     *
+     * @return The response handler for this request.
+     */
+    public SdkAsyncHttpResponseHandler handler() {
+        return executeRequest().responseHandler();
     }
 
-    public HttpRequest nettyRequest() {
-        return nettyRequest;
-    }
-
-    NettyConfiguration configuration() {
+    public NettyConfiguration configuration() {
         return configuration;
-    }
-
-    public SdkRequestContext sdkRequestContext() {
-        return sdkRequestContext;
     }
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.http.nio.netty.internal;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTE_FUTURE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
 
@@ -34,10 +35,12 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.reactivestreams.Publisher;
@@ -78,11 +81,13 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                                                              .statusText(response.status().reasonPhrase())
                                                              .build();
             channelContext.channel().attr(KEEP_ALIVE).set(HttpUtil.isKeepAlive(response));
-            requestContext.handler().headersReceived(sdkResponse);
+            requestContext.handler().onHeaders(sdkResponse);
         }
 
+        final CompletableFuture<Void> ef = executeFuture(channelContext);
         if (msg instanceof StreamedHttpResponse) {
-            requestContext.handler().onStream(new PublisherAdapter((StreamedHttpResponse) msg, channelContext, requestContext));
+            requestContext.handler().onStream(
+                    new PublisherAdapter((StreamedHttpResponse) msg, channelContext, requestContext, ef));
         } else if (msg instanceof FullHttpResponse) {
             // Be prepared to take care of (ignore) a trailing LastHttpResponse
             // from the HttpClientCodec if there is one.
@@ -92,23 +97,14 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
             ByteBuf fullContent = ((FullHttpResponse) msg).content();
             final ByteBuffer bb = copyToByteBuffer(fullContent);
             fullContent.release();
-            requestContext.handler().onStream(new FullResponseContentPublisher(channelContext, bb));
-            Subscriber<? super ByteBuffer> subscriber = channelContext.channel().attr(ChannelAttributeKey.SUBSCRIBER_KEY).get();
-            try {
-                subscriber.onComplete();
-                requestContext.handler().complete();
-            } catch (RuntimeException e) {
-                subscriber.onError(e);
-                requestContext.handler().exceptionOccurred(e);
-                throw e;
-            } finally {
-                finalizeRequest(requestContext, channelContext);
-            }
+            requestContext.handler().onStream(new FullResponseContentPublisher(channelContext, bb, ef));
+            finalizeRequest(requestContext, channelContext);
         }
     }
 
     private static void finalizeRequest(RequestContext requestContext, ChannelHandlerContext channelContext) {
         channelContext.channel().attr(RESPONSE_COMPLETE_KEY).set(true);
+        executeFuture(channelContext).complete(null);
         if (!channelContext.channel().attr(KEEP_ALIVE).get()) {
             closeAndRelease(channelContext);
         } else {
@@ -119,9 +115,9 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         RequestContext requestContext = ctx.channel().attr(REQUEST_CONTEXT_KEY).get();
-        log.error("Exception processing request: {}", requestContext.sdkRequest(), cause);
-        runAndLogError("SdkHttpResponseHandler threw an exception",
-            () -> requestContext.handler().exceptionOccurred(cause));
+        log.error("Exception processing request: {}", requestContext.executeRequest().request(), cause);
+        requestContext.handler().onError(cause);
+        executeFuture(ctx).completeExceptionally(cause);
         runAndLogError("Could not release channel back to the pool", () -> closeAndRelease(ctx));
     }
 
@@ -130,8 +126,9 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         RequestContext requestCtx = handlerCtx.channel().attr(REQUEST_CONTEXT_KEY).get();
         boolean responseCompleted = handlerCtx.channel().attr(RESPONSE_COMPLETE_KEY).get();
         if (!responseCompleted) {
-            runAndLogError("SdkHttpResponseHandler threw an exception when calling exceptionOccurred",
-                () -> requestCtx.handler().exceptionOccurred(new IOException("Server failed to send complete response")));
+            IOException err = new IOException("Server failed to send complete response");
+            requestCtx.handler().onError(err);
+            executeFuture(handlerCtx).completeExceptionally(err);
             runAndLogError("Could not release channel",
                 () -> requestCtx.channelPool().release(handlerCtx.channel()));
         }
@@ -175,17 +172,23 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         return bb;
     }
 
+    private static CompletableFuture<Void> executeFuture(ChannelHandlerContext ctx) {
+        return ctx.channel().attr(EXECUTE_FUTURE_KEY).get();
+    }
+
     private static class PublisherAdapter implements Publisher<ByteBuffer> {
         private final StreamedHttpResponse response;
         private final ChannelHandlerContext channelContext;
         private final RequestContext requestContext;
+        private final CompletableFuture<Void> executeFuture;
         private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 
         private PublisherAdapter(StreamedHttpResponse response, ChannelHandlerContext channelContext,
-                                 RequestContext requestContext) {
+                                 RequestContext requestContext, CompletableFuture<Void> executeFuture) {
             this.response = response;
             this.channelContext = channelContext;
             this.requestContext = requestContext;
+            this.executeFuture = executeFuture;
         }
 
         @Override
@@ -209,8 +212,10 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                 private void onCancel() {
                     try {
                         isCancelled.set(true);
-                        requestContext.handler().exceptionOccurred(
-                            new SdkCancellationException("Subscriber cancelled before all events were published"));
+                        SdkCancellationException e = new SdkCancellationException(
+                                "Subscriber cancelled before all events were published");
+                        requestContext.handler().onError(e);
+                        executeFuture.completeExceptionally(e);
                     } finally {
                         runAndLogError("Could not release channel back to the pool",
                             () -> closeAndRelease(channelContext));
@@ -234,7 +239,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                     try {
                         runAndLogError(String.format("Subscriber %s threw an exception in onError.", subscriber.toString()),
                             () -> subscriber.onError(t));
-                        requestContext.handler().exceptionOccurred(t);
+                        executeFuture.completeExceptionally(t);
                     } finally {
                         runAndLogError("Could not release channel back to the pool",
                             () -> closeAndRelease(channelContext));
@@ -251,7 +256,6 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                     try {
                         runAndLogError(String.format("Subscriber %s threw an exception in onComplete.", subscriber.toString()),
                                        subscriber::onComplete);
-                        requestContext.handler().complete();
                     } finally {
                         finalizeRequest(requestContext, channelContext);
                     }
@@ -282,12 +286,15 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
     static class FullResponseContentPublisher implements Publisher<ByteBuffer> {
         private final ChannelHandlerContext channelContext;
         private final ByteBuffer fullContent;
+        private final CompletableFuture<Void> executeFuture;
         private boolean running = true;
         private Subscriber<? super ByteBuffer> subscriber;
 
-        FullResponseContentPublisher(ChannelHandlerContext channelContext, ByteBuffer fullContent) {
+        FullResponseContentPublisher(ChannelHandlerContext channelContext, ByteBuffer fullContent,
+                                     CompletableFuture<Void> executeFuture) {
             this.channelContext = channelContext;
             this.fullContent = fullContent;
+            this.executeFuture = executeFuture;
         }
 
         @Override
@@ -310,6 +317,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                         running = false;
                         subscriber.onNext(fullContent);
                         subscriber.onComplete();
+                        executeFuture.complete(null);
                     }
                 }
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientSpiVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientSpiVerificationTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Verify the behavior of {@link NettyNioAsyncHttpClient} is consistent with the SPI.
+ */
+public class NettyNioAsyncHttpClientSpiVerificationTest {
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort());
+
+    private static SdkAsyncHttpClient client = NettyNioAsyncHttpClient.builder().buildWithDefaults(mapWithTrustAllCerts());
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        client.close();
+    }
+
+    @Test
+    public void signalsErrorViaOnErrorAndFuture() throws InterruptedException, ExecutionException, TimeoutException {
+        stubFor(any(urlEqualTo("/")).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        CompletableFuture<Boolean> errorSignaled = new CompletableFuture<>();
+
+        SdkAsyncHttpResponseHandler handler = new TestResponseHandler() {
+            @Override
+            public void onError(Throwable error) {
+                errorSignaled.complete(true);
+            }
+        };
+
+        SdkHttpRequest request = createRequest(URI.create("http://localhost:" + mockServer.port()));
+
+        CompletableFuture<Void> executeFuture = client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .responseHandler(handler)
+                .requestContentPublisher(new EmptyPublisher())
+                .build());
+
+        assertThat(errorSignaled.get(1, TimeUnit.SECONDS)).isTrue();
+        assertThatThrownBy(executeFuture::join).hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void callsOnStreamForEmptyResponseContent() throws InterruptedException, ExecutionException, TimeoutException {
+        stubFor(any(urlEqualTo("/")).willReturn(aResponse().withStatus(204).withHeader("foo", "bar")));
+
+        CompletableFuture<Boolean> streamReceived = new CompletableFuture<>();
+
+        SdkAsyncHttpResponseHandler handler = new TestResponseHandler() {
+            @Override
+            public void onStream(Publisher<ByteBuffer> stream) {
+                super.onStream(stream);
+                streamReceived.complete(true);
+            }
+        };
+
+        SdkHttpRequest request = createRequest(URI.create("http://localhost:" + mockServer.port()));
+
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .responseHandler(handler)
+                .requestContentPublisher(new EmptyPublisher())
+                .build());
+
+        assertThat(streamReceived.get(1, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private static AttributeMap mapWithTrustAllCerts() {
+        return AttributeMap.builder()
+                .put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true)
+                .build();
+    }
+
+    private SdkHttpFullRequest createRequest(URI endpoint) {
+        return createRequest(endpoint, "/", null, SdkHttpMethod.GET, emptyMap());
+    }
+
+    private SdkHttpFullRequest createRequest(URI endpoint,
+                                             String resourcePath,
+                                             String body,
+                                             SdkHttpMethod method,
+                                             Map<String, String> params) {
+
+        String contentLength = body == null ? null : String.valueOf(body.getBytes(UTF_8).length);
+        return SdkHttpFullRequest.builder()
+                .host(endpoint.getHost())
+                .protocol(endpoint.getScheme())
+                .port(endpoint.getPort())
+                .method(method)
+                .encodedPath(resourcePath)
+                .applyMutation(b -> params.forEach(b::putRawQueryParameter))
+                .applyMutation(b -> {
+                    b.putHeader("Host", endpoint.getHost());
+                    if (contentLength != null) {
+                        b.putHeader("Content-Length", contentLength);
+                    }
+                }).build();
+    }
+
+    private static class EmptyPublisher implements SdkHttpContentPublisher {
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+            subscriber.onSubscribe(new EmptySubscription(subscriber));
+        }
+
+        @Override
+        public Optional<Long> contentLength() {
+            return Optional.of(0L);
+        }
+    }
+
+    private static class TestResponseHandler implements SdkAsyncHttpResponseHandler {
+
+        @Override
+        public void onHeaders(SdkHttpResponse headers) {
+        }
+
+        @Override
+        public void onStream(Publisher<ByteBuffer> stream) {
+            stream.subscribe(new DrainingSubscriber<>());
+        }
+
+        @Override
+        public void onError(Throwable error) {
+        }
+    }
+
+    private static class EmptySubscription implements Subscription {
+        private final Subscriber subscriber;
+        private volatile boolean done;
+
+        EmptySubscription(Subscriber subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void request(long l) {
+            if (!done) {
+                done = true;
+                if (l <= 0) {
+                    this.subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+                } else {
+                    this.subscriber.onComplete();
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            done = true;
+        }
+    }
+
+    private static class DrainingSubscriber<T> implements Subscriber<T> {
+        private Subscription subscription;
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            this.subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T t) {
+            this.subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FullResponseContentPublisherTckTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FullResponseContentPublisherTckTest.java
@@ -57,7 +57,7 @@ public class FullResponseContentPublisherTckTest extends PublisherVerification<B
 
     @Override
     public Publisher<ByteBuffer> createPublisher(long l) {
-        return new ResponseHandler.FullResponseContentPublisher(mockCtx, ByteBuffer.wrap(CONTENT));
+        return new ResponseHandler.FullResponseContentPublisher(mockCtx, ByteBuffer.wrap(CONTENT), null);
     }
 
     @Override

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTION_ID_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.DefaultAttributeMap;
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+/**
+ * Unit tests for {@link FutureCancelHandler}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FutureCancelHandlerTest {
+
+    private FutureCancelHandler handler = new FutureCancelHandler();
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private ChannelPool channelPool;
+
+    private RequestContext requestContext;
+
+    @Mock
+    private SdkAsyncHttpResponseHandler responseHandler;
+
+    @Before
+    public void methodSetup() {
+        requestContext = new RequestContext(channelPool,
+                                            AsyncExecuteRequest.builder().responseHandler(responseHandler).build(),
+                                null);
+
+        DefaultAttributeMap attrMap = new DefaultAttributeMap();
+        attrMap.attr(EXECUTION_ID_KEY).set(1L);
+        attrMap.attr(REQUEST_CONTEXT_KEY).set(requestContext);
+
+        when(ctx.channel()).thenReturn(channel);
+        when(channel.attr(EXECUTION_ID_KEY)).thenReturn(attrMap.attr(EXECUTION_ID_KEY));
+        when(channel.attr(REQUEST_CONTEXT_KEY)).thenReturn(attrMap.attr(REQUEST_CONTEXT_KEY));
+    }
+
+    @Test
+    public void surfacesCancelExceptionAsIOException() {
+        FutureCancelledException cancelledException = new FutureCancelledException(1L, new CancellationException());
+        ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
+
+        handler.exceptionCaught(ctx, cancelledException);
+
+        verify(ctx).fireExceptionCaught(exceptionCaptor.capture());
+        assertThat(exceptionCaptor.getValue()).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void forwardsExceptionIfNotCancelledException() {
+        ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
+
+        Throwable err = new RuntimeException("some other exception");
+        handler.exceptionCaught(ctx, err);
+
+        verify(ctx).fireExceptionCaught(exceptionCaptor.capture());
+        assertThat(exceptionCaptor.getValue()).isEqualTo(err);
+    }
+}

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/AsyncApiCallAttemptsTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/AsyncApiCallAttemptsTimeoutTest.java
@@ -250,14 +250,27 @@ public class AsyncApiCallAttemptsTimeoutTest {
             this.delegate = AsyncResponseTransformer.toBytes();
         }
 
+        @Override
+        public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
+            return delegate.prepare()
+                    .thenApply(r -> {
+                        try {
+                            Thread.sleep(1_000);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                        return r;
+                    });
+        }
+
         public int currentCallCount() {
             return callCount.get();
         }
 
         @Override
-        public void responseReceived(ResponseT response) {
+        public void onResponse(ResponseT response) {
             callCount.incrementAndGet();
-            delegate.responseReceived(response);
+            delegate.onResponse(response);
         }
 
         @Override
@@ -268,16 +281,6 @@ public class AsyncApiCallAttemptsTimeoutTest {
         @Override
         public void exceptionOccurred(Throwable throwable) {
             delegate.exceptionOccurred(throwable);
-        }
-
-        @Override
-        public ResponseBytes<ResponseT> complete() {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            return delegate.complete();
         }
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.utils;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 /**
@@ -41,5 +43,21 @@ public final class CompletableFutureUtils {
         CompletableFuture<U> cf = new CompletableFuture<>();
         cf.completeExceptionally(t);
         return cf;
+    }
+
+    /**
+     * Wraps the given error in a {@link CompletionException} if necessary.
+     * Useful if an exception needs to be rethrown from within {@link
+     * CompletableFuture#handle(java.util.function.BiFunction)} or similar
+     * methods.
+     *
+     * @param t The error.
+     * @return The error as a CompletionException.
+     */
+    public static CompletionException errorAsCompletionException(Throwable t) {
+        if (t instanceof CompletionException) {
+            return (CompletionException) t;
+        }
+        return new CompletionException(t);
     }
 }


### PR DESCRIPTION
## Description

This commit makes changes to the HTTP Async SPI as well as the
AsyncResponseTransformer interface exposed by SDK clients.

For the HTTP SPI, the main changes are to SdkHttpResponseHandler and
SdkAsyncHttpClient.

- SdkHttpResponseHandler

  The most important change is to complete(). It has been removed as it was a
  potential spot where the async client could get blocked or where the
  implementation would be forced to block, since the handler must return the
  transformed response from this method. We also don't necessarily care about
  what the response handler does at the HTTP client layer, so there's no need to
  return the transformed result.

  Secondly, the interface now guarantees that onStream() is always called, even
  for responses with no content. This should simplify implementation a bit since
  implementers know to always expect a stream.

  Other changes are mostly minor, such as naming: the interface is now
  SdkAsyncResponseHandler to be more intuitive since it follows our current
  naming conventions.

- SdkAsyncHttpClient

  prepareRequest() has been replaced with execute() that takes a single
  parameter object. It now also returns a CompletableFuture rather than a
  RunnableRequest.

- AsyncResponseTransformer

  This continues to be almost identical to SdkAsyncHttpResponseHandler.

  The most important change here is in complete(). Like in
  SdkHttpResponseHandler, this method was problematic since it had the
  protential to block the caller. To address this, complete() has been replaced
  with a method named prepare() that returns a CompletableFuture. We guarantee
  that this method is always called before executing the request to allow
  implementers to do any setup/cleanup. This method could be called more than
  once in the event of retries.

  Another important result of prepare() returning a CompletableFuture is this
  gives users the ability to trigger retries by completing it exceptionally with
  a instance of RetryableException similar to the sync ReponseTransformer.

  Finally, this change decouples response transformation from request
  completion. With the current behavior, the complete() is only called when the
  entire response is received. This makes doing things like returning the
  Publisher from onStream() as the result of the transformer awkward.

## Motivation and Context
(See above)

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature **Breaking change: changes public interfaces**

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license