### PR TITLE
Attach extendedRequestId for event streaming operations

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-dbb2456.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-dbb2456.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Attach `extendedRequestId` to `AwsResponseMetadata` if available for event streaming operations so that customers can retrieve it from response metadata"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
@@ -60,7 +60,7 @@ import software.amazon.eventstream.MessageDecoder;
  * @param <EventT> Base type of event stream message frames.
  */
 @SdkProtectedApi
-public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
+public final class EventStreamAsyncResponseTransformer<ResponseT, EventT>
     implements AsyncResponseTransformer<SdkResponse, Void> {
 
     private static final Logger log = LoggerFactory.getLogger(EventStreamAsyncResponseTransformer.class);
@@ -317,6 +317,10 @@ public class EventStreamAsyncResponseTransformer<ResponseT, EventT>
 
         if (requestId != null) {
             headers.put(X_AMZN_REQUEST_ID_HEADER, singletonList(requestId));
+        }
+
+        if (extendedRequestId != null) {
+            headers.put(X_AMZ_ID_2_HEADER, singletonList(extendedRequestId));
         }
 
         SdkHttpFullResponse.Builder builder =

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamResponseHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamResponseHandler.java
@@ -24,6 +24,12 @@ import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.async.SdkPublisher;
 
+/**
+ * Response handler for event streaming operations.
+ *
+ * @param <ResponseT> the POJO response type
+ * @param <EventT> the event type
+ */
 @SdkProtectedApi
 public interface EventStreamResponseHandler<ResponseT, EventT> {
 

--- a/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/SubscribeToShardIntegrationTest.java
+++ b/services/kinesis/src/it/java/software/amazon/awssdk/services/kinesis/SubscribeToShardIntegrationTest.java
@@ -225,5 +225,8 @@ public class SubscribeToShardIntegrationTest extends AbstractTestCase {
         assertThat(sdkHttpResponse).isNotNull();
         assertThat(sdkHttpResponse.isSuccessful()).isTrue();
         assertThat(sdkHttpResponse.headers()).isNotEmpty();
+        assertThat(response.responseMetadata()).isNotNull();
+        assertThat(response.responseMetadata().extendedRequestId()).isNotEqualTo("UNKNOWN");
+        assertThat(response.responseMetadata().requestId()).isNotEqualTo("UNKNOWN");
     }
 }


### PR DESCRIPTION
## Description
Attach `extendedRequestId` to the response metadata for event streaming operations so that customers can retrieve it for debugging from response metadata.

## Background
`extendedRequestId` header is only present in `DefaultHttp2Headers` and not the event messages.

When we firstly receive `DefaultHttp2Headers`, `EventStreamAsyncResponseTransformer#onResponse` is being invoked and we retrieve the extendedRequestId from the header and store it.

https://github.com/aws/aws-sdk-java-v2/blob/6464a2d2105da423300180bd9cb9b9062f10e57a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java#L193-L201

Once we receive the event, we need to attach it to the response in `adaptMessageToResponse` https://github.com/aws/aws-sdk-java-v2/pull/1079/files#diff-41f82e2c7780cf9d923258d6d68f163aR322

## Testing
Added extendedRequestId verification in kinesis integ test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
