### PR TITLE
Update mime types to add gz and gzip extensions

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-cea02db.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-cea02db.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Add application/gzip mime type"
+}

--- a/core/sdk-core/src/main/resources/software/amazon/awssdk/core/util/mime.types
+++ b/core/sdk-core/src/main/resources/software/amazon/awssdk/core/util/mime.types
@@ -37,6 +37,8 @@ application/font-tdpfr				pfr
 application/gml+xml				gml
 application/gpx+xml				gpx
 application/gxf					gxf
+application/gzip					gz
+application/gzip					gzip
 application/hyperstudio				stk
 application/inkml+xml				ink inkml
 application/ipfix				ipfix

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/PutObjectHeaderTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/PutObjectHeaderTest.java
@@ -85,6 +85,27 @@ public class PutObjectHeaderTest {
     }
 
     @Test
+    public void putObject_gzipFile_hasProperContentType() throws IOException {
+        File file = new RandomTempFile("test.gz", 10);
+        stubFor(any(urlMatching(".*"))
+                    .willReturn(response()));
+        s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
+        verify(putRequestedFor(anyUrl()).withHeader(CONTENT_TYPE, equalTo("application/gzip")));
+    }
+
+    @Test
+    public void putObject_gzipFile_shouldNotOverrideContentTypeInRequest() throws IOException {
+        File file = new RandomTempFile("test.gz", 10);
+        String contentType = "something";
+        stubFor(any(urlMatching(".*"))
+                    .willReturn(response()));
+
+        s3Client.putObject(putObjectRequest.toBuilder().contentType(contentType).build(),
+                           RequestBody.fromFile(file));
+        verify(putRequestedFor(anyUrl()).withHeader(CONTENT_TYPE, equalTo(contentType)));
+    }
+
+    @Test
     public void putObjectUnknownFileExtension_contentTypeDefaultToBeStream() throws IOException {
         File file = new RandomTempFile("test.unknown", 10);
         stubFor(any(urlMatching(".*"))


### PR DESCRIPTION
Fix https://github.com/aws/aws-sdk-java-v2/issues/899

Official list at [iana](https://www.iana.org/assignments/media-types/media-types.xhtml) doesn't have the .gz extension. So hand editing the file to add .gz and .gzip