### PR TITLE
Fixing date unmarshalling for CBOR protocol. See ticket P19810053

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-7e0d23d.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-7e0d23d.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2",
+    "type": "bugfix",
+    "description": "Fix an issue where dates were being unmarshalled incorrectly for the CBOR protocol used by Amazon Kinesis."
+}

--- a/core/protocols/aws-cbor-protocol/src/main/java/software/amazon/awssdk/protocols/cbor/AwsCborProtocolFactory.java
+++ b/core/protocols/aws-cbor-protocol/src/main/java/software/amazon/awssdk/protocols/cbor/AwsCborProtocolFactory.java
@@ -15,8 +15,13 @@
 
 package software.amazon.awssdk.protocols.cbor;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.traits.TimestampFormatTrait;
 import software.amazon.awssdk.protocols.cbor.internal.AwsStructuredCborFactory;
 import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
@@ -63,6 +68,17 @@ public final class AwsCborProtocolFactory extends BaseAwsJsonProtocolFactory {
         } else {
             return super.getSdkFactory();
         }
+    }
+
+    /**
+     * CBOR uses epoch millis for timestamps rather than epoch seconds with millisecond decimal precision like JSON protocols.
+     */
+    @Override
+    protected Map<MarshallLocation, TimestampFormatTrait.Format> getDefaultTimestampFormats() {
+        Map<MarshallLocation, TimestampFormatTrait.Format> formats = new HashMap<>();
+        formats.put(MarshallLocation.HEADER, TimestampFormatTrait.Format.RFC_822);
+        formats.put(MarshallLocation.PAYLOAD, TimestampFormatTrait.Format.UNIX_TIMESTAMP_MILLIS);
+        return Collections.unmodifiableMap(formats);
     }
 
     private boolean isCborEnabled() {

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/HeaderUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/HeaderUnmarshaller.java
@@ -36,8 +36,6 @@ final class HeaderUnmarshaller {
     public static final JsonUnmarshaller<Long> LONG = new SimpleHeaderUnmarshaller<>(StringToValueConverter.TO_LONG);
     public static final JsonUnmarshaller<Double> DOUBLE = new SimpleHeaderUnmarshaller<>(StringToValueConverter.TO_DOUBLE);
     public static final JsonUnmarshaller<Boolean> BOOLEAN = new SimpleHeaderUnmarshaller<>(StringToValueConverter.TO_BOOLEAN);
-    public static final JsonUnmarshaller<Instant> INSTANT =
-        new SimpleHeaderUnmarshaller<>(JsonProtocolUnmarshaller.INSTANT_STRING_TO_VALUE);
     public static final JsonUnmarshaller<Float> FLOAT = new SimpleHeaderUnmarshaller<>(StringToValueConverter.TO_FLOAT);
 
     private HeaderUnmarshaller() {
@@ -54,6 +52,11 @@ final class HeaderUnmarshaller {
                                                  SdkField<String> field) {
         return field.containsTrait(JsonValueTrait.class) ?
                new String(BinaryUtils.fromBase64(value), StandardCharsets.UTF_8) : value;
+    }
+
+    public static JsonUnmarshaller<Instant> createInstantHeaderUnmarshaller(
+        StringToValueConverter.StringToValue<Instant> instantStringToValue) {
+        return new SimpleHeaderUnmarshaller<>(instantStringToValue);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TimestampFormatTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TimestampFormatTrait.java
@@ -61,7 +61,12 @@ public final class TimestampFormatTrait implements Trait {
         /**
          * See {@link DateUtils#parseUnixTimestampInstant(String)}
          */
-        UNIX_TIMESTAMP;
+        UNIX_TIMESTAMP,
+
+        /**
+         * See {@link DateUtils#parseUnixTimestampMillisInstant(String)}. This is only used by the CBOR protocol currently.
+         */
+        UNIX_TIMESTAMP_MILLIS;
 
         /**
          * Creates a timestamp format enum from the string defined in the model.
@@ -77,6 +82,7 @@ public final class TimestampFormatTrait implements Trait {
                     return RFC_822;
                 case "unixTimestamp":
                     return UNIX_TIMESTAMP;
+                // UNIX_TIMESTAMP_MILLIS does not have a defined string format so intentionally omitted here.
                 default:
                     throw new RuntimeException("Unknown timestamp format - " + strFormat);
             }

--- a/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
+++ b/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/KinesisIntegrationTests.java
@@ -15,10 +15,15 @@
 
 package software.amazon.awssdk.services.kinesis;
 
+import static org.junit.Assert.assertThat;
+
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.core.SdkBytes;
@@ -183,6 +188,10 @@ public class KinesisIntegrationTests extends AbstractTestCase {
 
             records = result.records();
             if (records.size() > 0) {
+                long arrivalTime = records.get(0).approximateArrivalTimestamp().toEpochMilli();
+                Long delta = Math.abs(Instant.now().minusMillis(arrivalTime).toEpochMilli());
+                // Assert that the arrival date is within a minute of the current date to make sure it unmarshalled correctly.
+                assertThat(delta, Matchers.lessThan(60 * 1000L));
                 break;
             }
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
@@ -137,6 +137,16 @@ public final class DateUtils {
     }
 
     /**
+     * Parses the given string containing a Unix timestamp in epoch millis into a {@link Instant} object.
+     */
+    public static Instant parseUnixTimestampMillisInstant(String dateString) throws NumberFormatException {
+        if (dateString == null) {
+            return null;
+        }
+        return Instant.ofEpochMilli(Long.parseLong(dateString));
+    }
+
+    /**
      * Formats the give {@link Instant} object into an Unix timestamp with millisecond decimal precision.
      */
     public static String formatUnixTimestampInstant(Instant instant) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dates were being unmarshalled as epoch seconds for CBOR but it uses epoch millis on the wire.

## Motivation and Context
Date unmarshalling is broken for Kinesis.

## Testing
Amended existing integ test to assert on date. Failed before change, passes after.

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
