### PR TITLE
Cleanup TODO in ResponseHandler

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -202,8 +202,6 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                     if (Protocol.HTTP2.equals(ChannelAttributeKey.getProtocolNow(channelContext.channel()))) {
                         return new Http2ResetSendingSubscription(channelContext, subscription);
                     } else {
-                        // TODO I believe the behavior for H1 is to finish reading the data. Do we want to do this
-                        // or abort the connection?
                         return subscription;
                     }
                 }


### PR DESCRIPTION
Current behavior is we close the connection and release it to pool ([here](https://github.com/aws/aws-sdk-java-v2/blob/5f8d7182150fc4256102f3dad4def0a8a24cc63e/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java#L145-L148)) which is the desired behavior.