### PR TITLE
Don't generate item paginator for non-containers

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/AsyncResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/AsyncResponseClassSpec.java
@@ -25,6 +25,7 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -158,6 +159,7 @@ public class AsyncResponseClassSpec extends PaginatorsClassSpec {
         if (paginatorDefinition.getResultKey() != null) {
             return paginatorDefinition.getResultKey().stream()
                                       .map(this::getMethodsSpecForSingleResultKey)
+                                      .filter(Objects::nonNull)
                                       .collect(Collectors.toList());
         }
         return Collections.emptyList();
@@ -182,8 +184,14 @@ public class AsyncResponseClassSpec extends PaginatorsClassSpec {
      *  }
      */
     private MethodSpec getMethodsSpecForSingleResultKey(String resultKey) {
-        TypeName resultKeyType = getTypeForResultKey(resultKey);
         MemberModel resultKeyModel = memberModelForResponseMember(resultKey);
+
+        // TODO: Support other types besides List or Map
+        if (!(resultKeyModel.isList() || resultKeyModel.isMap())) {
+            return null;
+        }
+
+        TypeName resultKeyType = getTypeForResultKey(resultKey);
 
         return MethodSpec.methodBuilder(resultKeyModel.getFluentGetterMethodName())
                          .addModifiers(Modifier.PUBLIC, Modifier.FINAL)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/SyncResponseClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/paginators/SyncResponseClassSpec.java
@@ -24,6 +24,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -132,6 +133,7 @@ public class SyncResponseClassSpec extends PaginatorsClassSpec {
         if (paginatorDefinition.getResultKey() != null) {
             return paginatorDefinition.getResultKey().stream()
                                       .map(this::getMethodsSpecForSingleResultKey)
+                                      .filter(Objects::nonNull)
                                       .collect(Collectors.toList());
         }
         return Collections.emptyList();
@@ -154,8 +156,14 @@ public class SyncResponseClassSpec extends PaginatorsClassSpec {
      *  }
      */
     private MethodSpec getMethodsSpecForSingleResultKey(String resultKey) {
-        TypeName resultKeyType = getTypeForResultKey(resultKey);
         MemberModel resultKeyModel = memberModelForResponseMember(resultKey);
+
+        // TODO: Support other types besides List or Map
+        if (!(resultKeyModel.isList() || resultKeyModel.isMap())) {
+            return null;
+        }
+
+        TypeName resultKeyType = getTypeForResultKey(resultKey);
 
         return MethodSpec.methodBuilder(resultKeyModel.getFluentGetterMethodName())
                          .addModifiers(Modifier.PUBLIC, Modifier.FINAL)


### PR DESCRIPTION
## Description
It's possible for the `result_key` member to be something other than a List or Map. How we do item level iteration for those types will be done in a separate PR.

## Motivation and Context
Update service models. Related to #693.

## Testing
`mvn clean install`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
