### PR TITLE
Fix ChecksumValidationInterceptor to use long for contentLength

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-98da78b.json
+++ b/.changes/next-release/bugfix-AmazonS3-98da78b.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Fix `SyncChecksumValidationInterceptor` and `AsyncChecksumValidationInterceptor` to use `long` instead of `int` for contentLength`. See [#963](https://github.com/aws/aws-sdk-java-v2/issues/963)"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
@@ -43,7 +43,7 @@ public class ChecksumValidatingInputStream extends InputStream implements Aborta
      * @param cksum the Checksum implementation
      * @param streamLength the total length of the expected stream (including the extra 4 bytes on the end).
      */
-    public ChecksumValidatingInputStream(final InputStream in, final SdkChecksum cksum, long streamLength) {
+    public ChecksumValidatingInputStream(InputStream in, SdkChecksum cksum, long streamLength) {
         inputStream = in;
         checkSum = cksum;
         this.strippedLength = streamLength - CHECKSUM_SIZE;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
@@ -29,15 +29,15 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.utils.BinaryUtils;
 
 @SdkInternalApi
-public class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffer> {
+public final class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffer> {
 
     private final Publisher<ByteBuffer> publisher;
     private final SdkChecksum sdkChecksum;
-    private final int contentLength;
+    private final long contentLength;
 
     public ChecksumValidatingPublisher(Publisher<ByteBuffer> publisher,
                                        SdkChecksum sdkChecksum,
-                                       int contentLength) {
+                                       long contentLength) {
         this.publisher = publisher;
         this.sdkChecksum = sdkChecksum;
         this.contentLength = contentLength;
@@ -59,11 +59,9 @@ public class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffer> {
         private byte[] streamChecksum = new byte[CHECKSUM_SIZE];
         private long lengthRead = 0;
 
-        private Subscription subscription;
-
         ChecksumValidatingSubscriber(Subscriber<? super ByteBuffer> wrapped,
                                      SdkChecksum sdkChecksum,
-                                     int contentLength) {
+                                     long contentLength) {
             this.wrapped = wrapped;
             this.sdkChecksum = sdkChecksum;
             this.strippedLength = contentLength - CHECKSUM_SIZE;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/SyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/SyncChecksumValidationInterceptor.java
@@ -81,7 +81,10 @@ public class SyncChecksumValidationInterceptor implements ExecutionInterceptor {
         if (context.request() instanceof GetObjectRequest && checksumValidationEnabled) {
             SdkChecksum checksum = new Md5Checksum();
 
-            int contentLength = Integer.valueOf(context.httpResponse().firstMatchingHeader(CONTENT_LENGTH_HEADER).orElse("0"));
+            long contentLength = context.httpResponse()
+                                        .firstMatchingHeader(CONTENT_LENGTH_HEADER)
+                                        .map(Long::parseLong)
+                                        .orElse(0L);
 
             if (contentLength > 0) {
                 return Optional.of(new ChecksumValidatingInputStream(context.responseBody().get(), checksum, contentLength));


### PR DESCRIPTION

## Description
Fix SyncChecksumValidationInterceptor and AsyncChecksumValidationInter to use `long` for `contentLength`

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context
See #963 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
