### PR TITLE
Remove read limit option

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsS3V4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsS3V4Signer.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.IoUtils;
 
 /**
  * AWS4 signer implementation for AWS S3
@@ -242,7 +243,7 @@ public final class AwsS3V4Signer extends AbstractAws4Signer<AwsS3V4SignerParams,
         long contentLength = 0;
         byte[] tmp = new byte[4096];
         int read;
-        content.mark(getReadLimit());
+        IoUtils.markStreamWithMaxReadLimit(content);
         while ((read = content.read(tmp)) != -1) {
             contentLength += read;
         }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.signer.Presigner;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
@@ -146,7 +147,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
      */
     protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, T signerParams) {
         InputStream payloadStream = getBinaryRequestPayloadStream(mutableRequest.content());
-        payloadStream.mark(getReadLimit());
+        IoUtils.markStreamWithMaxReadLimit(payloadStream);
         String contentSha256 = BinaryUtils.toHex(hash(payloadStream));
         try {
             payloadStream.reset();

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsSigner.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsSigner.java
@@ -29,12 +29,10 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.core.RequestOption;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.io.SdkDigestInputStream;
 import software.amazon.awssdk.core.signer.Signer;
@@ -242,12 +240,6 @@ public abstract class AbstractAwsSigner implements Signer {
         }
 
         return SdkHttpUtils.flattenQueryParameters(sorted).orElse("");
-    }
-
-    @ReviewBeforeRelease("Do we still want to make read limit user-configurable as in V1?")
-    protected static int getReadLimit() {
-        return RequestOption.DEFAULT_STREAM_BUFFER_SIZE;
-
     }
 
     protected InputStream getBinaryRequestPayloadStream(InputStream stream) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOption.java
@@ -22,7 +22,5 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
  */
 @SdkProtectedApi
 public final class RequestOption {
-    public static final int DEFAULT_STREAM_BUFFER_SIZE = (1 << 17) + 1;
-
     private RequestOption() {}
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -95,7 +95,7 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         final ResponseHandler handler = new ResponseHandler(responseHandler.prepare(), errorResponseFuture);
 
         SdkHttpContentPublisher requestProvider = context.requestProvider() == null
-                ? new SimpleHttpContentPublisher(request, context.executionAttributes())
+                ? new SimpleHttpContentPublisher(request)
                 : context.requestProvider();
         // Set content length if it hasn't been set already.
         SdkHttpFullRequest requestWithContentLength = getRequestWithContentLength(request, requestProvider);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/RetryableStage.java
@@ -19,9 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import software.amazon.awssdk.annotations.ReviewBeforeRelease;
+
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.RequestOption;
 import software.amazon.awssdk.core.SdkStandardLogger;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.ResetException;
@@ -39,6 +38,7 @@ import software.amazon.awssdk.core.internal.util.ClockSkewUtil;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.retry.RetryUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Logger;
 
 /**
@@ -131,7 +131,7 @@ public final class RetryableStage<OutputT> implements RequestToResponsePipeline<
                 doPauseBeforeRetry();
             }
 
-            request.content().ifPresent(this::markInputStream);
+            request.content().ifPresent(IoUtils::markStreamWithMaxReadLimit);
 
             SdkStandardLogger.REQUEST_LOGGER.debug(() -> (retryHandler.isRetry() ? "Retrying " : "Sending ") + "Request: " +
                                                          request);
@@ -171,24 +171,6 @@ public final class RetryableStage<OutputT> implements RequestToResponsePipeline<
             }
 
             return sdkClientException;
-        }
-
-        /**
-         * Mark the input stream at the current position to allow a reset on retries.
-         */
-        private void markInputStream(InputStream originalContent) {
-            if (originalContent.markSupported()) {
-                originalContent.mark(readLimit());
-            }
-        }
-
-        /**
-         * @return Allowed read limit that we can mark request input stream. If we read past this limit we cannot reset the stream
-         * so we cannot retry the request.
-         */
-        @ReviewBeforeRelease("Do we still want to make read limit user-configurable as in V1?")
-        private int readLimit() {
-            return RequestOption.DEFAULT_STREAM_BUFFER_SIZE;
         }
 
         /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/async/SimpleRequestProviderTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/async/SimpleRequestProviderTckTest.java
@@ -20,7 +20,7 @@ public class SimpleRequestProviderTckTest extends PublisherVerification<ByteBuff
 
     @Override
     public Publisher<ByteBuffer> createPublisher(long l) {
-        return new SimpleHttpContentPublisher(makeFullRequest(), new ExecutionAttributes());
+        return new SimpleHttpContentPublisher(makeFullRequest());
     }
 
     @Override

--- a/utils/src/main/java/software/amazon/awssdk/utils/IoUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/IoUtils.java
@@ -124,4 +124,16 @@ public final class IoUtils {
             // Stream may be self closed by HTTP client so we ignore any failures.
         }
     }
+
+    /**
+     * If the stream supports marking, marks the stream at the current position with a {@code readLimit} value of
+     * 128 KiB.
+     *
+     * @param s The stream.
+     */
+    public static void markStreamWithMaxReadLimit(InputStream s) {
+        if (s.markSupported()) {
+            s.mark(1 << 17);
+        }
+    }
 }


### PR DESCRIPTION

## Description
This is a fairly low level configuration that we don't foresee many customers
using; can be added back in if requested.

For now, when marking, we set the read limit to the max value of
Integer#MAX_VALUE.

## Motivation and Context

## Testing
`mvn clean install`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
