### PR TITLE
Awaits EventLoopGroup Shutdown when closing Netty client

### DIFF
--- a/.changes/next-release/bugfix-NettyNioHTTPClient-6558564.json
+++ b/.changes/next-release/bugfix-NettyNioHTTPClient-6558564.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty Nio HTTP Client", 
+    "type": "bugfix", 
+    "description": "Awaits `EventLoopGroup#shutdownGracefully` to complete when closing Netty client."
+}

--- a/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/PluralEnumNames.java
+++ b/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/PluralEnumNames.java
@@ -70,6 +70,13 @@ public class PluralEnumNames extends AbstractCheck {
         DetailAST classBody = ast.findFirstToken(TokenTypes.OBJBLOCK);
         DetailAST maybeVariableDefinition = classBody.getFirstChild();
 
+        String className = ast.findFirstToken(TokenTypes.IDENT).getText();
+
+        // Filter out util classes
+        if (className.endsWith("Utils")) {
+            return false;
+        }
+
         while (maybeVariableDefinition != null) {
             if (maybeVariableDefinition.getType() == TokenTypes.VARIABLE_DEF) {
                 DetailAST modifiers = maybeVariableDefinition.findFirstToken(TokenTypes.MODIFIERS);

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/DelegatingEventLoopGroup.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/DelegatingEventLoopGroup.java
@@ -15,6 +15,9 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration.EVENTLOOP_SHUTDOWN_QUIET_PERIOD_SECONDS;
+import static software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration.EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
@@ -58,7 +61,7 @@ public abstract class DelegatingEventLoopGroup implements EventLoopGroup {
 
     @Override
     public Future<?> shutdownGracefully() {
-        return delegate.shutdownGracefully();
+        return shutdownGracefully(EVENTLOOP_SHUTDOWN_QUIET_PERIOD_SECONDS, EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyConfiguration.java
@@ -31,6 +31,11 @@ import software.amazon.awssdk.utils.AttributeMap;
  */
 @SdkInternalApi
 public final class NettyConfiguration {
+
+    public static final int EVENTLOOP_SHUTDOWN_QUIET_PERIOD_SECONDS = 2;
+    public static final int EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS = 15;
+    public static final int EVENTLOOP_SHUTDOWN_FUTURE_TIMEOUT_SECONDS = 16;
+
     private final AttributeMap configuration;
 
     public NettyConfiguration(AttributeMap configuration) {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NonManagedEventLoopGroup.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NonManagedEventLoopGroup.java
@@ -15,8 +15,11 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static software.amazon.awssdk.http.nio.netty.internal.utils.NettyUtils.SUCCEEDED_FUTURE;
+
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
@@ -31,8 +34,7 @@ public final class NonManagedEventLoopGroup extends DelegatingEventLoopGroup {
     }
 
     @Override
-    public Future<?> shutdownGracefully() {
-        return null;
+    public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+        return SUCCEEDED_FUTURE;
     }
-
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/NettyUtils.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/NettyUtils.java
@@ -19,6 +19,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.SucceededFuture;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -26,6 +27,11 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 
 @SdkInternalApi
 public final class NettyUtils {
+
+    /**
+     * Completed succeed future.
+     */
+    public static final SucceededFuture<?> SUCCEEDED_FUTURE = new SucceededFuture<>(null, null);
 
     private NettyUtils() {
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Awaits `EventLoopGroup#shutdownGracefully` to complete when closing Netty client.

## Motivation and Context
Fun fact: `EventLoopGroup#shutdownGracefully` is also asynchronous.

## Testing
unit tests and manually triggered smart integ tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
