### PR TITLE
Fix an issue where an exception could be raised when configuring the idle connection reaper in the apache HTTP client.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-a03ec88.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-a03ec88.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix",
+    "description": "Fix an issue where an exception could be raised when configuring the idle connection reaper in the apache HTTP client [#1059](https://github.com/aws/aws-sdk-java-v2/issues/1059)."
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
@@ -45,7 +45,7 @@ public interface SdkHttpClient extends SdkAutoCloseable {
     @FunctionalInterface
     interface Builder<T extends SdkHttpClient.Builder<T>> extends SdkBuilder<T, SdkHttpClient> {
         /**
-         * Create a {@link SdkHttpClient} without defaults applied. This is useful for reusing an HTTP client across multiple
+         * Create a {@link SdkHttpClient} with global defaults applied. This is useful for reusing an HTTP client across multiple
          * services.
          */
         default SdkHttpClient build() {

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
@@ -47,7 +47,7 @@ public interface SdkAsyncHttpClient extends SdkAutoCloseable {
     @FunctionalInterface
     interface Builder<T extends SdkAsyncHttpClient.Builder<T>> extends SdkBuilder<T, SdkAsyncHttpClient> {
         /**
-         * Create a {@link SdkAsyncHttpClient} without defaults applied. This is useful for reusing an HTTP client across
+         * Create a {@link SdkAsyncHttpClient} with global defaults applied. This is useful for reusing an HTTP client across
          * multiple services.
          */
         default SdkAsyncHttpClient build() {

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache;
+
+import org.junit.Test;
+
+/**
+ * @see ApacheHttpClientWireMockTest
+ */
+public class ApacheHttpClientTest {
+    @Test
+    public void connectionReaperCanBeManuallyEnabled() {
+        ApacheHttpClient.builder()
+                        .useIdleConnectionReaper(true)
+                        .build()
+                        .close();
+    }
+}


### PR DESCRIPTION
This change is up for debate, but it doesn't make much sense that zero defaults are applied when a client is built, and will be prone to cause issues in the future where customers might assume some type of default would be applied, like is true for every other build() method in the SDK.