### PR TITLE
Fix the issue where putobject requests sometimes is hanging

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-5b20e7b.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-5b20e7b.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Async HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fix the issue where streaming requests with `Expect: 100-continue` header sometimes are hanging because 100Continue response message is not being read automatically. See [#459](https://github.com/aws/aws-sdk-java-v2/issues/459)"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Related to #459 

For `PutObjectRequest`, we are sending `Expect: 100-continue` header and waiting for the service to return "100 Continue" before streaming request. `ChannelOption.AUTO_READ` is disabled, so sometimes it's possible no channel read is triggered to read that message and the request is forever "blocked" waiting for the "100 Continue" response.

The fix is explicitly call `channel.read()` if the request contains "Expect: 100-continue" header

## Testing
Tested with the sample code provided by customer in #459 and verified it worked after the fix.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
