### PR TITLE
Wrap ReadTimeoutException and WriteTimeoutException in ResponseHandler

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -191,7 +191,7 @@ public final class NettyRequestExecutor {
     }
 
     private void handleFailure(Supplier<String> msg, Throwable cause) {
-        log.error(msg.get(), cause);
+        log.debug(msg.get(), cause);
         cause = decorateException(cause);
         context.handler().onError(cause);
         executeFuture.completeExceptionally(cause);


### PR DESCRIPTION
- Wrap Netty `ReadTimeoutException` and `WriteTimeoutException` in ResponseHandler so they can be retried
- Update logging level from "error" to "debug"  because some errors are retryable and unretryable errors will be logged again in the upper layer.