### PR TITLE
Make ChecksumValidatingInputStream implement close(). Preserve abort semantics through interceptor modification.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-f82a8d4.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-f82a8d4.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fixed an issue where close() and abort() weren't being honored for streaming responses in all cases."
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/AbortableInputStream.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/AbortableInputStream.java
@@ -54,6 +54,9 @@ public final class AbortableInputStream extends FilterInputStream implements Abo
      * @return a new instance of AbortableInputStream
      */
     public static AbortableInputStream create(InputStream delegate) {
+        if (delegate instanceof Abortable) {
+            return new AbortableInputStream(delegate, (Abortable) delegate);
+        }
         return new AbortableInputStream(delegate, () -> { });
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
@@ -21,9 +21,10 @@ import java.nio.ByteBuffer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.Abortable;
 
 @SdkInternalApi
-public class ChecksumValidatingInputStream extends InputStream {
+public class ChecksumValidatingInputStream extends InputStream implements Abortable {
     private static final int CHECKSUM_SIZE = 16;
 
     private final SdkChecksum checkSum;
@@ -146,6 +147,18 @@ public class ChecksumValidatingInputStream extends InputStream {
         }
     }
 
+    @Override
+    public void abort() {
+        if (inputStream instanceof Abortable) {
+            ((Abortable) inputStream).abort();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+
     /**
      * Gets the stream's checksum as an integer.
      *
@@ -165,4 +178,5 @@ public class ChecksumValidatingInputStream extends InputStream {
                               computedChecksumInt, streamChecksumInt)).build();
         }
     }
+
 }


### PR DESCRIPTION
Fixes #438