### PR TITLE
Updating to add additional resiliency to endpoint creation

### DIFF
--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/PartitionMetadataGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/PartitionMetadataGenerator.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.codegen.lite.PoetClass;
 import software.amazon.awssdk.codegen.lite.Utils;
 import software.amazon.awssdk.codegen.lite.regions.model.Partition;
@@ -52,6 +53,7 @@ public class PartitionMetadataGenerator implements PoetClass {
         return TypeSpec.classBuilder(className())
                        .addModifiers(FINAL, PUBLIC)
                        .addSuperinterface(ClassName.get(regionBasePackage, "PartitionMetadata"))
+                       .addAnnotation(SdkPublicApi.class)
                        .addAnnotation(AnnotationSpec.builder(Generated.class)
                                                     .addMember("value",
                                                                "$S",

--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/PartitionMetadataGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/PartitionMetadataGenerator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.lite.regions;
+
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.codegen.lite.PoetClass;
+import software.amazon.awssdk.codegen.lite.Utils;
+import software.amazon.awssdk.codegen.lite.regions.model.Partition;
+
+public class PartitionMetadataGenerator implements PoetClass {
+
+    private final Partition partition;
+    private final String basePackage;
+    private final String regionBasePackage;
+
+    public PartitionMetadataGenerator(Partition partition,
+                                      String basePackage,
+                                      String regionBasePackage) {
+        this.partition = partition;
+        this.basePackage = basePackage;
+        this.regionBasePackage = regionBasePackage;
+    }
+
+    @Override
+    public TypeSpec poetClass() {
+        return TypeSpec.classBuilder(className())
+                       .addModifiers(FINAL, PUBLIC)
+                       .addSuperinterface(ClassName.get(regionBasePackage, "PartitionMetadata"))
+                       .addAnnotation(AnnotationSpec.builder(Generated.class)
+                                                    .addMember("value",
+                                                               "$S",
+                                                               "software.amazon.awssdk:codegen")
+                                                    .build())
+                       .addField(FieldSpec.builder(String.class, "DNS_SUFFIX")
+                                          .addModifiers(PRIVATE, FINAL, STATIC)
+                                          .initializer("$S", partition.getDnsSuffix())
+                                          .build())
+                       .addField(FieldSpec.builder(String.class, "HOSTNAME")
+                                          .addModifiers(PRIVATE, FINAL, STATIC)
+                                          .initializer("$S", partition.getDefaults().getHostname())
+                                          .build())
+                       .addField(FieldSpec.builder(String.class, "ID")
+                                          .addModifiers(PRIVATE, FINAL, STATIC)
+                                          .initializer("$S", partition.getPartition())
+                                          .build())
+                       .addField(FieldSpec.builder(String.class, "PARTITION_NAME")
+                                          .addModifiers(PRIVATE, FINAL, STATIC)
+                                          .initializer("$S", partition.getPartitionName())
+                                          .build())
+                       .addField(FieldSpec.builder(String.class, "REGION_REGEX")
+                                          .addModifiers(PRIVATE, FINAL, STATIC)
+                                          .initializer("$S", partition.getRegionRegex())
+                                          .build())
+                       .addMethod(getter("dnsSuffix", "DNS_SUFFIX"))
+                       .addMethod(getter("hostname", "HOSTNAME"))
+                       .addMethod(getter("id", "ID"))
+                       .addMethod(getter("partitionName", "PARTITION_NAME"))
+                       .addMethod(getter("regionRegex", "REGION_REGEX"))
+                       .build();
+    }
+
+    @Override
+    public ClassName className() {
+        return ClassName.get(basePackage, Stream.of(partition.getPartition().split("-"))
+                                                .map(Utils::capitalize)
+                                                .collect(Collectors.joining()) + "PartitionMetadata");
+    }
+
+    private MethodSpec getter(String methodName, String field) {
+        return MethodSpec.methodBuilder(methodName)
+                         .addAnnotation(Override.class)
+                         .addModifiers(Modifier.PUBLIC)
+                         .returns(String.class)
+                         .addStatement("return $L", field)
+                         .build();
+    }
+}

--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/PartitionMetadataProviderGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/PartitionMetadataProviderGenerator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.lite.regions;
+
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.codegen.lite.PoetClass;
+import software.amazon.awssdk.codegen.lite.Utils;
+import software.amazon.awssdk.codegen.lite.regions.model.Partitions;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+public class PartitionMetadataProviderGenerator implements PoetClass {
+    private final Partitions partitions;
+    private final String basePackage;
+    private final String regionBasePackage;
+
+    public PartitionMetadataProviderGenerator(Partitions partitions,
+                                           String basePackage,
+                                           String regionBasePackage) {
+        this.partitions = partitions;
+        this.basePackage = basePackage;
+        this.regionBasePackage = regionBasePackage;
+    }
+
+    @Override
+    public TypeSpec poetClass() {
+        TypeName mapOfPartitionMetadata = ParameterizedTypeName.get(ClassName.get(Map.class),
+                                                                 ClassName.get(String.class),
+                                                                 ClassName.get(regionBasePackage, "PartitionMetadata"));
+        return TypeSpec.classBuilder(className())
+                       .addModifiers(PUBLIC)
+                       .addSuperinterface(ClassName.get(regionBasePackage, "PartitionMetadataProvider"))
+                       .addAnnotation(AnnotationSpec.builder(Generated.class)
+                                                    .addMember("value", "$S", "software.amazon.awssdk:codegen")
+                                                    .build())
+                       .addAnnotation(SdkPublicApi.class)
+                       .addModifiers(FINAL)
+                       .addField(FieldSpec.builder(mapOfPartitionMetadata, "PARTITION_METADATA")
+                                          .addModifiers(PRIVATE, FINAL, STATIC)
+                                          .initializer(partitions(partitions))
+                                          .build())
+                       .addMethod(getter())
+                       .addMethod(partitionMetadata())
+                       .build();
+    }
+
+    @Override
+    public ClassName className() {
+        return ClassName.get(regionBasePackage, "GeneratedPartitionMetadataProvider");
+    }
+
+    private CodeBlock partitions(Partitions partitions) {
+        CodeBlock.Builder builder = CodeBlock.builder().add("$T.<String, PartitionMetadata>builder()", ImmutableMap.class);
+
+        partitions.getPartitions()
+                  .stream()
+                  .forEach(p -> builder.add(".put($S, new $T())", p.getPartition(), partitionMetadataClass(p.getPartition())));
+
+        return builder.add(".build()").build();
+    }
+
+    private ClassName partitionMetadataClass(String partition) {
+        return ClassName.get(basePackage, Stream.of(partition.split("-"))
+                                                .map(Utils::capitalize)
+                                                .collect(Collectors.joining()) + "PartitionMetadata");
+    }
+
+    private MethodSpec partitionMetadata() {
+        return MethodSpec.methodBuilder("partitionMetadata")
+                         .addModifiers(PUBLIC)
+                         .addParameter(ClassName.get(regionBasePackage, "Region"), "region")
+                         .returns(ClassName.get(regionBasePackage, "PartitionMetadata"))
+                         .addStatement("return $L.values().stream().filter(p -> $L.id().matches(p.regionRegex()))" +
+                                       ".findFirst().orElse(new $L())",
+                                       "PARTITION_METADATA",
+                                       "region",
+                                       "AwsPartitionMetadata")
+                         .build();
+    }
+
+    private MethodSpec getter() {
+        return MethodSpec.methodBuilder("partitionMetadata")
+                         .addModifiers(PUBLIC)
+                         .addParameter(String.class, "partition")
+                         .returns(ClassName.get(regionBasePackage, "PartitionMetadata"))
+                         .addStatement("return $L.get($L)", "PARTITION_METADATA", "partition")
+                         .build();
+    }
+}

--- a/codegen-lite/src/test/java/software/amazon/awssdk/codegen/lite/regions/RegionGenerationTest.java
+++ b/codegen-lite/src/test/java/software/amazon/awssdk/codegen/lite/regions/RegionGenerationTest.java
@@ -29,6 +29,7 @@ public class RegionGenerationTest {
     private static final String ENDPOINTS = "/software/amazon/awssdk/codegen/lite/endpoints.json";
     private static final String SERVICE_METADATA_BASE = "software.amazon.awssdk.regions.servicemetadata";
     private static final String REGION_METADATA_BASE = "software.amazon.awssdk.regions.regionmetadata";
+    private static final String PARTITION_METADATA_BASE = "software.amazon.awssdk.regions.partitionmetadata";
     private static final String REGION_BASE = "software.amazon.awssdk.regions";
 
     private File endpoints;
@@ -83,5 +84,22 @@ public class RegionGenerationTest {
                                                                                                                  REGION_BASE);
 
         assertThat(serviceMetadataProviderGenerator, generatesTo("service-metadata-provider.java"));
+    }
+
+    @Test
+    public void partitionMetadataClass() {
+        PartitionMetadataGenerator partitionMetadataGenerator = new PartitionMetadataGenerator(partitions.getPartitions().get(0),
+                                                                              PARTITION_METADATA_BASE,
+                                                                              REGION_BASE);
+
+        assertThat(partitionMetadataGenerator, generatesTo("partition-metadata.java"));
+    }
+
+    @Test
+    public void partitionMetadataProviderClass() {
+        PartitionMetadataProviderGenerator partitionMetadataProviderGenerator =
+            new PartitionMetadataProviderGenerator(partitions, PARTITION_METADATA_BASE, REGION_BASE);
+
+        assertThat(partitionMetadataProviderGenerator, generatesTo("partition-metadata-provider.java"));
     }
 }

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/partition-metadata-provider.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/partition-metadata-provider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions;
+
+import java.util.Map;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.regions.partitionmetadata.AwsCnPartitionMetadata;
+import software.amazon.awssdk.regions.partitionmetadata.AwsPartitionMetadata;
+import software.amazon.awssdk.regions.partitionmetadata.AwsUsGovPartitionMetadata;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public final class GeneratedPartitionMetadataProvider implements PartitionMetadataProvider {
+    private static final Map<String, PartitionMetadata> PARTITION_METADATA = ImmutableMap.<String, PartitionMetadata> builder()
+            .put("aws", new AwsPartitionMetadata()).put("aws-cn", new AwsCnPartitionMetadata())
+            .put("aws-us-gov", new AwsUsGovPartitionMetadata()).build();
+
+    public PartitionMetadata partitionMetadata(String partition) {
+        return PARTITION_METADATA.get(partition);
+    }
+
+    public PartitionMetadata partitionMetadata(Region region) {
+        return PARTITION_METADATA.values().stream().filter(p -> region.id().matches(p.regionRegex())).findFirst()
+                .orElse(new AwsPartitionMetadata());
+    }
+}

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/partition-metadata.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/partition-metadata.java
@@ -1,21 +1,10 @@
-/*
- * Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- * http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
-
 package software.amazon.awssdk.regions.partitionmetadata;
 
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.regions.PartitionMetadata;
 
+@SdkPublicApi
 @Generated("software.amazon.awssdk:codegen")
 public final class AwsPartitionMetadata implements PartitionMetadata {
     private static final String DNS_SUFFIX = "amazonaws.com";

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/partition-metadata.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/partition-metadata.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions.partitionmetadata;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.regions.PartitionMetadata;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class AwsPartitionMetadata implements PartitionMetadata {
+    private static final String DNS_SUFFIX = "amazonaws.com";
+
+    private static final String HOSTNAME = "{service}.{region}.{dnsSuffix}";
+
+    private static final String ID = "aws";
+
+    private static final String PARTITION_NAME = "AWS Standard";
+
+    private static final String REGION_REGEX = "^(us|eu|ap|sa|ca)\\-\\w+\\-\\d+$";
+
+    @Override
+    public String dnsSuffix() {
+        return DNS_SUFFIX;
+    }
+
+    @Override
+    public String hostname() {
+        return HOSTNAME;
+    }
+
+    @Override
+    public String id() {
+        return ID;
+    }
+
+    @Override
+    public String partitionName() {
+        return PARTITION_NAME;
+    }
+
+    @Override
+    public String regionRegex() {
+        return REGION_REGEX;
+    }
+}

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/s3-service-metadata.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/s3-service-metadata.java
@@ -16,13 +16,15 @@ import software.amazon.awssdk.utils.ImmutableMap;
 public final class S3ServiceMetadata implements ServiceMetadata {
     private static final String ENDPOINT_PREFIX = "s3";
 
+    private static final Map<String, String> PARTITION_OVERRIDDEN_ENDPOINTS = ImmutableMap.<String, String> builder().build();
+
     private static final Map<String, String> REGION_OVERRIDDEN_ENDPOINTS = ImmutableMap.<String, String> builder()
-            .put("ap-northeast-1", "s3.ap-northeast-1.amazonaws.com").put("ap-southeast-1", "s3.ap-southeast-1.amazonaws.com")
-            .put("ap-southeast-2", "s3.ap-southeast-2.amazonaws.com").put("eu-west-1", "s3.eu-west-1.amazonaws.com")
-            .put("s3-external-1", "s3-external-1.amazonaws.com").put("sa-east-1", "s3.sa-east-1.amazonaws.com")
-            .put("us-east-1", "s3.amazonaws.com").put("us-west-1", "s3.us-west-1.amazonaws.com")
-            .put("us-west-2", "s3.us-west-2.amazonaws.com").put("fips-us-gov-west-1", "s3-fips-us-gov-west-1.amazonaws.com")
-            .put("us-gov-west-1", "s3.us-gov-west-1.amazonaws.com").build();
+            .put("fips-us-gov-west-1", "s3-fips-us-gov-west-1.amazonaws.com")
+            .put("us-gov-west-1", "s3.us-gov-west-1.amazonaws.com").put("ap-northeast-1", "s3.ap-northeast-1.amazonaws.com")
+            .put("ap-southeast-1", "s3.ap-southeast-1.amazonaws.com").put("ap-southeast-2", "s3.ap-southeast-2.amazonaws.com")
+            .put("eu-west-1", "s3.eu-west-1.amazonaws.com").put("s3-external-1", "s3-external-1.amazonaws.com")
+            .put("sa-east-1", "s3.sa-east-1.amazonaws.com").put("us-east-1", "s3.amazonaws.com")
+            .put("us-west-1", "s3.us-west-1.amazonaws.com").put("us-west-2", "s3.us-west-2.amazonaws.com").build();
 
     private static final List<Region> REGIONS = Collections.unmodifiableList(Arrays.asList(Region.of("ap-northeast-1"),
             Region.of("ap-northeast-2"), Region.of("ap-south-1"), Region.of("ap-southeast-1"), Region.of("ap-southeast-2"),
@@ -32,7 +34,7 @@ public final class S3ServiceMetadata implements ServiceMetadata {
             Region.of("cn-northwest-1"), Region.of("fips-us-gov-west-1"), Region.of("us-gov-west-1")));
 
     private static final Map<String, String> SIGNING_REGION_OVERRIDES = ImmutableMap.<String, String> builder()
-            .put("s3-external-1", "us-east-1").put("fips-us-gov-west-1", "us-gov-west-1").build();
+            .put("fips-us-gov-west-1", "us-gov-west-1").put("s3-external-1", "us-east-1").build();
 
     @Override
     public List<Region> regions() {
@@ -42,7 +44,7 @@ public final class S3ServiceMetadata implements ServiceMetadata {
     @Override
     public URI endpointFor(Region region) {
         return URI.create(REGION_OVERRIDDEN_ENDPOINTS.containsKey(region.id()) ? REGION_OVERRIDDEN_ENDPOINTS.get(region.id())
-                : computeEndpoint(ENDPOINT_PREFIX, region));
+                : computeEndpoint(ENDPOINT_PREFIX, PARTITION_OVERRIDDEN_ENDPOINTS, region));
     }
 
     @Override

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/DefaultServiceMetadata.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/DefaultServiceMetadata.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.regions;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -40,7 +41,7 @@ public class DefaultServiceMetadata implements ServiceMetadata {
 
     @Override
     public URI endpointFor(Region region) {
-        return URI.create(computeEndpoint(endpointPrefix, region));
+        return URI.create(computeEndpoint(endpointPrefix, new HashMap<>(), region));
     }
 
     @Override

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/MetadataLoader.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/MetadataLoader.java
@@ -28,7 +28,17 @@ public class MetadataLoader {
 
     private static final ServiceMetadataProvider SERVICE_METADATA_PROVIDER = new GeneratedServiceMetadataProvider();
 
+    private static final PartitionMetadataProvider PARTITION_METADATA_PROVIDER = new GeneratedPartitionMetadataProvider();
+
     private MetadataLoader() {}
+
+    public static PartitionMetadata partitionMetadata(Region region) {
+        return PARTITION_METADATA_PROVIDER.partitionMetadata(region);
+    }
+
+    public static PartitionMetadata partitionMetadata(String partition) {
+        return PARTITION_METADATA_PROVIDER.partitionMetadata(partition);
+    }
 
     public static RegionMetadata regionMetadata(Region region) {
         return REGION_METADATA_PROVIDER.regionMetadata(region);

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadata.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadata.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions;
+
+public interface PartitionMetadata {
+
+    String dnsSuffix();
+
+    String hostname();
+
+    String id();
+
+    String partitionName();
+
+    String regionRegex();
+
+    static PartitionMetadata of(String partition) {
+        return MetadataLoader.partitionMetadata(partition);
+    }
+}

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadata.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadata.java
@@ -15,18 +15,56 @@
 
 package software.amazon.awssdk.regions;
 
+/**
+ * Metadata about a partition such as aws or aws-cn.
+ *
+ * <p>This is useful for building meta-functionality around AWS services. Partition metadata helps to provide
+ * data about regions which may not yet be in the endpoints.json file but have a specific prefix.</p>
+ */
 public interface PartitionMetadata {
 
+    /**
+     * Returns the DNS suffix, such as amazonaws.com for this partition.
+     *
+     * @return The DNS suffix for this partition.
+     */
     String dnsSuffix();
 
+    /**
+     * Returns the hostname pattern, such as {service}.{region}.{dnsSuffix} for this partition.
+     *
+     * @return The hostname pattern for this partition
+     */
     String hostname();
 
+    /**
+     * Returns the identifier for this partition, such as aws.
+     *
+     * @return The identifier for this partition.
+     */
     String id();
 
+    /**
+     * Returns the partition name for this partition, such as AWS Standard
+     *
+     * @return The name of this partition
+     */
     String partitionName();
 
+    /**
+     * Returns the region regex used for pattern matching for this partition.
+     *
+     * @return The region regex of this partition.
+     */
     String regionRegex();
 
+    /**
+     * Retrieves the partition metadata for a given partition.
+     *
+     * @param partition The partition to get metadata for.
+     *
+     * @return {@link PartitionMetadata} for the given partition.
+     */
     static PartitionMetadata of(String partition) {
         return MetadataLoader.partitionMetadata(partition);
     }

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadata.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadata.java
@@ -15,12 +15,15 @@
 
 package software.amazon.awssdk.regions;
 
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
 /**
  * Metadata about a partition such as aws or aws-cn.
  *
  * <p>This is useful for building meta-functionality around AWS services. Partition metadata helps to provide
  * data about regions which may not yet be in the endpoints.json file but have a specific prefix.</p>
  */
+@SdkPublicApi
 public interface PartitionMetadata {
 
     /**

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadataProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadataProvider.java
@@ -20,7 +20,19 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 @SdkPublicApi
 public interface PartitionMetadataProvider {
 
+    /**
+     * Returns the partition metadata for a given partition.
+     *
+     * @param partition The partition to find partition metadata for.
+     * @return {@link PartitionMetadata} for the given partition
+     */
     PartitionMetadata partitionMetadata(String partition);
 
+    /**
+     * Returns the partition metadata for a given region.
+     *
+     * @param region The region to find partition metadata for.
+     * @return {@link PartitionMetadata} for the given region.
+     */
     PartitionMetadata partitionMetadata(Region region);
 }

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadataProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/PartitionMetadataProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+@SdkPublicApi
+public interface PartitionMetadataProvider {
+
+    PartitionMetadata partitionMetadata(String partition);
+
+    PartitionMetadata partitionMetadata(Region region);
+}

--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/IntegrationTestBase.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/IntegrationTestBase.java
@@ -36,7 +36,7 @@ public abstract class IntegrationTestBase extends AwsTestBase {
         setUpCredentials();
         sts = StsClient.builder()
                        .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
-                       .region(Region.AWS_GLOBAL)
+                       .region(Region.US_EAST_1)
                        .build();
     }
 }


### PR DESCRIPTION
Adds additional resiliency to endpoint creation. Partially fixes STS situation but I also moved those tests to use us-east-1 while we wait for STS to fix their configuration in endpoints.json

## Motivation and Context
Fixes broken integ/unit tests

## Testing
Ran all unit tests. Ran failing STS integ tests and those now pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
