### PR TITLE
Filter blanks in getJavaClassName

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -214,7 +214,10 @@ public class DefaultNamingStrategy implements NamingStrategy {
 
     @Override
     public String getJavaClassName(String shapeName) {
-        return Arrays.stream(shapeName.split("[._-]|\\W")).map(Utils::capitalize).collect(Collectors.joining());
+        return Arrays.stream(shapeName.split("[._-]|\\W"))
+                     .filter(s -> !StringUtils.isEmpty(s))
+                     .map(Utils::capitalize)
+                     .collect(Collectors.joining());
     }
 
     @Override

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
@@ -275,4 +275,53 @@ public class DefaultNamingStrategyTest {
     private void validateConversion(String input, String expectedOutput) {
         assertThat(strat.getEnumValueName(input)).isEqualTo(expectedOutput);
     }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_ClassStartingWithUnderscore() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("_MyClass");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_ClassStartingWithDoubleUnderscore() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("__MyClass");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_ClassStartingWithDoublePeriods() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("..MyClass");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_ClassStartingWithDoubleDashes() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("--MyClass");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_DoubleUnderscoresInClass() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("My__Class");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_DoublePeriodsInClass() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("My..Class");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
+
+    @Test
+    public void getJavaClassName_ReturnsSanitizedName_DoubleDashesInClass() {
+        NamingStrategy strategy = new DefaultNamingStrategy(null, null);
+        String javaClassName = strategy.getJavaClassName("My--Class");
+        assertThat(javaClassName).isEqualTo("MyClass");
+    }
 }


### PR DESCRIPTION
## Description
This ports the same fix added to DefaultNamingStrategy from V1.

Related to #693.

## Motivation and Context
Update service models.

## Testing
`mvn clean install`, also ported over tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
