### PR TITLE
Enable module path tests for json error scenarios

### DIFF
--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/JsonProtocolApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/JsonProtocolApiCall.java
@@ -59,15 +59,4 @@ public class JsonProtocolApiCall extends BaseMockApiCall {
         return () -> asyncClient.allTypes().join();
     }
 
-    //TODO: remove override once we fix the json error unmarshalling to not use reflection
-    @Override
-    public void failedApiCall() {
-        logger.info("Skipping failed api call testing for json");
-    }
-
-    //TODO: remove override once we fix the json error unmarshalling to not use reflection
-    @Override
-    public void failedAsyncApiCall() {
-        logger.info("Skipping async failed api call testing for json");
-    }
 }


### PR DESCRIPTION
Enable module path tests for json error scenarios because reflection is gone (Yay!)