### PR TITLE
Refactor RepsonseTransformer.apply

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseSyncClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseSyncClientHandler.java
@@ -19,12 +19,17 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.http.ExecutionContext;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient;
+import software.amazon.awssdk.core.internal.http.InterruptMonitor;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 
@@ -121,7 +126,21 @@ public abstract class BaseSyncClientHandler extends BaseClientHandler implements
         @Override
         public ReturnT handle(SdkHttpFullResponse response, ExecutionAttributes executionAttributes) throws Exception {
             OutputT resp = httpResponseHandler.handle(response, executionAttributes);
-            return responseTransformer.apply(resp, response.content().get());
+            return transformResponse(resp, response.content().get());
+        }
+
+        private ReturnT transformResponse(OutputT resp, AbortableInputStream inputStream) throws Exception {
+            try {
+                InterruptMonitor.checkInterrupted();
+                ReturnT result = responseTransformer.transform(resp, inputStream);
+                InterruptMonitor.checkInterrupted();
+                return result;
+            }  catch (RetryableException | InterruptedException | AbortedException e) {
+                throw e;
+            } catch (Exception e) {
+                InterruptMonitor.checkInterrupted();
+                throw NonRetryableException.builder().cause(e).build();
+            }
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
@@ -31,6 +31,14 @@ public final class RetryableException extends SdkClientException {
         super(b);
     }
 
+    public static RetryableException create(String message) {
+        return builder().message(message).build();
+    }
+
+    public static RetryableException create(String message, Throwable cause) {
+        return builder().message(message).cause(cause).build();
+    }
+
     @Override
     public boolean retryable() {
         return true;


### PR DESCRIPTION
## Description
- Move the logic in `RepsonseTransformer.apply` to `BaseSyncClientHandler`  so that the behavior would not be lost if that method is overriden. 

- Remove the apply method

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
will run integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
