### PR TITLE
Changed the region resolution logic for role_arn-based profiles.

### DIFF
--- a/.changes/next-release/bugfix-AWSSTS-1b6f264.json
+++ b/.changes/next-release/bugfix-AWSSTS-1b6f264.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS STS", 
+    "type": "bugfix", 
+    "description": "Changed the region resolution logic for `role_arn`-based profiles: 1. Check for a `region` property in the same profile as the `role_arn` definition. 2. Check the default region chain. 3. Fall back to the global endpoint and `us-east-1` signing. Fixes [#988](https://github.com/aws/aws-sdk-java-v2/issues/988)."
+}

--- a/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
+++ b/services/sts/src/it/java/software/amazon/awssdk/services/sts/AssumeRoleIntegrationTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.sts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
+import java.net.URI;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import software.amazon.awssdk.core.auth.policy.Principal;
 import software.amazon.awssdk.core.auth.policy.Resource;
 import software.amazon.awssdk.core.auth.policy.Statement;
 import software.amazon.awssdk.core.auth.policy.Statement.Effect;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.services.iam.model.AccessKeyMetadata;


### PR DESCRIPTION
1. Check for a `region` property in the same profile as the `role_arn` definition.
2. Check the default region chain.
3. Fall back to the global endpoint and `us-east-1` signing. Fixes #988.