### PR TITLE
Fix nullpointerexception in case a map has null values.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-a5e899c.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-a5e899c.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fixes nullpointerexception when server responds with null values in map."
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
@@ -17,7 +18,7 @@ final class BlobMapTypeCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, SdkBytes> blobMapTypeParamCopy = blobMapTypeParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> StandardMemberCopier.copy(e.getValue())));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), StandardMemberCopier.copy(e.getValue())), HashMap::putAll);
         return Collections.unmodifiableMap(blobMapTypeParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,7 +16,7 @@ final class MapOfEnumToEnumCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
     }
 
@@ -24,7 +25,7 @@ final class MapOfEnumToEnumCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                .collect(toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue().toString()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,7 +16,7 @@ final class MapOfEnumToSimpleStructCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
     }
 
@@ -31,7 +32,7 @@ final class MapOfEnumToSimpleStructCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                .collect(toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,7 +16,7 @@ final class MapOfEnumToStringCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
     }
 
@@ -24,7 +25,7 @@ final class MapOfEnumToStringCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                .collect(toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,7 +16,7 @@ final class MapOfStringToEnumCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
     }
 
@@ -24,7 +25,7 @@ final class MapOfStringToEnumCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue().toString()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
@@ -17,7 +18,7 @@ final class MapOfStringToIntegerListCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, List<Integer>> mapOfStringToIntegerListParamCopy = mapOfStringToIntegerListParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> ListOfIntegersCopier.copy(e.getValue())));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfIntegersCopier.copy(e.getValue())), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToIntegerListParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
@@ -13,12 +14,14 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToListOfListOfStringsCopier {
     static Map<String, List<List<String>>> copy(
-            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
+        Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
         if (mapOfStringToListOfListOfStringsParam == null || mapOfStringToListOfListOfStringsParam instanceof SdkAutoConstructMap) {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, List<List<String>>> mapOfStringToListOfListOfStringsParamCopy = mapOfStringToListOfListOfStringsParam
-                .entrySet().stream().collect(toMap(Map.Entry::getKey, e -> ListOfListOfStringsCopier.copy(e.getValue())));
+            .entrySet()
+            .stream()
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfListOfStringsCopier.copy(e.getValue())), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToListOfListOfStringsParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,7 +16,7 @@ final class MapOfStringToSimpleStructCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, SimpleStruct> mapOfStringToSimpleStructParamCopy = mapOfStringToSimpleStructParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToSimpleStructParamCopy);
     }
 
@@ -24,6 +25,6 @@ final class MapOfStringToSimpleStructCopier {
             return null;
         }
         return copy(mapOfStringToSimpleStructParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+            .collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,7 +16,7 @@ final class MapOfStringToStringCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, String> mapOfStringToStringParamCopy = mapOfStringToStringParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToStringParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/blobmaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/blobmaptypecopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
@@ -15,7 +16,7 @@ final class BlobMapTypeCopier {
             return null;
         }
         Map<String, SdkBytes> blobMapTypeParamCopy = blobMapTypeParam.entrySet().stream()
-                                                                     .collect(toMap(Map.Entry::getKey, e -> StandardMemberCopier.copy(e.getValue())));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), StandardMemberCopier.copy(e.getValue())), HashMap::putAll);
         return Collections.unmodifiableMap(blobMapTypeParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofenumtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofenumtoenumcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,7 +14,7 @@ final class MapOfEnumToEnumCopier {
             return null;
         }
         Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                                                                           .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
     }
 
@@ -22,7 +23,7 @@ final class MapOfEnumToEnumCopier {
             return null;
         }
         Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                                                                           .collect(toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue().toString()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofenumtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofenumtosimplestructcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,7 +14,7 @@ final class MapOfEnumToSimpleStructCopier {
             return null;
         }
         Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
     }
 
@@ -29,7 +30,7 @@ final class MapOfEnumToSimpleStructCopier {
             return null;
         }
         Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                .collect(toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofenumtostringcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,7 +14,7 @@ final class MapOfEnumToStringCopier {
             return null;
         }
         Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                                                                               .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
     }
 
