### PR TITLE
Move isDone reset to prepare()

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
@@ -185,6 +185,7 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
     @Override
     public CompletableFuture<Void> prepare() {
         transformFuture = new CompletableFuture<>();
+        isDone = false;
         return transformFuture;
     }
 
@@ -202,10 +203,6 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
 
     @Override
     public void onStream(SdkPublisher<ByteBuffer> publisher) {
-        synchronized (this) {
-            // Reset to allow more exceptions to propagate for retries
-            isDone = false;
-        }
         CompletableFuture<Subscription> dataSubscriptionFuture = new CompletableFuture<>();
         publisher.subscribe(new ByteSubscriber(dataSubscriptionFuture));
         dataSubscriptionFuture.thenAccept(dataSubscription -> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move the `isDone` reset to `prepare()` which we guarantee is called before each request attempt.

## Motivation and Context
Code cleanup.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
