### PR TITLE
Create AutoRenewable STS/SAML credentialsProvider

### DIFF
--- a/.changes/next-release/feature-AWSSecurityTokenService-cdd6371.json
+++ b/.changes/next-release/feature-AWSSecurityTokenService-cdd6371.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Security Token Service", 
+    "type": "feature", 
+    "description": "Added supplier functionality to StsAssumeRoleWithSamlCredentialProvider.  This allows for the saml assertion to be refreshed before getting new credentials from STS."
+}

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sts.auth;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
@@ -41,16 +42,17 @@ import software.amazon.awssdk.utils.Validate;
 @SdkPublicApi
 @ThreadSafe
 public final class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentialsProvider {
-    private final AssumeRoleWithSamlRequest assumeRoleWithSamlRequest;
+    private final Supplier<AssumeRoleWithSamlRequest> assumeRoleWithSamlRequestSupplier;
+
 
     /**
      * @see #builder()
      */
     private StsAssumeRoleWithSamlCredentialsProvider(Builder builder) {
         super(builder, "sts-assume-role-with-saml-credentials-provider");
-        Validate.notNull(builder.assumeRoleWithSamlRequest, "Assume role with SAML request must not be null.");
+        Validate.notNull(builder.assumeRoleWithSamlRequestSupplier, "Assume role with SAML request must not be null.");
 
-        this.assumeRoleWithSamlRequest = builder.assumeRoleWithSamlRequest;
+        this.assumeRoleWithSamlRequestSupplier = builder.assumeRoleWithSamlRequestSupplier;
     }
 
     /**
@@ -62,13 +64,15 @@ public final class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentia
 
     @Override
     protected Credentials getUpdatedCredentials(StsClient stsClient) {
+        AssumeRoleWithSamlRequest assumeRoleWithSamlRequest = assumeRoleWithSamlRequestSupplier.get();
+        Validate.notNull(assumeRoleWithSamlRequest, "Assume role with saml request must not be null.");
         return stsClient.assumeRoleWithSAML(assumeRoleWithSamlRequest).credentials();
     }
 
     @Override
     public String toString() {
         return ToString.builder("StsAssumeRoleWithSamlCredentialsProvider")
-                       .add("refreshRequest", assumeRoleWithSamlRequest)
+                       .add("refreshRequest", assumeRoleWithSamlRequestSupplier)
                        .build();
     }
 
@@ -78,7 +82,7 @@ public final class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentia
      */
     @NotThreadSafe
     public static final class Builder extends BaseBuilder<Builder, StsAssumeRoleWithSamlCredentialsProvider> {
-        private AssumeRoleWithSamlRequest assumeRoleWithSamlRequest;
+        private Supplier<AssumeRoleWithSamlRequest> assumeRoleWithSamlRequestSupplier;
 
         private Builder() {
             super(StsAssumeRoleWithSamlCredentialsProvider::new);
@@ -92,7 +96,18 @@ public final class StsAssumeRoleWithSamlCredentialsProvider extends StsCredentia
          * @return This object for chained calls.
          */
         public Builder refreshRequest(AssumeRoleWithSamlRequest assumeRoleWithSamlRequest) {
-            this.assumeRoleWithSamlRequest = assumeRoleWithSamlRequest;
+            return refreshRequest(() -> assumeRoleWithSamlRequest);
+        }
+
+        /**
+         * Similar to {@link #refreshRequest(AssumeRoleRequest)}, but takes a {@link Supplier} to supply the request to
+         * STS.
+         *
+         * @param assumeRoleWithSamlRequestSupplier A supplier
+         * @return This object for chained calls.
+         */
+        public Builder refreshRequest(Supplier<AssumeRoleWithSamlRequest> assumeRoleWithSamlRequestSupplier) {
+            this.assumeRoleWithSamlRequestSupplier = assumeRoleWithSamlRequestSupplier;
             return this;
         }
 

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProviderTest.java
@@ -26,7 +26,8 @@ import software.amazon.awssdk.services.sts.model.Credentials;
  * Inherits tests from {@link StsCredentialsProviderTestBase}.
  */
 public class StsAssumeRoleWithSamlCredentialsProviderTest
-        extends StsCredentialsProviderTestBase<AssumeRoleWithSamlRequest, AssumeRoleWithSamlResponse> {
+    extends StsCredentialsProviderTestBase<AssumeRoleWithSamlRequest, AssumeRoleWithSamlResponse> {
+
     @Override
     protected AssumeRoleWithSamlRequest getRequest() {
         return AssumeRoleWithSamlRequest.builder().build();

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 @RunWith(MockitoJUnitRunner.class)
 public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
     @Mock
-    private StsClient stsClient;
+    protected StsClient stsClient;
 
     @Test
     public void cachingDoesNotApplyToExpiredSession() {
@@ -68,7 +68,7 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
     protected abstract ResponseT getResponse(Credentials credentials);
 
     protected abstract StsCredentialsProvider.BaseBuilder<?, ? extends StsCredentialsProvider>
-            createCredentialsProviderBuilder(RequestT request);
+    createCredentialsProviderBuilder(RequestT request);
 
     protected abstract ResponseT callClient(StsClient client, RequestT request);
 
@@ -80,7 +80,7 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
         when(callClient(stsClient, request)).thenReturn(response);
 
         try (StsCredentialsProvider credentialsProvider = createCredentialsProviderBuilder(request).stsClient(stsClient).build()) {
-            for(int i = 0; i < numTimesInvokeCredentialsProvider; ++i) {
+            for (int i = 0; i < numTimesInvokeCredentialsProvider; ++i) {
                 AwsSessionCredentials providedCredentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
                 assertThat(providedCredentials.accessKeyId()).isEqualTo("a");
                 assertThat(providedCredentials.secretAccessKey()).isEqualTo("b");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added new Sts credential provider class that auto renews a SAML assertion
Created interface that can be implemented to provide functionality to CredentialProvider

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
When using the StsAssumeRoleWithSamlCredentialProvider, a non expired saml assertion is needed before the AWS credentials can be refreshed.  Currently, the SDK doesn't provide a way to handle renewing the saml assertion before calling the STS service to obtain new AWS credentials.  This pull requests implements a generic solution for this.

It's possible that the new class could be merged into the current StsAssumeRoleWithSamlCredentialProvider, but I wasn't sure if that would be the best way to handle it.

## Testing
Added unit tests for the new class. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have read the **CONTRIBUTING** document
- [ X] Local run of `mvn install` succeeds
- [ X ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ X ] I have read the **README** document
- [ X ] I have added tests to cover my changes
- [ X ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ X ] I confirm that this pull request can be released under the Apache 2 license
