### PR TITLE
Fix HeaderUnmarshaller to compare headers ignoring cases

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-f8f1130.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-f8f1130.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix HeaderUnmarshaller to compare header ignoring cases."
+}

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/HeaderUnmarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/unmarshall/HeaderUnmarshaller.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.protocols.xml.internal.unmarshall;
 
+import static software.amazon.awssdk.utils.StringUtils.replacePrefixIgnoreCase;
+import static software.amazon.awssdk.utils.StringUtils.startsWithIgnoreCase;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.protocols.core.StringToValueConverter;
@@ -39,9 +41,9 @@ public final class HeaderUnmarshaller {
     public static final XmlUnmarshaller<Map<String, ?>> MAP = ((context, content, field) -> {
         Map<String, String> result = new HashMap<>();
         context.response().headers().entrySet().stream()
-               .filter(e -> e.getKey().startsWith(field.locationName()))
-               .forEach(e -> result.put(e.getKey().replace(field.locationName(), ""),
-                                        e.getValue().stream().collect(Collectors.joining(","))));
+               .filter(e -> startsWithIgnoreCase(e.getKey(), field.locationName()))
+               .forEach(e -> result.put(replacePrefixIgnoreCase(e.getKey(), field.locationName(), ""),
+                                        String.join(",", e.getValue())));
         return result;
     });
 

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-xml-output.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-xml-output.json
@@ -310,5 +310,29 @@
         "stringMember": ""
       }
     }
+  },
+  {
+    "description": "Map headers are unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "headers": {
+          "x-amz-meta-FoO": "foo",
+          "X-aMZ-mEtA-bAr": "bar"
+        }
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "MembersInHeaders"
+    },
+    "then": {
+      "deserializedAs": {
+        "MetadataMember": {
+          "FoO": "foo",
+          "bAr": "bar"
+        }
+      }
+    }
   }
 ]

--- a/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restxml/service-2.json
@@ -295,6 +295,11 @@
           "shape":"Timestamp",
           "location":"header",
           "locationName":"x-amz-timestamp"
+        },
+        "MetadataMember":{
+          "shape":"Metadata",
+          "location":"header",
+          "locationName":"x-amz-meta-"
         }
       }
     },
@@ -535,12 +540,6 @@
       },
       "exception":true
     },
-    "EmptyModeledException":{
-      "type":"structure",
-      "members":{
-      },
-      "exception":true
-    },
     "ExplicitPayloadAndHeadersException":{
       "type":"structure",
       "members":{
@@ -584,6 +583,13 @@
       "exception":true,
       "payload":"PayloadMember"
     },
-    "Timestamp":{"type":"timestamp"}
+    "Timestamp":{"type":"timestamp"},
+    "Metadata":{
+      "type":"map",
+      "key":{"shape":"MetadataKey"},
+      "value":{"shape":"MetadataValue"}
+    },
+    "MetadataKey":{"type":"string"},
+    "MetadataValue":{"type":"string"}
   }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/StringUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/StringUtils.java
@@ -578,4 +578,31 @@ public final class StringUtils {
             throw new UncheckedIOException("Cannot encode string.", e);
         }
     }
+
+    /**
+     * Tests if this string starts with the specified prefix ignoring case considerations.
+     *
+     * @param str the string to be tested
+     * @param prefix the prefix
+     * @return true if the string starts with the prefix ignoring case
+     */
+    public static boolean startsWithIgnoreCase(String str, String prefix) {
+        return str.regionMatches(true, 0, prefix, 0, prefix.length());
+    }
+
+    /**
+     * Replace the prefix of the string provided ignoring case considerations.
+     *
+     * <p>
+     * The unmatched part is unchanged.
+     *
+     *
+     * @param str the string to replace
+     * @param prefix the prefix to find
+     * @param replacement the replacement
+     * @return the replaced string
+     */
+    public static String replacePrefixIgnoreCase(String str, String prefix, String replacement) {
+        return str.replaceFirst("(?i)" + prefix, replacement);
+    }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/StringUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/StringUtilsTest.java
@@ -16,7 +16,11 @@
 package software.amazon.awssdk.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static software.amazon.awssdk.utils.StringUtils.replacePrefixIgnoreCase;
 
 import org.junit.Test;
 
@@ -106,5 +110,19 @@ public class StringUtilsTest {
                 FOO_UNCAP, StringUtils.uncapitalize(StringUtils.capitalize(FOO_UNCAP)));
         assertEquals("capitalize(uncapitalize(String)) failed",
                 FOO_CAP, StringUtils.capitalize(StringUtils.uncapitalize(FOO_CAP)));
+    }
+
+    @Test
+    public void testStartsWithIgnoreCase() {
+        assertTrue(StringUtils.startsWithIgnoreCase("helloworld", "hello"));
+        assertTrue(StringUtils.startsWithIgnoreCase("hELlOwOrlD", "hello"));
+        assertFalse(StringUtils.startsWithIgnoreCase("hello", "world"));
+    }
+
+    @Test
+    public void testReplacePrefixIgnoreCase() {
+        assertEquals("lloWorld" ,replacePrefixIgnoreCase("helloWorld", "he", ""));
+        assertEquals("lloWORld" ,replacePrefixIgnoreCase("helloWORld", "He", ""));
+        assertEquals("llOwOrld" ,replacePrefixIgnoreCase("HEllOwOrld", "he", ""));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix xml `HeaderUnmarshaller#MAP` to compare headers ignoring cases. Checked Json HeaderUnmarshaller and it doesn't have MAP type.

## Motivation and Context
Fixes #1091 

## Testing
Added unit tests and integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
