### PR TITLE
Default chunked signing just PutObject/UploadPart

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/params/AwsS3V4SignerParams.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/params/AwsS3V4SignerParams.java
@@ -87,7 +87,7 @@ public final class AwsS3V4SignerParams extends Aws4SignerParams {
     }
 
     private static final class BuilderImpl extends Aws4SignerParams.BuilderImpl<Builder> implements Builder {
-        static final boolean DEFAULT_CHUNKED_ENCODING_ENABLED = true;
+        static final boolean DEFAULT_CHUNKED_ENCODING_ENABLED = false;
         static final boolean DEFAULT_PAYLOAD_SIGNING_ENABLED = false;
 
         private Boolean enableChunkedEncoding = DEFAULT_CHUNKED_ENCODING_ENABLED;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionAttributes.java
@@ -47,4 +47,12 @@ public final class ExecutionAttributes {
         this.attributes.put(attribute, value);
         return this;
     }
+
+    /**
+     * Set the provided attribute in this collection of attributes if it does not already exist in the collection.
+     */
+    public <U> ExecutionAttributes putAttributeIfAbsent(ExecutionAttribute<U> attribute, U value) {
+        attributes.putIfAbsent(attribute, value);
+        return this;
+    }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -43,9 +43,17 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
      */
     private static final boolean DEFAULT_DUALSTACK_ENABLED = false;
 
-    private final Boolean pathStyleAccessEnabled;
-    private final Boolean accelerateModeEnabled;
-    private final Boolean dualstackEnabled;
+    /**
+     * S3 The default value for enabling chunked encoding for {@link
+     * software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link
+     * software.amazon.awssdk.services.s3.model.UploadPartRequest}.
+     */
+    private static final boolean DEFAULT_CHUNKED_ENCODING_ENABLED = true;
+
+    private final boolean pathStyleAccessEnabled;
+    private final boolean accelerateModeEnabled;
+    private final boolean dualstackEnabled;
+    private final boolean chunkedEncodingEnabled;
 
     private S3Configuration(DefaultS3ServiceConfigurationBuilder builder) {
         this.dualstackEnabled = resolveBoolean(builder.dualstackEnabled, DEFAULT_DUALSTACK_ENABLED);
@@ -54,6 +62,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         if (accelerateModeEnabled && pathStyleAccessEnabled) {
             throw new IllegalArgumentException("Accelerate mode cannot be used with path style addressing");
         }
+        this.chunkedEncodingEnabled = resolveBoolean(builder.chunkedEncodingEnabled, DEFAULT_CHUNKED_ENCODING_ENABLED);
     }
 
     /**
@@ -119,6 +128,20 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         return dualstackEnabled;
     }
 
+    /**
+     * Returns whether the client should use chunked encoding when signing the
+     * payload body.
+     * <p>
+     * This option only currently applies to {@link
+     * software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link
+     * software.amazon.awssdk.services.s3.model.UploadPartRequest}.
+     *
+     * @return True if chunked encoding should be used.
+     */
+    public boolean chunkedEncodingEnabled() {
+        return chunkedEncodingEnabled;
+    }
+
     private boolean resolveBoolean(Boolean customerSuppliedValue, boolean defaultValue) {
         return customerSuppliedValue == null ? defaultValue : customerSuppliedValue;
     }
@@ -171,6 +194,16 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
          * @see S3Configuration#pathStyleAccessEnabled().
          */
         Builder pathStyleAccessEnabled(Boolean pathStyleAccessEnabled);
+
+        /**
+         * Option to enable using chunked encoding when signing the request
+         * payload for {@link
+         * software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link
+         * software.amazon.awssdk.services.s3.model.UploadPartRequest}.
+         *
+         * @see S3Configuration#accelerateModeEnabled()
+         */
+        Builder chunkedEncodingEnabled(Boolean chunkedEncodingEnabled);
     }
 
     private static final class DefaultS3ServiceConfigurationBuilder implements Builder {
@@ -178,6 +211,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         private Boolean dualstackEnabled;
         private Boolean accelerateModeEnabled;
         private Boolean pathStyleAccessEnabled;
+        private Boolean chunkedEncodingEnabled;
 
         public Builder dualstackEnabled(Boolean dualstackEnabled) {
             this.dualstackEnabled = dualstackEnabled;
@@ -204,6 +238,15 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
 
         public void setPathStyleAccessEnabled(Boolean pathStyleAccessEnabled) {
             pathStyleAccessEnabled(pathStyleAccessEnabled);
+        }
+
+        public Builder chunkedEncodingEnabled(Boolean chunkedEncodingEnabled) {
+            this.chunkedEncodingEnabled = chunkedEncodingEnabled;
+            return this;
+        }
+
+        public void setChunkedEncodingEnabled(Boolean chunkedEncodingEnabled) {
+            chunkedEncodingEnabled(chunkedEncodingEnabled);
         }
 
         public S3Configuration build() {


### PR DESCRIPTION
## Description

Other operations e.g. PutObjectTagging do not support it.

Only really make sense for these two operations anyway, where the payload can
potentially very large so avoiding a pass over the entire stream to calculate
the content SHA is very desirable.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
`mvn clean install`

~~Will run integration tests.~~ Integration tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
