### PR TITLE
Not fireExceptionCaught if the channel was released back to the pool

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-3e595bb.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-3e595bb.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Async HTTP Client", 
+    "type": "bugfix", 
+    "description": "Not invoke fireExceptionCaught if the channel is not active. see [#452](https://github.com/aws/aws-sdk-java-v2/issues/452)"
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -33,33 +33,43 @@ public final class ChannelAttributeKey {
     /**
      * Future that when a protocol (http/1.1 or h2) has been selected.
      */
-    public static final AttributeKey<CompletableFuture<Protocol>> PROTOCOL_FUTURE = AttributeKey.newInstance("protocolFuture");
+    public static final AttributeKey<CompletableFuture<Protocol>> PROTOCOL_FUTURE = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.protocolFuture");
 
     /**
      * Reference to {@link MultiplexedChannelRecord} which stores information about leased streams for a multiplexed connection.
      */
-    public static final AttributeKey<MultiplexedChannelRecord> CHANNEL_POOL_RECORD =
-        AttributeKey.newInstance("channelPoolRecord");
+    public static final AttributeKey<MultiplexedChannelRecord> CHANNEL_POOL_RECORD = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.channelPoolRecord");
 
     /**
      * Value of the MAX_CONCURRENT_STREAMS from the server's SETTING frame.
      */
-    public static final AttributeKey<Long> MAX_CONCURRENT_STREAMS = AttributeKey.newInstance("maxConcurrentStreams");
+    public static final AttributeKey<Long> MAX_CONCURRENT_STREAMS = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.maxConcurrentStreams");
 
     /**
      * Attribute key for {@link RequestContext}.
      */
-    static final AttributeKey<RequestContext> REQUEST_CONTEXT_KEY = AttributeKey.newInstance("requestContext");
+    static final AttributeKey<RequestContext> REQUEST_CONTEXT_KEY = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.requestContext");
 
-    static final AttributeKey<Subscriber<? super ByteBuffer>> SUBSCRIBER_KEY = AttributeKey.newInstance("subscriber");
+    static final AttributeKey<Subscriber<? super ByteBuffer>> SUBSCRIBER_KEY = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.subscriber");
 
-    static final AttributeKey<Boolean> RESPONSE_COMPLETE_KEY = AttributeKey.newInstance("responseComplete");
+    static final AttributeKey<Boolean> RESPONSE_COMPLETE_KEY = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.responseComplete");
 
     static final AttributeKey<CompletableFuture<Void>> EXECUTE_FUTURE_KEY = AttributeKey.newInstance(
             "aws.http.nio.netty.async.executeFuture");
 
     static final AttributeKey<Long> EXECUTION_ID_KEY = AttributeKey.newInstance(
             "aws.http.nio.netty.async.executionId");
+
+    /**
+     * Whether the channel is still in use
+     */
+    static final AttributeKey<Boolean> IN_USE = AttributeKey.newInstance("aws.http.nio.netty.async.inUse");
 
     private ChannelAttributeKey() {
     }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.IN_USE;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ChannelUtils.removeIfExists;
 
 import com.typesafe.netty.http.HttpStreamsClientHandler;
@@ -68,6 +69,7 @@ public class HandlerRemovingChannelPool implements ChannelPool {
     }
 
     private void removePerRequestHandlers(Channel channel) {
+        channel.attr(IN_USE).set(false);
         removeIfExists(channel.pipeline(),
                        HttpStreamsClientHandler.class,
                        ResponseHandler.class,

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -132,8 +132,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
             IOException err = new IOException("Server failed to send complete response");
             requestCtx.handler().onError(err);
             executeFuture(handlerCtx).completeExceptionally(err);
-            runAndLogError("Could not release channel",
-                () -> requestCtx.channelPool().release(handlerCtx.channel()));
+            runAndLogError("Could not release channel", () -> closeAndRelease(handlerCtx));
         }
     }
 


### PR DESCRIPTION
Not fireExceptionCaught if the channel is released back to the pool to avoid warning messages showing up like the following.

```
2018-11-16 15:13:30,347 [aws-java-sdk-NettyEventLoop-1-3] WARN  io.netty.channel.DefaultChannelPipeline - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
software.amazon.awssdk.http.nio.netty.internal.FutureCancelledException: java.io.IOException: Server failed to send complete response"
```

see https://github.com/aws/aws-sdk-java-v2/issues/452


Tested with the the example code customer provided in the above issue: sending s3 request every 60s