### PR TITLE
Plumbing through service name to execution interceptors

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsClientHandlerUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsClientHandlerUtils.java
@@ -79,7 +79,8 @@ public final class AwsClientHandlerUtils {
             .putAttribute(AwsExecutionAttribute.AWS_REGION, clientConfig.option(AwsClientOption.AWS_REGION))
             .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, clientConfig.option(AwsClientOption.SIGNING_REGION))
             .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, executionParams.isFullDuplex())
-            .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, clientConfig.option(SdkClientOption.CLIENT_TYPE));
+            .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, clientConfig.option(SdkClientOption.CLIENT_TYPE))
+            .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfig.option(SdkClientOption.SERVICE_NAME));
 
         ExecutionInterceptorChain executionInterceptorChain =
                 new ExecutionInterceptorChain(clientConfig.option(SdkClientOption.EXECUTION_INTERCEPTORS));

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseClientHandler.java
@@ -50,9 +50,6 @@ public abstract class BaseClientHandler {
         runBeforeMarshallingInterceptors(executionContext);
         SdkHttpFullRequest request = executionParams.getMarshaller().marshall(inputT);
 
-        executionContext.executionAttributes().putAttribute(SdkExecutionAttribute.SERVICE_NAME,
-                                                            clientConfiguration.option(SdkClientOption.SERVICE_NAME));
-
         addHttpRequest(executionContext, request);
         runAfterMarshallingInterceptors(executionContext);
         return runModifyHttpRequestInterceptors(request, executionContext);
@@ -123,7 +120,8 @@ public abstract class BaseClientHandler {
         SdkRequest originalRequest = params.getInput();
         ExecutionAttributes executionAttributes = new ExecutionAttributes()
             .putAttribute(SdkExecutionAttribute.SERVICE_CONFIG,
-                          clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION));
+                          clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
+            .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfiguration.option(SdkClientOption.SERVICE_NAME));
 
         ExecutionInterceptorChain interceptorChain =
                 new ExecutionInterceptorChain(clientConfiguration.option(SdkClientOption.EXECUTION_INTERCEPTORS));


### PR DESCRIPTION
Not sure why we were only setting it after finalizeSdkRequest but now it gets set for reading by all interceptors.