@@ -22,7 +23,7 @@ final class MapOfEnumToStringCopier {
             return null;
         }
         Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                                                                               .collect(toMap(e -> e.getKey().toString(), Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtoenumcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,7 +14,7 @@ final class MapOfStringToEnumCopier {
             return null;
         }
         Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                                                                               .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
     }
 
@@ -22,7 +23,7 @@ final class MapOfStringToEnumCopier {
             return null;
         }
         Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                                                                               .collect(toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue().toString()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtointegerlistcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtointegerlistcopier.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
@@ -15,7 +16,7 @@ final class MapOfStringToIntegerListCopier {
             return null;
         }
         Map<String, List<Integer>> mapOfStringToIntegerListParamCopy = mapOfStringToIntegerListParam.entrySet().stream()
-                                                                                                    .collect(toMap(Map.Entry::getKey, e -> ListOfIntegersCopier.copy(e.getValue())));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfIntegersCopier.copy(e.getValue())), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToIntegerListParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtolistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtolistoflistofstringscopier.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
@@ -11,12 +12,14 @@ import software.amazon.awssdk.annotations.Generated;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToListOfListOfStringsCopier {
     static Map<String, List<List<String>>> copy(
-            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
+        Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
         if (mapOfStringToListOfListOfStringsParam == null) {
             return null;
         }
         Map<String, List<List<String>>> mapOfStringToListOfListOfStringsParamCopy = mapOfStringToListOfListOfStringsParam
-                .entrySet().stream().collect(toMap(Map.Entry::getKey, e -> ListOfListOfStringsCopier.copy(e.getValue())));
+            .entrySet()
+            .stream()
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfListOfStringsCopier.copy(e.getValue())), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToListOfListOfStringsParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtosimplestructcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,7 +14,7 @@ final class MapOfStringToSimpleStructCopier {
             return null;
         }
         Map<String, SimpleStruct> mapOfStringToSimpleStructParamCopy = mapOfStringToSimpleStructParam.entrySet().stream()
-                                                                                                     .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToSimpleStructParamCopy);
     }
 
