### PR TITLE
Add h2 protocol even when service defaults are set

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -80,11 +80,7 @@ public class BaseClientBuilderClass implements ClassSpec {
                    .addMethod(beanStyleSetServiceConfigurationMethod());
         }
 
-        if (model.getCustomizationConfig().getServiceSpecificHttpConfig() != null) {
-            builder.addMethod(serviceSpecificHttpConfigMethod());
-        } else if (model.getMetadata().supportsH2()) {
-            builder.addMethod(enableH2HttpConfigMethod());
-        }
+        addServiceHttpConfigIfNeeded(builder, model);
 
         return builder.build();
     }
@@ -180,25 +176,45 @@ public class BaseClientBuilderClass implements ClassSpec {
                          .build();
     }
 
-    private MethodSpec serviceSpecificHttpConfigMethod() {
+    private void addServiceHttpConfigIfNeeded(TypeSpec.Builder builder, IntermediateModel model) {
+        String serviceDefaultFqcn = model.getCustomizationConfig().getServiceSpecificHttpConfig();
+        boolean supportsH2 = model.getMetadata().supportsH2();
+
+        if (serviceDefaultFqcn != null || supportsH2) {
+            builder.addMethod(serviceSpecificHttpConfigMethod(serviceDefaultFqcn, supportsH2));
+        }
+    }
+
+    private MethodSpec serviceSpecificHttpConfigMethod(String serviceDefaultFqcn, boolean supportsH2) {
         return MethodSpec.methodBuilder("serviceHttpConfig")
                          .addAnnotation(Override.class)
                          .addModifiers(Modifier.PROTECTED, Modifier.FINAL)
                          .returns(AttributeMap.class)
-                         .addCode("return $T.defaultHttpConfig();",
-                                  PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getServiceSpecificHttpConfig()))
+                         .addCode(serviceSpecificHttpConfigMethodBody(serviceDefaultFqcn, supportsH2))
                          .build();
     }
 
-    private MethodSpec enableH2HttpConfigMethod() {
-        return MethodSpec.methodBuilder("serviceHttpConfig")
-                         .addAnnotation(Override.class)
-                         .addModifiers(Modifier.PROTECTED, Modifier.FINAL)
-                         .returns(AttributeMap.class)
-                         .addCode("return $T.builder()\n"
-                                  + ".put($T.PROTOCOL, $T.HTTP2)\n"
-                                  + ".build();", AttributeMap.class, SdkHttpConfigurationOption.class, Protocol.class)
-                         .build();
+    private CodeBlock serviceSpecificHttpConfigMethodBody(String serviceDefaultFqcn, boolean supportsH2) {
+        CodeBlock.Builder builder =  CodeBlock.builder();
+
+        if (serviceDefaultFqcn != null) {
+            builder.addStatement("$T result = $T.defaultHttpConfig()",
+                                 AttributeMap.class,
+                                 PoetUtils.classNameFromFqcn(model.getCustomizationConfig().getServiceSpecificHttpConfig()));
+        } else {
+            builder.addStatement("$1T result = $1T.empty()", AttributeMap.class);
+        }
+
+        if (supportsH2) {
+            builder.addStatement("return result.merge(AttributeMap.builder()"
+                                 + ".put($T.PROTOCOL, $T.HTTP2)"
+                                 + ".build())",
+                                 SdkHttpConfigurationOption.class, Protocol.class);
+        } else {
+            builder.addStatement("return result");
+        }
+
+        return builder.build();
     }
 
     private CodeBlock signerDefinitionMethodBody() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -61,6 +61,7 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
 
     @Override
     protected final AttributeMap serviceHttpConfig() {
-        return MyServiceHttpConfig.defaultHttpConfig();
+        AttributeMap result = MyServiceHttpConfig.defaultHttpConfig();
+        return result;
     }
 }


### PR DESCRIPTION
**Current Behavior**
H2 protocol is ignored if service http defaults are set

**New Behavior**
H2 protocol will be added to AttributeMap if service defaults is missing the `PROTOCOL` attribute