### PR TITLE
Make default region and credential loading lazy.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-d33383e.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-d33383e.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Defer all errors raised when creating `ProfileCredentialsProvider` to the `resolveCredentials()` call."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-63c04be.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-63c04be.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Never initialize the default credentials provider chain if credentials are always specified in the client builder."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-6c062f1.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-6c062f1.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Never initialie the default region provider chain if the region is always specified in the client builder."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/LazyAwsCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/LazyAwsCredentialsProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials.internal;
+
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.ToString;
+
+/**
+ * A wrapper for {@link AwsCredentialsProvider} that defers creation of the underlying provider until the first time the
+ * {@link AwsCredentialsProvider#resolveCredentials()} method is invoked.
+ */
+@SdkInternalApi
+public class LazyAwsCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
+    private final Supplier<AwsCredentialsProvider> delegateConstructor;
+    private volatile AwsCredentialsProvider delegate;
+
+    private LazyAwsCredentialsProvider(Supplier<AwsCredentialsProvider> delegateConstructor) {
+        this.delegateConstructor = delegateConstructor;
+    }
+
+    public static LazyAwsCredentialsProvider create(Supplier<AwsCredentialsProvider> delegateConstructor) {
+        return new LazyAwsCredentialsProvider(delegateConstructor);
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        if (delegate == null) {
+            synchronized (this) {
+                if (delegate == null) {
+                    delegate = delegateConstructor.get();
+                }
+            }
+        }
+        return delegate.resolveCredentials();
+    }
+
+    @Override
+    public void close() {
+        IoUtils.closeIfCloseable(delegate, null);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("LazyAwsCredentialsProvider")
+                       .add("delegateConstructor", delegateConstructor)
+                       .add("delegate", delegate)
+                       .build();
+    }
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderTest.java
@@ -28,6 +28,16 @@ import software.amazon.awssdk.utils.StringInputStream;
  */
 public class ProfileCredentialsProviderTest {
     @Test
+    public void missingCredentialsFileThrowsExceptionInGetCredentials() {
+        ProfileCredentialsProvider provider =
+                new ProfileCredentialsProvider.BuilderImpl()
+                        .defaultProfileFileLoader(() -> { throw new IllegalStateException(); })
+                        .build();
+
+        assertThatThrownBy(provider::resolveCredentials).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
     public void missingProfileFileThrowsExceptionInGetCredentials() {
         ProfileCredentialsProvider provider =
             new ProfileCredentialsProvider.BuilderImpl()

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/LazyAwsCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/LazyAwsCredentialsProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials.internal;
+
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+public class LazyAwsCredentialsProviderTest {
+    @SuppressWarnings("unchecked")
+    private Supplier<AwsCredentialsProvider> credentialsConstructor = Mockito.mock(Supplier.class);
+
+    private AwsCredentialsProvider credentials = Mockito.mock(AwsCredentialsProvider.class);
+
+    @Before
+    public void reset() {
+        Mockito.reset(credentials, credentialsConstructor);
+        Mockito.when(credentialsConstructor.get()).thenReturn(credentials);
+    }
+
+    @Test
+    public void creationDoesntInvokeSupplier() {
+        LazyAwsCredentialsProvider.create(credentialsConstructor);
+        Mockito.verifyZeroInteractions(credentialsConstructor);
+    }
+
+    @Test
+    public void resolveCredentialsInvokesSupplierExactlyOnce() {
+        LazyAwsCredentialsProvider credentialsProvider = LazyAwsCredentialsProvider.create(credentialsConstructor);
+        credentialsProvider.resolveCredentials();
+        credentialsProvider.resolveCredentials();
+
+        Mockito.verify(credentialsConstructor, Mockito.times(1)).get();
+        Mockito.verify(credentials, Mockito.times(2)).resolveCredentials();
+    }
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.regions.providers.LazyAwsRegionProvider;
 import software.amazon.awssdk.utils.AttributeMap;
 
 /**
@@ -60,7 +61,8 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     extends SdkDefaultClientBuilder<BuilderT, ClientT>
     implements AwsClientBuilder<BuilderT, ClientT> {
     private static final String DEFAULT_ENDPOINT_PROTOCOL = "https";
-    private static final AwsRegionProvider DEFAULT_REGION_PROVIDER = new DefaultAwsRegionProviderChain();
+    private static final AwsRegionProvider DEFAULT_REGION_PROVIDER =
+            new LazyAwsRegionProvider(DefaultAwsRegionProviderChain::new);
 
     protected AwsDefaultClientBuilder() {
         super();

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/providers/LazyAwsRegionProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/providers/LazyAwsRegionProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions.providers;
+
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.ToString;
+
+/**
+ * A wrapper for {@link AwsRegionProvider} that defers creation of the underlying provider until the first time the
+ * {@link AwsRegionProvider#getRegion()} method is invoked.
+ */
+@SdkProtectedApi
+public class LazyAwsRegionProvider implements AwsRegionProvider {
+    private final Supplier<AwsRegionProvider> delegateConstructor;
+    private volatile AwsRegionProvider delegate;
+
+    public LazyAwsRegionProvider(Supplier<AwsRegionProvider> delegateConstructor) {
+        this.delegateConstructor = delegateConstructor;
+    }
+
+    @Override
+    public Region getRegion() {
+        if (delegate == null) {
+            synchronized (this) {
+                if (delegate == null) {
+                    delegate = delegateConstructor.get();
+                }
+            }
+        }
+        return delegate.getRegion();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("LazyAwsRegionProvider")
+                       .add("delegateConstructor", delegateConstructor)
+                       .add("delegate", delegate)
+                       .build();
+    }
+}

--- a/core/regions/src/test/java/software/amazon/awssdk/regions/providers/LazyAwsRegionProviderTest.java
+++ b/core/regions/src/test/java/software/amazon/awssdk/regions/providers/LazyAwsRegionProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.regions.providers;
+
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class LazyAwsRegionProviderTest {
+    @SuppressWarnings("unchecked")
+    private Supplier<AwsRegionProvider> regionProviderConstructor = Mockito.mock(Supplier.class);
+
+    private AwsRegionProvider regionProvider = Mockito.mock(AwsRegionProvider.class);
+
+    @Before
+    public void reset() {
+        Mockito.reset(regionProvider, regionProviderConstructor);
+        Mockito.when(regionProviderConstructor.get()).thenReturn(regionProvider);
+    }
+
+    @Test
+    public void creationDoesntInvokeSupplier() {
+        new LazyAwsRegionProvider(regionProviderConstructor);
+        Mockito.verifyZeroInteractions(regionProviderConstructor);
+    }
+
+    @Test
+    public void getRegionInvokesSupplierExactlyOnce() {
+        LazyAwsRegionProvider lazyRegionProvider = new LazyAwsRegionProvider(regionProviderConstructor);
+        lazyRegionProvider.getRegion();
+        lazyRegionProvider.getRegion();
+
+        Mockito.verify(regionProviderConstructor, Mockito.times(1)).get();
+        Mockito.verify(regionProvider, Mockito.times(2)).getRegion();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientConfiguration.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.core.client.config;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.SdkAutoCloseable;


### PR DESCRIPTION
The default credentials provider chain and region provider chains will no longer be loaded until they are first used. Further, the profile credentials provider will never raise an exception when it is created. The exception won't be raised until it is first used.

Fixes #1030, #1014, #749