### PR TITLE
Disable following redirects on UrlConnectionHttpClient

### DIFF
--- a/.changes/next-release/bugfix-URLConnectionHTTPClient-2357bd0.json
+++ b/.changes/next-release/bugfix-URLConnectionHTTPClient-2357bd0.json
@@ -1,0 +1,5 @@
+{
+    "category": "URLConnection HTTP Client", 
+    "type": "bugfix", 
+    "description": "Disable following redirects automatically since doing so causes SDK response handling to fail"
+}

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -112,6 +112,10 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
             connection.setDoOutput(true);
         }
 
+        // Disable following redirects since it breaks SDK error handling and matches Apache.
+        // See: https://github.com/aws/aws-sdk-java-v2/issues/975
+        connection.setInstanceFollowRedirects(false);
+
         return connection;
     }
 

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
@@ -28,6 +28,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -129,8 +130,15 @@ public abstract class SdkHttpClientTestSuite {
     }
 
     private void stubForMockRequest(int returnCode) {
-        stubFor(any(urlPathEqualTo("/")).willReturn(
-                aResponse().withStatus(returnCode).withHeader("Some-Header", "With Value").withBody("hello")));
+        ResponseDefinitionBuilder responseBuilder = aResponse().withStatus(returnCode)
+                                                               .withHeader("Some-Header", "With Value")
+                                                               .withBody("hello");
+
+        if (returnCode >= 300 && returnCode <= 399) {
+            responseBuilder.withHeader("Location", "Some New Location");
+        }
+
+        stubFor(any(urlPathEqualTo("/")).willReturn(responseBuilder));
     }
 
     private void validateResponse(HttpExecuteResponse response, int returnCode) throws IOException {


### PR DESCRIPTION
* Also include a Location header if the request is 3xx in SdkHttpClientTestSuite

<!--- Provide a general summary of your changes in the Title above -->

## Description
Always disable following redirects in UrlConnectionHttpClient since SDK handles redirects manually.

## Motivation and Context
Fixes #975 

## Testing
Fixed unit tests not adding in Location header, which caused software.amazon.awssdk.http.SdkHttpClientTestSuite#supportsResponseCode302 to fail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
