### PR TITLE
Add Athena artifact to BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -568,6 +568,11 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <version>${awsjavasdk.version}</version>
             </dependency>
+            <dependency>
+                <artifactId>athena</artifactId>
+                <groupId>software.amazon.awssdk</groupId>
+                <version>${awsjavasdk.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
## Description

The artifact for AWS Athena is missing in the BOM.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have read the **README** document
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
