### PR TITLE
Fix bug in ChecksumCalculatingInputStream

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-5df5cc4.json
+++ b/.changes/next-release/bugfix-AmazonS3-5df5cc4.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "S3 putObject API using UrlConnectionHttpClient goes into infinite loop. See https://github.com/aws/aws-sdk-java-v2/pull/942 for more details."
+}

--- a/http-clients/url-connection-client/pom.xml
+++ b/http-clients/url-connection-client/pom.xml
@@ -55,6 +55,35 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <artifactId>service-test-utils</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/S3WithUrlHttpClientIntegrationTest.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/S3WithUrlHttpClientIntegrationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.urlconnection;
+
+import static software.amazon.awssdk.testutils.service.AwsTestBase.CREDENTIALS_PROVIDER_CHAIN;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+public class S3WithUrlHttpClientIntegrationTest {
+
+    /**
+     * The name of the bucket created, used, and deleted by these tests.
+     */
+    private static String BUCKET_NAME = "java-sdk-integ-" + System.currentTimeMillis();
+
+    private static String KEY = "key";
+
+    private static Region REGION = Region.US_WEST_2;
+
+    private static S3Client s3;
+
+    /**
+     * Creates all the test resources for the tests.
+     */
+    @BeforeClass
+    public static void createResources() throws Exception {
+        s3 = S3Client.builder()
+                     .region(REGION)
+                     .httpClient(UrlConnectionHttpClient.builder().build())
+                     .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                     .build();
+
+        createBucket(BUCKET_NAME, REGION);
+    }
+
+    /**
+     * Releases all resources created in this test.
+     */
+    @AfterClass
+    public static void tearDown() {
+        deleteObject(BUCKET_NAME, KEY);
+        deleteBucket(BUCKET_NAME);
+    }
+
+    @Test
+    public void verifyPutObject() {
+        Assertions.assertThat(objectCount(BUCKET_NAME)).isEqualTo(0);
+
+        // Put Object
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(KEY).build(),
+                     RequestBody.fromString("foobar"));
+
+
+        Assertions.assertThat(objectCount(BUCKET_NAME)).isEqualTo(1);
+    }
+
+
+    private static void createBucket(String bucket, Region region) {
+        s3.createBucket(CreateBucketRequest
+                            .builder()
+                            .bucket(bucket)
+                            .createBucketConfiguration(
+                                CreateBucketConfiguration.builder()
+                                                         .locationConstraint(region.id())
+                                                         .build())
+                            .build());
+    }
+
+    private static void deleteObject(String bucket, String key) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder().bucket(bucket).key(key).build();
+        s3.deleteObject(deleteObjectRequest);
+    }
+
+    private static void deleteBucket(String bucket) {
+        DeleteBucketRequest deleteBucketRequest = DeleteBucketRequest.builder().bucket(bucket).build();
+        s3.deleteBucket(deleteBucketRequest);
+    }
+
+    private int objectCount(String bucket) {
+        ListObjectsV2Request listReq = ListObjectsV2Request.builder()
+                                                           .bucket(bucket)
+                                                           .build();
+
+        return s3.listObjectsV2(listReq).keyCount();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingInputStream.java
@@ -78,7 +78,7 @@ public class ChecksumCalculatingInputStream extends InputStream {
             throw new NullPointerException();
         }
 
-        int read = 0;
+        int read = -1;
 
         if (!endOfStream) {
             read = inputStream.read(buf, off, len);
@@ -89,7 +89,6 @@ public class ChecksumCalculatingInputStream extends InputStream {
 
             if (read == -1) {
                 endOfStream = true;
-                read = 0;
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/aws/aws-sdk-java-v2/issues/941

**Bug Description**
When request has content stream, [UrlConnectionHttpClient](https://github.com/aws/aws-sdk-java-v2/blob/8128c9922ce1e3516a33e8c29f383bfc852fe456/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java#L109) copies the content stream to the connection output stream using [IoUtils.copy](https://github.com/aws/aws-sdk-java-v2/blob/8128c9922ce1e3516a33e8c29f383bfc852fe456/utils/src/main/java/software/amazon/awssdk/utils/IoUtils.java#L101-L111) method. The copy methods writes to the outputStream until the endOfStream is reached ie., _in.read method returns -1_. As [ChecksumCalculatingInputStream](https://github.com/aws/aws-sdk-java-v2/blob/8128c9922ce1e3516a33e8c29f383bfc852fe456/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingInputStream.java#L81) returns 0 for eos, the copy method goes into infinite loop. 

**Fix:** Make read method return -1 when eos is reached.

**Testing**
Verified the tests in reported [issue](https://github.com/aws/aws-sdk-java-v2/issues/941) passed after the change.
* Its not possible to write tests in s3 module without adding url client module as dependency and forcing us to update all other tests to explicitly pick http client. Instead of that, I would prefer adding a module in [test directory](https://github.com/aws/aws-sdk-java-v2/tree/master/test) to add integ tests for S3 using UrlConnectionHttpClient. What do you think?
* Ideally we would need tests for all InputStream classes, but its not in the scope of the PR