### PR TITLE
Add better-integ-test buildspec 

### DIFF
--- a/buildspecs/better-integ-test.yml
+++ b/buildspecs/better-integ-test.yml
@@ -1,0 +1,6 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - python scripts/run-integ-test

--- a/scripts/run-integ-test
+++ b/scripts/run-integ-test
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""Run Integ Tests based on the changed files
+
+"""
+from subprocess import call, check_call, Popen, PIPE
+
+# Minimal modules to tests when core changes are detected.
+# s3 - xml, dynamodb - json, sqs - query
+core_modules_to_test = ["s3", "dynamodb", "sqs"]
+
+# Minimal modules to tests when http client changes are detected.
+# s3 - streaming/non streaming, kinesis - h2
+http_modules_to_test = {
+    "apache-client": ["s3", "apache-client"],
+    "netty-nio-client": ["kinesis", "s3", "netty-nio-client"],
+    "url-connection-client": ["url-connection-client"]
+}
+
+def check_diffs():
+    """
+    Retrieve the changed files
+    """
+    ret = Popen(["git", "diff", "HEAD^", "--name-only"], stdout=PIPE)
+
+    diff, stderr = ret.communicate()
+    return diff.splitlines(False)
+
+def get_modules(file_path):
+    """
+    Parse the changed file path and get the respective module names
+    """
+    path = file_path.split('/')
+    top_directory = path[0]
+
+    if top_directory in ["core", "codegen"]:
+        return core_modules_to_test
+    if top_directory in ["http-clients"]:
+        return http_modules_to_test[path[1]]
+    elif top_directory== "services":
+        return path[1]
+
+def run_tests(modules):
+    """
+    Run integration tests for the given modules
+    """
+    print("Running integ tests in the following modules: " + ', '.join(modules))
+    modules_to_include = ""
+
+    for m in modules:
+        modules_to_include += ":" + m + ","
+
+    # remove last comma
+    modules_to_include = modules_to_include[:-1]
+
+    # build necessary dependencies first
+    check_call(["mvn", "clean", "install", "-pl", modules_to_include, "-P", "quick", "--am", "-Dmaven.wagon.httpconnectionManager.maxPerRoute=2"])
+    check_call(["mvn", "verify", "-pl", modules_to_include, "-P", "integration-tests", "-Dfailsafe.rerunFailingTestsCount=1"])
+
+if __name__ == "__main__":
+    diffs = check_diffs()
+    modules = set()
+    for d in diffs:
+        module = get_modules(d)
+        if isinstance(module, list):
+            modules.update(module)
+        elif module:
+            modules.add(module)
+
+    if modules:
+        run_tests(modules)
+    else:
+        print("No modules configured to run. Skipping integ tests")


### PR DESCRIPTION
## Description
Add `better-integ-test` buildspec to only trigger integ tests that are related to the changed files so that we can make integ tests as part of PR process.

- Changes in `core`, `codegen` -> minimal required integ tests (`s3`, `dynamodb`, `sqs`). I chose those three services because they can cover `xml`, `json`, `query` protocols respectively. This is open to discussion. 

- Changes in `netty-nio-client` -> `kinesis`, `s3`, `netty-nio-client`
- Changes in `url-connection-client` -> `url-connection-client`
- Changes in `apache-client` -> `apache-client`, `s3`
- Changes in individual service changes -> integ test in that service module

We can add more complex logic in the future as needed. 

## Testing
Tested it using CodeBuild and verified the core change in this PR I made triggered the minimal required integ tests. The job took 8 mins.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
