### PR TITLE
Async interceptor payload + S3 Checksums

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/Ec2ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/Ec2ProtocolSpec.java
@@ -51,7 +51,7 @@ public class Ec2ProtocolSpec extends QueryProtocolSpec {
                         StaxResponseHandler.class,
                         dryRunResult,
                         VoidStaxUnmarshaller.class)
-                .addStatement("\nclientHandler.execute(new $T<$T, $T>().withMarshaller($L).withResponseHandler($N)" +
+                .addStatement("\nclientHandler.execute(new $T<$T, $T>().marshaller($L).withResponseHandler($N)" +
                                 ".withInput($L))",
                         ClientExecutionParams.class,
                         Request.class,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -174,7 +174,8 @@ public class JsonProtocolSpec implements ProtocolSpec {
                  opModel.getInput().getVariableName());
 
         if (opModel.hasStreamingInput()) {
-            codeBlock.add(".withMarshaller(new $T(new $T(protocolFactory), requestBody))",
+            codeBlock.add(".withRequestBody(requestBody)")
+                     .add(".withMarshaller(new $T(new $T(protocolFactory), requestBody))",
                           ParameterizedTypeName.get(ClassName.get(StreamingRequestMarshaller.class), requestType),
                           marshaller);
         } else {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
@@ -106,7 +106,8 @@ public class QueryProtocolSpec implements ProtocolSpec {
                  "errorResponseHandler",
                  opModel.getInput().getVariableName());
         if (opModel.hasStreamingInput()) {
-            return codeBlock.add(".withMarshaller(new $T(new $T(protocolFactory), requestBody)));",
+            return codeBlock.add(".withRequestBody(requestBody)")
+                            .add(".withMarshaller(new $T(new $T(protocolFactory), requestBody)));",
                                  ParameterizedTypeName.get(ClassName.get(StreamingRequestMarshaller.class), requestType),
                                  marshaller)
                             .build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -100,19 +100,19 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
-                                                                                                     AwsServiceException, SdkClientException, JsonException {
+            AwsServiceException, SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                .isPayloadJson(true).build();
 
         HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(operationMetadata,
-                                                                                                            APostOperationResponse::builder);
+                APostOperationResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
-                                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                         .withInput(aPostOperationRequest).withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
+                .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                .withInput(aPostOperationRequest).withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -137,22 +137,22 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public APostOperationWithOutputResponse aPostOperationWithOutput(
-        APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
-                                                                                SdkClientException, JsonException {
+            APostOperationWithOutputRequest aPostOperationWithOutputRequest) throws InvalidInputException, AwsServiceException,
+            SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                .isPayloadJson(true).build();
 
         HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, APostOperationWithOutputResponse::builder);
+                operationMetadata, APostOperationWithOutputResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler
-            .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
-                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                         .withInput(aPostOperationWithOutputRequest)
-                         .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
+                .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                        .withInput(aPostOperationWithOutputRequest)
+                        .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -177,22 +177,22 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public GetWithoutRequiredMembersResponse getWithoutRequiredMembers(
-        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
-                                                                                  SdkClientException, JsonException {
+            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) throws InvalidInputException, AwsServiceException,
+            SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                .isPayloadJson(true).build();
 
         HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, GetWithoutRequiredMembersResponse::builder);
+                operationMetadata, GetWithoutRequiredMembersResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler
-            .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
-                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                         .withInput(getWithoutRequiredMembersRequest)
-                         .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory)));
+                .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                        .withInput(getWithoutRequiredMembersRequest)
+                        .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -213,22 +213,22 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithResultKeyResponse paginatedOperationWithResultKey(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
+            SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                .isPayloadJson(true).build();
 
         HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, PaginatedOperationWithResultKeyResponse::builder);
+                operationMetadata, PaginatedOperationWithResultKeyResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler
-            .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
-                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                         .withInput(paginatedOperationWithResultKeyRequest)
-                         .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory)));
+                .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                        .withInput(paginatedOperationWithResultKeyRequest)
+                        .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -300,8 +300,8 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithResultKeyIterable paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
-                                                                                              SdkClientException, JsonException {
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) throws AwsServiceException,
+            SdkClientException, JsonException {
         return new PaginatedOperationWithResultKeyIterable(this, applyPaginatorUserAgent(paginatedOperationWithResultKeyRequest));
     }
 
@@ -323,22 +323,22 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithoutResultKeyResponse paginatedOperationWithoutResultKey(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
+            SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                .isPayloadJson(true).build();
 
         HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, PaginatedOperationWithoutResultKeyResponse::builder);
+                operationMetadata, PaginatedOperationWithoutResultKeyResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler
-            .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
-                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                         .withInput(paginatedOperationWithoutResultKeyRequest)
-                         .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory)));
+                .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                        .withInput(paginatedOperationWithoutResultKeyRequest)
+                        .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -410,10 +410,10 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public PaginatedOperationWithoutResultKeyIterable paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
-                                                                                                    SdkClientException, JsonException {
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) throws AwsServiceException,
+            SdkClientException, JsonException {
         return new PaginatedOperationWithoutResultKeyIterable(this,
-                                                              applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
+                applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
     }
 
     /**
@@ -445,23 +445,24 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
-                                                                   RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
+            RequestBody requestBody) throws AwsServiceException, SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                       .isPayloadJson(true).build();
+                .isPayloadJson(true).build();
 
         HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, StreamingInputOperationResponse::builder);
+                operationMetadata, StreamingInputOperationResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
-                                         .withResponseHandler(responseHandler)
-                                         .withErrorResponseHandler(errorResponseHandler)
-                                         .withInput(streamingInputOperationRequest)
-                                         .withMarshaller(
-                                             new StreamingRequestMarshaller<StreamingInputOperationRequest>(
-                                                 new StreamingInputOperationRequestMarshaller(protocolFactory), requestBody)));
+                .withResponseHandler(responseHandler)
+                .withErrorResponseHandler(errorResponseHandler)
+                .withInput(streamingInputOperationRequest)
+                .withRequestBody(requestBody)
+                .withMarshaller(
+                        new StreamingRequestMarshaller<StreamingInputOperationRequest>(
+                                new StreamingInputOperationRequestMarshaller(protocolFactory), requestBody)));
     }
 
     /**
@@ -500,29 +501,30 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public <ReturnT> ReturnT streamingInputOutputOperation(
-        StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, RequestBody requestBody,
-        ResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
-                                                                                                        SdkClientException, JsonException {
+            StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, RequestBody requestBody,
+            ResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
+            SdkClientException, JsonException {
         streamingInputOutputOperationRequest = applySignerOverride(streamingInputOutputOperationRequest,
-                                                                   Aws4UnsignedPayloadSigner.create());
+                Aws4UnsignedPayloadSigner.create());
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
-                                                                       .isPayloadJson(false).build();
+                .isPayloadJson(false).build();
 
         HttpResponseHandler<StreamingInputOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, StreamingInputOutputOperationResponse::builder);
+                operationMetadata, StreamingInputOutputOperationResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler.execute(
-            new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
-                .withResponseHandler(responseHandler)
-                .withErrorResponseHandler(errorResponseHandler)
-                .withInput(streamingInputOutputOperationRequest)
-                .withMarshaller(
-                    new StreamingRequestMarshaller<StreamingInputOutputOperationRequest>(
-                        new StreamingInputOutputOperationRequestMarshaller(protocolFactory), requestBody)),
-            responseTransformer);
+                new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
+                        .withResponseHandler(responseHandler)
+                        .withErrorResponseHandler(errorResponseHandler)
+                        .withInput(streamingInputOutputOperationRequest)
+                        .withRequestBody(requestBody)
+                        .withMarshaller(
+                                new StreamingRequestMarshaller<StreamingInputOutputOperationRequest>(
+                                        new StreamingInputOutputOperationRequestMarshaller(protocolFactory), requestBody)),
+                responseTransformer);
     }
 
     /**
@@ -550,38 +552,38 @@ final class DefaultJsonClient implements JsonClient {
      */
     @Override
     public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
-                                                      ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
-                                                                                                                                                 SdkClientException, JsonException {
+            ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
+            SdkClientException, JsonException {
         JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
-                                                                       .isPayloadJson(false).build();
+                .isPayloadJson(false).build();
 
         HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-            operationMetadata, StreamingOutputOperationResponse::builder);
+                operationMetadata, StreamingOutputOperationResponse::builder);
 
         HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                   operationMetadata);
+                operationMetadata);
 
         return clientHandler.execute(
             new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
-                .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                .withInput(streamingOutputOperationRequest)
-                .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
+                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                        .withInput(streamingOutputOperationRequest)
+                        .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
     }
 
     private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
-                                                                                JsonOperationMetadata operationMetadata) {
+            JsonOperationMetadata operationMetadata) {
         return protocolFactory.createErrorResponseHandler(operationMetadata);
     }
 
     private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
         return builder
-            .clientConfiguration(clientConfiguration)
-            .defaultServiceExceptionSupplier(JsonException::builder)
-            .protocol(AwsJsonProtocol.REST_JSON)
-            .protocolVersion("1.1")
-            .registerModeledException(
-                ExceptionMetadata.builder().errorCode("InvalidInput")
-                                 .exceptionBuilderSupplier(InvalidInputException::builder).httpStatusCode(400).build());
+                .clientConfiguration(clientConfiguration)
+                .defaultServiceExceptionSupplier(JsonException::builder)
+                .protocol(AwsJsonProtocol.REST_JSON)
+                .protocolVersion("1.1")
+                .registerModeledException(
+                        ExceptionMetadata.builder().errorCode("InvalidInput")
+                                .exceptionBuilderSupplier(InvalidInputException::builder).httpStatusCode(400).build());
     }
 
     @Override
@@ -591,10 +593,10 @@ final class DefaultJsonClient implements JsonClient {
 
     private <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
         Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
+                .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
         AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
+                .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
+                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
         return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
@@ -604,8 +606,8 @@ final class DefaultJsonClient implements JsonClient {
         }
         Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
         AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(signerOverride).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
+                .map(c -> c.toBuilder().applyMutation(signerOverride).build())
+                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
         return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 }

