### PR TITLE
Blacklist failing simple methods

### DIFF
--- a/services/applicationdiscovery/src/main/resources/codegen-resources/customization.config
+++ b/services/applicationdiscovery/src/main/resources/codegen-resources/customization.config
@@ -9,6 +9,7 @@
         "getDiscoverySummary"
     ],
     "blacklistedSimpleMethods" : [
-        "startContinuousExport"
+        "startContinuousExport",
+        "describeContinuousExports"
     ]
 }

--- a/services/devicefarm/src/main/resources/codegen-resources/customization.config
+++ b/services/devicefarm/src/main/resources/codegen-resources/customization.config
@@ -1,7 +1,8 @@
 {
     "blacklistedSimpleMethods" : [
         "purchaseOffering",
-        "renewOffering"
+        "renewOffering",
+        "listVPCEConfigurations"
     ],
     "verifiedSimpleMethods" : ["listOfferingTransactions"]
 }

--- a/services/ec2/src/main/resources/codegen-resources/customization.config
+++ b/services/ec2/src/main/resources/codegen-resources/customization.config
@@ -367,7 +367,8 @@
     "revokeSecurityGroupIngress",
     "deleteLaunchTemplate",
     "modifyLaunchTemplate",
-    "requestSpotInstances"
+    "requestSpotInstances",
+    "describeLaunchTemplateVersions"
   ],
   "verifiedSimpleMethods" : [
     "allocateAddress",

--- a/services/iot/src/main/resources/codegen-resources/customization.config
+++ b/services/iot/src/main/resources/codegen-resources/customization.config
@@ -16,6 +16,11 @@
     "updateAccountAuditConfiguration",
     "updateEventConfigurations",
     "updateIndexingConfiguration",
-    "updateThingGroupsForThing"
+    "updateThingGroupsForThing",
+    "describeDefaultAuthorizer",
+    "getEffectivePolicies",
+    "getV2LoggingOptions",
+    "listAuditFindings",
+    "listV2LoggingLevels"
   ]
 }

--- a/services/shield/src/main/resources/codegen-resources/customization.config
+++ b/services/shield/src/main/resources/codegen-resources/customization.config
@@ -11,6 +11,8 @@
      ],
      "blacklistedSimpleMethods" : [
         "updateEmergencyContactSettings",
-        "updateSubscription"
+        "updateSubscription",
+        "describeDRTAccess",
+        "describeEmergencyContactSettings"
      ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The code generator whitelists some simple method candidate methods by
default based on the verb used, but these methods fail the generated
integration tests.

## Motivation and Context
Fix integration tests.

## Testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
