### PR TITLE
Translate S3Exception for headObject and headBucket

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-b7ad196.json
+++ b/.changes/next-release/bugfix-AmazonS3-b7ad196.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Update S3 headObject/headBucket operations to throw NoSuchKey/NoSuchException when S3 is returning 404. See [#123](https://github.com/aws/aws-sdk-java-v2/issues/123), [#544](https://github.com/aws/aws-sdk-java-v2/issues/544)"
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-aca5ef8.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-aca5ef8.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Add `modifyException` API to `ExecutionInterceptor`."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsErrorDetails.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsErrorDetails.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.utils.ToString;
 
 @SdkPublicApi
 public class AwsErrorDetails implements Serializable {
@@ -99,6 +100,15 @@ public class AwsErrorDetails implements Serializable {
 
     public static Class<? extends Builder> serializableBuilderClass() {
         return BuilderImpl.class;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("AwsErrorDetails")
+                       .add("errorMessage", errorMessage)
+                       .add("errorCode", errorCode)
+                       .add("serviceName", serviceName)
+                       .build();
     }
 
     public interface Builder {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionInterceptor.java
@@ -331,6 +331,23 @@ public interface ExecutionInterceptor {
     }
 
     /**
+     * Modify the exception before it is thrown.
+     *
+     * <p>This will only be invoked if the entire execution fails. If a retriable error happens (according to the
+     * {@link RetryPolicy}) and a subsequent retry succeeds, this method will not be invoked.
+     *
+     * @param context The context associated with the execution that failed. An SDK request will always be available, but
+     * depending on the time at which the failure happened, the HTTP request, HTTP response and SDK response may
+     * not be available. This also includes the exception that triggered the failure.
+     * @param executionAttributes A mutable set of attributes scoped to one specific request/response cycle that can be used to
+     * give data to future lifecycle methods.
+     * @return the modified Exception
+     */
+    default Throwable modifyException(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+        return context.exception();
+    }
+
+    /**
      * Invoked when any error happens during an execution that prevents the request from succeeding. This could be due to an
      * error returned by a service call, a request timeout or even another interceptor raising an exception. The provided
      * exception will be thrown by the service client.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/ExceptionReportingUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/utils/ExceptionReportingUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages.utils;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.interceptor.DefaultFailedExecutionContext;
+import software.amazon.awssdk.utils.Logger;
+
+@SdkInternalApi
+public final class ExceptionReportingUtils {
+    private static final Logger log = Logger.loggerFor(ExceptionReportingUtils.class);
+
+    private ExceptionReportingUtils() {
+    }
+
+    /**
+     * Report the failure to the execution interceptors. Swallow any exceptions thrown from the interceptor since
+     * we don't want to replace the execution failure.
+     *
+     * @param context The execution context.
+     * @param failure The execution failure.
+     */
+    public static Throwable reportFailureToInterceptors(RequestExecutionContext context, Throwable failure) {
+        DefaultFailedExecutionContext modifiedContext = runModifyException(context, failure);
+
+        try {
+            context.interceptorChain().onExecutionFailure(modifiedContext, context.executionAttributes());
+        } catch (Exception exception) {
+            log.warn(() -> "Interceptor chain threw an error from onExecutionFailure().", exception);
+        }
+
+        return modifiedContext.exception();
+    }
+
+    private static DefaultFailedExecutionContext runModifyException(RequestExecutionContext context, Throwable e) {
+        DefaultFailedExecutionContext failedContext =
+            DefaultFailedExecutionContext.builder()
+                                         .interceptorContext(context.executionContext().interceptorContext())
+                                         .exception(e).build();
+        return context.interceptorChain().modifyException(failedContext, context.executionAttributes());
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/DefaultFailedExecutionContext.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/DefaultFailedExecutionContext.java
@@ -25,18 +25,22 @@ import software.amazon.awssdk.core.interceptor.InterceptorContext;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * An SDK-internal implementation of {@link Context.FailedExecution}.
  */
 @SdkInternalApi
-public class DefaultFailedExecutionContext implements Context.FailedExecution {
+public class DefaultFailedExecutionContext implements Context.FailedExecution,
+                                                      ToCopyableBuilder<DefaultFailedExecutionContext.Builder,
+                                                          DefaultFailedExecutionContext> {
     private final InterceptorContext interceptorContext;
     private final Throwable exception;
 
-    public DefaultFailedExecutionContext(InterceptorContext interceptorContext, Throwable exception) {
-        this.interceptorContext = Validate.paramNotNull(interceptorContext, "interceptorContext");
-        this.exception = unwrap(Validate.paramNotNull(exception, "exception"));
+    private DefaultFailedExecutionContext(Builder builder) {
+        this.exception = unwrap(Validate.paramNotNull(builder.exception, "exception"));
+        this.interceptorContext = Validate.paramNotNull(builder.interceptorContext, "interceptorContext");
     }
 
     private Throwable unwrap(Throwable exception) {
@@ -69,5 +73,42 @@ public class DefaultFailedExecutionContext implements Context.FailedExecution {
     @Override
     public Throwable exception() {
         return exception;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder implements CopyableBuilder<Builder, DefaultFailedExecutionContext> {
+        private InterceptorContext interceptorContext;
+        private Throwable exception;
+
+        private Builder() {
+        }
+
+        public Builder(DefaultFailedExecutionContext defaultFailedExecutionContext) {
+            this.exception = defaultFailedExecutionContext.exception;
+            this.interceptorContext = defaultFailedExecutionContext.interceptorContext;
+        }
+
+        public Builder exception(Throwable exception) {
+            this.exception = exception;
+            return this;
+        }
+
+        public Builder interceptorContext(InterceptorContext interceptorContext) {
+            this.interceptorContext = interceptorContext;
+            return this;
+        }
+
+        @Override
+        public DefaultFailedExecutionContext build() {
+            return new DefaultFailedExecutionContext(this);
+        }
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ExceptionReportingUtilsTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ExceptionReportingUtilsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptorChain;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.pipeline.stages.utils.ExceptionReportingUtils;
+import software.amazon.awssdk.core.signer.NoOpSigner;
+import utils.ValidSdkObjects;
+
+public class ExceptionReportingUtilsTest {
+
+    @Test
+    public void onExecutionFailureThrowException_shouldSwallow() {
+        RequestExecutionContext context = context(new ThrowErrorOnExecutionFailureInterceptor());
+
+        assertThat(ExceptionReportingUtils.reportFailureToInterceptors(context, SdkClientException.create("test")))
+            .isExactlyInstanceOf(SdkClientException.class);
+    }
+
+    @Test
+    public void modifyException_shouldReturnModifiedException() {
+        ApiCallTimeoutException modifiedException = ApiCallTimeoutException.create(1000);
+        RequestExecutionContext context = context(new ModifyExceptionInterceptor(modifiedException));
+        assertThat(ExceptionReportingUtils.reportFailureToInterceptors(context, SdkClientException.create("test")))
+            .isEqualTo(modifiedException);
+    }
+
+    public RequestExecutionContext context(ExecutionInterceptor... executionInterceptors) {
+        List<ExecutionInterceptor> interceptors = Arrays.asList(executionInterceptors);
+        ExecutionInterceptorChain executionInterceptorChain = new ExecutionInterceptorChain(interceptors);
+        return RequestExecutionContext.builder()
+                                      .executionContext(ExecutionContext.builder()
+                                                                        .signer(new NoOpSigner())
+                                                                        .executionAttributes(new ExecutionAttributes())
+                                                                        .interceptorContext(InterceptorContext.builder()
+                                                                                                              .request(ValidSdkObjects.sdkRequest())
+                                                                                                              .build())
+                                                                        .interceptorChain(executionInterceptorChain)
+                                                                        .build())
+                                      .originalRequest(ValidSdkObjects.sdkRequest())
+                                      .build();
+    }
+
+    private static class ThrowErrorOnExecutionFailureInterceptor implements ExecutionInterceptor {
+
+        @Override
+        public void onExecutionFailure(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+            throw new RuntimeException("OOPS");
+        }
+    }
+
+    private static class ModifyExceptionInterceptor implements ExecutionInterceptor {
+
+        private final Exception exceptionToThrow;
+
+        private ModifyExceptionInterceptor(Exception exceptionToThrow) {
+            this.exceptionToThrow = exceptionToThrow;
+        }
+
+        @Override
+        public Throwable modifyException(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+            return exceptionToThrow;
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/utils/ValidSdkObjects.java
+++ b/core/sdk-core/src/test/java/utils/ValidSdkObjects.java
@@ -16,6 +16,11 @@
 package utils;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpMethod;
@@ -26,6 +31,25 @@ import software.amazon.awssdk.http.SdkHttpMethod;
  */
 public final class ValidSdkObjects {
     private ValidSdkObjects() {}
+
+    public static SdkRequest sdkRequest() {
+        return new SdkRequest() {
+            @Override
+            public Optional<? extends RequestOverrideConfiguration> overrideConfiguration() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Builder toBuilder() {
+                return null;
+            }
+
+            @Override
+            public List<SdkField<?>> sdkFields() {
+                return null;
+            }
+        };
+    }
 
     public static SdkHttpFullRequest.Builder sdkHttpFullRequest() {
         return sdkHttpFullRequest(80);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.handlers;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Translate S3Exception for the API calls that do not contain the detailed error code.
+ */
+@SdkInternalApi
+public final class ExceptionTranslationInterceptor implements ExecutionInterceptor {
+
+    @Override
+    public Throwable modifyException(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+
+        if (!isS3Exception404(context.exception()) || !isHeadRequest(context.request())) {
+            return context.exception();
+        }
+
+        String message = context.exception().getMessage();
+        S3Exception exception = (S3Exception) (context.exception());
+
+        String requestIdFromHeader = exception.awsErrorDetails()
+                                              .sdkHttpResponse()
+                                              .firstMatchingHeader("x-amz-request-id")
+                                              .orElse(null);
+
+        String requestId = Optional.ofNullable(exception.requestId()).orElse(requestIdFromHeader);
+
+        AwsErrorDetails errorDetails = exception.awsErrorDetails();
+
+        if (context.request() instanceof HeadObjectRequest) {
+            return NoSuchKeyException.builder()
+                                    .awsErrorDetails(fillErrorDetails(errorDetails, "NoSuchKey",
+                                                                      "The specified key does not exist."))
+                                    .statusCode(404)
+                                    .requestId(requestId)
+                                    .message(message)
+                                    .build();
+        }
+
+        if (context.request() instanceof HeadBucketRequest) {
+            return NoSuchBucketException.builder()
+                                       .awsErrorDetails(fillErrorDetails(errorDetails, "NoSuchBucket",
+                                                                         "The specified bucket does not exist."))
+                                       .statusCode(404)
+                                       .requestId(requestId)
+                                       .message(message)
+                                       .build();
+        }
+
+        return context.exception();
+    }
+
+    private AwsErrorDetails fillErrorDetails(AwsErrorDetails original, String errorCode, String errorMessage) {
+        return original.toBuilder().errorMessage(errorMessage).errorCode(errorCode).build();
+    }
+
+    private boolean isHeadRequest(SdkRequest request) {
+        return (request instanceof HeadObjectRequest || request instanceof HeadBucketRequest);
+    }
+
+    private boolean isS3Exception404(Throwable thrown) {
+        if (!(thrown instanceof S3Exception)) {
+            return false;
+        }
+
+        return ((S3Exception) thrown).statusCode() == 404;
+    }
+}

--- a/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
+++ b/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
@@ -10,3 +10,4 @@ software.amazon.awssdk.services.s3.internal.handlers.GetBucketPolicyInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.AsyncChecksumValidationInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.SyncChecksumValidationInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.EnableTrailingChecksumInterceptor
+software.amazon.awssdk.services.s3.internal.handlers.ExceptionTranslationInterceptor

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/ExceptionTranslationInterceptorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.handlers;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.internal.interceptor.DefaultFailedExecutionContext;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class ExceptionTranslationInterceptorTest {
+
+    private static ExceptionTranslationInterceptor interceptor;
+
+    @BeforeClass
+    public static void setup() {
+        interceptor = new ExceptionTranslationInterceptor();
+    }
+
+    @Test
+    public void headBucket404_shouldTranslateException() {
+        S3Exception s3Exception = create404S3Exception();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadBucketRequest.builder().build());
+
+        assertThat(interceptor.modifyException(failedExecution, new ExecutionAttributes()))
+            .isExactlyInstanceOf(NoSuchBucketException.class);
+    }
+
+    @Test
+    public void headObject404_shouldTranslateException() {
+        S3Exception s3Exception = create404S3Exception();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadObjectRequest.builder().build());
+
+        assertThat(interceptor.modifyException(failedExecution, new ExecutionAttributes()))
+            .isExactlyInstanceOf(NoSuchKeyException.class);
+    }
+
+    @Test
+    public void headObjectOtherException_shouldNotThrowException() {
+        S3Exception s3Exception = (S3Exception) S3Exception.builder().statusCode(500).build();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     HeadObjectRequest.builder().build());
+
+        assertThat(interceptor.modifyException(failedExecution, new ExecutionAttributes())).isEqualTo(s3Exception);
+    }
+
+    private Context.FailedExecution getFailedExecution(S3Exception s3Exception, SdkRequest sdkRequest) {
+        return DefaultFailedExecutionContext.builder().interceptorContext(InterceptorContext.builder()
+                                                                                            .request(sdkRequest)
+                                                                                            .build()).exception(s3Exception).build();
+    }
+
+    @Test
+    public void otherRequest_shouldNotThrowException() {
+        S3Exception s3Exception = create404S3Exception();
+        Context.FailedExecution failedExecution = getFailedExecution(s3Exception,
+                                                                     PutObjectRequest.builder().build());
+        assertThat(interceptor.modifyException(failedExecution, new ExecutionAttributes())).isEqualTo(s3Exception);
+    }
+
+    private S3Exception create404S3Exception() {
+        return (S3Exception) S3Exception.builder()
+                                        .awsErrorDetails(AwsErrorDetails.builder()
+                                                                        .sdkHttpResponse(SdkHttpFullResponse.builder()
+                                                                                                            .build())
+                                                                        .build())
+                                        .statusCode(404)
+                                        .build();
+    }
+}

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
@@ -383,6 +383,7 @@ public class ExecutionInterceptorTest {
         inOrder.verify(interceptor).afterExecution(afterExecutionArg.capture(), attributes.capture());
         if (expectedException != null) {
             ArgumentCaptor<Context.FailedExecution> failedExecutionArg = ArgumentCaptor.forClass(Context.FailedExecution.class);
+            inOrder.verify(interceptor).modifyException(failedExecutionArg.capture(), attributes.capture());
             inOrder.verify(interceptor).onExecutionFailure(failedExecutionArg.capture(), attributes.capture());
             verifyFailedExecutionMethodCalled(failedExecutionArg, true);
             assertThat(failedExecutionArg.getValue().exception()).isEqualTo(expectedException);
@@ -440,6 +441,7 @@ public class ExecutionInterceptorTest {
         if (isAsync) {
             inOrder.verify(interceptor).modifyAsyncHttpResponseContent(any(), attributes.capture());
         }
+        inOrder.verify(interceptor).modifyException(failedExecutionArg.capture(), attributes.capture());
         inOrder.verify(interceptor).onExecutionFailure(failedExecutionArg.capture(), attributes.capture());
         verifyNoMoreInteractions(interceptor);
 


### PR DESCRIPTION
- Translate S3Exception for headObject and headBucket via interceptor
Throw `NoSuchKey` exception for headObject and `NoSuchBucket` exception for headBucket for 404 status code.

- Added `modifyException` interceptor method

All S3 integration tests passed