### PR TITLE
Updating content length when trailing checksums enabled

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectAsyncIntegrationTest.java
@@ -16,28 +16,26 @@
 package software.amazon.awssdk.services.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
-import static software.amazon.awssdk.services.s3.utils.S3TestUtils.assertMd5MatchesEtag;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
-import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.http.async.SimpleSubscriber;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -77,9 +75,11 @@ public class GetObjectAsyncIntegrationTest extends S3IntegrationTestBase {
     @Test
     public void toFile() throws Exception {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
+        GetObjectResponse response = null;
         try {
-            GetObjectResponse response = s3Async.getObject(getObjectRequest, path).join();
+            response = s3Async.getObject(getObjectRequest, path).join();
         } finally {
+            assertEquals(Long.valueOf(path.toFile().length()), response.contentLength());
             path.toFile().delete();
         }
     }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
 import java.io.ByteArrayOutputStream;
@@ -73,9 +74,12 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     @Test
     public void toFile() throws Exception {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
+
+        GetObjectResponse response = null;
         try {
-            GetObjectResponse response = s3.getObject(getObjectRequest, path);
+            response = s3.getObject(getObjectRequest, path);
         } finally {
+            assertEquals(Long.valueOf(path.toFile().length()), response.contentLength());
             path.toFile().delete();
         }
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumConstant.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumConstant.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public final class ChecksumConstant {
+
+    /**
+     * Header name for the content-length of an S3 object.
+     */
+    public static final String CONTENT_LENGTH_HEADER = "Content-Length";
+
+    /**
+     * Header name for specifying S3 to send a trailing checksum.
+     */
+    public static final String ENABLE_CHECKSUM_REQUEST_HEADER = "x-amz-te";
+
+    /**
+     * Header name for specifying if trailing checksums were sent on an object.
+     */
+    public static final String CHECKSUM_ENABLED_RESPONSE_HEADER = "x-amz-transfer-encoding";
+
+    /**
+     * Header value for specifying MD5 as the trailing checksum of an object.
+     */
+    public static final String ENABLE_MD5_CHECKSUM_HEADER_VALUE = "append-md5";
+
+    /**
+     * Length of an MD5 checksum in bytes.
+     */
+    public static final int S3_MD5_CHECKSUM_LENGTH = 16;
+
+    private ChecksumConstant() {}
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.s3.handlers;
+package software.amazon.awssdk.services.s3.internal.handlers;
 
 import static software.amazon.awssdk.core.ClientType.ASYNC;
 
@@ -34,7 +34,6 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.checksums.ChecksumCalculatingAsyncRequestBody;
 import software.amazon.awssdk.services.s3.checksums.ChecksumValidatingPublisher;
@@ -48,17 +47,6 @@ import software.amazon.awssdk.utils.internal.Base16Lower;
 public class AsyncChecksumValidationInterceptor implements ExecutionInterceptor {
 
     private static final ExecutionAttribute<SdkChecksum> CHECKSUM = new ExecutionAttribute("checksum");
-
-    @Override
-    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
-                                            ExecutionAttributes executionAttributes) {
-
-        if (context.request() instanceof GetObjectRequest && checksumValidationEnabled(executionAttributes)) {
-            return context.httpRequest().toBuilder().putHeader("x-amz-te", "append-md5").build();
-        }
-
-        return context.httpRequest();
-    }
 
     @Override
     public Optional<AsyncRequestBody> modifyAsyncHttpContent(Context.ModifyHttpRequest context,

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/EnableTrailingChecksumInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/EnableTrailingChecksumInterceptor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.handlers;
+
+import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.CHECKSUM_ENABLED_RESPONSE_HEADER;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.ENABLE_CHECKSUM_REQUEST_HEADER;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.ENABLE_MD5_CHECKSUM_HEADER_VALUE;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.S3_MD5_CHECKSUM_LENGTH;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+@SdkInternalApi
+public class EnableTrailingChecksumInterceptor implements ExecutionInterceptor {
+
+    @Override
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                            ExecutionAttributes executionAttributes) {
+
+        if (context.request() instanceof GetObjectRequest && checksumValidationEnabled(executionAttributes)) {
+            return context.httpRequest().toBuilder().putHeader(ENABLE_CHECKSUM_REQUEST_HEADER,
+                                                               ENABLE_MD5_CHECKSUM_HEADER_VALUE)
+                          .build();
+        }
+
+        return context.httpRequest();
+    }
+
+    @Override
+    public SdkResponse modifyResponse(Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
+        SdkResponse response = context.response();
+        SdkHttpResponse httpResponse = context.httpResponse();
+
+        if (response instanceof GetObjectResponse && httpResponse.firstMatchingHeader(CHECKSUM_ENABLED_RESPONSE_HEADER)
+                                                                 .isPresent()) {
+            GetObjectResponse getResponse = (GetObjectResponse) response;
+            return getResponse.toBuilder().contentLength(getResponse.contentLength() - S3_MD5_CHECKSUM_LENGTH).build();
+        }
+
+        return response;
+    }
+
+    private boolean checksumValidationEnabled(ExecutionAttributes executionAttributes) {
+
+        S3Configuration serviceConfiguration =
+            (S3Configuration) executionAttributes.getAttribute(AwsSignerExecutionAttribute.SERVICE_CONFIG);
+
+        return serviceConfiguration == null || serviceConfiguration.checksumValidationEnabled();
+    }
+}

--- a/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
+++ b/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
@@ -7,5 +7,6 @@ software.amazon.awssdk.services.s3.internal.handlers.DisableDoubleUrlEncodingInt
 software.amazon.awssdk.services.s3.internal.handlers.DecodeUrlEncodedResponseInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.AddContentMd5HeaderInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.GetBucketPolicyInterceptor
-software.amazon.awssdk.services.s3.handlers.AsyncChecksumValidationInterceptor
-software.amazon.awssdk.services.s3.handlers.SyncChecksumValidationInterceptor
+software.amazon.awssdk.services.s3.internal.handlers.AsyncChecksumValidationInterceptor
+software.amazon.awssdk.services.s3.internal.handlers.SyncChecksumValidationInterceptor
+software.amazon.awssdk.services.s3.internal.handlers.EnableTrailingChecksumInterceptor


### PR DESCRIPTION
Updates the content-length on responses to be the content-length minus the trailing checksum size when trailing checksums are enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
