### PR TITLE
Apache configuration cleanup

### DIFF
--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/AsyncHttpClientApiCallTimeoutTests.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/AsyncHttpClientApiCallTimeoutTests.java
@@ -147,7 +147,7 @@ public class AsyncHttpClientApiCallTimeoutTests {
     }
 
     @Test
-    public void  slowApiAttempt_ThrowsApiCallAttemptTimeoutException() {
+    public void slowApiAttempt_ThrowsApiCallAttemptTimeoutException() {
         httpClient = testAsyncClientBuilder()
             .apiCallTimeout(API_CALL_TIMEOUT)
             .apiCallAttemptTimeout(Duration.ofMillis(100))

--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.http.apache;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.CONNECTION_ACQUIRE_TIMEOUT;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.CONNECTION_TIMEOUT;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.MAX_CONNECTIONS;
@@ -78,6 +79,7 @@ import software.amazon.awssdk.http.apache.internal.impl.ConnectionManagerAwareHt
 import software.amazon.awssdk.http.apache.internal.utils.ApacheUtils;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * An implementation of {@link SdkHttpClient} that uses Apache HTTP client to communicate with the service. This is the most
@@ -140,10 +142,11 @@ public final class ApacheHttpClient implements SdkHttpClient {
                                 ProxyConfiguration proxyConfiguration) {
         if (isProxyEnabled(proxyConfiguration)) {
 
-            log.debug(() -> "Configuring Proxy. Proxy Host: " + proxyConfiguration.endpoint());
+            log.debug(() -> "Configuring Proxy. Proxy Host: " + proxyConfiguration.host());
 
-            builder.setRoutePlanner(new SdkProxyRoutePlanner(proxyConfiguration.endpoint().getHost(),
-                                                             proxyConfiguration.endpoint().getPort(),
+            builder.setRoutePlanner(new SdkProxyRoutePlanner(proxyConfiguration.host(),
+                                                             proxyConfiguration.port(),
+                                                             proxyConfiguration.scheme(),
                                                              proxyConfiguration.nonProxyHosts()));
 
             if (isAuthenticatedProxy(proxyConfiguration)) {
@@ -164,9 +167,8 @@ public final class ApacheHttpClient implements SdkHttpClient {
     }
 
     private boolean isProxyEnabled(ProxyConfiguration proxyConfiguration) {
-        return proxyConfiguration.endpoint() != null
-               && proxyConfiguration.endpoint().getHost() != null
-               && proxyConfiguration.endpoint().getPort() > 0;
+        return proxyConfiguration.host() != null
+               && proxyConfiguration.port() > 0;
     }
 
     @Override
@@ -240,6 +242,7 @@ public final class ApacheHttpClient implements SdkHttpClient {
         return ApacheHttpRequestConfig.builder()
                                       .socketTimeout(resolvedOptions.get(READ_TIMEOUT))
                                       .connectionTimeout(resolvedOptions.get(CONNECTION_TIMEOUT))
+                                      .connectionAcquireTimeout(resolvedOptions.get(CONNECTION_ACQUIRE_TIMEOUT))
                                       .proxyConfiguration(builder.proxyConfiguration)
                                       .localAddress(Optional.ofNullable(builder.localAddress).orElse(null))
                                       .expectContinueEnabled(Optional.ofNullable(builder.expectContinueEnabled)
@@ -272,6 +275,13 @@ public final class ApacheHttpClient implements SdkHttpClient {
          * means infinity, and is not recommended.
          */
         Builder connectionTimeout(Duration connectionTimeout);
+
+        /**
+         * The amount of time to wait when acquiring a connection from the pool before giving up and timing out.
+         * @param connectionAcquisitionTimeout the timeout duration
+         * @return this builder for method chaining.
+         */
+        Builder connectionAcquisitionTimeout(Duration connectionAcquisitionTimeout);
 
         /**
          * The maximum number of connections allowed in the connection pool. Each built HTTP client has it's own private
@@ -334,6 +344,22 @@ public final class ApacheHttpClient implements SdkHttpClient {
 
         public void setConnectionTimeout(Duration connectionTimeout) {
             connectionTimeout(connectionTimeout);
+        }
+
+        /**
+         * The amount of time to wait when acquiring a connection from the pool before giving up and timing out.
+         * @param connectionAcquisitionTimeout the timeout duration
+         * @return this builder for method chaining.
+         */
+        @Override
+        public Builder connectionAcquisitionTimeout(Duration connectionAcquisitionTimeout) {
+            Validate.isPositive(connectionAcquisitionTimeout, "connectionAcquisitionTimeout");
+            standardOptions.put(CONNECTION_ACQUIRE_TIMEOUT, connectionAcquisitionTimeout);
+            return this;
+        }
+
+        public void setConnectionAcquisitionTimeout(Duration connectionAcquisitionTimeout) {
+            connectionAcquisitionTimeout(connectionAcquisitionTimeout);
         }
 
         @Override

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/ApacheHttpRequestConfig.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/ApacheHttpRequestConfig.java
@@ -29,6 +29,7 @@ public final class ApacheHttpRequestConfig {
 
     private final Duration socketTimeout;
     private final Duration connectionTimeout;
+    private final Duration connectionAcquireTimeout;
     private final InetAddress localAddress;
     private final boolean expectContinueEnabled;
     private final ProxyConfiguration proxyConfiguration;
@@ -36,6 +37,7 @@ public final class ApacheHttpRequestConfig {
     private ApacheHttpRequestConfig(Builder builder) {
         this.socketTimeout = builder.socketTimeout;
         this.connectionTimeout = builder.connectionTimeout;
+        this.connectionAcquireTimeout = builder.connectionAcquireTimeout;
         this.localAddress = builder.localAddress;
         this.expectContinueEnabled = builder.expectContinueEnabled;
         this.proxyConfiguration = builder.proxyConfiguration;
@@ -47,6 +49,10 @@ public final class ApacheHttpRequestConfig {
 
     public Duration connectionTimeout() {
         return connectionTimeout;
+    }
+
+    public Duration connectionAcquireTimeout() {
+        return connectionAcquireTimeout;
     }
 
     public InetAddress localAddress() {
@@ -75,6 +81,7 @@ public final class ApacheHttpRequestConfig {
 
         private Duration socketTimeout;
         private Duration connectionTimeout;
+        private Duration connectionAcquireTimeout;
         private InetAddress localAddress;
         private Boolean expectContinueEnabled;
         private ProxyConfiguration proxyConfiguration;
@@ -89,6 +96,11 @@ public final class ApacheHttpRequestConfig {
 
         public Builder connectionTimeout(Duration connectionTimeout) {
             this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public Builder connectionAcquireTimeout(Duration connectionAcquireTimeout) {
+            this.connectionAcquireTimeout = connectionAcquireTimeout;
             return this;
         }
 

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlanner.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlanner.java
@@ -37,9 +37,9 @@ public class SdkProxyRoutePlanner extends DefaultRoutePlanner {
     private HttpHost proxy;
     private Set<String> hostPatterns;
 
-    public SdkProxyRoutePlanner(String proxyHost, int proxyPort, Set<String> nonProxyHosts) {
+    public SdkProxyRoutePlanner(String proxyHost, int proxyPort, String proxyProtocol, Set<String> nonProxyHosts) {
         super(DefaultSchemePortResolver.INSTANCE);
-        proxy = new HttpHost(proxyHost, proxyPort);
+        proxy = new HttpHost(proxyHost, proxyPort, proxyProtocol);
         this.hostPatterns = nonProxyHosts;
     }
 

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
@@ -65,9 +65,10 @@ public class ApacheHttpRequestFactory {
                                   final SdkHttpFullRequest request,
                                   final ApacheHttpRequestConfig requestConfig) {
         final int connectTimeout = saturatedCast(requestConfig.connectionTimeout().toMillis());
+        final int connectAcquireTimeout = saturatedCast(requestConfig.connectionAcquireTimeout().toMillis());
         final RequestConfig.Builder requestConfigBuilder = RequestConfig
                 .custom()
-                .setConnectionRequestTimeout(connectTimeout)
+                .setConnectionRequestTimeout(connectAcquireTimeout)
                 .setConnectTimeout(connectTimeout)
                 .setSocketTimeout(saturatedCast(requestConfig.socketTimeout().toMillis()))
                 .setLocalAddress(requestConfig.localAddress());

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/utils/ApacheUtils.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/utils/ApacheUtils.java
@@ -86,14 +86,14 @@ public final class ApacheUtils {
      * Returns a new instance of AuthScope used for proxy authentication.
      */
     private static AuthScope newAuthScope(ProxyConfiguration proxyConfiguration) {
-        return new AuthScope(proxyConfiguration.endpoint().getHost(), proxyConfiguration.endpoint().getPort());
+        return new AuthScope(proxyConfiguration.host(), proxyConfiguration.port());
     }
 
     private static void addPreemptiveAuthenticationProxy(HttpClientContext clientContext,
                                                          ProxyConfiguration proxyConfiguration) {
 
         if (proxyConfiguration.preemptiveBasicAuthenticationEnabled()) {
-            HttpHost targetHost = new HttpHost(proxyConfiguration.endpoint().getHost(), proxyConfiguration.endpoint().getPort());
+            HttpHost targetHost = new HttpHost(proxyConfiguration.host(), proxyConfiguration.port());
             final CredentialsProvider credsProvider = newProxyCredentialsProvider(proxyConfiguration);
             // Create AuthCache instance
             AuthCache authCache = new BasicAuthCache();

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ProxyConfigurationTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ProxyConfigurationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProxyConfigurationTest {
+
+    @Before
+    public void setup() {
+        clearProxyProperties();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        clearProxyProperties();
+    }
+
+    @Test
+    public void testEndpointValues_SystemPropertyEnabled() {
+        String host = "foo.com";
+        int port = 7777;
+        System.setProperty("http.proxyHost", host);
+        System.setProperty("http.proxyPort", Integer.toString(port));
+
+        ProxyConfiguration config = ProxyConfiguration.builder().useSystemPropertyValues(true).build();
+
+        assertThat(config.host()).isEqualTo(host);
+        assertThat(config.port()).isEqualTo(port);
+        assertThat(config.scheme()).isNull();
+    }
+
+    @Test
+    public void testEndpointValues_SystemPropertyDisabled() {
+        ProxyConfiguration config = ProxyConfiguration.builder()
+                                                      .endpoint(URI.create("http://localhost:1234"))
+                                                      .useSystemPropertyValues(Boolean.FALSE)
+                                                      .build();
+
+        assertThat(config.host()).isEqualTo("localhost");
+        assertThat(config.port()).isEqualTo(1234);
+        assertThat(config.scheme()).isEqualTo("http");
+    }
+
+    @Test
+    public void testProxyConfigurationWithSystemPropertyDisabled() throws Exception {
+        Set<String> nonProxyHosts = new HashSet<>();
+        nonProxyHosts.add("foo.com");
+
+        // system property should not be used
+        System.setProperty("http.proxyHost", "foo.com");
+        System.setProperty("http.proxyPort", "5555");
+        System.setProperty("http.nonProxyHosts", "bar.com");
+        System.setProperty("http.proxyUser", "user");
+
+        ProxyConfiguration config = ProxyConfiguration.builder()
+                                                      .endpoint(URI.create("http://localhost:1234"))
+                                                      .nonProxyHosts(nonProxyHosts)
+                                                      .useSystemPropertyValues(Boolean.FALSE)
+                                                      .build();
+
+        assertThat(config.host()).isEqualTo("localhost");
+        assertThat(config.port()).isEqualTo(1234);
+        assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
+        assertThat(config.username()).isNull();
+    }
+
+    @Test
+    public void testProxyConfigurationWithSystemPropertyEnabled() throws Exception {
+        Set<String> nonProxyHosts = new HashSet<>();
+        nonProxyHosts.add("foo.com");
+
+        // system property should not be used
+        System.setProperty("http.proxyHost", "foo.com");
+        System.setProperty("http.proxyPort", "5555");
+        System.setProperty("http.nonProxyHosts", "bar.com");
+        System.setProperty("http.proxyUser", "user");
+
+        ProxyConfiguration config = ProxyConfiguration.builder()
+                                                      .nonProxyHosts(nonProxyHosts)
+                                                      .build();
+
+        assertThat(config.nonProxyHosts()).isEqualTo(nonProxyHosts);
+        assertThat(config.host()).isEqualTo("foo.com");
+        assertThat(config.username()).isEqualTo("user");
+    }
+
+    private static void clearProxyProperties() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+        System.clearProperty("http.proxyUser");
+        System.clearProperty("http.proxyPassword");
+    }
+}

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlannerTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlannerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SdkProxyRoutePlanner}.
+ */
+public class SdkProxyRoutePlannerTest {
+    private static final HttpHost S3_HOST = new HttpHost("s3.us-west-2.amazonaws.com", 443, "https");
+    private static final HttpGet S3_REQUEST = new HttpGet("/my-bucket/my-object");
+    private static final HttpClientContext CONTEXT = new HttpClientContext();
+
+    @Test
+    public void testSetsCorrectSchemeBasedOnProcotol_HTTPS() throws HttpException {
+        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner("localhost", 1234, "https", Collections.emptySet());
+
+        HttpHost proxyHost = planner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
+        assertEquals("localhost", proxyHost.getHostName());
+        assertEquals("https", proxyHost.getSchemeName());
+    }
+
+    @Test
+    public void testSetsCorrectSchemeBasedOnProcotol_HTTP() throws HttpException {
+        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner("localhost", 1234, "http", Collections.emptySet());
+
+        HttpHost proxyHost = planner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
+        assertEquals("localhost", proxyHost.getHostName());
+        assertEquals("http", proxyHost.getSchemeName());
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/ProxySystemSetting.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ProxySystemSetting.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * The system properties related to http proxy
+ */
+@SdkProtectedApi
+public enum ProxySystemSetting implements SystemSetting  {
+
+    PROXY_HOST("http.proxyHost"),
+    PROXY_PORT("http.proxyPort"),
+    NON_PROXY_HOSTS("http.nonProxyHosts"),
+    PROXY_USERNAME("http.proxyUser"),
+    PROXY_PASSWORD("http.proxyPassword")
+    ;
+
+    private final String systemProperty;
+
+    ProxySystemSetting(String systemProperty) {
+        this.systemProperty = systemProperty;
+    }
+
+    @Override
+    public String property() {
+        return systemProperty;
+    }
+
+    @Override
+    public String environmentVariable() {
+        return null;
+    }
+
+    @Override
+    public String defaultValue() {
+        return null;
+    }
+}


### PR DESCRIPTION
* Current Apache [configuration options](https://github.com/aws/aws-sdk-java-v2/blob/32ea7e74844975dcbb38e99967fa2a0e7b6d9db5/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java#L263-L307) and [default values](https://github.com/aws/aws-sdk-java-v2/blob/32ea7e74844975dcbb38e99967fa2a0e7b6d9db5/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/DefaultConfiguration.java) seems fine (matches v1)
* Includes changes to support nonProxyHosts proxy configuration ([v1 reference](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/http/apache/SdkProxyRoutePlanner.java))