### PR TITLE
add organizations to aws-sdk-java module

### DIFF
--- a/.changes/next-release/bugfix-AWSOrganizations-e9534c7.json
+++ b/.changes/next-release/bugfix-AWSOrganizations-e9534c7.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Organizations", 
+    "type": "bugfix", 
+    "description": "Add `organizations` to `aws-sdk-java` module."
+}

--- a/aws-sdk-java/pom.xml
+++ b/aws-sdk-java/pom.xml
@@ -535,6 +535,11 @@
             <artifactId>appsync</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>organizations</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
fixes #872 

Will find an automatic way to add the missing service modules.