### PR TITLE
Fix #1035: Skip Etag validation for upload of KMS encrypted objects 

### DIFF
--- a/.changes/next-release/bugfix-AWSS3-3112634.json
+++ b/.changes/next-release/bugfix-AWSS3-3112634.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS S3", 
+    "type": "bugfix", 
+    "description": "Use request header to determine if checksum validation should be enabled for `s3#putObject`"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java
@@ -80,7 +80,7 @@ public final class AsyncChecksumValidationInterceptor implements ExecutionInterc
     public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
 
         boolean putObjectChecksumsEnabled =
-            putObjectChecksumEnabled(context.request(), ASYNC, executionAttributes, context.httpResponse());
+            putObjectChecksumEnabled(context.request(), ASYNC, executionAttributes, context.httpRequest());
 
         if (putObjectChecksumsEnabled) {
             validatePutObjectChecksum((PutObjectResponse) context.response(), executionAttributes);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/InterceptorTestUtils.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/InterceptorTestUtils.java
@@ -162,4 +162,48 @@ public final class InterceptorTestUtils {
             }
         };
     }
+
+    public static Context.AfterUnmarshalling afterUnmarshallingContext(SdkRequest request, SdkHttpRequest sdkHttpRequest, SdkResponse response, SdkHttpResponse sdkHttpResponse) {
+        return new Context.AfterUnmarshalling() {
+            @Override
+            public SdkResponse response() {
+                return response;
+            }
+
+            @Override
+            public SdkHttpResponse httpResponse() {
+                return sdkHttpResponse;
+            }
+
+            @Override
+            public Optional<Publisher<ByteBuffer>> responsePublisher() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<InputStream> responseBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public SdkHttpRequest httpRequest() {
+                return sdkHttpRequest;
+            }
+
+            @Override
+            public Optional<RequestBody> requestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<AsyncRequestBody> asyncRequestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public SdkRequest request() {
+                return request;
+            }
+        };
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The check in `putObjectChecksumEnabled` in [AsyncChecksumValidationInterceptor](https://github.com/aws/aws-sdk-java-v2/blob/a0379920f54cba715773f821ac5d237be8a47985/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java#L82) should use request headers, rather than response headers, to determine if the put request is a SSE KMS request. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fix for https://github.com/aws/aws-sdk-java-v2/issues/1035 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests for `afterUnmarshalling`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
