### PR TITLE
More integration tests cleanup

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/UploadLargeObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/UploadLargeObjectIntegrationTest.java
@@ -28,7 +28,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.IoUtils;
 
-@Ignore("The tests are intended to run manually as it can take a relatively long time")
 public class UploadLargeObjectIntegrationTest extends S3IntegrationTestBase {
 
     private static final String BUCKET = temporaryBucketName(UploadLargeObjectIntegrationTest.class);
@@ -51,13 +50,13 @@ public class UploadLargeObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void syncPutLargeObject() throws Exception {
+    public void syncPutLargeObject() {
         s3.putObject(b -> b.bucket(BUCKET).key(SYNC_KEY), file.toPath());
         verifyResponse(SYNC_KEY);
     }
 
     @Test
-    public void asyncPutLargeObject() throws Exception {
+    public void asyncPutLargeObject() {
         s3Async.putObject(b -> b.bucket(BUCKET).key(ASYNC_KEY), file.toPath()).join();
         verifyResponse(ASYNC_KEY);
     }


### PR DESCRIPTION
Fixed TemplateIntegrationTest by moving resources in #1103 

Modified BucketAccelerateIntegrationTest to verify that we can enable/disable accelerate and that other operations use the accelerate endpoint.

Removed ignore annotation from UploadLargeObjectIntegrationTest. This test takes about 3 minutes to run from my desktop. Should presumably be faster in CodeBuild since it will be uploading to S3 within region. Don't think it's an issue to just run this test always.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
