### PR TITLE
feat(core): Adds OperationName to the ExecutionContext class

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-20b9756.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-20b9756.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Adds the operation name of the calling API to the ExecutionContext class. This exposes a way to get the API name from within an ExecutionInterceptor."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -163,6 +163,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
         CodeBlock.Builder codeBlock = CodeBlock
             .builder()
             .add("\n\nreturn clientHandler.execute(new $T<$T, $T>()\n" +
+                 ".withOperationName(\"$N\")\n" +
                  ".withResponseHandler($N)\n" +
                  ".withErrorResponseHandler($N)\n" +
                  hostPrefixExpression(opModel) +
@@ -170,6 +171,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                  ClientExecutionParams.class,
                  requestType,
                  responseType,
+                 opModel.getOperationName(),
                  "responseHandler",
                  "errorResponseHandler",
                  opModel.getInput().getVariableName());
@@ -228,6 +230,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
         String protocolFactory = protocolFactoryLiteral(opModel);
         String customerResponseHandler = opModel.hasEventStreamOutput() ? "asyncResponseHandler" : "asyncResponseTransformer";
         builder.add("\n\n$L clientHandler.execute(new $T<$T, $T>()\n" +
+                    ".withOperationName(\"$N\")\n" +
                     ".withMarshaller(new $T($L))\n" +
                     "$L" +
                     "$L" +
@@ -242,6 +245,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                     ClientExecutionParams.class,
                     requestType,
                     opModel.hasEventStreamOutput() && !isRestJson ? SdkResponse.class : pojoResponseType,
+                    opModel.getOperationName(),
                     marshaller,
                     protocolFactory,
                     opModel.hasEventStreamInput() ? CodeBlock.builder()

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
@@ -96,6 +96,7 @@ public class QueryProtocolSpec implements ProtocolSpec {
         CodeBlock.Builder codeBlock = CodeBlock
             .builder()
             .add("\n\nreturn clientHandler.execute(new $T<$T, $T>()" +
+                 ".withOperationName(\"$N\")\n" +
                  ".withResponseHandler($N)" +
                  ".withErrorResponseHandler($N)" +
                  hostPrefixExpression(opModel) +
@@ -103,6 +104,7 @@ public class QueryProtocolSpec implements ProtocolSpec {
                  ClientExecutionParams.class,
                  requestType,
                  responseType,
+                 opModel.getOperationName(),
                  "responseHandler",
                  "errorResponseHandler",
                  opModel.getInput().getVariableName());
@@ -126,6 +128,7 @@ public class QueryProtocolSpec implements ProtocolSpec {
         String asyncRequestBody = opModel.hasStreamingInput() ? ".withAsyncRequestBody(requestBody)"
                                                               : "";
         return CodeBlock.builder().add("\n\nreturn clientHandler.execute(new $T<$T, $T>()\n" +
+                                       ".withOperationName(\"$N\")\n" +
                                        ".withMarshaller(new $T(protocolFactory))" +
                                        ".withResponseHandler(responseHandler)" +
                                        ".withErrorResponseHandler($N)\n" +
@@ -135,6 +138,7 @@ public class QueryProtocolSpec implements ProtocolSpec {
                                        ClientExecutionParams.class,
                                        requestType,
                                        pojoResponseType,
+                                       opModel.getOperationName(),
                                        marshaller,
                                        "errorResponseHandler",
                                        opModel.getInput().getVariableName(),

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -159,6 +159,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                                                                                                        operationMetadata);
 
             return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                                             .withOperationName("APostOperation")
                                              .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
                                              .withErrorResponseHandler(errorResponseHandler).hostPrefixExpression(resolvedHostExpression)
                                              .withInput(aPostOperationRequest));
@@ -205,6 +206,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler
                 .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                             .withOperationName("APostOperationWithOutput")
                              .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
                              .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                              .withInput(aPostOperationWithOutputRequest));
@@ -272,6 +274,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             clientHandler.execute(
                 new ClientExecutionParams<EventStreamOperationRequest, EventStreamOperationResponse>()
+                    .withOperationName("EventStreamOperation")
                     .withMarshaller(new EventStreamOperationRequestMarshaller(protocolFactory))
                     .withAsyncRequestBody(software.amazon.awssdk.core.async.AsyncRequestBody.fromPublisher(adapted))
                     .withFullDuplex(true).withResponseHandler(responseHandler)
@@ -337,6 +340,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler
                 .execute(new ClientExecutionParams<EventStreamOperationWithOnlyInputRequest, EventStreamOperationWithOnlyInputResponse>()
+                             .withOperationName("EventStreamOperationWithOnlyInput")
                              .withMarshaller(new EventStreamOperationWithOnlyInputRequestMarshaller(protocolFactory))
                              .withAsyncRequestBody(software.amazon.awssdk.core.async.AsyncRequestBody.fromPublisher(adapted))
                              .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
@@ -384,6 +388,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler
                 .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                             .withOperationName("GetWithoutRequiredMembers")
                              .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
                              .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                              .withInput(getWithoutRequiredMembersRequest));
@@ -427,6 +432,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler
                 .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                             .withOperationName("PaginatedOperationWithResultKey")
                              .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
                              .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                              .withInput(paginatedOperationWithResultKeyRequest));
@@ -543,6 +549,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler
                 .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                             .withOperationName("PaginatedOperationWithoutResultKey")
                              .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
                              .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                              .withInput(paginatedOperationWithoutResultKeyRequest));
@@ -664,6 +671,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler
                 .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                             .withOperationName("StreamingInputOperation")
                              .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
                              .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                              .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
@@ -719,6 +727,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler.execute(
                 new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
+                    .withOperationName("StreamingInputOutputOperation")
                     .withMarshaller(new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
                     .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                     .withAsyncRequestBody(requestBody).withInput(streamingInputOutputOperationRequest),
@@ -774,6 +783,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             return clientHandler.execute(
                 new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                    .withOperationName("StreamingOutputOperation")
                     .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
                     .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                     .withInput(streamingOutputOperationRequest), asyncResponseTransformer).whenComplete((r, e) -> {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -115,6 +115,7 @@ final class DefaultJsonClient implements JsonClient {
                                                                                                    operationMetadata);
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                                         .withOperationName("APostOperation")
                                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                                          .hostPrefixExpression(resolvedHostExpression).withInput(aPostOperationRequest)
                                          .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
@@ -155,6 +156,7 @@ final class DefaultJsonClient implements JsonClient {
 
         return clientHandler
             .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                         .withOperationName("APostOperationWithOutput")
                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                          .withInput(aPostOperationWithOutputRequest)
                          .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
@@ -195,6 +197,7 @@ final class DefaultJsonClient implements JsonClient {
 
         return clientHandler
             .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                         .withOperationName("GetWithoutRequiredMembers")
                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                          .withInput(getWithoutRequiredMembersRequest)
                          .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory)));
@@ -231,6 +234,7 @@ final class DefaultJsonClient implements JsonClient {
 
         return clientHandler
             .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                         .withOperationName("PaginatedOperationWithResultKey")
                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                          .withInput(paginatedOperationWithResultKeyRequest)
                          .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory)));
@@ -341,6 +345,7 @@ final class DefaultJsonClient implements JsonClient {
 
         return clientHandler
             .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                         .withOperationName("PaginatedOperationWithoutResultKey")
                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                          .withInput(paginatedOperationWithoutResultKeyRequest)
                          .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory)));
@@ -461,6 +466,7 @@ final class DefaultJsonClient implements JsonClient {
                                                                                                    operationMetadata);
 
         return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                                         .withOperationName("StreamingInputOperation")
                                          .withResponseHandler(responseHandler)
                                          .withErrorResponseHandler(errorResponseHandler)
                                          .withInput(streamingInputOperationRequest)
@@ -522,6 +528,7 @@ final class DefaultJsonClient implements JsonClient {
 
         return clientHandler.execute(
             new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
+                .withOperationName("StreamingInputOutputOperation")
                 .withResponseHandler(responseHandler)
                 .withErrorResponseHandler(errorResponseHandler)
                 .withInput(streamingInputOutputOperationRequest)
@@ -570,6 +577,7 @@ final class DefaultJsonClient implements JsonClient {
 
         return clientHandler.execute(
             new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                .withOperationName("StreamingOutputOperation")
                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                 .withInput(streamingOutputOperationRequest)
                 .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -77,6 +77,7 @@ final class DefaultQueryClient implements QueryClient {
         HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                                         .withOperationName("APostOperation")
                                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                                          .hostPrefixExpression(resolvedHostExpression).withInput(aPostOperationRequest)
                                          .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
@@ -114,6 +115,7 @@ final class DefaultQueryClient implements QueryClient {
 
         return clientHandler
             .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                         .withOperationName("APostOperationWithOutput")
                          .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                          .withInput(aPostOperationWithOutputRequest)
                          .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsClientHandlerUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsClientHandlerUtils.java
@@ -80,7 +80,8 @@ public final class AwsClientHandlerUtils {
             .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, clientConfig.option(AwsClientOption.SIGNING_REGION))
             .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, executionParams.isFullDuplex())
             .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, clientConfig.option(SdkClientOption.CLIENT_TYPE))
-            .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfig.option(SdkClientOption.SERVICE_NAME));
+            .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfig.option(SdkClientOption.SERVICE_NAME))
+            .putAttribute(SdkExecutionAttribute.OPERATION_NAME, executionParams.getOperationName());
 
         ExecutionInterceptorChain executionInterceptorChain =
                 new ExecutionInterceptorChain(clientConfig.option(SdkClientOption.EXECUTION_INTERCEPTORS));

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
@@ -42,6 +42,7 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
     private HttpResponseHandler<? extends SdkException> errorResponseHandler;
     private boolean fullDuplex;
     private String hostPrefixExpression;
+    private String operationName;
 
     public Marshaller<InputT> getMarshaller() {
         return marshaller;
@@ -108,6 +109,18 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
      */
     public ClientExecutionParams<InputT, OutputT> withFullDuplex(boolean fullDuplex) {
         this.fullDuplex = fullDuplex;
+        return this;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    /**
+     * Sets the operation name of the API.
+     */
+    public ClientExecutionParams<InputT, OutputT> withOperationName(String operationName) {
+        this.operationName = operationName;
         return this;
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -43,6 +43,8 @@ public class SdkExecutionAttribute {
     public static final ExecutionAttribute<Integer> TIME_OFFSET = new ExecutionAttribute<>("TimeOffset");
 
     public static final ExecutionAttribute<ClientType> CLIENT_TYPE = new ExecutionAttribute<>("ClientType");
+
+    public static final ExecutionAttribute<String> OPERATION_NAME = new ExecutionAttribute<>("OperationName");
     
     protected SdkExecutionAttribute() {
     }


### PR DESCRIPTION
## Description
Adds the operation name of the calling API to the ExecutionContext class. This exposes a way to get the API name from within an ExecutionInterceptor.

Also exposes the `OPERATION_NAME` attribute as an `SdkExecutionAttribute` attribute.

I'm not sure if I've properly documented the feature, I tried to copy what was already existing.

## Motivation and Context
This provides a way to get the operation name from within an `ExecutionInterceptor`. Currently to get the operation name, you have to reflect on the request object and trim `Request` from the name.

## Testing
I updated the unit tests that check the generated clients and ran mvn install. I do see the protocol tests failing due to a missing JSON file on my local copy of the repo, but that was happening prior to this change as well and is unrelated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
