### PR TITLE
Add functional and integration tests for module path

### DIFF
--- a/buildspecs/build.yml
+++ b/buildspecs/build.yml
@@ -3,4 +3,12 @@ version: 0.2
 phases:
   build:
     commands:
-    - mvn clean install -Dmaven.wagon.httpconnectionManager.maxPerRoute=2
+      - mvn clean install -Dmaven.wagon.httpconnectionManager.maxPerRoute=2
+      - JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d\" -f 2)
+      - echo $JAVA_VERSION
+      - |
+        if [ "$JAVA_VERSION" \> "9" ]; then
+          cd test/module-path-tests
+          mvn package
+          mvn exec:exec -P mock-tests
+        fi

--- a/buildspecs/integ-test.yml
+++ b/buildspecs/integ-test.yml
@@ -3,4 +3,12 @@ version: 0.2
 phases:
   build:
     commands:
-    - mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2
+      - mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2
+      - JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d\" -f 2)
+      - echo $JAVA_VERSION
+      - |
+        if [ "$JAVA_VERSION" \> "9" ]; then
+          cd test/module-path-tests
+          mvn package
+          mvn exec:exec -P integ-tests
+        fi

--- a/buildspecs/on-demand-integ-test.yml
+++ b/buildspecs/on-demand-integ-test.yml
@@ -3,4 +3,12 @@ version: 0.2
 phases:
   build:
     commands:
-    - mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2 --fail-at-end
+      - mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2 --fail-at-end
+      - JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d\" -f 2)
+      - echo $JAVA_VERSION
+      - |
+        if [ "$JAVA_VERSION" \> "9" ]; then
+          cd test/module-path-tests
+          mvn package
+          mvn exec:exec -P integ-tests
+        fi

--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -50,10 +50,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <checkstyle.version>7.8.2</checkstyle.version>
         <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 
         <!-- These properties are used by Step functions for its dependencies -->
         <json-path.version>2.4.0</json-path.version>
@@ -528,6 +529,7 @@
                         <failsOnError>true</failsOnError>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <failOnViolation>true</failOnViolation>
+                        <excludes>**/module-info.java</excludes>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/protocols/aws-ion-protocol/pom.xml
+++ b/protocols/aws-ion-protocol/pom.xml
@@ -59,10 +59,6 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>software.amazon.ion</groupId>
-            <artifactId>ion-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/test/module-path-tests/README.md
+++ b/test/module-path-tests/README.md
@@ -1,0 +1,16 @@
+# AWS SDK Module Path Tests
+
+## Description
+This module is used to test using SDK on module path with Java 9+.
+
+- Mock tests: calling xml/json prococol sync/async clients using mock http clients.
+- Integ tests: calling service clients using `UrlConnectionHttpClient`, `ApacheHttpClient` and `NettyNioAsyncHttpClient`.
+
+## How to run
+```
+mvn clean package
+mvn exec:exec -P mock-tests
+mvn exec:exec -P integ-tests
+```
+
+

