### PR TITLE
Attach SdkHttpResponse to the responses of event streaming opeartions

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7b7c331.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7b7c331.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Attach `SdkHttpResponse` to the responses of event streaming operations."
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.internal.client.config.SdkClientConfiguration;
@@ -216,9 +217,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                                                         EventStreamOperationResponseHandler asyncResponseHandler) {
         try {
 
-            HttpResponseHandler<EventStreamOperationResponse> responseHandler = jsonProtocolFactory.createResponseHandler(
-                new JsonOperationMetadata().withPayloadJson(true).withHasStreamingSuccessResponse(false),
-                new EventStreamOperationResponseUnmarshaller());
+            HttpResponseHandler<EventStreamOperationResponse> responseHandler = new AttachHttpMetadataResponseHandler(
+                jsonProtocolFactory.createResponseHandler(new JsonOperationMetadata().withPayloadJson(true)
+                                                                                     .withHasStreamingSuccessResponse(false), new EventStreamOperationResponseUnmarshaller()));
 
             HttpResponseHandler<SdkResponse> voidResponseHandler = jsonProtocolFactory.createResponseHandler(
                 new JsonOperationMetadata().withPayloadJson(false).withHasStreamingSuccessResponse(true),

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/AttachHttpMetadataResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/AttachHttpMetadataResponseHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client.handler;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+/**
+ * Decorate {@link HttpResponseHandler} to attach {@link SdkHttpResponse} to the response object.
+ */
+@SdkProtectedApi
+public final class AttachHttpMetadataResponseHandler<T extends SdkResponse> implements HttpResponseHandler<T> {
+
+    private final HttpResponseHandler<T> delegate;
+
+    public AttachHttpMetadataResponseHandler(HttpResponseHandler<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T handle(SdkHttpFullResponse response, ExecutionAttributes executionAttributes) throws Exception {
+        return (T) delegate.handle(response, executionAttributes)
+                           .toBuilder()
+                           .sdkHttpResponse(response)
+                           .build();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.core.internal.http.response.SdkErrorResponseHandle
 import software.amazon.awssdk.core.internal.interceptor.ExecutionInterceptorChain;
 import software.amazon.awssdk.core.internal.interceptor.InterceptorContext;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpResponse;
 
 @SdkProtectedApi
 public abstract class BaseClientHandler {
@@ -117,21 +116,6 @@ public abstract class BaseClientHandler {
         return (OutputT) interceptorContext.response();
     }
 
-    /**
-     * Add {@link SdkHttpResponse} to SdkResponse.
-     */
-    @SuppressWarnings("unchecked")
-    private static <OutputT extends SdkResponse> HttpResponseHandler<OutputT> addHttpResponseMetadataResponseHandler(
-        HttpResponseHandler<OutputT> delegate) {
-        return (response, executionAttributes) -> {
-            OutputT sdkResponse = delegate.handle(response, executionAttributes);
-
-            return (OutputT) sdkResponse.toBuilder()
-                                        .sdkHttpResponse(response)
-                                        .build();
-        };
-    }
-
     static <OutputT extends SdkResponse> HttpResponseHandler<OutputT> interceptorCalling(
         HttpResponseHandler<OutputT> delegate, ExecutionContext context) {
         return (response, executionAttributes) ->
@@ -182,6 +166,6 @@ public abstract class BaseClientHandler {
     <OutputT extends SdkResponse> HttpResponseHandler<OutputT> decorateResponseHandlers(
         HttpResponseHandler<OutputT> delegate, ExecutionContext executionContext) {
         HttpResponseHandler<OutputT> interceptorCallingResponseHandler = interceptorCalling(delegate, executionContext);
-        return addHttpResponseMetadataResponseHandler(interceptorCallingResponseHandler);
+        return new AttachHttpMetadataResponseHandler<>(interceptorCallingResponseHandler);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bug fix. `SdkHttpResponse` is missing from the response of event streaming operations. 
Created `AttachHttpMetadataResponseHandler` as a decorator to set the `SdkHttpResponse`.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [X] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
