### PR TITLE
Fix marshalling and Netty async bugs

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
@@ -196,8 +196,8 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
     public boolean hasPayloadMembers() {
         return hasPayloadMember ||
                getExplicitEventPayloadMember() != null ||
-               getUnboundMembers().size() > 0 ||
-               getUnboundEventMembers().size() > 0;
+               !getUnboundMembers().isEmpty() ||
+               (isEvent() && !getUnboundEventMembers().isEmpty());
     }
 
     /**

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -164,10 +164,12 @@ public final class NettyRequestExecutor {
                .addListener(wireCall -> {
                    // Done writing so remove the idle write timeout handler
                    ChannelUtils.removeIfExists(channel.pipeline(), WriteTimeoutHandler.class);
-                   if (wireCall.isSuccess()) {
+                   if (wireCall.isSuccess() && !context.executeRequest().fullDuplex()) {
                        // Starting read so add the idle read timeout handler, removed when channel is released
                        channel.pipeline().addFirst(new ReadTimeoutHandler(context.configuration().readTimeoutMillis(),
                                                                           TimeUnit.MILLISECONDS));
+                       channel.read();
+
                    } else {
                        // TODO: Are there cases where we can keep the channel open?
                        closeAndRelease(channel);
@@ -175,13 +177,12 @@ public final class NettyRequestExecutor {
                    }
                });
 
+        // FullDuplex calls need to start reading at the same time we make the request.
         if (context.executeRequest().fullDuplex()) {
             channel.pipeline().addFirst(new ReadTimeoutHandler(context.configuration().readTimeoutMillis(),
                                                                TimeUnit.MILLISECONDS));
+            channel.read();
         }
-
-        // Auto-read is turned off so trigger an explicit read to give control to HttpStreamsClientHandler
-        channel.read();
     }
 
     private URI endpoint() {


### PR DESCRIPTION
## Description
 - Fix hasPayloadMembers() to ensure that the shape is an event before checking
   for unbound event members. Otherwise, the test will always return true for
   any shape that has member.

 - For non full duplex requests, continue to perform a channel.read() call only
   after writing the request to avoid ReadTimeoutExceptions.

## Motivation and Context
Bug fixes.

## Testing
Run integration tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
