### PR TITLE
Add more tests to verify connection closure and small code clean up

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HandleResponseStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HandleResponseStage.java
@@ -130,7 +130,7 @@ public class HandleResponseStage<OutputT> implements RequestPipeline<SdkHttpFull
      */
     private void closeInputStreamIfNeeded(SdkHttpFullResponse httpResponse,
                                           boolean didRequestFail) {
-        // Always close on failed requests. Close on successful unless streaming operation.
+        // Always close on failed requests. Close on successful requests unless it needs connection left open
         if (didRequestFail || !successResponseHandler.needsConnectionLeftOpen()) {
             Optional.ofNullable(httpResponse)
                     .flatMap(SdkHttpFullResponse::content) // If no content, no need to close

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -251,13 +251,12 @@ public final class MakeAsyncHttpRequestStage<OutputT>
             return headersFuture.thenCompose(headers -> {
                 if (headers.isSuccessful()) {
                     return transformFuture.thenApply(r -> Response.fromSuccess(r, response));
-                } else {
-                    if (errorTransformFuture != null) {
-                        return errorTransformFuture.thenApply(e -> Response.fromFailure(e, response));
-                    } else {
-                        return CompletableFuture.completedFuture(Response.fromFailure(null, response));
-                    }
                 }
+
+                if (errorTransformFuture != null) {
+                    return errorTransformFuture.thenApply(e -> Response.fromFailure(e, response));
+                }
+                return CompletableFuture.completedFuture(Response.fromFailure(null, response));
             });
         }
     }

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -61,6 +61,7 @@ import org.apache.http.impl.conn.DefaultSchemePortResolver;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpRequestExecutor;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.HttpExecuteRequest;
@@ -76,6 +77,7 @@ import software.amazon.awssdk.http.apache.internal.conn.IdleConnectionReaper;
 import software.amazon.awssdk.http.apache.internal.conn.SdkConnectionKeepAliveStrategy;
 import software.amazon.awssdk.http.apache.internal.conn.SdkTlsSocketFactory;
 import software.amazon.awssdk.http.apache.internal.impl.ApacheHttpRequestFactory;
