### PR TITLE
Fix 954

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-a6485c4.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-a6485c4.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "type": "bugfix", 
+    "description": "Add `OneTimeReadTimeoutHanlder` to requests with `expect: 100-continue` header to avoid unexpected `ReadTimeoutException`. See [#954](https://github.com/aws/aws-sdk-java-v2/issues/954)"
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/OneTimeReadTimeoutHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/OneTimeReadTimeoutHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.util.ReferenceCountUtil;
+import java.util.concurrent.TimeUnit;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Handler to add an one-time {@link ReadTimeoutHandler} to the pipeline and remove it afterwards.
+ */
+@SdkInternalApi
+public final class OneTimeReadTimeoutHandler extends SimpleChannelInboundHandler {
+
+    private static final String READ_TIMEOUT_HANDLER_NAME = "RemoveAfterReadTimeoutHandler";
+    private final long readTimeoutMillis;
+    private final TimeUnit timeUnit;
+
+    OneTimeReadTimeoutHandler(long readTimeoutMillis, TimeUnit timeUnit) {
+        this.readTimeoutMillis = readTimeoutMillis;
+        this.timeUnit = timeUnit;
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, Object msg) {
+        ReferenceCountUtil.retain(msg);
+        ctx.pipeline().addFirst(READ_TIMEOUT_HANDLER_NAME, new ReadTimeoutHandler(readTimeoutMillis, timeUnit));
+        ctx.fireChannelRead(msg);
+
+        ctx.pipeline().remove(READ_TIMEOUT_HANDLER_NAME);
+        ctx.pipeline().remove(this);
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/OneTimeReadTimeoutHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/OneTimeReadTimeoutHandlerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import java.util.concurrent.TimeUnit;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OneTimeReadTimeoutHandlerTest {
+
+    private static final long TIMEOUT_IN_MILLIS = 1000;
+    private static OneTimeReadTimeoutHandler handler;
+
+    @Mock
+    private ChannelHandlerContext context;
+
+    @Mock
+    private ChannelPipeline channelPipeline;
+
+    @Mock
+    private Object object;
+
+    @BeforeClass
+    public static void setup() {
+        handler = new OneTimeReadTimeoutHandler(TIMEOUT_IN_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void channelRead_shouldAddReadTimeoutHandlerBeforeRead() {
+        ArgumentCaptor<ReadTimeoutHandler> argumentCaptor = ArgumentCaptor.forClass(ReadTimeoutHandler.class);
+        ArgumentCaptor<String> handlerNameCaptor = ArgumentCaptor.forClass(String.class);
+
+        when(context.pipeline()).thenReturn(channelPipeline);
+
+        handler.channelRead0(context, object);
+
+        verify(channelPipeline, times(1)).addFirst(handlerNameCaptor.capture(),
+                                                   argumentCaptor.capture());
+
+        verify(context, times(1)).fireChannelRead(object);
+
+        ReadTimeoutHandler readTimeoutHandler = argumentCaptor.getValue();
+        assertThat(readTimeoutHandler.getReaderIdleTimeInMillis()).isEqualTo(TIMEOUT_IN_MILLIS);
+
+        verify(channelPipeline, times(1)).remove(handlerNameCaptor.getValue());
+
+        verify(channelPipeline, times(1)).remove(handler);
+
+    }
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/UploadLargeObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/UploadLargeObjectIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.utils.IoUtils;
+
+@Ignore("The tests are intended to run manually as it can take a relatively long time")
+public class UploadLargeObjectIntegrationTest extends S3IntegrationTestBase {
+
+    private static final String BUCKET = temporaryBucketName(UploadLargeObjectIntegrationTest.class);
+
+    private static final String ASYNC_KEY = "async-key";
+    private static final String SYNC_KEY = "sync-key";
+
+    private static File file;
+
+    @BeforeClass
+    public static void setupFixture() throws IOException {
+        createBucket(BUCKET);
+        file = new RandomTempFile(500 * 1024 * 1024);
+    }
+
+    @AfterClass
+    public static void tearDownFixture() {
+        deleteBucketAndAllContents(BUCKET);
+        file.delete();
+    }
+
+    @Test
+    public void syncPutLargeObject() throws Exception {
+        s3.putObject(b -> b.bucket(BUCKET).key(SYNC_KEY), file.toPath());
+        verifyResponse(SYNC_KEY);
+    }
+
+    @Test
+    public void asyncPutLargeObject() throws Exception {
+        s3Async.putObject(b -> b.bucket(BUCKET).key(ASYNC_KEY), file.toPath()).join();
+        verifyResponse(ASYNC_KEY);
+    }
+
+    private void verifyResponse(String key) {
+        ResponseInputStream<GetObjectResponse> responseInputStream = s3.getObject(b -> b.bucket(BUCKET).key(key));
+        IoUtils.drainInputStream(responseInputStream);
+    }
+}

--- a/test/test-utils/src/main/java/software/amazon/awssdk/testutils/RandomTempFile.java
+++ b/test/test-utils/src/main/java/software/amazon/awssdk/testutils/RandomTempFile.java
@@ -50,7 +50,7 @@ public class RandomTempFile extends File {
      *                    file.
      * @throws IOException If any problems were encountered creating the new temp file.
      */
-    public RandomTempFile(int sizeInBytes) throws IOException {
+    public RandomTempFile(long sizeInBytes) throws IOException {
         this(UUID.randomUUID().toString(), sizeInBytes, false);
     }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `OneTimeReadTimeoutHandler` to requests with expect continue header to avoid unexpected ReadTimeoutException

For `100ContinueExpected` requests, we are explicitly invoking `channel.read()` and adding a new `ReadTimeoutHandler`. For `s3#putObject` with large object, `ReadTimeoutException` will be fired during streaming as there is no READ involved.

The fix is to remove `ReadTimeoutHandler` right after the explicit `channel.read` by adding a new `OneTimeReadTimeoutHandler`.

## Motivation and Context
See #954 

## Testing
Added manual integ tests and existing s3 integ tests passed.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
