### PR TITLE
Reduced netty client logging noise.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-476c34f.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-476c34f.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Reduced netty client logging noise, by logging at a DEBUG level (instead of WARN) when encountering IO errors on channels not currently in use and not logging the whole stack trace."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
@@ -75,6 +75,7 @@ public class ChannelPipelineInitializer extends AbstractChannelPoolHandler {
         }
 
         pipeline.addLast(new FutureCancelHandler());
+        pipeline.addLast(new UnusedChannelExceptionHandler());
     }
 
     private void configureHttp2(Channel ch, ChannelPipeline pipeline) {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/UnusedChannelExceptionHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/UnusedChannelExceptionHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * A handler for exceptions occurring on channels not current in use (according to {@link ChannelAttributeKey#IN_USE}). This
+ * does nothing if the channel is currently in use. If it's not currently in use, it will close the channel and log an
+ * appropriate notification.
+ *
+ * This prevents spamming customer logs when errors (eg. connection resets) occur on an unused channel.
+ */
+@SdkInternalApi
+public class UnusedChannelExceptionHandler extends ChannelHandlerAdapter {
+    private static final Logger log = Logger.loggerFor(UnusedChannelExceptionHandler.class);
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        boolean channelInUse = getAttribute(ctx, ChannelAttributeKey.IN_USE).orElse(false);
+
+        if (channelInUse) {
+            ctx.fireExceptionCaught(cause);
+        } else {
+            ctx.close();
+
+            Optional<CompletableFuture<Void>> executeFuture = getAttribute(ctx, ChannelAttributeKey.EXECUTE_FUTURE_KEY);
+
+            if (executeFuture.isPresent() && !executeFuture.get().isDone()) {
+                log.error(() -> "An exception occurred on an channel (" + ctx.channel().id() + ") that was not in use, " +
+                                "but was associated with a future that wasn't completed. This indicates a bug in the " +
+                                "Java SDK, where a future was not completed while the channel was in use. The channel has " +
+                                "been closed, and the future will be completed to prevent any ongoing issues.", cause);
+                executeFuture.get().completeExceptionally(cause);
+
+            } else if (cause instanceof IOException) {
+                log.debug(() -> "An I/O exception (" + cause.getMessage() + ") occurred on a channel (" + ctx.channel().id() +
+                                ") that was not in use. The channel has been closed. This is usually normal.");
+
+            } else {
+                log.warn(() -> "A non-I/O exception occurred on a channel (" + ctx.channel().id() + ") that was not in use. " +
+                               "The channel has been closed to prevent any ongoing issues.", cause);
+            }
+        }
+    }
+
+    private <T> Optional<T> getAttribute(ChannelHandlerContext ctx, AttributeKey<T> key) {
+        return Optional.ofNullable(ctx.channel().attr(key))
+                       .map(Attribute::get);
+    }
+
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/UnusedChannelExceptionHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/UnusedChannelExceptionHandlerTest.java
@@ -1,0 +1,79 @@
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.Times;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class UnusedChannelExceptionHandlerTest {
+    private Throwable exception = new Throwable();
+    private IOException ioException = new IOException();
+
+    private ChannelHandlerContext ctx;
+    private Channel channel;
+    private Attribute<Boolean> inUseAttribute;
+    private Attribute<CompletableFuture<Void>> futureAttribute;
+
+    @BeforeMethod
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        ctx = Mockito.mock(ChannelHandlerContext.class);
+        channel = Mockito.mock(Channel.class);
+
+        inUseAttribute = Mockito.mock(Attribute.class);
+        futureAttribute = Mockito.mock(Attribute.class);
+
+        Mockito.when(ctx.channel()).thenReturn(channel);
+        Mockito.when(channel.attr(ChannelAttributeKey.IN_USE)).thenReturn(inUseAttribute);
+        Mockito.when(channel.attr(ChannelAttributeKey.EXECUTE_FUTURE_KEY)).thenReturn(futureAttribute);
+    }
+
+    @Test
+    public void inUseDoesNothing() {
+        Mockito.when(inUseAttribute.get()).thenReturn(true);
+
+        new UnusedChannelExceptionHandler().exceptionCaught(ctx, exception);
+
+        Mockito.verify(ctx).fireExceptionCaught(exception);
+        Mockito.verify(ctx, new Times(0)).close();
+    }
+
+    @Test
+    public void notInUseNonIoExceptionCloses() {
+        notInUseCloses(exception);
+    }
+
+    @Test
+    public void notInUseIoExceptionCloses() {
+        notInUseCloses(ioException);
+    }
+
+    private void notInUseCloses(Throwable exception) {
+        Mockito.when(inUseAttribute.get()).thenReturn(false);
+        Mockito.when(futureAttribute.get()).thenReturn(CompletableFuture.completedFuture(null));
+
+        new UnusedChannelExceptionHandler().exceptionCaught(ctx, exception);
+
+        Mockito.verify(ctx).close();
+    }
+
+    @Test
+    public void notInUseFutureCompletes() {
+        CompletableFuture<Void> incompleteFuture = new CompletableFuture<>();
+
+        Mockito.when(inUseAttribute.get()).thenReturn(false);
+        Mockito.when(futureAttribute.get()).thenReturn(incompleteFuture);
+
+        new UnusedChannelExceptionHandler().exceptionCaught(ctx, exception);
+
+        Mockito.verify(ctx).close();
+        assertThat(incompleteFuture.isDone()).isTrue();
+    }
+}


### PR DESCRIPTION
Reduced netty client logging noise, by logging at a DEBUG level (instead of WARN) when encountering IO errors on channels not currently in use and not logging the whole stack trace.

Fixes #900 
Fixes #1039 