### PR TITLE
Fix possible NPE in HttpOrHttp2ChannelPool

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-2e50373.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-2e50373.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fix a possible `NullPointerException` if `HttpOrHttp2ChannelPool` is closed while the protocol is still being determined. The operation is now done synchronously with other operations on the pool to prevent a data race."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -197,7 +197,7 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
 
         // Wrap the channel pool such that HTTP 2 channels won't be released to the underlying pool while they're still in use.
         channelPool = new HttpOrHttp2ChannelPool(channelPool,
-                                                 bootstrap,
+                                                 bootstrap.config().group(),
                                                  configuration.maxConnections(),
                                                  configuration);
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/HttpOrHttp2ChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/HttpOrHttp2ChannelPoolTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.http2;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
+import software.amazon.awssdk.utils.AttributeMap;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.CONNECTION_ACQUIRE_TIMEOUT;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.MAX_PENDING_CONNECTION_ACQUIRES;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.PROTOCOL_FUTURE;
+
+/**
+ * Tests for {@link HttpOrHttp2ChannelPool}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpOrHttp2ChannelPoolTest {
+    private static EventLoopGroup eventLoopGroup;
+
+    @Mock
+    private ChannelPool mockDelegatePool;
+
+    private HttpOrHttp2ChannelPool httpOrHttp2ChannelPool;
+
+    @BeforeClass
+    public static void setup() {
+        eventLoopGroup = new NioEventLoopGroup(1);
+    }
+
+    @AfterClass
+    public static void teardown() throws InterruptedException {
+        eventLoopGroup.shutdownGracefully().await();
+    }
+
+    @Before
+    public void methodSetup() {
+        httpOrHttp2ChannelPool = new HttpOrHttp2ChannelPool(mockDelegatePool,
+                                                            eventLoopGroup,
+                                                            4,
+                                                            new NettyConfiguration(AttributeMap.builder()
+                                                                    .put(CONNECTION_ACQUIRE_TIMEOUT, Duration.ofSeconds(1))
+                                                                    .put(MAX_PENDING_CONNECTION_ACQUIRES, 5)
+                                                                    .build()));
+    }
+
+    @Test
+    public void protocolConfigNotStarted_closeSucceeds() {
+        httpOrHttp2ChannelPool.close();
+    }
+
+    @Test
+    public void protocolConfigNotStarted_closeClosesDelegatePool() throws InterruptedException {
+        httpOrHttp2ChannelPool.close();
+        Thread.sleep(500);
+        verify(mockDelegatePool).close();
+    }
+
+    @Test(timeout = 5_000)
+    public void poolClosed_acquireFails() throws InterruptedException {
+        httpOrHttp2ChannelPool.close();
+        Thread.sleep(500);
+        Future<Channel> p = httpOrHttp2ChannelPool.acquire(eventLoopGroup.next().newPromise());
+        assertThat(p.await().cause().getMessage()).contains("pool is closed");
+    }
+
+    @Test(timeout = 5_000)
+    public void protocolConfigInProgress_poolClosed_closesChannelAndDelegatePoolOnAcquireSuccess() throws InterruptedException {
+        Promise<Channel> acquirePromise = eventLoopGroup.next().newPromise();
+        when(mockDelegatePool.acquire()).thenReturn(acquirePromise);
+
+        // initiate the configuration
+        httpOrHttp2ChannelPool.acquire();
+
+        // close the pool before the config can complete (we haven't completed acquirePromise yet)
+        httpOrHttp2ChannelPool.close();
+
+        Thread.sleep(500);
+
+        Channel channel = new NioSocketChannel();
+        eventLoopGroup.register(channel);
+        try {
+            channel.attr(PROTOCOL_FUTURE).set(CompletableFuture.completedFuture(Protocol.HTTP1_1));
+
+            acquirePromise.setSuccess(channel);
+
+            assertThat(channel.closeFuture().await().isDone()).isTrue();
+            Thread.sleep(500);
+            verify(mockDelegatePool).release(eq(channel));
+            verify(mockDelegatePool).close();
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void protocolConfigInProgress_poolClosed_delegatePoolClosedOnAcquireFailure() throws InterruptedException {
+        Promise<Channel> acquirePromise = eventLoopGroup.next().newPromise();
+        when(mockDelegatePool.acquire()).thenReturn(acquirePromise);
+
+        // initiate the configuration
+        httpOrHttp2ChannelPool.acquire();
+
+        // close the pool before the config can complete (we haven't completed acquirePromise yet)
+        httpOrHttp2ChannelPool.close();
+
+        Thread.sleep(500);
+
+        acquirePromise.setFailure(new RuntimeException("Some failure"));
+
+        Thread.sleep(500);
+        verify(mockDelegatePool).close();
+    }
+
+    @Test(timeout = 5_000)
+    public void protocolConfigComplete_poolClosed_closesDelegatePool() throws InterruptedException {
+        Promise<Channel> acquirePromise = eventLoopGroup.next().newPromise();
+        when(mockDelegatePool.acquire()).thenReturn(acquirePromise);
+
+        // initiate the configuration
+        httpOrHttp2ChannelPool.acquire();
+
+        Thread.sleep(500);
+
+        Channel channel = new NioSocketChannel();
+        eventLoopGroup.register(channel);
+        try {
+            channel.attr(PROTOCOL_FUTURE).set(CompletableFuture.completedFuture(Protocol.HTTP1_1));
+
+            // this should complete the protocol config
+            acquirePromise.setSuccess(channel);
+
+            Thread.sleep(500);
+
+            // close the pool
+            httpOrHttp2ChannelPool.close();
+
+            Thread.sleep(500);
+            verify(mockDelegatePool).close();
+        } finally {
+            channel.close();
+        }
+    }
+}


### PR DESCRIPTION
## Description
The access to protocolImpl#close() could happen before it's assigned to, leading
to a NullPointerException.

Also, `protocolImpl` is not volatile or accessed in a threadafe manner, so
it's possible the thread calling `HttpOrHttp2ChannelPool#close` has a stale value.

## Motivation and Context
Bug fix.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