+import software.amazon.awssdk.http.apache.internal.impl.ApacheSdkHttpClient;
 import software.amazon.awssdk.http.apache.internal.impl.ConnectionManagerAwareHttpClient;
 import software.amazon.awssdk.http.apache.internal.utils.ApacheUtils;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -99,6 +101,15 @@ public final class ApacheHttpClient implements SdkHttpClient {
     private final ConnectionManagerAwareHttpClient httpClient;
     private final ApacheHttpRequestConfig requestConfig;
     private final AttributeMap resolvedOptions;
+
+    @SdkTestInternalApi
+    ApacheHttpClient(ConnectionManagerAwareHttpClient httpClient,
+                     ApacheHttpRequestConfig requestConfig,
+                     AttributeMap resolvedOptions) {
+        this.httpClient = httpClient;
+        this.requestConfig = requestConfig;
+        this.resolvedOptions = resolvedOptions;
+    }
 
     private ApacheHttpClient(DefaultBuilder builder, AttributeMap resolvedOptions) {
         this.httpClient = createClient(builder, resolvedOptions);
@@ -136,7 +147,7 @@ public final class ApacheHttpClient implements SdkHttpClient {
                     cm, connectionMaxIdleTime(configuration).toMillis());
         }
 
-        return new software.amazon.awssdk.http.apache.internal.impl.ApacheSdkHttpClient(builder.build(), cm);
+        return new ApacheSdkHttpClient(builder.build(), cm);
     }
 
     private void addProxyConfig(HttpClientBuilder builder,

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/ApacheHttpRequestConfig.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/ApacheHttpRequestConfig.java
@@ -83,7 +83,7 @@ public final class ApacheHttpRequestConfig {
         private Duration connectionTimeout;
         private Duration connectionAcquireTimeout;
         private InetAddress localAddress;
-        private Boolean expectContinueEnabled;
+        private boolean expectContinueEnabled;
         private ProxyConfiguration proxyConfiguration;
 
         private Builder() {
@@ -109,7 +109,7 @@ public final class ApacheHttpRequestConfig {
             return this;
         }
 
-        public Builder expectContinueEnabled(Boolean expectContinueEnabled) {
+        public Builder expectContinueEnabled(boolean expectContinueEnabled) {
             this.expectContinueEnabled = expectContinueEnabled;
             return this;
         }

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -99,7 +99,7 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
 
     @Override
     public void close() {
-
+        // Nothing to close. The connections will be closed by closing the InputStreams.
     }
 
     private HttpURLConnection createAndConfigureConnection(HttpExecuteRequest request) {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/connection/SyncClientConnectionTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/connection/SyncClientConnectionTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.protocol.tests.util.ClosableStringInputStream;
+import software.amazon.awssdk.protocol.tests.util.MockHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
+
+/**
+ * Tests to verify the correction of connection closure.
+ */
+public class SyncClientConnectionTest {
+    private ProtocolRestJsonClient client;
+    private MockHttpClient mockHttpClient;
+
+    @Before
+    public void setupClient() {
+        mockHttpClient = new MockHttpClient();
+        client = ProtocolRestJsonClient.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                                       "skid")))
+                                       .region(Region.US_EAST_1)
+                                       .httpClient(mockHttpClient)
+                                       .build();
+    }
+
+    @Test
+    public void nonStreaming_exception_shouldCloseConnection() throws IOException {
+        ClosableStringInputStream inputStream = new ClosableStringInputStream("{\"__type\":\"SomeUnknownType\"}");
+        mockHttpClient.stubNextResponse(mockResponse(inputStream, 400));
+
+        assertThatThrownBy(() -> client.allTypes(AllTypesRequest.builder().build()))
+            .isExactlyInstanceOf(ProtocolRestJsonException.class);
+        assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    @Test
+    public void nonStreaming_successfulResponse_shouldCloseConnection() {
+        ClosableStringInputStream inputStream = new ClosableStringInputStream("{}");
+        mockHttpClient.stubNextResponse(mockResponse(inputStream, 200));
+        client.allTypes(AllTypesRequest.builder().build());
+        assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    @Test
+    public void streamingOut_successfulResponse_shouldCloseConnection() {
+        ClosableStringInputStream inputStream = new ClosableStringInputStream("{}");
+        mockHttpClient.stubNextResponse(mockResponse(inputStream, 200));
+
+        client.streamingOutputOperation(b -> b.build(), ResponseTransformer.toBytes());
+        assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    @Test
+    public void streamingOut_errorResponse_shouldCloseConnection() {
+        ClosableStringInputStream inputStream = new ClosableStringInputStream("{\"__type\":\"SomeUnknownType\"}");
+        mockHttpClient.stubNextResponse(mockResponse(inputStream, 400));
+
+        assertThatThrownBy(() -> client.streamingOutputOperation(b -> b.build(), ResponseTransformer.toBytes()))
+            .isExactlyInstanceOf(ProtocolRestJsonException.class);
+        assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    @Test
+    public void streamingOut_connectionLeftOpen_shouldNotCloseStream() {
+        ClosableStringInputStream inputStream = new ClosableStringInputStream("{}");
+        mockHttpClient.stubNextResponse(mockResponse(inputStream, 200));
+
+        client.streamingOutputOperation(b -> b.build(), new ResponseTransformer<StreamingOutputOperationResponse, Object>() {
+
+            @Override
+            public Object transform(StreamingOutputOperationResponse response, AbortableInputStream inputStream) throws Exception {
+                return null;
+            }
+
+            @Override
+            public boolean needsConnectionLeftOpen() {
+                return true;
+            }
+        });
+        assertThat(inputStream.isClosed()).isFalse();
+    }
+
+    @Test
+    public void streamingOut_toInputStream_closeResponseStreamShouldCloseUnderlyingStream() throws IOException {
+        ClosableStringInputStream inputStream = new ClosableStringInputStream("{}");
+        mockHttpClient.stubNextResponse(mockResponse(inputStream, 200));
+
+        ResponseInputStream<StreamingOutputOperationResponse> responseInputStream =
+            client.streamingOutputOperation(b -> b.build(), ResponseTransformer.toInputStream());
+
+        assertThat(inputStream.isClosed()).isFalse();
+        responseInputStream.close();
+        assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    @Test
+    public void streamingIn_providedRequestBody_shouldNotCloseRequestStream() {
+        ClosableStringInputStream responseStream = new ClosableStringInputStream("{}");
+        ClosableStringInputStream requestStream = new ClosableStringInputStream("{}");
+        mockHttpClient.stubNextResponse(mockResponse(responseStream, 200));
+
+        RequestBody requestBody = RequestBody.fromInputStream(requestStream, requestStream.getString().getBytes().length);
+        client.streamingInputOperation(SdkBuilder::build, requestBody);
+        assertThat(responseStream.isClosed()).isTrue();
+        assertThat(requestStream.isClosed()).isFalse();
+    }
+
+    @Test
+    public void closeClient_nonManagedHttpClient_shouldNotCloseUnderlyingHttpClient() {
+        client.close();
+        assertThat(mockHttpClient.isClosed()).isFalse();
+    }
+
+    private HttpExecuteResponse mockResponse(InputStream inputStream, int statusCode) {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder().statusCode(statusCode).build())
+                                  .responseBody(AbortableInputStream.create(inputStream))
+                                  .build();
+    }
+}

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
@@ -21,7 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static util.exception.ExceptionTestUtils.stub404Response;
+import static software.amazon.awssdk.protocol.tests.util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/Ec2ExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/Ec2ExceptionTests.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.protocol.tests.exception;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static util.exception.ExceptionTestUtils.stub404Response;
+import static software.amazon.awssdk.protocol.tests.util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
@@ -21,7 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static util.exception.ExceptionTestUtils.stub404Response;
+import static software.amazon.awssdk.protocol.tests.util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestJsonExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestJsonExceptionTests.java
@@ -22,7 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static util.exception.ExceptionTestUtils.stub404Response;
+import static software.amazon.awssdk.protocol.tests.util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestXmlExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestXmlExceptionTests.java
@@ -21,7 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static util.exception.ExceptionTestUtils.stub404Response;
+import static software.amazon.awssdk.protocol.tests.util.exception.ExceptionTestUtils.stub404Response;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/ClosableStringInputStream.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/ClosableStringInputStream.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests.util;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Closable StringInputStream. Once closed, cannot be read again
+ */
+public class ClosableStringInputStream extends ByteArrayInputStream {
+    private final String string;
+    private boolean isClosed;
+
+    public ClosableStringInputStream(String s) {
+        super(s.getBytes(StandardCharsets.UTF_8));
+        this.string = s;
+    }
+
+    @Override
+    public void close() {
+        isClosed = true;
+    }
+
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    public String getString() {
+        return string;
+    }
+}

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/MockHttpClient.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/MockHttpClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests.util;
+
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+
+/**
+ * Mock implementation of {@link SdkHttpClient}.
+ */
+public final class MockHttpClient implements SdkHttpClient {
+
+    private HttpExecuteResponse nextResponse;
+    private boolean isClosed;
+
+    @Override
+    public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+        return new ExecutableHttpRequest() {
+            @Override
+            public HttpExecuteResponse call() {
+                return nextResponse;
+            }
+
+            @Override
+            public void abort() {
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        isClosed = true;
+    }
+
+    /**
+     * Sets up the next HTTP response that will be returned by the mock.
+     *
+     * @param nextResponse Next {@link SdkHttpFullResponse} to return from
+     *                     {@link #prepareRequest(HttpExecuteRequest)}
+     */
+    public void stubNextResponse(HttpExecuteResponse nextResponse) {
+        this.nextResponse = nextResponse;
+    }
+
+    public boolean isClosed() {
+        return isClosed;
+    }
+}

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/exception/ExceptionTestUtils.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/exception/ExceptionTestUtils.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package util.exception;
+package software.amazon.awssdk.protocol.tests.util.exception;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;


### PR DESCRIPTION
## Description
Reviewed all use of connection closure and verified the resources are being properly released/closed/shutdown after each request as well as after invoke `client#close`.

This PR added more tests to verify the correctness and did some small code cleanup.

## Summary of Connection Closure

### Per Request

- Sync  path:

Sockets are being closed by closing the underlying `InputStream` via [HandleResponseStage#closeInputStreamIfNeeded](https://github.com/aws/aws-sdk-java-v2/blob/7eb85a23ca9e3df49989d605c60b519828ef1ff1/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/HandleResponseStage.java#L62)  unless `needsConnectionLeftOpen` is true (default to false).

For streaming requests, if a customized `ResponseHandler` is provided with `needsConnectionLeftOpen` overriden to true, the underlying connection will not be closed.

- Async path:

Channels are being released after each request in netty module unless `keep alive` is true via [ResponseHandler#finalizeRequest](https://github.com/aws/aws-sdk-java-v2/blob/7eb85a23ca9e3df49989d605c60b519828ef1ff1/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java#L107) (I renamed it to `finalizeResponse` in this PR)

### Per Client After invoking `Client#close`

- SDK
   - the thread pools will be shutdown and all `Closable` will be closed via `AmazonSyncHttpClient#close` and `AmazonAsyncHttpClient#close`
   - the underlying http client will be closed unless it's a customer provided client.

- ApacheHttpClient:
`HttpClientConnectionManager` will be shutdown and `IdleConnectionReaper` will be cleaned up.

- NettyNioAyncHttpClient
`EventLoopGroup` will be shutdown and channel pools will be closed

- UrlConnectionHttpClient
No op. Nothing to close

Let me know if I missed anything.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
