### PR TITLE
Fixing CBOR unmarshalling of blobs and running Kinesis integ test

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavaV2-7ae0927.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavaV2-7ae0927.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java V2", 
+    "type": "bugfix", 
+    "description": "Fixes Issue [#864](https://github.com/aws/aws-sdk-java-v2/issues/864) by checking for embedded JSON objects while unmarshalling bytes."
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/dom/SdkEmbeddedObject.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/dom/SdkEmbeddedObject.java
@@ -37,6 +37,7 @@ public final class SdkEmbeddedObject implements SdkJsonNode {
     /**
      * @return The embedded object that was returned by the {@link JsonParser}.
      */
+    @Override
     public Object embeddedObject() {
         return embeddedObject;
     }

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/dom/SdkJsonNode.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/dom/SdkJsonNode.java
@@ -38,6 +38,13 @@ public interface SdkJsonNode {
     }
 
     /**
+     * @return The embedded object value of the node. See {@link SdkEmbeddedObject}.
+     */
+    default Object embeddedObject() {
+        return null;
+    }
+
+    /**
      * @param fieldName Field to get value for.
      * @return Value of field in the JSON object if this node represents an object, otherwise returns null.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -687,6 +687,7 @@
                                 <configuration>
                                     <includes>
                                         <include>**/*IntegrationTest.java</include>
+                                        <include>**/*IntegrationTests.java</include>
                                         <include>**/*IntegTest.java</include>
                                         <include>**/RunCucumberTest.java</include>
                                     </includes>


### PR DESCRIPTION
Fixing Issue #864 

## Description
CBOR doesn't Base64 bytes and can unmarshall them directly.

## Motivation and Context
Fixes Kinesis GetRecords

## Testing
Actually running the integ test we have for Kinesis.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
