### PR TITLE
Make module-path-tests child module of the parent pom 

### DIFF
--- a/buildspecs/integ-test.yml
+++ b/buildspecs/integ-test.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-      - mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2
+      - mvn clean install -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)
       - echo $JAVA_VERSION
       - |

--- a/buildspecs/on-demand-integ-test.yml
+++ b/buildspecs/on-demand-integ-test.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   build:
     commands:
-      - mvn clean verify -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2 --fail-at-end
+      - mvn clean install -Dskip.unit.tests -P integration-tests -Dfindbugs.skip -Dcheckstyle.skip -pl !:dynamodbmapper-v1 -Dfailsafe.rerunFailingTestsCount=1 -Dmaven.wagon.httpconnectionManager.maxPerRoute=2 --fail-at-end
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)
       - echo $JAVA_VERSION
       - |

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <module>test/test-utils</module>
         <module>test/codegen-generated-classes-test</module>
         <module>test/sdk-benchmarks</module>
+        <module>test/module-path-tests</module>
         <module>utils</module>
         <module>codegen-lite</module>
         <module>codegen-lite-maven-plugin</module>

--- a/test/module-path-tests/pom.xml
+++ b/test/module-path-tests/pom.xml
@@ -26,9 +26,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>module-path-tests</artifactId>
-    <!-- Setting it to a different version so it can always load dependencies from maven
-    rather than local module-->
-    <version>1.0.0-SNAPSHOT</version>
 
     <name>AWS Java SDK :: Test :: Module Path Tests</name>
     <description>A set of tests to run v2 in module path with Java 9+.</description>
@@ -81,43 +78,94 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                <execution>
-                    <id>default-compile</id>
-                    <configuration>
-                        <source>9</source>
-                        <release>9</release>
-                    </configuration>
-                </execution>
-                </executions>
-                <configuration>
-                    <jdkToolchain>
-                        <version>[9,)</version>
-                    </jdkToolchain>
-                    <release>9</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <!-- Disable spotbugs speed up the build. -->
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
+        <!-- Skip module-info.java on Java 8 -->
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>[1.8,9)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Don't compile module-info.java, see java 9 profile -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <!-- Disable spotbugs speed up the build. -->
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <!-- Skip because dependency analysis is on class path and does not apply on module path. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java9plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <source>9</source>
+                                    <release>9</release>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <jdkToolchain>
+                                <version>[9,)</version>
+                            </jdkToolchain>
+                            <release>9</release>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                    <!-- Disable spotbugs speed up the build. -->
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <!-- Skip because dependency analysis is on class path and does not apply on module path. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>mock-tests</id>
             <build>

--- a/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/integtests/S3ApiCall.java
+++ b/test/module-path-tests/src/main/java/software/amazon/awssdk/modulepath/tests/integtests/S3ApiCall.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.modulepath.tests.integtests;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -26,6 +27,7 @@ public class S3ApiCall extends BaseApiCall {
 
     private S3Client s3Client = S3Client.builder()
                                         .region(Region.US_WEST_2)
+                                        .httpClient(ApacheHttpClient.builder().build())
                                         .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
                                         .build();
 


### PR DESCRIPTION
so that we don't need to update the parent version for it manually after each release like this https://github.com/aws/aws-sdk-java-v2/commit/9baf986499cae160b2cdaa720b55247ffa1a8fd7#diff-a0ceec564b5bf60c5b3da61928510ad3

The version update will be handled automatically in udpate-snapshot-version step.