@@ -22,6 +23,6 @@ final class MapOfStringToSimpleStructCopier {
             return null;
         }
         return copy(mapOfStringToSimpleStructParam.entrySet().stream()
-                                                  .collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+            .collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/mapofstringtostringcopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,7 +14,7 @@ final class MapOfStringToStringCopier {
             return null;
         }
         Map<String, String> mapOfStringToStringParamCopy = mapOfStringToStringParam.entrySet().stream()
-                                                                                   .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(mapOfStringToStringParamCopy);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/recursivemaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/recursivemaptypecopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 
@@ -13,12 +14,12 @@ final class RecursiveMapTypeCopier {
             return null;
         }
         Map<String, RecursiveStructType> recursiveMapTypeParamCopy = recursiveMapTypeParam.entrySet().stream()
-                                                                                          .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(recursiveMapTypeParamCopy);
     }
 
     static Map<String, RecursiveStructType> copyFromBuilder(
-            Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
+        Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
         if (recursiveMapTypeParam == null) {
             return null;
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -15,12 +16,12 @@ final class RecursiveMapTypeCopier {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         Map<String, RecursiveStructType> recursiveMapTypeParamCopy = recursiveMapTypeParam.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
         return Collections.unmodifiableMap(recursiveMapTypeParamCopy);
     }
 
     static Map<String, RecursiveStructType> copyFromBuilder(
-            Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
+        Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
         if (recursiveMapTypeParam == null) {
             return null;
         }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/codegenerationjsonrpccustomized/model/MapCopierTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/codegenerationjsonrpccustomized/model/MapCopierTest.java
@@ -15,12 +15,15 @@
 
 package software.amazon.awssdk.services.codegenerationjsonrpccustomized.model;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.HashMap;
 import org.junit.Test;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for generated map member copiers.
@@ -39,5 +42,25 @@ public class MapCopierTest {
     @Test
     public void explicitlyEmptyMapsAreNotCopiedAsAutoConstructed() {
         assertThat(MapOfStringToStringCopier.copy(new HashMap<>())).isNotInstanceOf(SdkAutoConstructMap.class);
+    }
+
+    @Test
+    public void nullValuesInMapsAreCopied() {
+        Map<String, String> map = new HashMap<>();
+        map.put("test", null);
+        assertThat(MapOfStringToStringCopier.copy(map)).isEqualTo(map);
+    }
+
+    @Test
+    public void modificationsInOriginalMapDoNotReflectInCopiedMap() {
+        Map<String, String> map = new HashMap<>();
+        Map<String, String> copiedMap = MapOfStringToStringCopier.copy(map);
+        map.put("test", null);
+        assertThat(copiedMap).isEmpty();
+    }
+
+    @Test
+    public void copiedMapIsImmutable() {
+        assertThatThrownBy(() -> MapOfStringToStringCopier.copy(new HashMap<>()).put("test", "a")).isInstanceOf(UnsupportedOperationException.class);
     }
 }


### PR DESCRIPTION
While trying out the lexruntime sdk I noticed an issue. The server responds with a json containing `"slots": {"City": null}`, which should be converted to a `Map<String,String>`. However this causes a NullPointerException in `StringMapCopier.copy`. It tries to copy a hashmap by doing an `.entrySet().stream().collect(toMap)`. This fails on null values, there is an old issue logged in the jdk: https://bugs.openjdk.java.net/browse/JDK-8148463 

## Description

Instead of using `collect(toMap)`, I would copy the map as follows: `mapOfStringToStringParam.entrySet().stream().collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll)`. This still allows generating variants of `XXCopier.copy(e.getValue())`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes a NullPointerException that occurs if the server sends a null value in a map. For example, lexruntime sdk gave me following exception after it sent an ElicitSlot response.
```
Exception in thread "main" software.amazon.awssdk.core.exception.SdkClientException: Unable to unmarshall response (null). Response Code: 200, Response Text: OK
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:97)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.handleSuccessResponse(HandleResponseStage.java:100)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.handleResponse(HandleResponseStage.java:70)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:58)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:41)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:205)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:63)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:36)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:77)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:39)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage$RetryExecutor.doExecute(RetryableStage.java:115)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage$RetryExecutor.execute(RetryableStage.java:88)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:64)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:44)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:205)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:51)
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:33)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:79)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:205)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:205)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:25)
	at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:240)
	at software.amazon.awssdk.core.client.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:96)
	at software.amazon.awssdk.core.client.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:120)
	at software.amazon.awssdk.core.client.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:73)
	at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:44)
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:55)
	at software.amazon.awssdk.services.lexruntime.DefaultLexRuntimeClient.postText(DefaultLexRuntimeClient.java:432)
	at HelloLex.postText(HelloLex.java:18)
	at HelloLex.main(HelloLex.java:13)
Caused by: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:221)
	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:178)
	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1751)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at software.amazon.awssdk.services.lexruntime.model.StringMapCopier.copy(StringMapCopier.java:31)
	at software.amazon.awssdk.services.lexruntime.model.PostTextResponse$BuilderImpl.slots(PostTextResponse.java:1299)
	at software.amazon.awssdk.services.lexruntime.model.PostTextResponse.lambda$setter$1(PostTextResponse.java:725)
	at software.amazon.awssdk.core.SdkField.set(SdkField.java:162)
	at software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller.unmarshallStructured(JsonProtocolUnmarshaller.java:212)
	at software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller.unmarshall(JsonProtocolUnmarshaller.java:199)
	at software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller.unmarshall(JsonProtocolUnmarshaller.java:170)
	at software.amazon.awssdk.protocols.json.internal.unmarshall.JsonResponseHandler.handle(JsonResponseHandler.java:79)
	at software.amazon.awssdk.protocols.json.internal.unmarshall.JsonResponseHandler.handle(JsonResponseHandler.java:36)
	at software.amazon.awssdk.protocols.json.internal.unmarshall.AwsJsonResponseHandler.handle(AwsJsonResponseHandler.java:43)
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:88)
	at software.amazon.awssdk.core.client.handler.BaseClientHandler.lambda$interceptorCalling$2(BaseClientHandler.java:133)
	at software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler.handle(AttachHttpMetadataResponseHandler.java:40)
	at software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler.handle(AttachHttpMetadataResponseHandler.java:28)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.handleSuccessResponse(HandleResponseStage.java:89)
	... 31 more
```

<!--- If it fixes an open issue, please link to the issue here -->
Fixes #896 (I also created ticket/case on aws first (id: 5562678811))

## Testing

I added a unit test where I try to copy a HashMap with a null value. I also added two tests to verify the copied map is immutable as that didn't seem to be present yet.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project _Think so, it passes checkstyle_
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
