### PR TITLE
Modify S3Object#Size member type from integer to long

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-e1a5575.json
+++ b/.changes/next-release/bugfix-AmazonS3-e1a5575.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Modify type of S3Object#size member from integer to long. This is a breaking change for customers who are using the size() method currently"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
@@ -29,11 +29,11 @@ public final class DefaultCustomizationProcessor {
 
         return new CodegenCustomizationProcessorChain(
                 new MetadataModifiersProcessor(config.getCustomServiceMetadata()),
+                new RenameShapesProcessor(config.getRenameShapes()),
                 new ShapeModifiersProcessor(config.getShapeModifiers()),
                 new ShapeSubstitutionsProcessor(config.getShapeSubstitutions()),
                 new OperationModifiersProcessor(config.getOperationModifiers()),
-                new RemoveExceptionMessagePropertyProcessor(),
-                new RenameShapesProcessor(config.getRenameShapes())
+                new RemoveExceptionMessagePropertyProcessor()
         );
     }
 }

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,17 @@
         "Error" : "S3Error",
         "Object" : "S3Object"
     },
+    "shapeModifiers": {
+        "S3Object": {
+            "modify":[
+            {
+                "Size": {
+                    "emitAsType": "long"
+                }
+            }
+            ]
+        }
+    },
     "serviceSpecificClientConfigClass": "S3Configuration",
     "attachPayloadTraitToMember" : {
         "GetBucketLocationOutput": "LocationConstraint"


### PR DESCRIPTION
## Description
Fix https://github.com/aws/aws-sdk-java-v2/issues/917

## Changes
* Move RenameShapesProcessor before other shape modifiers as it removes the original shape from the list of available shapes. If RenameShapesProcessor is not run first, it causes build issues in other shape modifiers.
* Change Size type from Integer -> Long


The change is breaking to applications who are using the `size` method currently. We have decided to make the breaking change as this is a bug and breaking change will force the customers to know about this change and update the applications which have incorrect behavior for large objects