### PR TITLE
Fix the deadlock issue in event streaming operations

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-6e2fe73.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-6e2fe73.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix the deadlock issue in `EventStreamAsyncResponseTransformer` for event streaming operations triggered in an edge case where customer subscriber signals `Subscription#request` the same time as `SdkPublisher` signals `Subscriber#onComplete`"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
@@ -240,6 +240,11 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
      */
     private void onEventComplete() {
         synchronized (this) {
+            // No op if it's already done
+            if (isDone) {
+                return;
+            }
+
             isDone = true;
             runAndLogError(log, "Error thrown from Subscriber#onComplete, ignoring.",
                 () -> subscriberRef.get().onComplete());
@@ -462,11 +467,24 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
         if (isDone) {
             return;
         }
+
+        if (isCompletedOrDeliverEvent()) {
+            onEventComplete();
+        }
+    }
+
+    /**
+     * Checks whether the eventsToDeliver is completed and if it is not completed,
+     * deliver more events
+     *
+     * @return true if the eventsToDeliver is completed, otherwise false.
+     */
+    private boolean isCompletedOrDeliverEvent() {
         synchronized (eventsToDeliver) {
             if (eventsToDeliver.peek() == ON_COMPLETE_EVENT) {
-                onEventComplete();
-                return;
+                return true;
             }
+
             if (eventsToDeliver.isEmpty() || remainingDemand.get() == 0) {
                 isDelivering.compareAndSet(true, false);
                 // If we still have demand to fulfill then request more if we aren't already requesting
@@ -478,9 +496,16 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
                 Object event = eventsToDeliver.remove();
                 remainingDemand.decrementAndGet();
                 CompletableFuture.runAsync(() -> deliverEvent(event), executor)
-                                 .thenRunAsync(this::drainEvents, executor);
+                                 .thenRunAsync(this::drainEvents, executor)
+                                 .whenComplete((v, t) -> {
+                                     if (t != null) {
+                                         log.error("Error occurred when delivering an event", t);
+                                         throw SdkClientException.create("fail to deliver events", t);
+                                     }
+                                 });
             }
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Description
Fix the deadlock issue in event streaming operations triggered in an edge case where `request` and `onComplete` are signalled at the same time.

## Testing
Added unit test. `Kinesis` integ tests passed

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](../docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