--- a/core/sdk-core/src/it/java/software/amazon/awssdk/core/http/timers/client/AbortedExceptionClientExecutionTimerIntegrationTest.java
+++ b/core/sdk-core/src/it/java/software/amazon/awssdk/core/http/timers/client/AbortedExceptionClientExecutionTimerIntegrationTest.java
@@ -29,9 +29,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient;
-import software.amazon.awssdk.http.InvokeableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import utils.HttpTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -43,7 +44,7 @@ public class AbortedExceptionClientExecutionTimerIntegrationTest  {
     private SdkHttpClient sdkHttpClient;
 
     @Mock
-    private InvokeableHttpRequest abortableCallable;
+    private ExecutableHttpRequest abortableCallable;
 
     @Before
     public void setup() throws Exception {
@@ -51,8 +52,9 @@ public class AbortedExceptionClientExecutionTimerIntegrationTest  {
         httpClient = HttpTestUtils.testClientBuilder().httpClient(sdkHttpClient)
                                   .apiCallTimeout(Duration.ofMillis(1000))
                                   .build();
-        when(abortableCallable.call()).thenReturn(SdkHttpFullResponse.builder()
-                                                                     .statusCode(200)
+        when(abortableCallable.call()).thenReturn(HttpExecuteResponse.builder().response(SdkHttpResponse.builder()
+                                                                                                        .statusCode(200)
+                                                                                                        .build())
                                                                      .build());
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/ClientType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/ClientType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Enum that represents the type of client being used.
+ */
+@SdkPublicApi
+public enum ClientType {
+
+    ASYNC("Async"),
+    SYNC("Sync");
+
+    private final String clientType;
+
+    ClientType(String clientType) {
+        this.clientType = clientType;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Enum#toString()
+     */
+    @Override
+    public String toString() {
+        return clientType;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Md5Checksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/Md5Checksum.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.checksums;
+
+import java.security.MessageDigest;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Implementation of {@link SdkChecksum} to calculate an MD5 checksum.
+ */
+@SdkInternalApi
+public class Md5Checksum implements SdkChecksum {
+
+    private MessageDigest digest;
+
+    private MessageDigest digestLastMarked;
+
+    public Md5Checksum() {
+        this.digest = getDigest();
+    }
+
+    @Override
+    public void update(int b) {
+        digest.update((byte) b);
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+        digest.update(b, off, len);
+    }
+
+    @Override
+    public long getValue() {
+        throw new UnsupportedOperationException("Use getChecksumBytes() instead.");
+    }
+
+    @Override
+    public void reset() {
+        digest = (digestLastMarked == null)
+                   // This is necessary so that should there be a reset without a
+                   // preceding mark, the MD5 would still be computed correctly.
+                   ? getDigest()
+                   : cloneFrom(digestLastMarked);
+    }
+
+    private MessageDigest getDigest() {
+        try {
+            return MessageDigest.getInstance("MD5");
+        } catch (Exception e) {
+            throw new IllegalStateException("Unexpected error creating MD5 checksum", e);
+        }
+    }
+
+    @Override
+    public byte[] getChecksumBytes() {
+        return digest.digest();
+    }
+
+    @Override
+    public void mark(int readLimit) {
+        digestLastMarked = cloneFrom(digest);
+    }
+
+    private MessageDigest cloneFrom(MessageDigest from) {
+        try {
+            return (MessageDigest) from.clone();
+        } catch (CloneNotSupportedException e) { // should never occur
+            throw new IllegalStateException("unexpected", e);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/SdkChecksum.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/checksums/SdkChecksum.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.checksums;
+
+import java.util.zip.Checksum;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Extension of {@link Checksum} to support checksums and checksum validations used by the SDK that
+ * are not provided by the JDK.
+ */
+@SdkPublicApi
+public interface SdkChecksum extends Checksum {
+
+    /**
+     * Returns the computed checksum in a byte array rather than the long provided by
+     * {@link #getValue()}.
+     *
+     * @return byte[] containing the checksum
+     */
+    byte[] getChecksumBytes();
+
+    /**
+     * Allows marking a checksum for checksums that support the ability to mark and reset.
+     *
+     * @param readLimit the maximum limit of bytes that can be read before the mark position becomes invalid.
+     */
+    void mark(int readLimit);
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.core.client.builder;
 
+import static software.amazon.awssdk.core.ClientType.ASYNC;
+import static software.amazon.awssdk.core.ClientType.SYNC;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.SIGNER;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.USER_AGENT_PREFIX;
@@ -55,8 +57,8 @@ import software.amazon.awssdk.core.internal.http.loader.DefaultSdkAsyncHttpClien
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
 import software.amazon.awssdk.core.internal.util.UserAgentUtils;
 import software.amazon.awssdk.core.retry.RetryPolicy;
-import software.amazon.awssdk.http.ExecuteRequest;
-import software.amazon.awssdk.http.InvokeableHttpRequest;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -84,6 +86,7 @@ import software.amazon.awssdk.utils.Validate;
  */
 @SdkProtectedApi
 public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, C> implements SdkClientBuilder<B, C> {
+
     private static final SdkHttpClient.Builder DEFAULT_HTTP_CLIENT_BUILDER = new DefaultSdkHttpClientBuilder();
     private static final SdkAsyncHttpClient.Builder DEFAULT_ASYNC_HTTP_CLIENT_BUILDER = new DefaultSdkAsyncHttpClientBuilder();
 
@@ -204,6 +207,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
     private SdkClientConfiguration finalizeSyncConfiguration(SdkClientConfiguration config) {
         return config.toBuilder()
                      .option(SdkClientOption.SYNC_HTTP_CLIENT, resolveSyncHttpClient(config))
+                     .option(SdkClientOption.CLIENT_TYPE, SYNC)
                      .build();
     }
 
@@ -214,6 +218,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         return config.toBuilder()
                      .option(FUTURE_COMPLETION_EXECUTOR, resolveAsyncFutureCompletionExecutor(config))
                      .option(ASYNC_HTTP_CLIENT, resolveAsyncHttpClient(config))
+                     .option(SdkClientOption.CLIENT_TYPE, ASYNC)
                      .build();
     }
 
@@ -365,7 +370,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         }
 
         @Override
-        public InvokeableHttpRequest prepareRequest(ExecuteRequest request) {
+        public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
             return delegate.prepareRequest(request);
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -85,6 +86,11 @@ public final class SdkClientOption<T> extends ClientOption<T> {
      */
     public static final SdkClientOption<SdkHttpClient> SYNC_HTTP_CLIENT =
             new SdkClientOption<>(SdkHttpClient.class);
+
+    /**
+     * The type of client used to make requests.
+     */
+    public static final SdkClientOption<ClientType> CLIENT_TYPE = new SdkClientOption<ClientType>(ClientType.class);
 
     /**
      * @see ClientOverrideConfiguration#apiCallAttemptTimeout()

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
@@ -37,12 +37,12 @@ public abstract class BaseClientHandler {
         this.clientConfiguration = clientConfiguration;
     }
 
-    static <InputT extends SdkRequest> InputT finalizeSdkRequest(ExecutionContext executionContext) {
+    static InterceptorContext finalizeSdkRequest(ExecutionContext executionContext) {
         runBeforeExecutionInterceptors(executionContext);
         return runModifyRequestInterceptors(executionContext);
     }
 
-    static <InputT extends SdkRequest, OutputT> SdkHttpFullRequest finalizeSdkHttpFullRequest(
+    static <InputT extends SdkRequest, OutputT> InterceptorContext finalizeSdkHttpFullRequest(
         ClientExecutionParams<InputT, OutputT> executionParams,
         ExecutionContext executionContext, InputT inputT,
         SdkClientConfiguration clientConfiguration) {
@@ -55,7 +55,7 @@ public abstract class BaseClientHandler {
 
         addHttpRequest(executionContext, request);
         runAfterMarshallingInterceptors(executionContext);
-        return runModifyHttpRequestInterceptors(executionContext);
+        return runModifyHttpRequestInterceptors(request, executionContext);
     }
 
     private static void runBeforeExecutionInterceptors(ExecutionContext executionContext) {
@@ -63,12 +63,12 @@ public abstract class BaseClientHandler {
                                                             executionContext.executionAttributes());
     }
 
-    private static <T> T runModifyRequestInterceptors(ExecutionContext executionContext) {
+    private static InterceptorContext runModifyRequestInterceptors(ExecutionContext executionContext) {
         InterceptorContext interceptorContext =
             executionContext.interceptorChain().modifyRequest(executionContext.interceptorContext(),
                                                               executionContext.executionAttributes());
         executionContext.interceptorContext(interceptorContext);
-        return (T) interceptorContext.request();
+        return interceptorContext;
     }
 
     private static void runBeforeMarshallingInterceptors(ExecutionContext executionContext) {
@@ -86,12 +86,13 @@ public abstract class BaseClientHandler {
                                                              executionContext.executionAttributes());
     }
 
-    private static SdkHttpFullRequest runModifyHttpRequestInterceptors(ExecutionContext executionContext) {
+    private static InterceptorContext runModifyHttpRequestInterceptors(SdkHttpFullRequest sdkHttpFullRequest,
+                                                                       ExecutionContext executionContext) {
         InterceptorContext interceptorContext =
             executionContext.interceptorChain().modifyHttpRequest(executionContext.interceptorContext(),
                                                                   executionContext.executionAttributes());
         executionContext.interceptorContext(interceptorContext);
-        return interceptorContext.httpRequest();
+        return interceptorContext;
     }
 
     private static <OutputT extends SdkResponse> OutputT runAfterUnmarshallingInterceptors(OutputT response,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.core.sync.RequestBody;
 
 /**
  * Encapsulates parameters needed for a particular API call. Captures input and output pojo types.
@@ -36,6 +37,7 @@ import software.amazon.awssdk.core.runtime.transform.Marshaller;
 public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
 
     private InputT input;
+    private RequestBody requestBody;
     private AsyncRequestBody asyncRequestBody;
     private Marshaller<InputT> marshaller;
     private HttpResponseHandler<OutputT> responseHandler;
@@ -77,6 +79,15 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
     public ClientExecutionParams<InputT, OutputT> withErrorResponseHandler(
             HttpResponseHandler<? extends SdkException> errorResponseHandler) {
         this.errorResponseHandler = errorResponseHandler;
+        return this;
+    }
+
+    public RequestBody getRequestBody() {
+        return requestBody;
+    }
+
+    public ClientExecutionParams<InputT, OutputT> withRequestBody(RequestBody requestBody) {
+        this.requestBody = requestBody;
         return this;
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/Context.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/Context.java
@@ -15,14 +15,21 @@
 
 package software.amazon.awssdk.core.interceptor;
 
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Optional;
+import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
 
 /**
  * A wrapper for the immutable context objects that are visible to the {@link ExecutionInterceptor}s.
@@ -66,10 +73,20 @@ public final class Context {
     @SdkPublicApi
     public interface AfterMarshalling extends BeforeMarshalling {
         /**
-         * The {@link SdkHttpFullRequest} that was created as a result of marshalling the {@link #request()}. This is the HTTP
+         * The {@link SdkHttpRequest} that was created as a result of marshalling the {@link #request()}. This is the HTTP
          * request that will be sent to the downstream service.
          */
-        SdkHttpFullRequest httpRequest();
+        SdkHttpRequest httpRequest();
+
+        /**
+         * The {@link RequestBody} that represents the body of an HTTP request.
+         */
+        Optional<RequestBody> requestBody();
+
+        /**
+         * The {@link AsyncRequestBody} that allows non-blocking streaming of request content.
+         */
+        Optional<AsyncRequestBody> asyncRequestBody();
     }
 
     /**
@@ -97,7 +114,17 @@ public final class Context {
         /**
          * The HTTP response returned by the service with which the SDK is communicating.
          */
-        SdkHttpFullResponse httpResponse();
+        SdkHttpResponse httpResponse();
+
+        /**
+         * The {@link Publisher} that provides {@link ByteBuffer} events upon request.
+         */
+        Optional<Publisher<ByteBuffer>> responsePublisher();
+
+        /**
+         * The {@link InputStream} that provides streaming content returned from the service.
+         */
+        Optional<InputStream> responseBody();
     }
 
     /**
@@ -167,13 +194,13 @@ public final class Context {
          * The latest version of the {@link SdkHttpFullRequest} available when the execution failed. If the execution failed
          * before or during request marshalling, this will return {@link Optional#empty()}.
          */
-        Optional<SdkHttpFullRequest> httpRequest();
+        Optional<SdkHttpRequest> httpRequest();
 
         /**
          * The latest version of the {@link SdkHttpFullResponse} available when the execution failed. If the execution failed
          * before or during transmission, this will return {@link Optional#empty()}.
          */
-        Optional<SdkHttpFullResponse> httpResponse();
+        Optional<SdkHttpResponse> httpResponse();
 
         /**
          * The latest version of the {@link SdkResponse} available when the execution failed. If the execution failed before or

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/InterceptorContext.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/InterceptorContext.java
@@ -15,13 +15,19 @@
 
 package software.amazon.awssdk.core.interceptor;
 
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import org.reactivestreams.Publisher;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -32,17 +38,26 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 @SdkProtectedApi
 public final class InterceptorContext
         implements Context.AfterExecution,
+                   Context.ModifyHttpRequest,
                    ToCopyableBuilder<InterceptorContext.Builder, InterceptorContext> {
     private final SdkRequest request;
-    private final SdkHttpFullRequest httpRequest;
-    private final SdkHttpFullResponse httpResponse;
+    private final SdkHttpRequest httpRequest;
+    private final Optional<RequestBody> requestBody;
+    private final SdkHttpResponse httpResponse;
+    private final Optional<InputStream> responseBody;
     private final SdkResponse response;
+    private final Optional<AsyncRequestBody> asyncRequestBody;
+    private final Optional<Publisher<ByteBuffer>> responsePublisher;
 
     private InterceptorContext(Builder builder) {
         this.request = Validate.paramNotNull(builder.request, "request");
         this.httpRequest = builder.httpRequest;
+        this.requestBody = builder.requestBody;
         this.httpResponse = builder.httpResponse;
+        this.responseBody = builder.responseBody;
         this.response = builder.response;
+        this.asyncRequestBody = builder.asyncRequestBody;
+        this.responsePublisher = builder.responsePublisher;
     }
 
     public static Builder builder() {
@@ -60,13 +75,33 @@ public final class InterceptorContext
     }
 
     @Override
-    public SdkHttpFullRequest httpRequest() {
+    public Optional<RequestBody> requestBody() {
+        return requestBody;
+    }
+
+    @Override
+    public Optional<AsyncRequestBody> asyncRequestBody() {
+        return asyncRequestBody;
+    }
+
+    @Override
+    public Optional<Publisher<ByteBuffer>> responsePublisher() {
+        return responsePublisher;
+    }
+
+    @Override
+    public SdkHttpRequest httpRequest() {
         return httpRequest;
     }
 
     @Override
-    public SdkHttpFullResponse httpResponse() {
+    public SdkHttpResponse httpResponse() {
         return httpResponse;
+    }
+
+    @Override
+    public Optional<InputStream> responseBody() {
+        return responseBody;
     }
 
     @Override
@@ -78,9 +113,13 @@ public final class InterceptorContext
     @SdkPublicApi
     public static final class Builder implements CopyableBuilder<Builder, InterceptorContext> {
         private SdkRequest request;
-        private SdkHttpFullRequest httpRequest;
-        private SdkHttpFullResponse httpResponse;
+        private SdkHttpRequest httpRequest;
+        private Optional<RequestBody> requestBody = Optional.empty();
+        private SdkHttpResponse httpResponse;
+        private Optional<InputStream> responseBody = Optional.empty();
         private SdkResponse response;
+        private Optional<AsyncRequestBody> asyncRequestBody = Optional.empty();
+        private Optional<Publisher<ByteBuffer>> responsePublisher = Optional.empty();
 
         private Builder() {
             super();
@@ -89,8 +128,12 @@ public final class InterceptorContext
         private Builder(InterceptorContext context) {
             this.request = context.request;
             this.httpRequest = context.httpRequest;
+            this.requestBody = context.requestBody;
             this.httpResponse = context.httpResponse;
+            this.responseBody = context.responseBody;
             this.response = context.response;
+            this.asyncRequestBody = context.asyncRequestBody;
+            this.responsePublisher = context.responsePublisher;
         }
 
         public Builder request(SdkRequest request) {
@@ -98,18 +141,38 @@ public final class InterceptorContext
             return this;
         }
 
-        public Builder httpRequest(SdkHttpFullRequest httpRequest) {
+        public Builder httpRequest(SdkHttpRequest httpRequest) {
             this.httpRequest = httpRequest;
             return this;
         }
 
-        public Builder httpResponse(SdkHttpFullResponse httpResponse) {
+        public Builder requestBody(RequestBody requestBody) {
+            this.requestBody = Optional.ofNullable(requestBody);
+            return this;
+        }
+
+        public Builder httpResponse(SdkHttpResponse httpResponse) {
             this.httpResponse = httpResponse;
+            return this;
+        }
+
+        public Builder responseBody(InputStream responseBody) {
+            this.responseBody = Optional.ofNullable(responseBody);
             return this;
         }
 
         public Builder response(SdkResponse response) {
             this.response = response;
+            return this;
+        }
+
+        public Builder asyncRequestBody(AsyncRequestBody asyncRequestBody) {
+            this.asyncRequestBody = Optional.ofNullable(asyncRequestBody);
+            return this;
+        }
+
+        public Builder responsePublisher(Publisher<ByteBuffer> responsePublisher) {
+            this.responsePublisher = Optional.ofNullable(responsePublisher);
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.interceptor;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.signer.Signer;
 
@@ -41,6 +42,8 @@ public class SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<Integer> TIME_OFFSET = new ExecutionAttribute<>("TimeOffset");
 
+    public static final ExecutionAttribute<ClientType> CLIENT_TYPE = new ExecutionAttribute<>("ClientType");
+    
     protected SdkExecutionAttribute() {
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/DefaultFailedExecutionContext.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/DefaultFailedExecutionContext.java
@@ -22,8 +22,8 @@ import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -52,12 +52,12 @@ public class DefaultFailedExecutionContext implements Context.FailedExecution {
     }
 
     @Override
-    public Optional<SdkHttpFullRequest> httpRequest() {
+    public Optional<SdkHttpRequest> httpRequest() {
         return Optional.ofNullable(interceptorContext.httpRequest());
     }
 
     @Override
-    public Optional<SdkHttpFullResponse> httpResponse() {
+    public Optional<SdkHttpResponse> httpResponse() {
         return Optional.ofNullable(interceptorContext.httpResponse());
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
@@ -51,8 +51,8 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
@@ -200,7 +200,8 @@ public class AsyncClientHandlerInterceptorExceptionTest {
 
         MODIFY_HTTP_REQUEST(new ExecutionInterceptor() {
             @Override
-            public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+            public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                                    ExecutionAttributes executionAttributes) {
                 throw new RuntimeException(MODIFY_HTTP_REQUEST.name());
             }
         }),
@@ -221,7 +222,8 @@ public class AsyncClientHandlerInterceptorExceptionTest {
 
         MODIFY_HTTP_RESPONSE(new ExecutionInterceptor() {
             @Override
-            public SdkHttpFullResponse modifyHttpResponse(Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+            public SdkHttpFullResponse modifyHttpResponse(Context.ModifyHttpResponse context,
+                                                          ExecutionAttributes executionAttributes) {
                 throw new RuntimeException(MODIFY_HTTP_RESPONSE.name());
             }
         }),

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
@@ -46,10 +46,11 @@ import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.http.AbortableInputStream;
-import software.amazon.awssdk.http.InvokeableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import utils.HttpTestUtils;
 import utils.ValidSdkObjects;
 
@@ -69,7 +70,7 @@ public class SyncClientHandlerTest {
     private SdkHttpClient httpClient;
 
     @Mock
-    private InvokeableHttpRequest httpClientCall;
+    private ExecutableHttpRequest httpClientCall;
 
     @Mock
     private HttpResponseHandler<SdkResponse> responseHandler;
@@ -95,8 +96,12 @@ public class SyncClientHandlerTest {
 
         // Given
         expectRetrievalFromMocks();
-        when(httpClientCall.call()).thenReturn(SdkHttpFullResponse.builder().statusCode(200)
-                                                                  .headers(headers).build()); // Successful HTTP call
+        when(httpClientCall.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                  .response(SdkHttpResponse.builder()
+                                                                                       .statusCode(200)
+                                                                                       .headers(headers)
+                                                                                       .build())
+                                                                  .build()); // Successful HTTP call
         when(responseHandler.handle(any(), any())).thenReturn(expected); // Response handler call
 
         // When
@@ -117,7 +122,12 @@ public class SyncClientHandlerTest {
 
         // Given
         expectRetrievalFromMocks();
-        when(httpClientCall.call()).thenReturn(SdkHttpFullResponse.builder().statusCode(500).headers(headers).build()); // Failed HTTP call
+        when(httpClientCall.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                  .response(SdkHttpResponse.builder()
+                                                                                       .statusCode(500)
+                                                                                       .headers(headers)
+                                                                                       .build())
+                                                                  .build()); // Failed HTTP call
         when(errorResponseHandler.handle(any(), any())).thenReturn(exception); // Error response handler call
 
         // When
@@ -172,9 +182,10 @@ public class SyncClientHandlerTest {
 
     private void mockSuccessfulApiCall() throws Exception {
         expectRetrievalFromMocks();
-        when(httpClientCall.call()).thenReturn(SdkHttpFullResponse.builder()
-                                                                  .content(AbortableInputStream.create(new ByteArrayInputStream("TEST".getBytes())))
-                                                                  .statusCode(200).build());
+        when(httpClientCall.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                  .responseBody(AbortableInputStream.create(new ByteArrayInputStream("TEST".getBytes())))
+                                                                  .response(SdkHttpResponse.builder().statusCode(200).build())
+                                                                  .build());
         when(responseHandler.handle(any(), any())).thenReturn(VoidSdkResponse.builder().build());
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/AmazonHttpClientTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/AmazonHttpClientTest.java
@@ -37,10 +37,11 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient;
 import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils;
-import software.amazon.awssdk.http.ExecuteRequest;
-import software.amazon.awssdk.http.InvokeableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import utils.HttpTestUtils;
 import utils.ValidSdkObjects;
 
@@ -51,7 +52,7 @@ public class AmazonHttpClientTest {
     private SdkHttpClient sdkHttpClient;
 
     @Mock
-    private InvokeableHttpRequest abortableCallable;
+    private ExecutableHttpRequest abortableCallable;
 
     private AmazonSyncHttpClient client;
 
@@ -135,7 +136,7 @@ public class AmazonHttpClientTest {
               .executionContext(ClientExecutionAndRequestTimerTestUtils.executionContext(null))
               .execute(handler);
 
-        ArgumentCaptor<ExecuteRequest> httpRequestCaptor = ArgumentCaptor.forClass(ExecuteRequest.class);
+        ArgumentCaptor<HttpExecuteRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpExecuteRequest.class);
         verify(sdkHttpClient).prepareRequest(httpRequestCaptor.capture());
 
         final String userAgent = httpRequestCaptor.getValue().httpRequest().firstMatchingHeader("User-Agent")
@@ -146,8 +147,9 @@ public class AmazonHttpClientTest {
     }
 
     private void stubSuccessfulResponse() throws Exception {
-        when(abortableCallable.call()).thenReturn(SdkHttpFullResponse.builder()
-                                                                     .statusCode(200)
+        when(abortableCallable.call()).thenReturn(HttpExecuteResponse.builder().response(SdkHttpResponse.builder()
+                                                                                                        .statusCode(200)
+                                                                                                        .build())
                                                                      .build());
     }
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullRequest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -138,7 +139,8 @@ final class DefaultSdkHttpFullRequest implements SdkHttpFullRequest {
 
     @Override
     public SdkHttpFullRequest.Builder toBuilder() {
-        return new Builder()
+        return (SdkHttpFullRequest.Builder) new Builder()
+                .contentStreamProvider(contentStreamProvider)
                 .protocol(protocol)
                 .host(host)
                 .port(port)
@@ -146,7 +148,7 @@ final class DefaultSdkHttpFullRequest implements SdkHttpFullRequest {
                 .rawQueryParameters(queryParameters)
                 .method(httpMethod)
                 .headers(headers)
-                .contentStreamProvider(contentStreamProvider);
+            ;
     }
 
     @Override
@@ -311,6 +313,17 @@ final class DefaultSdkHttpFullRequest implements SdkHttpFullRequest {
 
         public ContentStreamProvider contentStreamProvider() {
             return contentStreamProvider;
+        }
+
+        @Override
+        public SdkHttpFullRequest.Builder copy() {
+            return build().toBuilder();
+        }
+
+        @Override
+        public SdkHttpFullRequest.Builder applyMutation(Consumer<SdkHttpRequest.Builder> mutator) {
+            mutator.accept(this);
+            return this;
         }
 
         @Override

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/ExecutableHttpRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/ExecutableHttpRequest.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  * which should release the thread that has invoked {@link #call()} as soon as possible.
  */
 @SdkPublicApi
-public interface InvokeableHttpRequest extends Callable<SdkHttpFullResponse>, Abortable {
+public interface ExecutableHttpRequest extends Callable<HttpExecuteResponse>, Abortable {
     @Override
-    SdkHttpFullResponse call() throws IOException;
+    HttpExecuteResponse call() throws IOException;
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpExecuteRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpExecuteRequest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http;
 
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
@@ -23,19 +24,28 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  * @see SdkHttpClient
  */
 @SdkPublicApi
-public final class ExecuteRequest {
+public final class HttpExecuteRequest {
 
-    private final SdkHttpFullRequest request;
+    private final SdkHttpRequest request;
+    private final Optional<ContentStreamProvider> contentStreamProvider;
 
-    private ExecuteRequest(BuilderImpl builder) {
+    private HttpExecuteRequest(BuilderImpl builder) {
         this.request = builder.request;
+        this.contentStreamProvider = builder.contentStreamProvider;
     }
 
     /**
      * @return The HTTP request.
      */
-    public SdkHttpFullRequest httpRequest() {
+    public SdkHttpRequest httpRequest() {
         return request;
+    }
+
+    /**
+     * @return The {@link ContentStreamProvider}.
+     */
+    public Optional<ContentStreamProvider> contentStreamProvider() {
+        return contentStreamProvider;
     }
 
     public static Builder builder() {
@@ -49,23 +59,37 @@ public final class ExecuteRequest {
          * @param request The request.
          * @return This builder for method chaining.
          */
-        Builder request(SdkHttpFullRequest request);
+        Builder request(SdkHttpRequest request);
 
-        ExecuteRequest build();
+        /**
+         * Set the {@link ContentStreamProvider} to be executed by the client.
+         * @param contentStreamProvider The content stream provider
+         * @return This builder for method chaining
+         */
+        Builder contentStreamProvider(ContentStreamProvider contentStreamProvider);
+
+        HttpExecuteRequest build();
     }
 
     private static class BuilderImpl implements Builder {
-        private SdkHttpFullRequest request;
+        private SdkHttpRequest request;
+        private Optional<ContentStreamProvider> contentStreamProvider = Optional.empty();
 
         @Override
-        public Builder request(SdkHttpFullRequest request) {
+        public Builder request(SdkHttpRequest request) {
             this.request = request;
             return this;
         }
 
         @Override
-        public ExecuteRequest build() {
-            return new ExecuteRequest(this);
+        public Builder contentStreamProvider(ContentStreamProvider contentStreamProvider) {
+            this.contentStreamProvider = Optional.ofNullable(contentStreamProvider);
+            return this;
+        }
+
+        @Override
+        public HttpExecuteRequest build() {
+            return new HttpExecuteRequest(this);
         }
     }
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpExecuteResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpExecuteResponse.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import java.io.InputStream;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+@SdkPublicApi
+public class HttpExecuteResponse {
+
+    private final SdkHttpResponse response;
+    private final Optional<AbortableInputStream> responseBody;
+
+    private HttpExecuteResponse(BuilderImpl builder) {
+        this.response = builder.response;
+        this.responseBody = builder.responseBody;
+    }
+
+    /**
+     * @return The HTTP response.
+     */
+    public SdkHttpResponse httpResponse() {
+        return response;
+    }
+
+    /**
+     * @return The {@link ContentStreamProvider}.
+     */
+    public Optional<AbortableInputStream> responseBody() {
+        return responseBody;
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder {
+        /**
+         * Set the HTTP response to be executed by the client.
+         *
+         * @param response The response.
+         * @return This builder for method chaining.
+         */
+        Builder response(SdkHttpResponse response);
+
+        /**
+         * Set the {@link InputStream} to be returned by the client.
+         * @param inputStream The {@link InputStream}
+         * @return This builder for method chaining
+         */
+        Builder responseBody(AbortableInputStream inputStream);
+
+        HttpExecuteResponse build();
+    }
+
+    private static class BuilderImpl implements Builder {
+
+        private SdkHttpResponse response;
+        private Optional<AbortableInputStream> responseBody = Optional.empty();
+
+        @Override
+        public Builder response(SdkHttpResponse response) {
+            this.response = response;
+            return this;
+        }
+
+        @Override
+        public Builder responseBody(AbortableInputStream responseBody) {
+            this.responseBody = Optional.ofNullable(responseBody);
+            return this;
+        }
+
+        @Override
+        public HttpExecuteResponse build() {
+            return new HttpExecuteResponse(this);
+        }
+    }
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
@@ -32,12 +32,12 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
 @SdkPublicApi
 public interface SdkHttpClient extends SdkAutoCloseable {
     /**
-     * Create a {@link InvokeableHttpRequest} that can be used to execute the HTTP request.
+     * Create a {@link ExecutableHttpRequest} that can be used to execute the HTTP request.
      *
      * @param request        Representation of an HTTP request.
      * @return Task that can execute an HTTP request and can be aborted.
      */
-    InvokeableHttpRequest prepareRequest(ExecuteRequest request);
+    ExecutableHttpRequest prepareRequest(HttpExecuteRequest request);
 
     /**
      * Interface for creating an {@link SdkHttpClient} with service specific defaults applied.

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullRequest.java
@@ -21,10 +21,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.utils.builder.CopyableBuilder;
-import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
@@ -36,13 +35,16 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @SdkPublicApi
 @Immutable
 public interface SdkHttpFullRequest
-        extends SdkHttpRequest, ToCopyableBuilder<SdkHttpFullRequest.Builder, SdkHttpFullRequest> {
+    extends SdkHttpRequest {
     /**
      * @return Builder instance to construct a {@link DefaultSdkHttpFullRequest}.
      */
-    static Builder builder() {
+    static SdkHttpFullRequest.Builder builder() {
         return new DefaultSdkHttpFullRequest.Builder();
     }
+
+    @Override
+    SdkHttpFullRequest.Builder toBuilder();
 
     /**
      * @return The optional {@link ContentStreamProvider} for this request.
@@ -53,8 +55,7 @@ public interface SdkHttpFullRequest
      * A mutable builder for {@link SdkHttpFullRequest}. An instance of this can be created using
      * {@link SdkHttpFullRequest#builder()}.
      */
-    interface Builder extends CopyableBuilder<Builder, SdkHttpFullRequest> {
-
+    interface Builder extends SdkHttpRequest.Builder {
         /**
          * Convenience method to set the {@link #protocol()}, {@link #host()}, {@link #port()}, and
          * {@link #encodedPath()} from a {@link URI} object.
@@ -62,6 +63,7 @@ public interface SdkHttpFullRequest
          * @param uri URI containing protocol, host, port and path.
          * @return This builder for method chaining.
          */
+        @Override
         default Builder uri(URI uri) {
             return this.protocol(uri.getScheme())
                        .host(uri.getHost())
@@ -72,23 +74,27 @@ public interface SdkHttpFullRequest
         /**
          * The protocol, exactly as it was configured with {@link #protocol(String)}.
          */
+        @Override
         String protocol();
 
         /**
          * Configure a {@link SdkHttpRequest#protocol()} to be used in the created HTTP request. This is not validated until the
          * http request is created.
          */
+        @Override
         Builder protocol(String protocol);
 
         /**
          * The host, exactly as it was configured with {@link #host(String)}.
          */
+        @Override
         String host();
 
         /**
          * Configure a {@link SdkHttpRequest#host()} to be used in the created HTTP request. This is not validated until the
          * http request is created.
          */
+        @Override
         Builder host(String host);
 
         /**
@@ -101,11 +107,13 @@ public interface SdkHttpFullRequest
          * http request is created. In order to simplify mapping from a {@link URI}, "-1" will be treated as "null" when the http
          * request is created.
          */
+        @Override
         Builder port(Integer port);
 
         /**
          * The path, exactly as it was configured with {@link #encodedPath(String)}.
          */
+        @Override
         String encodedPath();
 
         /**
@@ -116,12 +124,14 @@ public interface SdkHttpFullRequest
          * implementation to distinguish a "/" that is part of a resource name that should be encoded as "%2F" from a "/" that is
          * part of the actual path.</p>
          */
+        @Override
         Builder encodedPath(String path);
 
         /**
          * The query parameters, exactly as they were configured with {@link #rawQueryParameters(Map)},
          * {@link #putRawQueryParameter(String, String)} and {@link #putRawQueryParameter(String, List)}.
          */
+        @Override
         Map<String, List<String>> rawQueryParameters();
 
         /**
@@ -132,6 +142,7 @@ public interface SdkHttpFullRequest
          * @param paramName The name of the query parameter to add
          * @param paramValue The un-encoded value for the query parameter.
          */
+        @Override
         default Builder putRawQueryParameter(String paramName, String paramValue) {
             return putRawQueryParameter(paramName, singletonList(paramValue));
         }
@@ -145,6 +156,7 @@ public interface SdkHttpFullRequest
          * @param paramName The name of the query parameter to add
          * @param paramValue The un-encoded value for the query parameter.
          */
+        @Override
         Builder appendRawQueryParameter(String paramName, String paramValue);
 
         /**
@@ -155,6 +167,7 @@ public interface SdkHttpFullRequest
          * @param paramName The name of the query parameter to add
          * @param paramValues The un-encoded values for the query parameter.
          */
+        @Override
         Builder putRawQueryParameter(String paramName, List<String> paramValues);
 
         /**
@@ -165,27 +178,32 @@ public interface SdkHttpFullRequest
          * <p>Justification of requirements: The query parameters must not be encoded when they are configured because some HTTP
          * implementations perform this encoding automatically.</p>
          */
+        @Override
         Builder rawQueryParameters(Map<String, List<String>> queryParameters);
 
         /**
          * Remove all values for the requested query parameter from this builder.
          */
+        @Override
         Builder removeQueryParameter(String paramName);
 
         /**
          * Removes all query parameters from this builder.
          */
+        @Override
         Builder clearQueryParameters();
 
         /**
          * The path, exactly as it was configured with {@link #method(SdkHttpMethod)}.
          */
+        @Override
         SdkHttpMethod method();
 
         /**
          * Configure an {@link SdkHttpRequest#method()} to be used in the created HTTP request. This is not validated
          * until the http request is created.
          */
+        @Override
         Builder method(SdkHttpMethod httpMethod);
 
         /**
@@ -200,6 +218,7 @@ public interface SdkHttpFullRequest
          * @param header The header to search for (case insensitively).
          * @return The first header that matched the requested one, or empty if one was not found.
          */
+        @Override
         default Optional<String> firstMatchingHeader(String header) {
             return SdkHttpUtils.firstMatchingHeader(headers(), header);
         }
@@ -208,6 +227,7 @@ public interface SdkHttpFullRequest
          * The query parameters, exactly as they were configured with {@link #headers(Map)},
          * {@link #putHeader(String, String)} and {@link #putHeader(String, List)}.
          */
+        @Override
         Map<String, List<String>> headers();
 
         /**
@@ -218,6 +238,7 @@ public interface SdkHttpFullRequest
          * @param headerName The name of the header to add (eg. "Host")
          * @param headerValue The value for the header
          */
+        @Override
         default Builder putHeader(String headerName, String headerValue) {
             return putHeader(headerName, singletonList(headerValue));
         }
@@ -230,6 +251,7 @@ public interface SdkHttpFullRequest
          * @param headerName The name of the header to add
          * @param headerValues The values for the header
          */
+        @Override
         Builder putHeader(String headerName, List<String> headerValues);
 
         /**
@@ -241,22 +263,26 @@ public interface SdkHttpFullRequest
          * @param headerName The name of the header to add
          * @param headerValue The value for the header
          */
+        @Override
         Builder appendHeader(String headerName, String headerValue);
 
         /**
          * Configure an {@link SdkHttpRequest#headers()} to be used in the created HTTP request. This is not validated
          * until the http request is created. This overrides any values currently configured in the builder.
          */
+        @Override
         Builder headers(Map<String, List<String>> headers);
 
         /**
          * Remove all values for the requested header from this builder.
          */
+        @Override
         Builder removeHeader(String headerName);
 
         /**
          * Removes all headers from this builder.
          */
+        @Override
         Builder clearHeaders();
 
         /**
@@ -271,6 +297,15 @@ public interface SdkHttpFullRequest
          * @return The {@link ContentStreamProvider} for this request.
          */
         ContentStreamProvider contentStreamProvider();
+
+        @Override
+        SdkHttpFullRequest.Builder copy();
+
+        @Override
+        SdkHttpFullRequest.Builder applyMutation(Consumer<SdkHttpRequest.Builder> mutator);
+
+        @Override
+        SdkHttpFullRequest build();
     }
 
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpFullResponse.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.utils.builder.CopyableBuilder;
-import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
@@ -36,13 +34,16 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @SdkProtectedApi
 @Immutable
 public interface SdkHttpFullResponse
-        extends SdkHttpResponse, ToCopyableBuilder<SdkHttpFullResponse.Builder, SdkHttpFullResponse> {
+        extends SdkHttpResponse {
     /**
      * @return Builder instance to construct a {@link DefaultSdkHttpFullResponse}.
      */
     static Builder builder() {
         return new DefaultSdkHttpFullResponse.Builder();
     }
+
+    @Override
+    Builder toBuilder();
 
     /**
      * Returns the optional stream containing the payload data returned by the service. Note: an {@link AbortableInputStream}
@@ -58,7 +59,7 @@ public interface SdkHttpFullResponse
     /**
      * Builder for a {@link DefaultSdkHttpFullResponse}.
      */
-    interface Builder extends CopyableBuilder<Builder, SdkHttpFullResponse> {
+    interface Builder extends SdkHttpResponse.Builder {
         /**
          * The status text, exactly as it was configured with {@link #statusText(String)}.
          */
@@ -166,5 +167,8 @@ public interface SdkHttpFullResponse
          * This is usually done by closing the service connection.</p>
          */
         Builder content(AbortableInputStream content);
+
+        @Override
+        SdkHttpFullResponse build();
     }
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpResponse.java
@@ -15,10 +15,17 @@
 
 package software.amazon.awssdk.http;
 
+import static java.util.Collections.singletonList;
+
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * An immutable HTTP response without access to the response body. {@link SdkHttpFullResponse} should be used when access to a
@@ -26,7 +33,16 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  */
 @SdkPublicApi
 @Immutable
-public interface SdkHttpResponse extends SdkHttpHeaders, Serializable {
+public interface SdkHttpResponse extends ToCopyableBuilder<SdkHttpResponse.Builder, SdkHttpResponse>,
+                                         SdkHttpHeaders, Serializable {
+
+    /**
+     * @return Builder instance to construct a {@link DefaultSdkHttpFullResponse}.
+     */
+    static SdkHttpFullResponse.Builder builder() {
+        return new DefaultSdkHttpFullResponse.Builder();
+    }
+
     /**
      * Returns the HTTP status text returned by the service.
      *
@@ -46,5 +62,104 @@ public interface SdkHttpResponse extends SdkHttpHeaders, Serializable {
      */
     default boolean isSuccessful() {
         return HttpStatusFamily.of(statusCode()) == HttpStatusFamily.SUCCESSFUL;
+    }
+    
+    /**
+     * Builder for a {@link DefaultSdkHttpFullResponse}.
+     */
+    interface Builder extends CopyableBuilder<Builder, SdkHttpResponse> {
+        /**
+         * The status text, exactly as it was configured with {@link #statusText(String)}.
+         */
+        String statusText();
+
+        /**
+         * Configure an {@link SdkHttpResponse#statusText()} to be used in the created HTTP response. This is not validated
+         * until the http response is created.
+         */
+        Builder statusText(String statusText);
+
+        /**
+         * The status text, exactly as it was configured with {@link #statusCode(int)}.
+         */
+        int statusCode();
+
+        /**
+         * Configure an {@link SdkHttpResponse#statusCode()} to be used in the created HTTP response. This is not validated
+         * until the http response is created.
+         */
+        Builder statusCode(int statusCode);
+
+        /**
+         * The query parameters, exactly as they were configured with {@link #headers(Map)},
+         * {@link #putHeader(String, String)} and {@link #putHeader(String, List)}.
+         */
+        Map<String, List<String>> headers();
+
+        /**
+         * Perform a case-insensitive search for a particular header in this request, returning the first matching header, if one
+         * is found.
+         *
+         * <p>This is useful for headers like 'Content-Type' or 'Content-Length' of which there is expected to be only one value
+         * present.</p>
+         *
+         * <p>This is equivalent to invoking {@link SdkHttpUtils#firstMatchingHeader(Map, String)}</p>.
+         *
+         * @param header The header to search for (case insensitively).
+         * @return The first header that matched the requested one, or empty if one was not found.
+         */
+        default Optional<String> firstMatchingHeader(String header) {
+            return SdkHttpUtils.firstMatchingHeader(headers(), header);
+        }
+
+        /**
+         * Add a single header to be included in the created HTTP response.
+         *
+         * <p>This completely <b>OVERRIDES</b> any values already configured with this header name in the builder.</p>
+         *
+         * @param headerName The name of the header to add (eg. "Host")
+         * @param headerValue The value for the header
+         */
+        default Builder putHeader(String headerName, String headerValue) {
+            return putHeader(headerName, singletonList(headerValue));
+        }
+
+        /**
+         * Add a single header with multiple values to be included in the created HTTP response.
+         *
+         * <p>This completely <b>OVERRIDES</b> any values already configured with this header name in the builder.</p>
+         *
+         * @param headerName The name of the header to add
+         * @param headerValues The values for the header
+         */
+        Builder putHeader(String headerName, List<String> headerValues);
+
+
+        /**
+         * Add a single header to be included in the created HTTP request.
+         *
+         * <p>This will <b>ADD</b> the value to any existing values already configured with this header name in
+         * the builder.</p>
+         *
+         * @param headerName The name of the header to add
+         * @param headerValue The value for the header
+         */
+        Builder appendHeader(String headerName, String headerValue);
+
+        /**
+         * Configure an {@link SdkHttpResponse#headers()} to be used in the created HTTP response. This is not validated
+         * until the http response is created. This overrides any values currently configured in the builder.
+         */
+        Builder headers(Map<String, List<String>> headers);
+
+        /**
+         * Remove all values for the requested header from this builder.
+         */
+        Builder removeHeader(String headerName);
+
+        /**
+         * Removes all headers from this builder.
+         */
+        Builder clearHeaders();
     }
 }

--- a/http-client-spi/src/test/java/software/amazon/awssdk/http/SdkHttpRequestResponseTest.java
+++ b/http-client-spi/src/test/java/software/amazon/awssdk/http/SdkHttpRequestResponseTest.java
@@ -66,7 +66,7 @@ public class SdkHttpRequestResponseTest {
                 .isEqualTo("http://localhost/foo/?foo=bar");
     }
 
-    private String normalizedUri(Consumer<SdkHttpFullRequest.Builder> builderMutator) {
+    private String normalizedUri(Consumer<SdkHttpRequest.Builder> builderMutator) {
         return validRequestBuilder().applyMutation(builderMutator).build().getUri().toString();
     }
 
@@ -146,7 +146,7 @@ public class SdkHttpRequestResponseTest {
     @Test
     public void requestQueryParamNormalizationIsCorrect() {
         headerOrQueryStringNormalizationIsCorrect(() -> new BuilderProxy() {
-            private final SdkHttpFullRequest.Builder builder = validRequestBuilder();
+            private final SdkHttpRequest.Builder builder = validRequestBuilder();
 
             @Override
             public BuilderProxy setValue(String key, String value) {
@@ -194,7 +194,7 @@ public class SdkHttpRequestResponseTest {
     @Test
     public void requestHeaderNormalizationIsCorrect() {
         headerOrQueryStringNormalizationIsCorrect(() -> new BuilderProxy() {
-            private final SdkHttpFullRequest.Builder builder = validRequestBuilder();
+            private final SdkHttpRequest.Builder builder = validRequestBuilder();
 
             @Override
             public BuilderProxy setValue(String key, String value) {

--- a/services/apigateway/src/main/java/software/amazon/awssdk/services/apigateway/internal/AcceptJsonInterceptor.java
+++ b/services/apigateway/src/main/java/software/amazon/awssdk/services/apigateway/internal/AcceptJsonInterceptor.java
@@ -19,12 +19,13 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 @SdkInternalApi
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                            ExecutionAttributes executionAttributes) {
         return context.httpRequest()
                       .toBuilder()
                       .putHeader("Accept", "application/json")

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/SignersIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/SignersIntegrationTest.java
@@ -20,7 +20,6 @@ import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,12 +32,11 @@ import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
-import software.amazon.awssdk.http.ExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkRequestContext;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -127,12 +125,12 @@ public class SignersIntegrationTest extends DynamoDBTestBase {
 
         SdkHttpClient httpClient = ApacheHttpClient.builder().build();
 
-        SdkHttpFullResponse response = httpClient.prepareRequest(ExecuteRequest.builder().request(signedRequest).build())
+        HttpExecuteResponse response = httpClient.prepareRequest(HttpExecuteRequest.builder().request(signedRequest).build())
                                                  .call();
 
-        assertEquals("Non success http status code", 200, response.statusCode());
+        assertEquals("Non success http status code", 200, response.httpResponse().statusCode());
 
-        String actualResult = IoUtils.toUtf8String(response.content().get());
+        String actualResult = IoUtils.toUtf8String(response.responseBody().get());
         assertEquals(getExpectedResult(), actualResult);
     }
 
@@ -146,12 +144,12 @@ public class SignersIntegrationTest extends DynamoDBTestBase {
 
         SdkHttpClient httpClient = ApacheHttpClient.builder().build();
 
-        SdkHttpFullResponse response = httpClient.prepareRequest(ExecuteRequest.builder().request(signedRequest).build())
+        HttpExecuteResponse response = httpClient.prepareRequest(HttpExecuteRequest.builder().request(signedRequest).build())
                                                  .call();
 
-        assertEquals("Non success http status code", 200, response.statusCode());
+        assertEquals("Non success http status code", 200, response.httpResponse().statusCode());
 
-        String actualResult = IoUtils.toUtf8String(response.content().get());
+        String actualResult = IoUtils.toUtf8String(response.responseBody().get());
         assertEquals(getExpectedResult(), actualResult);
     }
 

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/internal/GeneratePreSignUrlInterceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/internal/GeneratePreSignUrlInterceptor.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.protocols.query.AwsEc2ProtocolFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
@@ -55,8 +56,8 @@ public final class GeneratePreSignUrlInterceptor implements ExecutionInterceptor
     private static final CopySnapshotRequestMarshaller MARSHALLER = new CopySnapshotRequestMarshaller(PROTOCOL_FACTORY);
 
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
-        SdkHttpFullRequest request = context.httpRequest();
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        SdkHttpRequest request = context.httpRequest();
         SdkRequest originalRequest = context.request();
 
         if (originalRequest instanceof CopySnapshotRequest) {

--- a/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/internal/TimestampFormatInterceptor.java
+++ b/services/ec2/src/main/java/software/amazon/awssdk/services/ec2/transform/internal/TimestampFormatInterceptor.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeSpotFleetRequestHistoryRequest;
 import software.amazon.awssdk.services.ec2.model.RequestSpotFleetRequest;
 
@@ -41,8 +41,8 @@ public final class TimestampFormatInterceptor implements ExecutionInterceptor {
     private static final String VALID_UNTIL = "SpotFleetRequestConfig.ValidUntil";
 
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
-        SdkHttpFullRequest request = context.httpRequest();
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        SdkHttpRequest request = context.httpRequest();
         Object original = context.request();
         if (original instanceof DescribeSpotFleetRequestHistoryRequest) {
             Map<String, List<String>> params = request.rawQueryParameters();

--- a/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
+++ b/services/glacier/src/it/java/software/amazon/awssdk/services/glacier/ServiceIntegrationTest.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.glacier.model.ListVaultsRequest;
 import software.amazon.awssdk.services.glacier.model.ResourceNotFoundException;
 import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
@@ -72,7 +72,7 @@ public class ServiceIntegrationTest extends AwsIntegrationTestBase {
 
     public static class CapturingExecutionInterceptor implements ExecutionInterceptor {
 
-        private SdkHttpFullRequest beforeTransmission;
+        private SdkHttpRequest beforeTransmission;
 
         @Override
         public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/AcceptJsonInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/AcceptJsonInterceptor.java
@@ -19,12 +19,12 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 @SdkInternalApi
 public final class AcceptJsonInterceptor implements ExecutionInterceptor {
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
         return context.httpRequest()
                       .toBuilder()
                       .putHeader("Accept", "application/json")

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.glacier.model.DescribeJobRequest;
 import software.amazon.awssdk.services.glacier.model.GetJobOutputRequest;
 import software.amazon.awssdk.services.glacier.model.UploadMultipartPartRequest;
@@ -28,15 +28,15 @@ import software.amazon.awssdk.services.glacier.model.UploadMultipartPartRequest;
 public final class GlacierExecutionInterceptor implements ExecutionInterceptor {
 
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
-        SdkHttpFullRequest request = context.httpRequest();
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        SdkHttpRequest request = context.httpRequest();
         Object originalRequest = context.request();
         return request.toBuilder()
                       .applyMutation(b -> beforeRequest(originalRequest, b))
                       .build();
     }
 
-    private SdkHttpFullRequest.Builder beforeRequest(Object originalRequest, SdkHttpFullRequest.Builder mutableRequest) {
+    private SdkHttpRequest.Builder beforeRequest(Object originalRequest, SdkHttpRequest.Builder mutableRequest) {
         mutableRequest.putHeader("x-amz-glacier-version", "2012-06-01");
 
         //  "x-amz-content-sha256" header is required for sig v4 for some streaming operations

--- a/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/PredictEndpointInterceptor.java
+++ b/services/machinelearning/src/main/java/software/amazon/awssdk/services/machinelearning/internal/PredictEndpointInterceptor.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.machinelearning.model.PredictRequest;
 
 /**
@@ -34,8 +34,8 @@ import software.amazon.awssdk.services.machinelearning.model.PredictRequest;
 public final class PredictEndpointInterceptor implements ExecutionInterceptor {
 
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
-        SdkHttpFullRequest request = context.httpRequest();
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        SdkHttpRequest request = context.httpRequest();
         Object originalRequest = context.request();
         if (originalRequest instanceof PredictRequest) {
             PredictRequest pr = (PredictRequest) originalRequest;

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.model.RdsRequest;
@@ -81,9 +82,9 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
     }
 
     @Override
-    public final SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+    public final SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
                                                       ExecutionAttributes executionAttributes) {
-        SdkHttpFullRequest request = context.httpRequest();
+        SdkHttpRequest request = context.httpRequest();
         SdkRequest originalRequest = context.request();
         if (!requestClassToPreSign.isInstance(originalRequest)) {
             return request;

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -70,12 +70,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>lambda</artifactId>
-            <groupId>software.amazon.awssdk</groupId>
-            <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <artifactId>iam</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
@@ -79,7 +79,6 @@ public class GetObjectAsyncIntegrationTest extends S3IntegrationTestBase {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
         try {
             GetObjectResponse response = s3Async.getObject(getObjectRequest, path).join();
-            assertMd5MatchesEtag(new FileInputStream(path.toFile()), response);
         } finally {
             path.toFile().delete();
         }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
@@ -17,12 +17,9 @@ package software.amazon.awssdk.services.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
-import static software.amazon.awssdk.services.s3.utils.S3TestUtils.assertMd5MatchesEtag;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.junit.AfterClass;
@@ -70,7 +67,6 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     @Test
     public void toInputStream() throws Exception {
         try (ResponseInputStream<GetObjectResponse> content = s3.getObject(getObjectRequest)) {
-            assertMd5MatchesEtag(content, content.response());
         }
     }
 
@@ -79,7 +75,6 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
         try {
             GetObjectResponse response = s3.getObject(getObjectRequest, path);
-            assertMd5MatchesEtag(new FileInputStream(path.toFile()), response);
         } finally {
             path.toFile().delete();
         }
@@ -89,7 +84,6 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     public void toOutputStream() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         GetObjectResponse response = s3.getObject(getObjectRequest, ResponseTransformer.toOutputStream(baos));
-        assertMd5MatchesEtag(new ByteArrayInputStream(baos.toByteArray()), response);
     }
 
     @Test

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/signer/AwsS3V4SignerIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/signer/AwsS3V4SignerIntegrationTest.java
@@ -32,20 +32,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.auth.signer.params.AwsS3V4SignerParams;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.ExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkRequestContext;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
@@ -120,12 +119,12 @@ public class AwsS3V4SignerIntegrationTest extends S3IntegrationTestBase {
 
         SdkHttpClient httpClient = ApacheHttpClient.builder().build();
 
-        SdkHttpFullResponse response = httpClient.prepareRequest(ExecuteRequest.builder().request(signedRequest).build())
+        HttpExecuteResponse response = httpClient.prepareRequest(HttpExecuteRequest.builder().request(signedRequest).build())
                                                  .call();
 
-        assertEquals("Non success http status code", 200, response.statusCode());
+        assertEquals("Non success http status code", 200, response.httpResponse().statusCode());
 
-        String actualResult = IoUtils.toUtf8String(response.content().get());
+        String actualResult = IoUtils.toUtf8String(response.responseBody().get());
         assertEquals(CONTENT, actualResult);
     }
 
@@ -139,12 +138,12 @@ public class AwsS3V4SignerIntegrationTest extends S3IntegrationTestBase {
 
         SdkHttpClient httpClient = ApacheHttpClient.builder().build();
 
-        SdkHttpFullResponse response = httpClient.prepareRequest(ExecuteRequest.builder().request(signedRequest).build())
+        HttpExecuteResponse response = httpClient.prepareRequest(HttpExecuteRequest.builder().request(signedRequest).build())
                                                  .call();
 
-        assertEquals("Non success http status code", 200, response.statusCode());
+        assertEquals("Non success http status code", 200, response.httpResponse().statusCode());
 
-        String actualResult = IoUtils.toUtf8String(response.content().get());
+        String actualResult = IoUtils.toUtf8String(response.responseBody().get());
         assertEquals(CONTENT, actualResult);
     }
 

--- a/services/s3/src/it/resources/log4j2.xml
+++ b/services/s3/src/it/resources/log4j2.xml
@@ -10,7 +10,7 @@
             <AppenderRef ref="Console"/>
         </Root>
 
-        <logger name="org.apache.http" level="debug"/>
-        <logger name="org.apache.http.wire" level="debug"/>
+        <logger name="org.apache.http" level="warn"/>
+        <logger name="org.apache.http.wire" level="warn"/>
     </Loggers>
 </Configuration>

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -44,6 +44,11 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
     private static final boolean DEFAULT_DUALSTACK_ENABLED = false;
 
     /**
+     * S3 payload checksum validation is by default enabled;
+     */
+    private static final boolean DEFAULT_CHECKSUM_VALIDATION_ENABLED = true;
+
+    /**
      * S3 The default value for enabling chunked encoding for {@link
      * software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link
      * software.amazon.awssdk.services.s3.model.UploadPartRequest}.
@@ -53,12 +58,14 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
     private final boolean pathStyleAccessEnabled;
     private final boolean accelerateModeEnabled;
     private final boolean dualstackEnabled;
+    private final boolean checksumValidationEnabled;
     private final boolean chunkedEncodingEnabled;
 
     private S3Configuration(DefaultS3ServiceConfigurationBuilder builder) {
         this.dualstackEnabled = resolveBoolean(builder.dualstackEnabled, DEFAULT_DUALSTACK_ENABLED);
         this.accelerateModeEnabled = resolveBoolean(builder.accelerateModeEnabled, DEFAULT_ACCELERATE_MODE_ENABLED);
         this.pathStyleAccessEnabled = resolveBoolean(builder.pathStyleAccessEnabled, DEFAULT_PATH_STYLE_ACCESS_ENABLED);
+        this.checksumValidationEnabled = resolveBoolean(builder.checksumValidationEnabled, DEFAULT_CHECKSUM_VALIDATION_ENABLED);
         if (accelerateModeEnabled && pathStyleAccessEnabled) {
             throw new IllegalArgumentException("Accelerate mode cannot be used with path style addressing");
         }
@@ -126,6 +133,10 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
      */
     public boolean dualstackEnabled() {
         return dualstackEnabled;
+    }
+
+    public boolean checksumValidationEnabled() {
+        return checksumValidationEnabled;
     }
 
     /**
@@ -196,6 +207,17 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         Builder pathStyleAccessEnabled(Boolean pathStyleAccessEnabled);
 
         /**
+         * Option to disable doing a validation of the checksum of an object stored in S3.
+         *
+         * <p>
+         * Checksum validation is enabled by default.
+         * </p>
+         *
+         * @see S3Configuration#checksumValidationEnabled().
+         */
+        Builder checksumValidationEnabled(Boolean checksumValidationEnabled);
+
+        /**
          * Option to enable using chunked encoding when signing the request
          * payload for {@link
          * software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link
@@ -211,6 +233,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         private Boolean dualstackEnabled;
         private Boolean accelerateModeEnabled;
         private Boolean pathStyleAccessEnabled;
+        private Boolean checksumValidationEnabled;
         private Boolean chunkedEncodingEnabled;
 
         public Builder dualstackEnabled(Boolean dualstackEnabled) {
@@ -238,6 +261,15 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
 
         public void setPathStyleAccessEnabled(Boolean pathStyleAccessEnabled) {
             pathStyleAccessEnabled(pathStyleAccessEnabled);
+        }
+
+        public Builder checksumValidationEnabled(Boolean checksumValidationEnabled) {
+            this.checksumValidationEnabled = checksumValidationEnabled;
+            return this;
+        }
+
+        public void setChecksumValidationEnabled(Boolean checksumValidationEnabled) {
+            checksumValidationEnabled(checksumValidationEnabled);
         }
 
         public Builder chunkedEncodingEnabled(Boolean chunkedEncodingEnabled) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingAsyncRequestBody.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingAsyncRequestBody.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+@SdkInternalApi
+public class ChecksumCalculatingAsyncRequestBody implements AsyncRequestBody {
+
+    private final AsyncRequestBody wrapped;
+    private final SdkChecksum sdkChecksum;
+
+    public ChecksumCalculatingAsyncRequestBody(AsyncRequestBody wrapped, SdkChecksum sdkChecksum) {
+        this.wrapped = wrapped;
+        this.sdkChecksum = sdkChecksum;
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return wrapped.contentLength();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        wrapped.subscribe(new ChecksumCalculatingSubscriber(s, sdkChecksum));
+    }
+
+    private static final class ChecksumCalculatingSubscriber implements Subscriber<ByteBuffer> {
+
+        private final Subscriber<? super ByteBuffer> wrapped;
+        private final SdkChecksum checksum;
+
+        ChecksumCalculatingSubscriber(Subscriber<? super ByteBuffer> wrapped,
+                                      SdkChecksum sdkChecksum) {
+            this.wrapped = wrapped;
+            this.checksum = sdkChecksum;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            wrapped.onSubscribe(s);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer);
+            checksum.update(buf, 0, buf.length);
+            wrapped.onNext(byteBuffer);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            wrapped.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            wrapped.onComplete();
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingInputStream.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import java.io.IOException;
+import java.io.InputStream;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+
+@SdkInternalApi
+public class ChecksumCalculatingInputStream extends InputStream {
+
+    private final SdkChecksum checkSum;
+    private final InputStream inputStream;
+    private boolean endOfStream = false;
+
+    /**
+     * Creates an input stream using the specified Checksum.
+     *
+     * @param in    the input stream to read
+     * @param cksum the Checksum implementation to use for computing the checksum
+     */
+    public ChecksumCalculatingInputStream(final InputStream in, final SdkChecksum cksum) {
+        inputStream = in;
+        checkSum = cksum;
+    }
+
+    /**
+     * Reads from the underlying stream. If the end of the stream is reached, the
+     * running checksum will be appended a byte at a time (1 per read call).
+     *
+     * @return byte read, if eos has been reached, -1 will be returned.
+     */
+    @Override
+    public int read() throws IOException {
+        int read = -1;
+
+        if (!endOfStream) {
+            read = inputStream.read();
+
+            if (read != -1) {
+                checkSum.update(read);
+            }
+
+            if (read == -1) {
+                endOfStream = true;
+            }
+        }
+
+        return read;
+    }
+
+    /**
+     * Reads up to len bytes at a time from the input stream, updates the checksum. If the end of the stream has been reached
+     * the checksum will be appended to the last 4 bytes.
+     *
+     * @param buf    buffer to write into
+     * @param off offset in the buffer to write to
+     * @param len maximum number of bytes to attempt to read.
+     * @return number of bytes written into buf, otherwise -1 will be returned to indicate eos.
+     */
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        if (buf == null) {
+            throw new NullPointerException();
+        }
+
+        int read = 0;
+
+        if (!endOfStream) {
+            read = inputStream.read(buf, off, len);
+
+            if (read != -1) {
+                checkSum.update(buf, off, read);
+            }
+
+            if (read == -1) {
+                endOfStream = true;
+                read = 0;
+            }
+        }
+
+        return read;
+    }
+
+    /**
+     * Resets stream state, including the running checksum.
+     */
+    @Override
+    public synchronized void reset() throws IOException {
+        inputStream.reset();
+        checkSum.reset();
+        endOfStream = false;
+    }
+
+    public byte[] getChecksumBytes() {
+        return checkSum.getChecksumBytes();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+@SdkInternalApi
+public class ChecksumValidatingInputStream extends InputStream {
+    private static final int CHECKSUM_SIZE = 16;
+
+    private final SdkChecksum checkSum;
+    private final InputStream inputStream;
+    private long strippedLength;
+    private byte[] streamChecksum = new byte[CHECKSUM_SIZE];
+    private long lengthRead = 0;
+
+    /**
+     * Creates an input stream using the specified Checksum, input stream, and length.
+     *
+     * @param in the input stream
+     * @param cksum the Checksum implementation
+     * @param streamLength the total length of the expected stream (including the extra 4 bytes on the end).
+     */
+    public ChecksumValidatingInputStream(final InputStream in, final SdkChecksum cksum, long streamLength) {
+        inputStream = in;
+        checkSum = cksum;
+        this.strippedLength = streamLength - CHECKSUM_SIZE;
+    }
+
+    /**
+     * Reads one byte at a time from the input stream, updates the checksum. If the end of the stream has been reached
+     * the checksum will be compared to the stream's checksum amd a SdkClientException will be thrown.
+     *
+     * @return byte read, if a read happened, otherwise -1 will be returned to indicate eos.
+     */
+    @Override
+    public int read() throws IOException {
+        int read = inputStream.read();
+
+        if (read != -1 && lengthRead < strippedLength) {
+            checkSum.update(read);
+        }
+
+        if (read != -1) {
+            lengthRead++;
+        }
+
+        if (read != -1 && lengthRead == strippedLength) {
+            int byteRead = -1;
+            byteRead = inputStream.read();
+
+            while (byteRead != -1 && lengthRead < strippedLength + CHECKSUM_SIZE) {
+                int index = Math.min((int) (lengthRead - strippedLength), CHECKSUM_SIZE - 1);
+                streamChecksum[index] = (byte) byteRead;
+                lengthRead++;
+                byteRead = inputStream.read();
+            }
+        }
+
+        if (read == -1) {
+            validateAndThrow();
+        }
+
+        return read;
+    }
+
+    /**
+     * Reads up to len bytes at a time from the input stream, updates the checksum. If the end of the stream has been reached
+     * the checksum will be compared to the stream's checksum amd a SdkClientException will be thrown.
+     *
+     * @param buf buffer to write into
+     * @param off offset in the buffer to write to
+     * @param len maximum number of bytes to attempt to read.
+     * @return number of bytes written into buf, otherwise -1 will be returned to indicate eos.
+     */
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+
+        if (buf == null) {
+            throw new NullPointerException();
+        }
+
+        int read = -1;
+
+        if (lengthRead < strippedLength) {
+            long maxRead = Math.min((long) Integer.MAX_VALUE, strippedLength - lengthRead);
+            int maxIterRead = (int) Math.min(maxRead, (long) len);
+
+            read = inputStream.read(buf, off, maxIterRead);
+
+            int toUpdate = (int) Math.min(strippedLength - lengthRead, (long) read);
+
+            if (toUpdate > 0) {
+                checkSum.update(buf, off, toUpdate);
+            }
+
+            lengthRead += read >= 0 ? read : 0;
+        }
+
+        if (lengthRead >= strippedLength) {
+            int byteRead = 0;
+
+            while ((byteRead = inputStream.read()) != -1) {
+                int index = Math.min((int) (lengthRead - strippedLength), CHECKSUM_SIZE - 1);
+                streamChecksum[index] = (byte) byteRead;
+                lengthRead++;
+            }
+
+            if (read == -1) {
+                validateAndThrow();
+            }
+        }
+
+        return read;
+    }
+
+    /**
+     * Resets stream state, including the running checksum.
+     */
+    @Override
+    public synchronized void reset() throws IOException {
+        inputStream.reset();
+        checkSum.reset();
+        lengthRead = 0;
+
+        for (int i = 0; i < CHECKSUM_SIZE; i++) {
+            streamChecksum[i] = 0;
+        }
+    }
+
+    /**
+     * Gets the stream's checksum as an integer.
+     *
+     * @return checksum.
+     */
+    public int getStreamChecksum() {
+        ByteBuffer bb = ByteBuffer.wrap(streamChecksum);
+        return bb.getInt();
+    }
+
+    private void validateAndThrow() {
+        int streamChecksumInt = getStreamChecksum();
+        int computedChecksumInt = ByteBuffer.wrap(checkSum.getChecksumBytes()).getInt();
+        if (streamChecksumInt != computedChecksumInt) {
+            throw SdkClientException.builder().message(
+                String.format("Data read has a different checksum than expected. Was %d, but expected %d",
+                              computedChecksumInt, streamChecksumInt)).build();
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import static java.lang.Math.toIntExact;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+@SdkInternalApi
+public class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffer> {
+
+    private final Publisher<ByteBuffer> publisher;
+    private final SdkChecksum sdkChecksum;
+    private final int contentLength;
+
+    public ChecksumValidatingPublisher(Publisher<ByteBuffer> publisher,
+                                       SdkChecksum sdkChecksum,
+                                       int contentLength) {
+        this.publisher = publisher;
+        this.sdkChecksum = sdkChecksum;
+        this.contentLength = contentLength;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        publisher.subscribe(new ChecksumValidatingSubscriber(s, sdkChecksum, contentLength));
+    }
+
+    private static class ChecksumValidatingSubscriber implements Subscriber<ByteBuffer> {
+
+        private static final int CHECKSUM_SIZE = 16;
+
+        private final Subscriber<? super ByteBuffer> wrapped;
+        private final SdkChecksum sdkChecksum;
+        private final long strippedLength;
+
+        private byte[] streamChecksum = new byte[CHECKSUM_SIZE];
+        private long lengthRead = 0;
+
+        private Subscription subscription;
+
+        ChecksumValidatingSubscriber(Subscriber<? super ByteBuffer> wrapped,
+                                     SdkChecksum sdkChecksum,
+                                     int contentLength) {
+            this.wrapped = wrapped;
+            this.sdkChecksum = sdkChecksum;
+            this.strippedLength = contentLength - CHECKSUM_SIZE;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            wrapped.onSubscribe(s);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer);
+
+            if (lengthRead < strippedLength) {
+                int toUpdate = (int) Math.min(strippedLength - lengthRead, buf.length);
+
+                sdkChecksum.update(buf, 0, toUpdate);
+                lengthRead += buf.length;
+            }
+
+            if (lengthRead >= strippedLength) {
+                int offset = toIntExact(lengthRead - strippedLength);
+                streamChecksum = Arrays.copyOfRange(buf, buf.length - offset, buf.length);
+                wrapped.onNext(ByteBuffer.wrap(Arrays.copyOfRange(buf, 0, buf.length - offset)));
+            } else {
+                wrapped.onNext(byteBuffer);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            wrapped.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            if (strippedLength > 0) {
+                int streamChecksumInt = ByteBuffer.wrap(streamChecksum).getInt();
+                int computedChecksumInt = ByteBuffer.wrap(sdkChecksum.getChecksumBytes()).getInt();
+                if (streamChecksumInt != computedChecksumInt) {
+                    onError(SdkClientException.create(
+                        String.format("Data read has a different checksum than expected. Was %d, but expected %d",
+                                      computedChecksumInt, streamChecksumInt)));
+                }
+            }
+            wrapped.onComplete();
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/AsyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/AsyncChecksumValidationInterceptor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.handlers;
+
+import static software.amazon.awssdk.core.ClientType.ASYNC;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Optional;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.checksums.Md5Checksum;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.checksums.ChecksumCalculatingAsyncRequestBody;
+import software.amazon.awssdk.services.s3.checksums.ChecksumValidatingPublisher;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.internal.Base16Lower;
+
+@SdkInternalApi
+public class AsyncChecksumValidationInterceptor implements ExecutionInterceptor {
+
+    private static final ExecutionAttribute<SdkChecksum> CHECKSUM = new ExecutionAttribute("checksum");
+
+    @Override
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                            ExecutionAttributes executionAttributes) {
+
+        if (context.request() instanceof GetObjectRequest && checksumValidationEnabled(executionAttributes)) {
+            return context.httpRequest().toBuilder().putHeader("x-amz-te", "append-md5").build();
+        }
+
+        return context.httpRequest();
+    }
+
+    @Override
+    public Optional<AsyncRequestBody> modifyAsyncHttpContent(Context.ModifyHttpRequest context,
+                                                             ExecutionAttributes executionAttributes) {
+
+        if (context.request() instanceof PutObjectRequest && checksumValidationEnabled(executionAttributes)) {
+            SdkChecksum checksum = new Md5Checksum();
+            executionAttributes.putAttribute(CHECKSUM, checksum);
+            return Optional.of(new ChecksumCalculatingAsyncRequestBody(context.asyncRequestBody().get(), checksum));
+        }
+
+        return context.asyncRequestBody();
+    }
+
+    @Override
+    public Optional<Publisher<ByteBuffer>> modifyAsyncHttpResponseContent(Context.ModifyHttpResponse context,
+                                                                ExecutionAttributes executionAttributes) {
+
+        if (context.request() instanceof GetObjectRequest && checksumValidationEnabled(executionAttributes)) {
+            int contentLength = Integer.parseInt(context.httpResponse().firstMatchingHeader("Content-Length").orElse("0"));
+            SdkChecksum checksum = new Md5Checksum();
+            executionAttributes.putAttribute(CHECKSUM, checksum);
+            return Optional.of(new ChecksumValidatingPublisher(context.responsePublisher().get(), checksum, contentLength));
+        }
+
+        return context.responsePublisher();
+    }
+
+    @Override
+    public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
+
+        boolean checksumValidationEnabled = checksumValidationEnabled(executionAttributes);
+
+        if (context.response() instanceof PutObjectResponse && checksumValidationEnabled) {
+            validatePutObjectChecksum(context.response(), executionAttributes);
+        }
+    }
+
+    private void validatePutObjectChecksum(SdkResponse sdkResponse, ExecutionAttributes executionAttributes) {
+        SdkChecksum checksum = executionAttributes.getAttribute(CHECKSUM);
+        PutObjectResponse response = (PutObjectResponse) sdkResponse;
+
+        if (response.eTag() != null) {
+            String contentMd5 = BinaryUtils.toBase64(checksum.getChecksumBytes());
+            byte[] digest = BinaryUtils.fromBase64(contentMd5);
+            byte[] ssHash = Base16Lower.decode(response.eTag().replace("\"", ""));
+
+            if (!Arrays.equals(digest, ssHash)) {
+                throw SdkClientException.create("Data read has a different checksum than expected.");
+            }
+        }
+    }
+
+    private boolean checksumValidationEnabled(ExecutionAttributes executionAttributes) {
+
+        ClientType clientType = executionAttributes.getAttribute(SdkExecutionAttribute.CLIENT_TYPE);
+
+        if (ASYNC.equals(clientType)) {
+            S3Configuration serviceConfiguration =
+                (S3Configuration) executionAttributes.getAttribute(AwsSignerExecutionAttribute.SERVICE_CONFIG);
+
+            return serviceConfiguration == null || serviceConfiguration.checksumValidationEnabled();
+        }
+
+        return false;
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/SyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/handlers/SyncChecksumValidationInterceptor.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.handlers;
+
+import static software.amazon.awssdk.core.ClientType.SYNC;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.checksums.Md5Checksum;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.checksums.ChecksumCalculatingInputStream;
+import software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.internal.Base16Lower;
+
+@SdkInternalApi
+public class SyncChecksumValidationInterceptor implements ExecutionInterceptor {
+
+    private static final ExecutionAttribute<SdkChecksum> CHECKSUM = new ExecutionAttribute("checksum");
+
+    @Override
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                            ExecutionAttributes executionAttributes) {
+
+        if (context.request() instanceof GetObjectRequest && checksumValidationEnabled(executionAttributes)) {
+            return context.httpRequest().toBuilder().putHeader("x-amz-te", "append-md5").build();
+        }
+
+        return context.httpRequest();
+    }
+
+    @Override
+    public Optional<RequestBody> modifyHttpContent(Context.ModifyHttpRequest context,
+                                                   ExecutionAttributes executionAttributes) {
+
+        boolean checksumValidationEnabled = checksumValidationEnabled(executionAttributes);
+
+        if (context.request() instanceof PutObjectRequest && checksumValidationEnabled) {
+            SdkChecksum checksum = new Md5Checksum();
+
+            ChecksumCalculatingInputStream is = new ChecksumCalculatingInputStream(context.requestBody()
+                                                                                          .get()
+                                                                                          .contentStreamProvider()
+                                                                                          .newStream(),
+                                                                                   checksum);
+            executionAttributes.putAttribute(CHECKSUM, checksum);
+            return Optional.of(RequestBody.fromContentProvider(() -> is,
+                                                   context.requestBody().get().contentLength(),
+                                                   context.requestBody().get().contentType()));
+        }
+
+        return context.requestBody();
+    }
+
+    @Override
+    public Optional<InputStream> modifyHttpResponseContent(Context.ModifyHttpResponse context,
+                                                 ExecutionAttributes executionAttributes) {
+
+        if (context.request() instanceof GetObjectRequest && checksumValidationEnabled(executionAttributes)) {
+            SdkHttpResponse originalResponse = context.httpResponse();
+            SdkChecksum checksum = new Md5Checksum();
+
+            int contentLength = Integer.valueOf(context.httpResponse().firstMatchingHeader("Content-Length").orElse("0"));
+
+            if (contentLength > 0) {
+                return Optional.of(new ChecksumValidatingInputStream(context.responseBody().get(), checksum, contentLength));
+            }
+        }
+
+        return context.responseBody();
+    }
+
+    @Override
+    public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
+
+        if (context.response() instanceof PutObjectResponse && checksumValidationEnabled(executionAttributes)) {
+            PutObjectResponse response = (PutObjectResponse) context.response();
+
+            if (response.eTag() != null) {
+                SdkChecksum checksum = executionAttributes.getAttribute(CHECKSUM);
+                String contentMd5 = BinaryUtils.toBase64(checksum.getChecksumBytes());
+                byte[] digest = BinaryUtils.fromBase64(contentMd5);
+                byte[] ssHash = Base16Lower.decode(response.eTag().replace("\"", ""));
+
+                if (!Arrays.equals(digest, ssHash)) {
+                    throw SdkClientException.create(String.format("Data read has a different checksum than expected. " +
+                                                                  "Was %d, but expected %d", digest, ssHash));
+                }
+            }
+        }
+    }
+
+    private boolean checksumValidationEnabled(ExecutionAttributes executionAttributes) {
+
+        ClientType clientType = executionAttributes.getAttribute(SdkExecutionAttribute.CLIENT_TYPE);
+
+        if (SYNC.equals(clientType)) {
+            S3Configuration serviceConfiguration =
+                (S3Configuration) executionAttributes.getAttribute(AwsSignerExecutionAttribute.SERVICE_CONFIG);
+            return serviceConfiguration == null || serviceConfiguration.checksumValidationEnabled();
+        }
+
+        return false;
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/CreateMultipartUploadRequestInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/CreateMultipartUploadRequestInterceptor.java
@@ -16,23 +16,33 @@
 package software.amazon.awssdk.services.s3.internal.handlers;
 
 import java.io.ByteArrayInputStream;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 
 @SdkInternalApi
 public class CreateMultipartUploadRequestInterceptor implements ExecutionInterceptor {
 
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    public Optional<RequestBody> modifyHttpContent(Context.ModifyHttpRequest context,
+                                                   ExecutionAttributes executionAttributes) {
         if (context.request() instanceof CreateMultipartUploadRequest) {
-            SdkHttpFullRequest.Builder mutableRequest = context.httpRequest().toBuilder();
-            mutableRequest.contentStreamProvider(() -> new ByteArrayInputStream(new byte[0]));
-            mutableRequest.putHeader("Content-Length", String.valueOf(0));
-            return mutableRequest.build();
+            return Optional.ofNullable(RequestBody.fromInputStream(new ByteArrayInputStream(new byte[0]), 0));
+        }
+
+        return context.requestBody();
+    }
+
+    @Override
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                            ExecutionAttributes executionAttributes) {
+        if (context.request() instanceof CreateMultipartUploadRequest) {
+            return context.httpRequest().toBuilder().putHeader("Content-Length", String.valueOf(0)).build();
         }
 
         return context.httpRequest();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/PutObjectInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/PutObjectInterceptor.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 /**
@@ -30,7 +30,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 @ReviewBeforeRelease("This should be generalized for all streaming requests when we refactor the marshallers.")
 public final class PutObjectInterceptor implements ExecutionInterceptor {
     @Override
-    public SdkHttpFullRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                            ExecutionAttributes executionAttributes) {
         if (context.request() instanceof PutObjectRequest) {
             return context.httpRequest().toBuilder().putHeader("Expect", "100-continue").build();
         }

--- a/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
+++ b/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
@@ -7,3 +7,5 @@ software.amazon.awssdk.services.s3.internal.handlers.DisableDoubleUrlEncodingInt
 software.amazon.awssdk.services.s3.internal.handlers.DecodeUrlEncodedResponseInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.AddContentMd5HeaderInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.GetBucketPolicyInterceptor
+software.amazon.awssdk.services.s3.handlers.AsyncChecksumValidationInterceptor
+software.amazon.awssdk.services.s3.handlers.SyncChecksumValidationInterceptor

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3MockUtils.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3MockUtils.java
@@ -17,7 +17,8 @@ package software.amazon.awssdk.services.s3;
 
 import java.io.UnsupportedEncodingException;
 import software.amazon.awssdk.http.AbortableInputStream;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.utils.StringInputStream;
 
 /**
@@ -31,48 +32,46 @@ public final class S3MockUtils {
     /**
      * @return A mocked result for the ListObjects operation.
      */
-    public static SdkHttpFullResponse mockListObjectsResponse() throws UnsupportedEncodingException {
-        return SdkHttpFullResponse.builder()
-                                  .statusCode(200)
-                                  .content(AbortableInputStream.create(new StringInputStream(
-                                          "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n" +
-                                          "  <Name>example-bucket</Name>\n" +
-                                          "  <Prefix>photos/2006/</Prefix>\n" +
-                                          "  <Marker></Marker>\n" +
-                                          "  <MaxKeys>1000</MaxKeys>\n" +
-                                          "  <Delimiter>/</Delimiter>\n" +
-                                          "  <IsTruncated>false</IsTruncated>\n" +
-                                          "\n" +
-                                          "  <CommonPrefixes>\n" +
-                                          "    <Prefix>photos/2006/February/</Prefix>\n" +
-                                          "  </CommonPrefixes>\n" +
-                                          "  <CommonPrefixes>\n" +
-                                          "    <Prefix>photos/2006/January/</Prefix>\n" +
-                                          "  </CommonPrefixes>\n" +
-                                          "</ListBucketResult>")))
+    public static HttpExecuteResponse mockListObjectsResponse() throws UnsupportedEncodingException {
+        return HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(200).build()).responseBody(
+            AbortableInputStream.create(new StringInputStream(
+                "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n" +
+                "  <Name>example-bucket</Name>\n" +
+                "  <Prefix>photos/2006/</Prefix>\n" +
+                "  <Marker></Marker>\n" +
+                "  <MaxKeys>1000</MaxKeys>\n" +
+                "  <Delimiter>/</Delimiter>\n" +
+                "  <IsTruncated>false</IsTruncated>\n" +
+                "\n" +
+                "  <CommonPrefixes>\n" +
+                "    <Prefix>photos/2006/February/</Prefix>\n" +
+                "  </CommonPrefixes>\n" +
+                "  <CommonPrefixes>\n" +
+                "    <Prefix>photos/2006/January/</Prefix>\n" +
+                "  </CommonPrefixes>\n" +
+                "</ListBucketResult>")))
                                   .build();
     }
 
     /**
      * @return A mocked result for the ListBuckets operation.
      */
-    public static SdkHttpFullResponse mockListBucketsResponse() throws UnsupportedEncodingException {
-        return SdkHttpFullResponse.builder()
-                                  .statusCode(200)
-                                  .content(AbortableInputStream.create(new StringInputStream(
-                                          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                          "<ListAllMyBucketsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01\">\n" +
-                                          "  <Owner>\n" +
-                                          "    <ID>bcaf1ffd86f461ca5fb16fd081034f</ID>\n" +
-                                          "    <DisplayName>webfile</DisplayName>\n" +
-                                          "  </Owner>\n" +
-                                          "  <Buckets>\n" +
-                                          "    <Bucket>\n" +
-                                          "      <Name>quotes</Name>\n" +
-                                          "      <CreationDate>2006-02-03T16:45:09.000Z</CreationDate>\n" +
-                                          "    </Bucket>\n" +
-                                          "  </Buckets>\n" +
-                                          "</ListAllMyBucketsResult>")))
+    public static HttpExecuteResponse mockListBucketsResponse() throws UnsupportedEncodingException {
+        return HttpExecuteResponse.builder().response(SdkHttpResponse.builder().statusCode(200).build()).responseBody(
+            AbortableInputStream.create(new StringInputStream(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ListAllMyBucketsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01\">\n" +
+                "  <Owner>\n" +
+                "    <ID>bcaf1ffd86f461ca5fb16fd081034f</ID>\n" +
+                "    <DisplayName>webfile</DisplayName>\n" +
+                "  </Owner>\n" +
+                "  <Buckets>\n" +
+                "    <Bucket>\n" +
+                "      <Name>quotes</Name>\n" +
+                "      <CreationDate>2006-02-03T16:45:09.000Z</CreationDate>\n" +
+                "    </Bucket>\n" +
+                "  </Buckets>\n" +
+                "</ListAllMyBucketsResult>")))
                                   .build();
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/CreateBucketInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/CreateBucketInterceptorTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.regions.Region;
@@ -26,7 +28,7 @@ import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 public class CreateBucketInterceptorTest {
-    
+
     @Test
     public void modifyRequest_DoesNotOverrideExistingLocationConstraint() {
         CreateBucketRequest request = CreateBucketRequest.builder()
@@ -38,6 +40,7 @@ public class CreateBucketInterceptorTest {
                                                          .build();
 
         Context.ModifyRequest context = () -> request;
+
         ExecutionAttributes attributes = new ExecutionAttributes()
                 .putAttribute(AwsExecutionAttribute.AWS_REGION, Region.US_EAST_1);
 
@@ -54,6 +57,7 @@ public class CreateBucketInterceptorTest {
                                                          .build();
 
         Context.ModifyRequest context = () -> request;
+
         ExecutionAttributes attributes = new ExecutionAttributes()
                 .putAttribute(AwsExecutionAttribute.AWS_REGION, Region.US_EAST_2);
 
@@ -72,6 +76,7 @@ public class CreateBucketInterceptorTest {
                                                          .build();
 
         Context.ModifyRequest context = () -> request;
+
         ExecutionAttributes attributes = new ExecutionAttributes()
                 .putAttribute(AwsExecutionAttribute.AWS_REGION, Region.US_WEST_2);
 
@@ -93,6 +98,7 @@ public class CreateBucketInterceptorTest {
                                                          .build();
 
         Context.ModifyRequest context = () -> request;
+
         ExecutionAttributes attributes = new ExecutionAttributes()
                 .putAttribute(AwsExecutionAttribute.AWS_REGION, Region.US_EAST_1);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/DecodeUrlEncodedResponseInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/DecodeUrlEncodedResponseInterceptorTest.java
@@ -17,16 +17,23 @@ package software.amazon.awssdk.services.s3.internal.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.Test;
+import org.reactivestreams.Publisher;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.s3.model.EncodingType;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
@@ -134,17 +141,37 @@ public class DecodeUrlEncodedResponseInterceptorTest {
     private static Context.ModifyResponse newContext(SdkResponse response) {
         return new Context.ModifyResponse() {
             @Override
+            public Optional<Publisher<ByteBuffer>> responsePublisher() {
+                return null;
+            }
+
+            @Override
+            public Optional<InputStream> responseBody() {
+                return null;
+            }
+
+            @Override
+            public SdkHttpRequest httpRequest() {
+                return null;
+            }
+
+            @Override
+            public Optional<RequestBody> requestBody() {
+                return null;
+            }
+
+            @Override
+            public Optional<AsyncRequestBody> asyncRequestBody() {
+                return null;
+            }
+
+            @Override
             public SdkResponse response() {
                 return response;
             }
 
             @Override
             public SdkHttpFullResponse httpResponse() {
-                return null;
-            }
-
-            @Override
-            public SdkHttpFullRequest httpRequest() {
                 return null;
             }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/PutObjectHeaderTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/PutObjectHeaderTest.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.testutils.RandomTempFile;
 
@@ -57,6 +58,7 @@ public class PutObjectHeaderTest {
         s3Client = S3Client.builder()
                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
                            .region(Region.US_WEST_2).endpointOverride(URI.create(getEndpoint()))
+                           .serviceConfiguration(S3Configuration.builder().checksumValidationEnabled(false).build())
                            .build();
         putObjectRequest = PutObjectRequest.builder().bucket("test").key("test").build();
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/S3EndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/S3EndpointResolutionTest.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -294,7 +295,7 @@ public class S3EndpointResolutionTest {
      * @param capturedRequest Request captured by mock HTTP client.
      * @param endpoint        Expected endpoint.
      */
-    private void assertEndpointMatches(SdkHttpFullRequest capturedRequest, String endpoint) {
+    private void assertEndpointMatches(SdkHttpRequest capturedRequest, String endpoint) {
         assertThat(capturedRequest.getUri()).isEqualTo(URI.create(endpoint));
     }
 

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/BaseMockApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/BaseMockApiCall.java
@@ -21,7 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.http.AbortableInputStream;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 
 /**
  * Base classes to mock sync and async api calls.
@@ -88,17 +89,21 @@ public abstract class BaseMockApiCall {
 
     abstract Runnable asyncRunnable();
 
-    private SdkHttpFullResponse successResponse(String protocol) {
-        return SdkHttpFullResponse.builder()
-                                  .statusCode(200)
-                                  .content(generateContent(protocol))
+    private HttpExecuteResponse successResponse(String protocol) {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder()
+                                                           .statusCode(200)
+                                                           .build())
+                                  .responseBody(generateContent(protocol))
                                   .build();
     }
 
-    private SdkHttpFullResponse errorResponse(String protocol) {
-        return SdkHttpFullResponse.builder()
-                                  .statusCode(500)
-                                  .content(generateContent(protocol))
+    private HttpExecuteResponse errorResponse(String protocol) {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder()
+                                                           .statusCode(500)
+                                                           .build())
+                                  .responseBody(generateContent(protocol))
                                   .build();
     }
 

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockAyncHttpClient.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockAyncHttpClient.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -37,16 +37,16 @@ import software.amazon.awssdk.utils.IoUtils;
 public final class MockAyncHttpClient implements SdkAsyncHttpClient {
 
     private final List<SdkHttpRequest> capturedRequests = new ArrayList<>();
-    private SdkHttpFullResponse nextResponse;
+    private HttpExecuteResponse nextResponse;
 
 
     @Override
     public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
         capturedRequests.add(request.request());
 
-        request.responseHandler().onHeaders(nextResponse);
+        request.responseHandler().onHeaders(nextResponse.httpResponse());
         request.responseHandler().onStream(new SdkHttpContentPublisher() {
-            byte[] content = nextResponse.content().map(p -> invokeSafely(() -> IoUtils.toByteArray(p)))
+            byte[] content = nextResponse.responseBody().map(p -> invokeSafely(() -> IoUtils.toByteArray(p)))
                                          .orElseGet(() -> new byte[0]);
 
             @Override
@@ -93,7 +93,7 @@ public final class MockAyncHttpClient implements SdkAsyncHttpClient {
         this.nextResponse = null;
     }
 
-    public void stubNextResponse(SdkHttpFullResponse nextResponse) {
+    public void stubNextResponse(HttpExecuteResponse nextResponse) {
         this.nextResponse = nextResponse;
     }
 

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockHttpClient.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/mocktests/MockHttpClient.java
@@ -17,26 +17,26 @@ package software.amazon.awssdk.modulepath.tests.mocktests;
 
 import java.util.ArrayList;
 import java.util.List;
-import software.amazon.awssdk.http.ExecuteRequest;
-import software.amazon.awssdk.http.InvokeableHttpRequest;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 /**
  * Mock implementation of {@link SdkHttpClient}.
  */
 public final class MockHttpClient implements SdkHttpClient {
 
-    private final List<SdkHttpFullRequest> capturedRequests = new ArrayList<>();
-    private SdkHttpFullResponse nextResponse;
+    private final List<SdkHttpRequest> capturedRequests = new ArrayList<>();
+    private HttpExecuteResponse nextResponse;
 
     @Override
-    public InvokeableHttpRequest prepareRequest(ExecuteRequest request) {
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
         capturedRequests.add(request.httpRequest());
-        return new InvokeableHttpRequest() {
+        return new ExecutableHttpRequest() {
             @Override
-            public SdkHttpFullResponse call() {
+            public HttpExecuteResponse call() {
                 return nextResponse;
             }
 
@@ -62,10 +62,10 @@ public final class MockHttpClient implements SdkHttpClient {
     /**
      * Sets up the next HTTP response that will be returned by the mock.
      *
-     * @param nextResponse Next {@link SdkHttpFullResponse} to return from
-     *                     {@link #prepareRequest(ExecuteRequest)}
+     * @param nextResponse Next {@link HttpExecuteResponse} to return from
+     *                     {@link #prepareRequest(HttpExecuteRequest)}
      */
-    public void stubNextResponse(SdkHttpFullResponse nextResponse) {
+    public void stubNextResponse(HttpExecuteResponse nextResponse) {
         this.nextResponse = nextResponse;
     }
 
@@ -73,7 +73,7 @@ public final class MockHttpClient implements SdkHttpClient {
      * @return The last executed request that went through this mock client.
      * @throws IllegalStateException If no requests have been captured.
      */
-    public SdkHttpFullRequest getLastRequest() {
+    public SdkHttpRequest getLastRequest() {
         if (capturedRequests.isEmpty()) {
             throw new IllegalStateException("No requests were captured by the mock");
         }

--- a/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/http/MockHttpClient.java
+++ b/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/http/MockHttpClient.java
@@ -17,26 +17,27 @@ package software.amazon.awssdk.testutils.service.http;
 
 import java.util.ArrayList;
 import java.util.List;
-import software.amazon.awssdk.http.ExecuteRequest;
-import software.amazon.awssdk.http.InvokeableHttpRequest;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 /**
  * Mockable implementation of {@link SdkHttpClient}.
  */
 public final class MockHttpClient implements SdkHttpClient {
 
-    private final List<SdkHttpFullRequest> capturedRequests = new ArrayList<>();
-    private SdkHttpFullResponse nextResponse;
+    private final List<SdkHttpRequest> capturedRequests = new ArrayList<>();
+    private HttpExecuteResponse nextResponse;
 
     @Override
-    public InvokeableHttpRequest prepareRequest(ExecuteRequest request) {
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
         capturedRequests.add(request.httpRequest());
-        return new InvokeableHttpRequest() {
+        return new ExecutableHttpRequest() {
             @Override
-            public SdkHttpFullResponse call() {
+            public HttpExecuteResponse call() {
                 return nextResponse;
             }
 
@@ -63,9 +64,9 @@ public final class MockHttpClient implements SdkHttpClient {
      * Sets up the next HTTP response that will be returned by the mock.
      *
      * @param nextResponse Next {@link SdkHttpFullResponse} to return from
-     *                     {@link #prepareRequest(ExecuteRequest)}
+     *                     {@link #prepareRequest(HttpExecuteRequest)}
      */
-    public void stubNextResponse(SdkHttpFullResponse nextResponse) {
+    public void stubNextResponse(HttpExecuteResponse nextResponse) {
         this.nextResponse = nextResponse;
     }
 
@@ -73,7 +74,7 @@ public final class MockHttpClient implements SdkHttpClient {
      * @return The last executed request that went through this mock client.
      * @throws IllegalStateException If no requests have been captured.
      */
-    public SdkHttpFullRequest getLastRequest() {
+    public SdkHttpRequest getLastRequest() {
         if (capturedRequests.isEmpty()) {
             throw new IllegalStateException("No requests were captured by the mock");
         }


### PR DESCRIPTION
Exposes the ability to modify the AsyncRequestBody and AsyncResponseTransformer.

Currently this is done by adding two new interceptors.

For AsyncRequestBody:

```java
default AsyncRequestBody modifyAsyncRequestBody(Context.ModifyRequest context,
                                                ExecutionAttributes executionAttributes) {
    return context.requestBody();
}
```

For AsyncResponseTransformer:

```java
default AsyncResponseTransformer modifyAsyncResponseTransformer(Context.ModifyRequest context,
                                                                ExecutionAttributes executionAttributes) {
    return context.responseTransformer();
}
```

Possible other options include making modifyRequest return back a container object instead of an SdkRequest:

```java
default SdkRequestContext modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
    return context.request();
}
```

Where SdkRequestContext contains SdkRequest, AsyncRequestBody and AsyncResponseTransformer.

Or we could introduce an AsyncExecutionInterceptor interface that again either has two methods as in the PR or one method with a container object for async.

In general, trying to avoid potential confusion of when these interceptors are valid and when the values will be populated. If we use the approach in the PR, users of the Sync client should not use the new interceptors. If we go with the container approach for modifyRequest, then the asyncRequestBody and asyncResponseTransformer will be null.