--- a/test/module-path-tests/pom.xml
+++ b/test/module-path-tests/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>aws-sdk-java-pom</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.0.0-preview-13-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>module-path-tests</artifactId>
+    <!-- Setting it to a different version so it can always load dependencies from maven
+    rather than local module-->
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>AWS Java SDK :: Test :: Module Path Tests</name>
+    <description>A set of tests to run v2 in module path with Java 9+.</description>
+    <url>https://aws.amazon.com/sdkforjava</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- TODO remove exclusions after we fix netty module -->
+                    <artifactId>netty-nio-client</artifactId>
+                    <groupId>software.amazon.awssdk</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-tests</artifactId>
+            <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- TODO remove exclusions after we fix netty module -->
+                    <artifactId>netty-nio-client</artifactId>
+                    <groupId>software.amazon.awssdk</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>service-test-utils</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                <execution>
+                    <id>default-compile</id>
+                    <configuration>
+                        <source>9</source>
+                        <release>9</release>
+                    </configuration>
+                </execution>
+                </executions>
+                <configuration>
+                    <jdkToolchain>
+                        <version>[9,)</version>
+                    </jdkToolchain>
+                    <release>9</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <!-- Disable spotbugs speed up the build. -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>mock-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <!-- https://www.mojohaus.org/exec-maven-plugin/examples/example-exec-for-java-programs.html -->
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>--module-path</argument>
+                                <modulepath/>
+                                <argument>--module</argument>
+                                <argument>software.amazon.awssdk.modulepath.tests/software.amazon.awssdk.modulepath.tests.MockTestsRunner
+                                </argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>integ-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <!-- https://www.mojohaus.org/exec-maven-plugin/examples/example-exec-for-java-programs.html -->
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>--module-path</argument>
+                                <modulepath/>
+                                <argument>--module</argument>
+                                <argument>software.amazon.awssdk.modulepath.tests/software.amazon.awssdk.modulepath.tests.IntegTestsRunner
+                                </argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/test/module-path-tests/src/main/java/module-info.java
+++ b/test/module-path-tests/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+module software.amazon.awssdk.modulepath.tests {
+    requires software.amazon.awssdk.regions;
+    requires software.amazon.awssdk.http.urlconnection;
+    requires software.amazon.awssdk.http.apache;
+    requires software.amazon.awssdk.http;
+    requires software.amazon.awssdk.core;
+    requires software.amazon.awssdk.awscore;
+    requires software.amazon.awssdk.auth;
+    requires software.amazon.awssdk.services.s3;
+    requires software.amazon.awssdk.protocol.tests;
+    requires org.reactivestreams;
+    requires software.amazon.awssdk.utils;
+    requires software.amazon.awssdk.testutils.service;
+
+    // This is fine because those are just used in unit test.
+    // https://jira.qos.ch/browse/SLF4J-420
+    requires slf4j.api;
+    requires slf4j.simple;
+
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/IntegTestsRunner.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/IntegTestsRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.modulepath.tests.integtests.BaseApiCall;
+import software.amazon.awssdk.modulepath.tests.integtests.S3ApiCall;
+
+/**
+ * Tests runner to test module path on real service.
+ */
+public class IntegTestsRunner {
+
+    private IntegTestsRunner() {
+    }
+
+    public static void main(String... args) {
+
+        List<BaseApiCall> tests = new ArrayList<>();
+        tests.add(new S3ApiCall());
+
+        tests.forEach(test -> {
+            test.usingApacheClient();
+            test.usingUrlConnectionClient();
+            test.usingNettyClient();
+        });
+    }
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/MockTestsRunner.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/MockTestsRunner.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.modulepath.tests.mocktests.BaseMockApiCall;
+import software.amazon.awssdk.modulepath.tests.mocktests.JsonProtocolApiCall;
+import software.amazon.awssdk.modulepath.tests.mocktests.XmlProtocolApiCall;
+
+/**
+ * Executor to run mock tests on module path.
+ */
+public class MockTestsRunner {
+
+    private MockTestsRunner() {
+    }
+
+    public static void main(String... args) {
+        List<BaseMockApiCall> tests = new ArrayList<>();
+        tests.add(new XmlProtocolApiCall());
+        tests.add(new JsonProtocolApiCall());
+
+        tests.forEach(t -> {
+            t.successfulApiCall();
+            t.failedApiCall();
+
+            t.successfulAsyncApiCall();
+            t.failedAsyncApiCall();
+        });
+    }
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/integtests/BaseApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/integtests/BaseApiCall.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.integtests;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.testutils.service.AwsTestBase;
+
+/**
+ * Base Api Call class
+ */
+public abstract class BaseApiCall extends AwsTestBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseApiCall.class);
+
+    private final String serviceName;
+
+    public BaseApiCall(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public void usingApacheClient() {
+        logger.info("Starting testing {} client with Apache http client", serviceName);
+        apacheClientRunnable().run();
+    }
+
+    public void usingUrlConnectionClient() {
+        logger.info("Starting testing {} client with url connection http client", serviceName);
+        urlHttpConnectionClientRunnable().run();
+    }
+
+    public void usingNettyClient() {
+        logger.info("Starting testing {} client with netty client", serviceName);
+        nettyClientRunnable().run();
+    }
+
+    public abstract Runnable apacheClientRunnable();
+
+    public abstract Runnable urlHttpConnectionClientRunnable();
+
+    public abstract Runnable nettyClientRunnable();
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/integtests/S3ApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/integtests/S3ApiCall.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.integtests;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3ApiCall extends BaseApiCall {
+    private static final Logger logger = LoggerFactory.getLogger(S3ApiCall.class);
+
+    private S3Client s3Client = S3Client.builder()
+                                        .region(Region.US_WEST_2)
+                                        .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                        .build();
+
+    private S3Client s3ClientWithHttpUrlConnection = S3Client.builder()
+                                                             .region(Region.US_WEST_2)
+                                                             .httpClient(UrlConnectionHttpClient.builder().build())
+                                                             .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).build();
+
+    public S3ApiCall() {
+        super("s3");
+    }
+
+    @Override
+    public Runnable apacheClientRunnable() {
+        return () -> s3Client.listBuckets();
+    }
+
+    @Override
+    public Runnable urlHttpConnectionClientRunnable() {
+        return () -> s3ClientWithHttpUrlConnection.listBuckets();
+    }
+
+    //TODO: testing netty client once it's fixed
+    @Override
+    public Runnable nettyClientRunnable() {
+        return () -> logger.info("Skipping testing s3 client with netty client");
+    }
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/BaseMockApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/BaseMockApiCall.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.mocktests;
+
+import java.io.ByteArrayInputStream;
+import java.util.concurrent.CompletionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+
+/**
+ * Base classes to mock sync and async api calls.
+ */
+public abstract class BaseMockApiCall {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseMockApiCall.class);
+
+    protected final MockHttpClient mockHttpClient;
+    protected final MockAyncHttpClient mockAyncHttpClient;
+    private final String protocol;
+
+    public BaseMockApiCall(String protocol) {
+        this.protocol = protocol;
+        this.mockHttpClient = new MockHttpClient();
+        this.mockAyncHttpClient = new MockAyncHttpClient();
+    }
+
+    public void successfulApiCall() {
+        logger.info("stubing successful api call for {} protocol", protocol);
+        mockHttpClient.stubNextResponse(successResponse(protocol));
+        runnable().run();
+        mockHttpClient.reset();
+    }
+
+    public void failedApiCall() {
+        logger.info("stubing failed api call for {} protocol", protocol);
+        mockHttpClient.stubNextResponse(errorResponse(protocol));
+
+        try {
+            runnable().run();
+        } catch (AwsServiceException e) {
+            logger.info("Received expected service exception", e.getMessage());
+        }
+
+        mockHttpClient.reset();
+    }
+
+    public void successfulAsyncApiCall() {
+        logger.info("stubing successful async api call for {} protocol", protocol);
+        mockAyncHttpClient.stubNextResponse(successResponse(protocol));
+        asyncRunnable().run();
+        mockAyncHttpClient.reset();
+    }
+
+    public void failedAsyncApiCall() {
+        logger.info("stubing failed async api call for {} protocol", protocol);
+        mockAyncHttpClient.stubNextResponse(errorResponse(protocol));
+
+        try {
+            asyncRunnable().run();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof AwsServiceException) {
+                logger.info("expected service exception {}", e.getMessage());
+            } else {
+                throw new RuntimeException("Unexpected exception is thrown");
+            }
+        }
+
+        mockAyncHttpClient.reset();
+    }
+
+    abstract Runnable runnable();
+
+    abstract Runnable asyncRunnable();
+
+    private SdkHttpFullResponse successResponse(String protocol) {
+        return SdkHttpFullResponse.builder()
+                                  .statusCode(200)
+                                  .content(generateContent(protocol))
+                                  .build();
+    }
+
+    private SdkHttpFullResponse errorResponse(String protocol) {
+        return SdkHttpFullResponse.builder()
+                                  .statusCode(500)
+                                  .content(generateContent(protocol))
+                                  .build();
+    }
+
+    private AbortableInputStream generateContent(String protocol) {
+        String content;
+        switch (protocol) {
+            case "xml":
+                content = "<foo></foo>";
+                break;
+            default:
+            case "json":
+                content = "{}";
+        }
+
+        return AbortableInputStream.create(new ByteArrayInputStream(content.getBytes()));
+    }
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/JsonProtocolApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/JsonProtocolApiCall.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.mocktests;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+
+/**
+ * Protocol tests for json protocol
+ */
+public class JsonProtocolApiCall extends BaseMockApiCall {
+
+    private static final Logger logger = LoggerFactory.getLogger(JsonProtocolApiCall.class);
+    private ProtocolRestJsonClient client;
+    private ProtocolRestJsonAsyncClient asyncClient;
+
+    public JsonProtocolApiCall() {
+        super("json");
+        this.client = ProtocolRestJsonClient.builder()
+                                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                                                "akid", "skid")))
+                                            .region(Region.US_EAST_1)
+                                            .httpClient(mockHttpClient)
+                                            .build();
+        this.asyncClient = ProtocolRestJsonAsyncClient.builder()
+                                                      .credentialsProvider(
+                                                          StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                                                          "akid", "skid")))
+                                                      .region(Region.US_EAST_1)
+                                                      .httpClient(mockAyncHttpClient)
+                                                      .build();
+    }
+
+    @Override
+    Runnable runnable() {
+        return () -> client.allTypes();
+    }
+
+    @Override
+    Runnable asyncRunnable() {
+        return () -> asyncClient.allTypes().join();
+    }
+
+    //TODO: remove override once we fix the json error unmarshalling to not use reflection
+    @Override
+    public void failedApiCall() {
+        logger.info("Skipping failed api call testing for json");
+    }
+
+    //TODO: remove override once we fix the json error unmarshalling to not use reflection
+    @Override
+    public void failedAsyncApiCall() {
+        logger.info("Skipping async failed api call testing for json");
+    }
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockAyncHttpClient.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockAyncHttpClient.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.mocktests;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Mock implementation of {@link SdkAsyncHttpClient}.
+ */
+public final class MockAyncHttpClient implements SdkAsyncHttpClient {
+
+    private final List<SdkHttpRequest> capturedRequests = new ArrayList<>();
+    private SdkHttpFullResponse nextResponse;
+
+
+    @Override
+    public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+        capturedRequests.add(request.request());
+
+        request.responseHandler().onHeaders(nextResponse);
+        request.responseHandler().onStream(new SdkHttpContentPublisher() {
+            byte[] content = nextResponse.content().map(p -> invokeSafely(() -> IoUtils.toByteArray(p)))
+                                         .orElseGet(() -> new byte[0]);
+
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of((long) content.length);
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                s.onSubscribe(new Subscription() {
+                    private boolean running = true;
+
+                    @Override
+                    public void request(long n) {
+                        if (n <= 0) {
+                            running = false;
+                            s.onError(new IllegalArgumentException("Demand must be positive"));
+                        } else if (running) {
+                            running = false;
+                            s.onNext(ByteBuffer.wrap(content));
+                            s.onComplete();
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {
+                        running = false;
+                    }
+                });
+            }
+        });
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Resets this mock by clearing any captured requests and wiping any stubbed responses.
+     */
+    public void reset() {
+        this.capturedRequests.clear();
+        this.nextResponse = null;
+    }
+
+    public void stubNextResponse(SdkHttpFullResponse nextResponse) {
+        this.nextResponse = nextResponse;
+    }
+
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockHttpClient.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockHttpClient.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.mocktests;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.http.AbortableCallable;
+import software.amazon.awssdk.http.ExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+
+/**
+ * Mock implementation of {@link SdkHttpClient}.
+ */
+public final class MockHttpClient implements SdkHttpClient {
+
+    private final List<SdkHttpFullRequest> capturedRequests = new ArrayList<>();
+    private SdkHttpFullResponse nextResponse;
+
+    @Override
+    public AbortableCallable<SdkHttpFullResponse> prepareRequest(ExecuteRequest request) {
+        capturedRequests.add(request.httpRequest());
+        return new AbortableCallable<>() {
+            @Override
+            public SdkHttpFullResponse call() throws Exception {
+                return nextResponse;
+            }
+
+            @Override
+            public void abort() {
+            }
+        };
+    }
+
+
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Resets this mock by clearing any captured requests and wiping any stubbed responses.
+     */
+    public void reset() {
+        this.capturedRequests.clear();
+        this.nextResponse = null;
+    }
+
+    /**
+     * Sets up the next HTTP response that will be returned by the mock.
+     *
+     * @param nextResponse Next {@link SdkHttpFullResponse} to return from
+     *                     {@link #prepareRequest(ExecuteRequest)}
+     */
+    public void stubNextResponse(SdkHttpFullResponse nextResponse) {
+        this.nextResponse = nextResponse;
+    }
+
+    /**
+     * @return The last executed request that went through this mock client.
+     * @throws IllegalStateException If no requests have been captured.
+     */
+    public SdkHttpFullRequest getLastRequest() {
+        if (capturedRequests.isEmpty()) {
+            throw new IllegalStateException("No requests were captured by the mock");
+        }
+        return capturedRequests.get(capturedRequests.size() - 1);
+    }
+
+}

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/XmlProtocolApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/XmlProtocolApiCall.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.modulepath.tests.mocktests;
+
+import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlAsyncClient;
+import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
+
+/**
+ * Protocol tests for xml protocol
+ */
+public class XmlProtocolApiCall extends BaseMockApiCall {
+
+    private ProtocolRestXmlClient client;
+    private ProtocolRestXmlAsyncClient asyncClient;
+
+    public XmlProtocolApiCall() {
+        super("xml");
+        client = ProtocolRestXmlClient.builder().httpClient(mockHttpClient).build();
+        asyncClient = ProtocolRestXmlAsyncClient.builder().httpClient(mockAyncHttpClient).build();
+    }
+
+    @Override
+    Runnable runnable() {
+        return () -> client.allTypes();
+    }
+
+    @Override
+    Runnable asyncRunnable() {
+        return () -> asyncClient.allTypes().join();
+    }
+}

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -186,6 +186,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.protocol.tests</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
 
     </build>

--- a/test/service-test-utils/pom.xml
+++ b/test/service-test-utils/pom.xml
@@ -98,6 +98,17 @@
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.testutils.service</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is to make sure we cover the module path testing for Java 9+. The existing tests we will only run on the class path and we cannot guarantee it will work on module path.

- Created `module-path-test` module and add functional and integration tests for module path
    - mock tests: calling xml/json prococol sync/async clients using mock http clients. (I tried Wiremock but there are split packages in wiremock and it throws errors when running in module path)
   - integ tests: calling `S3Client` using `UrlConnectionHttpClient` and `ApacheHttpClient`. (Netty client is not currently working because of two root packages)

- Updated CodeBuild buildspec files to run the tests only when the Java version is 9+

**Note**
- The reason that the "tests" are actually in the main methods and are not Junit tests is because `mvn-surefire-plugin` still doesn't have very good support on Java 9 module path. There are still gaps, eg: when I tried to run the same code using unit tests, I didn't get any errors using the netty client which I would get from running on the main program.

- `module-path-test` is not a module in the parent so it will not run when you do `mvn clean install` because it only compiles in Java 9+ and it will be triggered in our gate keeper CodeBuild jobs and release jobs.

## Motivation and Context
Testing module path using Java 9+

## Testing
`mvn exec:exec -P mock-tests`, `mvn exec:exec -P integ-tests` succeeded locally and on CodeBuild

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
