### PR TITLE
Fixed the issue where NoSuchBucketException is not unmarshalled

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-241dcc9.json
+++ b/.changes/next-release/bugfix-AmazonS3-241dcc9.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Fix the issue where NoSuchBucketException was not unmarshalled for `s3#getBucketPolicy` when the bucket doesn't exist. See [#1088](https://github.com/aws/aws-sdk-java-v2/issues/1088)"
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ExceptionUnmarshallingIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ExceptionUnmarshallingIntegrationTest.java
@@ -76,6 +76,20 @@ public class ExceptionUnmarshallingIntegrationTest extends S3IntegrationTestBase
     }
 
     @Test
+    public void getBucketPolicyNoSuchBucket() {
+        assertThatThrownBy(() -> s3.getBucketPolicy(b -> b.bucket(BUCKET + KEY)))
+            .isInstanceOf(NoSuchBucketException.class)
+            .satisfies(e -> assertMetadata((S3Exception) e, "NoSuchBucket"));
+    }
+
+    @Test
+    public void asyncGetBucketPolicyNoSuchBucket() {
+        assertThatThrownBy(() -> s3Async.getBucketPolicy(b -> b.bucket(BUCKET + KEY)).join())
+            .hasCauseExactlyInstanceOf(NoSuchBucketException.class)
+            .satisfies(e -> assertMetadata((S3Exception) e.getCause(), "NoSuchBucket"));
+    }
+
+    @Test
     public void getObjectAclNoSuchKey() {
         assertThatThrownBy(() -> s3.getObjectAcl(b -> b.bucket(BUCKET).key(KEY)))
             .isInstanceOf(NoSuchKeyException.class)

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/GetBucketPolicyInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/GetBucketPolicyInterceptorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.services.s3.utils.InterceptorTestUtils.modifyHttpResponseContent;
+
+import java.io.InputStream;
+import java.util.Optional;
+import org.junit.Test;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.model.GetBucketPolicyRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+public class GetBucketPolicyInterceptorTest {
+
+    private GetBucketPolicyInterceptor interceptor = new GetBucketPolicyInterceptor();
+
+    @Test
+    public void getBucketPolicy_shouldModifyResponseContent() {
+        GetBucketPolicyRequest request = GetBucketPolicyRequest.builder().build();
+        Context.ModifyHttpResponse context = modifyHttpResponseContent(request, SdkHttpResponse.builder()
+                                                                                               .statusCode(200)
+                                                                                               .build());
+        Optional<InputStream> inputStream = interceptor.modifyHttpResponseContent(context, new ExecutionAttributes());
+        assertThat(inputStream).isNotEqualTo(context.responseBody());
+    }
+
+    @Test
+    public void nonGetBucketPolicyResponse_ShouldNotModifyResponse() {
+        GetObjectRequest request = GetObjectRequest.builder().build();
+        Context.ModifyHttpResponse context = modifyHttpResponseContent(request, SdkHttpResponse.builder().statusCode(200).build());
+        Optional<InputStream> inputStream = interceptor.modifyHttpResponseContent(context, new ExecutionAttributes());
+        assertThat(inputStream).isEqualTo(context.responseBody());
+    }
+
+    @Test
+    public void errorResponseShouldNotModifyResponse() {
+        GetBucketPolicyRequest request = GetBucketPolicyRequest.builder().build();
+        Context.ModifyHttpResponse context = modifyHttpResponseContent(request, SdkHttpResponse.builder().statusCode(404).build());
+        Optional<InputStream> inputStream = interceptor.modifyHttpResponseContent(context, new ExecutionAttributes());
+        assertThat(inputStream).isEqualTo(context.responseBody());
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/InterceptorTestUtils.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/InterceptorTestUtils.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.EmptyPublisher;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -188,6 +189,52 @@ public final class InterceptorTestUtils {
             @Override
             public SdkHttpRequest httpRequest() {
                 return sdkHttpRequest;
+            }
+
+            @Override
+            public Optional<RequestBody> requestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<AsyncRequestBody> asyncRequestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public SdkRequest request() {
+                return request;
+            }
+        };
+    }
+
+    public static Context.ModifyHttpResponse modifyHttpResponseContent(SdkRequest request, SdkHttpResponse sdkHttpResponse) {
+        InputStream stream = new StringInputStream("hello world");
+
+        return new Context.ModifyResponse() {
+            @Override
+            public SdkResponse response() {
+                return null;
+            }
+
+            @Override
+            public SdkHttpResponse httpResponse() {
+                return sdkHttpResponse;
+            }
+
+            @Override
+            public Optional<Publisher<ByteBuffer>> responsePublisher() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<InputStream> responseBody() {
+                return Optional.of(stream);
+            }
+
+            @Override
+            public SdkHttpRequest httpRequest() {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the issue where `NoSuchBucketException` is not unmarshalled correctly for `s3#getBucketPolicy`

Fix #1088 

## Testing
Added unit tests and integ test.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
