### PR TITLE
Use EventStreamAws4Signer by default for APIs with input event stream

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/IntermediateModel.java
@@ -227,4 +227,11 @@ public final class IntermediateModel {
                           .findAny()
                           .isPresent();
     }
+
+    public boolean containsRequestEventStreams() {
+        return getOperations().values().stream()
+                              .filter(opModel -> opModel.hasEventStreamInput())
+                              .findAny()
+                              .isPresent();
+    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -106,7 +106,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
             classBuilder.addMethod(applyPaginatorUserAgentMethod(poetExtensions, model));
         }
 
-        if (model.containsRequestSigners()) {
+        if (model.containsRequestSigners() || model.containsRequestEventStreams()) {
             classBuilder.addMethod(applySignerOverrideMethod(poetExtensions, model));
         }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -25,6 +25,7 @@ import com.squareup.javapoet.TypeVariableName;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.auth.signer.EventStreamAws4Signer;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -170,6 +171,10 @@ final class ClientClassUtils {
             code.addStatement("$1L = applySignerOverride($1L, $2T.create())",
                               opModel.getInput().getVariableName(),
                               PoetUtils.classNameFromFqcn(inputShape.getRequestSignerClassFqcn()));
+        } else if (opModel.hasEventStreamInput()) {
+            code.addStatement("$1L = applySignerOverride($1L, $2T.create())",
+                              opModel.getInput().getVariableName(), EventStreamAws4Signer.class);
+
         }
 
         return code.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4UnsignedPayloadSigner;
+import software.amazon.awssdk.auth.signer.EventStreamAws4Signer;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
 import software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer;
@@ -224,6 +225,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
     public CompletableFuture<Void> eventStreamOperation(EventStreamOperationRequest eventStreamOperationRequest,
                                                         Publisher<InputEventStream> requestStream, EventStreamOperationResponseHandler asyncResponseHandler) {
         try {
+            eventStreamOperationRequest = applySignerOverride(eventStreamOperationRequest, EventStreamAws4Signer.create());
 
             HttpResponseHandler<EventStreamOperationResponse> responseHandler = new AttachHttpMetadataResponseHandler(
                 protocolFactory.createResponseHandler(new JsonOperationMetadata().withPayloadJson(true)
@@ -304,6 +306,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         EventStreamOperationWithOnlyInputRequest eventStreamOperationWithOnlyInputRequest,
         Publisher<InputEventStreamTwo> requestStream) {
         try {
+            eventStreamOperationWithOnlyInputRequest = applySignerOverride(eventStreamOperationWithOnlyInputRequest,
+                                                                           EventStreamAws4Signer.create());
 
             HttpResponseHandler<EventStreamOperationWithOnlyInputResponse> responseHandler = protocolFactory
                 .createResponseHandler(


### PR DESCRIPTION
* By default, use EventStreamAws4Signer for signing APIs with input events
* If service doesn't not want to sign a particular API, it can be exposed through a c2j trait