### PR TITLE
Fix async request cancellation

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKForJavav2-0076c08.json
+++ b/.changes/next-release/bugfix-AWSSDKForJavav2-0076c08.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK For Java v2", 
+    "type": "bugfix", 
+    "description": "Fix bug in the generated async clients where cancelling the `CompletableFuture` returned from an async operation does not result in cancelling the underlying HTTP request execution. In some cases, this can lead to unnecesarily keeping resources from being freed until the request execution finishes."
+}

--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-1969be2.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-1969be2.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fix a bug where, if the future returned from the `NettyRequestExecutor#execute` is cancelled, the client continues to wait for the `Channel` acquire to complete, which leads to keeping potentially many resources around unnecessarily."
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -150,19 +150,21 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             Validate.paramNotBlank(aPostOperationRequest.stringMember(), "StringMember");
             String resolvedHostExpression = String.format("%s-foo.", aPostOperationRequest.stringMember());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, APostOperationResponse::builder);
+                    operationMetadata, APostOperationResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
-                                             .withOperationName("APostOperation")
-                                             .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
-                                             .withErrorResponseHandler(errorResponseHandler).hostPrefixExpression(resolvedHostExpression)
-                                             .withInput(aPostOperationRequest));
+            CompletableFuture<APostOperationResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                            .withOperationName("APostOperation")
+                            .withMarshaller(new APostOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .hostPrefixExpression(resolvedHostExpression).withInput(aPostOperationRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -193,23 +195,24 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<APostOperationWithOutputResponse> aPostOperationWithOutput(
-        APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
+            APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
         try {
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, APostOperationWithOutputResponse::builder);
+                    operationMetadata, APostOperationWithOutputResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler
-                .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
-                             .withOperationName("APostOperationWithOutput")
-                             .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
-                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                             .withInput(aPostOperationWithOutputRequest));
+            CompletableFuture<APostOperationWithOutputResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                            .withOperationName("APostOperationWithOutput")
+                            .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(aPostOperationWithOutputRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -236,50 +239,51 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<Void> eventStreamOperation(EventStreamOperationRequest eventStreamOperationRequest,
-                                                        Publisher<InputEventStream> requestStream, EventStreamOperationResponseHandler asyncResponseHandler) {
+            Publisher<InputEventStream> requestStream, EventStreamOperationResponseHandler asyncResponseHandler) {
         try {
             eventStreamOperationRequest = applySignerOverride(eventStreamOperationRequest, EventStreamAws4Signer.create());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<EventStreamOperationResponse> responseHandler = new AttachHttpMetadataResponseHandler(
-                protocolFactory.createResponseHandler(operationMetadata, EventStreamOperationResponse::builder));
+                    protocolFactory.createResponseHandler(operationMetadata, EventStreamOperationResponse::builder));
 
             HttpResponseHandler<SdkResponse> voidResponseHandler = protocolFactory.createResponseHandler(JsonOperationMetadata
-                                                                                                             .builder().isPayloadJson(false).hasStreamingSuccessResponse(true).build(), VoidSdkResponse::builder);
+                    .builder().isPayloadJson(false).hasStreamingSuccessResponse(true).build(), VoidSdkResponse::builder);
 
             HttpResponseHandler<? extends EventStream> eventResponseHandler = protocolFactory.createResponseHandler(
-                JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
-                EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
-                                                  .putSdkPojoSupplier("EventTwo", EventTwo::builder).defaultSdkPojoSupplier(() -> EventStream.UNKNOWN)
-                                                  .build());
+                    JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
+                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
+                            .putSdkPojoSupplier("EventTwo", EventTwo::builder).defaultSdkPojoSupplier(() -> EventStream.UNKNOWN)
+                            .build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
             EventStreamTaggedUnionJsonMarshaller eventMarshaller = EventStreamTaggedUnionJsonMarshaller.builder()
-                                                                                                       .putMarshaller(InputEvent.class, new InputEventMarshaller(protocolFactory)).build();
+                    .putMarshaller(InputEvent.class, new InputEventMarshaller(protocolFactory)).build();
             SdkPublisher<InputEventStream> eventPublisher = SdkPublisher.adapt(requestStream);
             Publisher<ByteBuffer> adapted = eventPublisher.map(event -> eventMarshaller.marshall(event)).map(
-                AwsClientHandlerUtils::encodeEventStreamRequestToByteBuffer);
+                    AwsClientHandlerUtils::encodeEventStreamRequestToByteBuffer);
             CompletableFuture<Void> future = new CompletableFuture<>();
             EventStreamAsyncResponseTransformer<EventStreamOperationResponse, EventStream> asyncResponseTransformer = EventStreamAsyncResponseTransformer
-                .<EventStreamOperationResponse, EventStream> builder().eventStreamResponseHandler(asyncResponseHandler)
-                                                                      .eventResponseHandler(eventResponseHandler).initialResponseHandler(responseHandler)
-                                                                      .exceptionResponseHandler(errorResponseHandler).future(future).executor(executor).serviceName(serviceName())
-                                                                      .build();
+                    .<EventStreamOperationResponse, EventStream> builder().eventStreamResponseHandler(asyncResponseHandler)
+                    .eventResponseHandler(eventResponseHandler).initialResponseHandler(responseHandler)
+                    .exceptionResponseHandler(errorResponseHandler).future(future).executor(executor).serviceName(serviceName())
+                    .build();
             RestEventStreamAsyncResponseTransformer<EventStreamOperationResponse, EventStream> restAsyncResponseTransformer = RestEventStreamAsyncResponseTransformer
-                .<EventStreamOperationResponse, EventStream> builder()
-                .eventStreamAsyncResponseTransformer(asyncResponseTransformer)
-                .eventStreamResponseHandler(asyncResponseHandler).build();
+                    .<EventStreamOperationResponse, EventStream> builder()
+                    .eventStreamAsyncResponseTransformer(asyncResponseTransformer)
+                    .eventStreamResponseHandler(asyncResponseHandler).build();
 
-            clientHandler.execute(
-                new ClientExecutionParams<EventStreamOperationRequest, EventStreamOperationResponse>()
-                    .withOperationName("EventStreamOperation")
-                    .withMarshaller(new EventStreamOperationRequestMarshaller(protocolFactory))
-                    .withAsyncRequestBody(software.amazon.awssdk.core.async.AsyncRequestBody.fromPublisher(adapted))
-                    .withFullDuplex(true).withResponseHandler(responseHandler)
-                    .withErrorResponseHandler(errorResponseHandler).withInput(eventStreamOperationRequest),
-                restAsyncResponseTransformer).whenComplete((r, e) -> {
+            CompletableFuture<Void> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<EventStreamOperationRequest, EventStreamOperationResponse>()
+                            .withOperationName("EventStreamOperation")
+                            .withMarshaller(new EventStreamOperationRequestMarshaller(protocolFactory))
+                            .withAsyncRequestBody(software.amazon.awssdk.core.async.AsyncRequestBody.fromPublisher(adapted))
+                            .withFullDuplex(true).withResponseHandler(responseHandler)
+                            .withErrorResponseHandler(errorResponseHandler).withInput(eventStreamOperationRequest),
+                    restAsyncResponseTransformer);
+            executeFuture.whenComplete((r, e) -> {
                 if (e != null) {
                     try {
                         asyncResponseHandler.exceptionOccurred(e);
@@ -288,10 +292,10 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     }
                 }
             });
-            return future;
+            return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
-                           () -> asyncResponseHandler.exceptionOccurred(t));
+                    () -> asyncResponseHandler.exceptionOccurred(t));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -318,33 +322,34 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<EventStreamOperationWithOnlyInputResponse> eventStreamOperationWithOnlyInput(
-        EventStreamOperationWithOnlyInputRequest eventStreamOperationWithOnlyInputRequest,
-        Publisher<InputEventStreamTwo> requestStream) {
+            EventStreamOperationWithOnlyInputRequest eventStreamOperationWithOnlyInputRequest,
+            Publisher<InputEventStreamTwo> requestStream) {
         try {
             eventStreamOperationWithOnlyInputRequest = applySignerOverride(eventStreamOperationWithOnlyInputRequest,
-                                                                           EventStreamAws4Signer.create());
+                    EventStreamAws4Signer.create());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<EventStreamOperationWithOnlyInputResponse> responseHandler = protocolFactory
-                .createResponseHandler(operationMetadata, EventStreamOperationWithOnlyInputResponse::builder);
+                    .createResponseHandler(operationMetadata, EventStreamOperationWithOnlyInputResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
             EventStreamTaggedUnionJsonMarshaller eventMarshaller = EventStreamTaggedUnionJsonMarshaller.builder()
-                                                                                                       .putMarshaller(InputEventOne.class, new InputEventOneMarshaller(protocolFactory))
-                                                                                                       .putMarshaller(InputEventTwo.class, new InputEventTwoMarshaller(protocolFactory)).build();
+                    .putMarshaller(InputEventOne.class, new InputEventOneMarshaller(protocolFactory))
+                    .putMarshaller(InputEventTwo.class, new InputEventTwoMarshaller(protocolFactory)).build();
             SdkPublisher<InputEventStreamTwo> eventPublisher = SdkPublisher.adapt(requestStream);
             Publisher<ByteBuffer> adapted = eventPublisher.map(event -> eventMarshaller.marshall(event)).map(
-                AwsClientHandlerUtils::encodeEventStreamRequestToByteBuffer);
+                    AwsClientHandlerUtils::encodeEventStreamRequestToByteBuffer);
 
-            return clientHandler
-                .execute(new ClientExecutionParams<EventStreamOperationWithOnlyInputRequest, EventStreamOperationWithOnlyInputResponse>()
-                             .withOperationName("EventStreamOperationWithOnlyInput")
-                             .withMarshaller(new EventStreamOperationWithOnlyInputRequestMarshaller(protocolFactory))
-                             .withAsyncRequestBody(software.amazon.awssdk.core.async.AsyncRequestBody.fromPublisher(adapted))
-                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                             .withInput(eventStreamOperationWithOnlyInputRequest));
+            CompletableFuture<EventStreamOperationWithOnlyInputResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<EventStreamOperationWithOnlyInputRequest, EventStreamOperationWithOnlyInputResponse>()
+                            .withOperationName("EventStreamOperationWithOnlyInput")
+                            .withMarshaller(new EventStreamOperationWithOnlyInputRequestMarshaller(protocolFactory))
+                            .withAsyncRequestBody(software.amazon.awssdk.core.async.AsyncRequestBody.fromPublisher(adapted))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(eventStreamOperationWithOnlyInputRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -375,23 +380,24 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<GetWithoutRequiredMembersResponse> getWithoutRequiredMembers(
-        GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
+            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
         try {
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, GetWithoutRequiredMembersResponse::builder);
+                    operationMetadata, GetWithoutRequiredMembersResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler
-                .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
-                             .withOperationName("GetWithoutRequiredMembers")
-                             .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
-                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                             .withInput(getWithoutRequiredMembersRequest));
+            CompletableFuture<GetWithoutRequiredMembersResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                            .withOperationName("GetWithoutRequiredMembers")
+                            .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(getWithoutRequiredMembersRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -419,23 +425,24 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
         try {
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, PaginatedOperationWithResultKeyResponse::builder);
+                    operationMetadata, PaginatedOperationWithResultKeyResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler
-                .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
-                             .withOperationName("PaginatedOperationWithResultKey")
-                             .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
-                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                             .withInput(paginatedOperationWithResultKeyRequest));
+            CompletableFuture<PaginatedOperationWithResultKeyResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                            .withOperationName("PaginatedOperationWithResultKey")
+                            .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(paginatedOperationWithResultKeyRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -463,7 +470,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * The following are few ways to use the response class:
      * </p>
      * 1) Using the subscribe helper method
-     *
+     * 
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
@@ -473,19 +480,19 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * </pre>
      *
      * 2) Using a custom subscriber
-     *
+     * 
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
      * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse>() {
-     *
+     * 
      * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
+     * 
+     * 
      * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response) { //... };
      * });}
      * </pre>
-     *
+     * 
      * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
@@ -510,7 +517,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      *      target="_top">AWS API Documentation</a>
      */
     public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
-        PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
         return new PaginatedOperationWithResultKeyPublisher(this, applyPaginatorUserAgent(paginatedOperationWithResultKeyRequest));
     }
 
@@ -536,23 +543,24 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
         try {
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory
-                .createResponseHandler(operationMetadata, PaginatedOperationWithoutResultKeyResponse::builder);
+                    .createResponseHandler(operationMetadata, PaginatedOperationWithoutResultKeyResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler
-                .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
-                             .withOperationName("PaginatedOperationWithoutResultKey")
-                             .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
-                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                             .withInput(paginatedOperationWithoutResultKeyRequest));
+            CompletableFuture<PaginatedOperationWithoutResultKeyResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                            .withOperationName("PaginatedOperationWithoutResultKey")
+                            .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(paginatedOperationWithoutResultKeyRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -580,7 +588,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * The following are few ways to use the response class:
      * </p>
      * 1) Using the subscribe helper method
-     *
+     * 
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
@@ -590,19 +598,19 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * </pre>
      *
      * 2) Using a custom subscriber
-     *
+     * 
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
      * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse>() {
-     *
+     * 
      * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     *
-     *
+     * 
+     * 
      * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response) { //... };
      * });}
      * </pre>
-     *
+     * 
      * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
@@ -627,9 +635,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      *      target="_top">AWS API Documentation</a>
      */
     public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
-        PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
         return new PaginatedOperationWithoutResultKeyPublisher(this,
-                                                               applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
+                applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
     }
 
     /**
@@ -658,23 +666,24 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public CompletableFuture<StreamingInputOperationResponse> streamingInputOperation(
-        StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestBody requestBody) {
+            StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestBody requestBody) {
         try {
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
-                                                                           .isPayloadJson(true).build();
+                    .isPayloadJson(true).build();
 
             HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, StreamingInputOperationResponse::builder);
+                    operationMetadata, StreamingInputOperationResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler
-                .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
-                             .withOperationName("StreamingInputOperation")
-                             .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
-                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                             .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
+            CompletableFuture<StreamingInputOperationResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                            .withOperationName("StreamingInputOperation")
+                            .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -711,34 +720,36 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public <ReturnT> CompletableFuture<ReturnT> streamingInputOutputOperation(
-        StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, AsyncRequestBody requestBody,
-        AsyncResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> asyncResponseTransformer) {
+            StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, AsyncRequestBody requestBody,
+            AsyncResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> asyncResponseTransformer) {
         try {
             streamingInputOutputOperationRequest = applySignerOverride(streamingInputOutputOperationRequest,
-                                                                       Aws4UnsignedPayloadSigner.create());
+                    Aws4UnsignedPayloadSigner.create());
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
-                                                                           .isPayloadJson(false).build();
+                    .isPayloadJson(false).build();
 
             HttpResponseHandler<StreamingInputOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, StreamingInputOutputOperationResponse::builder);
+                    operationMetadata, StreamingInputOutputOperationResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler.execute(
-                new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
-                    .withOperationName("StreamingInputOutputOperation")
-                    .withMarshaller(new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                    .withAsyncRequestBody(requestBody).withInput(streamingInputOutputOperationRequest),
-                asyncResponseTransformer).whenComplete((r, e) -> {
+            CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
+                            .withOperationName("StreamingInputOutputOperation")
+                            .withMarshaller(new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withAsyncRequestBody(requestBody).withInput(streamingInputOutputOperationRequest),
+                    asyncResponseTransformer);
+            executeFuture.whenComplete((r, e) -> {
                 if (e != null) {
                     asyncResponseTransformer.exceptionOccurred(e);
                 }
             });
+            return executeFuture;
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
-                           () -> asyncResponseTransformer.exceptionOccurred(t));
+                    () -> asyncResponseTransformer.exceptionOccurred(t));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -769,31 +780,33 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      */
     @Override
     public <ReturnT> CompletableFuture<ReturnT> streamingOutputOperation(
-        StreamingOutputOperationRequest streamingOutputOperationRequest,
-        AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
+            StreamingOutputOperationRequest streamingOutputOperationRequest,
+            AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
         try {
             JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
-                                                                           .isPayloadJson(false).build();
+                    .isPayloadJson(false).build();
 
             HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
-                operationMetadata, StreamingOutputOperationResponse::builder);
+                    operationMetadata, StreamingOutputOperationResponse::builder);
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
-                                                                                                       operationMetadata);
+                    operationMetadata);
 
-            return clientHandler.execute(
-                new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
-                    .withOperationName("StreamingOutputOperation")
-                    .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                    .withInput(streamingOutputOperationRequest), asyncResponseTransformer).whenComplete((r, e) -> {
+            CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                            .withOperationName("StreamingOutputOperation")
+                            .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(streamingOutputOperationRequest), asyncResponseTransformer);
+            executeFuture.whenComplete((r, e) -> {
                 if (e != null) {
                     asyncResponseTransformer.exceptionOccurred(e);
                 }
             });
+            return executeFuture;
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
-                           () -> asyncResponseTransformer.exceptionOccurred(t));
+                    () -> asyncResponseTransformer.exceptionOccurred(t));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -805,21 +818,21 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
         return builder
-            .clientConfiguration(clientConfiguration)
-            .defaultServiceExceptionSupplier(JsonException::builder)
-            .protocol(AwsJsonProtocol.REST_JSON)
-            .protocolVersion("1.1")
-            .registerModeledException(
-                ExceptionMetadata.builder().errorCode("InvalidInput")
-                                 .exceptionBuilderSupplier(InvalidInputException::builder).httpStatusCode(400).build());
+                .clientConfiguration(clientConfiguration)
+                .defaultServiceExceptionSupplier(JsonException::builder)
+                .protocol(AwsJsonProtocol.REST_JSON)
+                .protocolVersion("1.1")
+                .registerModeledException(
+                        ExceptionMetadata.builder().errorCode("InvalidInput")
+                                .exceptionBuilderSupplier(InvalidInputException::builder).httpStatusCode(400).build());
     }
 
     private <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
         Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
-                                                                                                      .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
+                .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
         AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
+                .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
+                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
         return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
@@ -829,13 +842,13 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         }
         Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
         AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
-                                                                       .map(c -> c.toBuilder().applyMutation(signerOverride).build())
-                                                                       .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
+                .map(c -> c.toBuilder().applyMutation(signerOverride).build())
+                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
         return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
     }
 
     private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
-                                                                                JsonOperationMetadata operationMetadata) {
+            JsonOperationMetadata operationMetadata) {
         return protocolFactory.createErrorResponseHandler(operationMetadata);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
@@ -99,10 +99,13 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
                     operationMetadata);
 
-            return clientHandler.execute(new ClientExecutionParams<DescribeEndpointsRequest, DescribeEndpointsResponse>()
-                    .withOperationName("DescribeEndpoints")
-                    .withMarshaller(new DescribeEndpointsRequestMarshaller(protocolFactory)).withResponseHandler(responseHandler)
-                    .withErrorResponseHandler(errorResponseHandler).withInput(describeEndpointsRequest));
+            CompletableFuture<DescribeEndpointsResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<DescribeEndpointsRequest, DescribeEndpointsResponse>()
+                            .withOperationName("DescribeEndpoints")
+                            .withMarshaller(new DescribeEndpointsRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withInput(describeEndpointsRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -147,12 +150,13 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
                 cachedEndpoint = endpointDiscoveryCache.get(key, endpointDiscoveryRequest);
             }
 
-            return clientHandler
+            CompletableFuture<TestDiscoveryIdentifiersRequiredResponse> executeFuture = clientHandler
                     .execute(new ClientExecutionParams<TestDiscoveryIdentifiersRequiredRequest, TestDiscoveryIdentifiersRequiredResponse>()
                             .withOperationName("TestDiscoveryIdentifiersRequired")
                             .withMarshaller(new TestDiscoveryIdentifiersRequiredRequestMarshaller(protocolFactory))
                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                             .discoveredEndpoint(cachedEndpoint).withInput(testDiscoveryIdentifiersRequiredRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -196,11 +200,13 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
                 cachedEndpoint = endpointDiscoveryCache.get(key, endpointDiscoveryRequest);
             }
 
-            return clientHandler.execute(new ClientExecutionParams<TestDiscoveryOptionalRequest, TestDiscoveryOptionalResponse>()
-                    .withOperationName("TestDiscoveryOptional")
-                    .withMarshaller(new TestDiscoveryOptionalRequestMarshaller(protocolFactory))
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                    .discoveredEndpoint(cachedEndpoint).withInput(testDiscoveryOptionalRequest));
+            CompletableFuture<TestDiscoveryOptionalResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<TestDiscoveryOptionalRequest, TestDiscoveryOptionalResponse>()
+                            .withOperationName("TestDiscoveryOptional")
+                            .withMarshaller(new TestDiscoveryOptionalRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .discoveredEndpoint(cachedEndpoint).withInput(testDiscoveryOptionalRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }
@@ -244,11 +250,13 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
                 cachedEndpoint = endpointDiscoveryCache.get(key, endpointDiscoveryRequest);
             }
 
-            return clientHandler.execute(new ClientExecutionParams<TestDiscoveryRequiredRequest, TestDiscoveryRequiredResponse>()
-                    .withOperationName("TestDiscoveryRequired")
-                    .withMarshaller(new TestDiscoveryRequiredRequestMarshaller(protocolFactory))
-                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                    .discoveredEndpoint(cachedEndpoint).withInput(testDiscoveryRequiredRequest));
+            CompletableFuture<TestDiscoveryRequiredResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<TestDiscoveryRequiredRequest, TestDiscoveryRequiredResponse>()
+                            .withOperationName("TestDiscoveryRequired")
+                            .withMarshaller(new TestDiscoveryRequiredRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .discoveredEndpoint(cachedEndpoint).withInput(testDiscoveryRequiredRequest));
+            return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/RequestPipelineBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/RequestPipelineBuilder.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Builder for a {@link RequestPipeline}.
@@ -224,7 +225,9 @@ public final class RequestPipelineBuilder<InputT, OutputT> {
         @Override
         public CompletableFuture<OutputT> execute(CompletableFuture<InputT> inputFuture, RequestExecutionContext context)
                 throws Exception {
-            return inputFuture.thenApply(safeFunction(input -> delegate.execute(input, context)));
+            CompletableFuture<OutputT> outputFuture =
+                    inputFuture.thenApply(safeFunction(input -> delegate.execute(input, context)));
+            return CompletableFutureUtils.forwardExceptionTo(outputFuture, inputFuture);
         }
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncExecutionFailureExceptionReportingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncExecutionFailureExceptionReportingStage.java
@@ -38,7 +38,8 @@ public final class AsyncExecutionFailureExceptionReportingStage<OutputT>
 
     @Override
     public CompletableFuture<OutputT> execute(SdkHttpFullRequest input, RequestExecutionContext context) throws Exception {
-        return wrapped.execute(input, context).handle((o, t) -> {
+        CompletableFuture<OutputT> wrappedExecute = wrapped.execute(input, context);
+        CompletableFuture<OutputT> executeFuture = wrappedExecute.handle((o, t) -> {
             if (t != null) {
                 Throwable toReport = t;
 
@@ -52,6 +53,7 @@ public final class AsyncExecutionFailureExceptionReportingStage<OutputT>
                 return o;
             }
         });
+        return CompletableFutureUtils.forwardExceptionTo(executeFuture, wrappedExecute);
     }
 
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/CancellableAcquireChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/CancellableAcquireChannelPool.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Simple decorator {@link ChannelPool} that attempts to complete the promise
+ * given to {@link #acquire(Promise)} with the channel acquired from the underlying
+ * pool. If it fails (because the promise is already done), the acquired channel
+ * is closed then released back to the delegate.
+ */
+@SdkInternalApi
+public final class CancellableAcquireChannelPool implements ChannelPool {
+    private final EventExecutor executor;
+    private final ChannelPool delegatePool;
+
+    public CancellableAcquireChannelPool(EventExecutor executor, ChannelPool delegatePool) {
+        this.executor = executor;
+        this.delegatePool = delegatePool;
+    }
+
+    @Override
+    public Future<Channel> acquire() {
+        return this.acquire(executor.newPromise());
+    }
+
+    @Override
+    public Future<Channel> acquire(Promise<Channel> acquirePromise) {
+        Future<Channel> channelFuture = delegatePool.acquire(executor.newPromise());
+        channelFuture.addListener((Future<Channel> f) -> {
+            if (f.isSuccess()) {
+                Channel ch = f.getNow();
+                if (!acquirePromise.trySuccess(ch)) {
+                    ch.close().addListener(closeFuture -> delegatePool.release(ch));
+                }
+            } else {
+                acquirePromise.tryFailure(f.cause());
+            }
+        });
+        return acquirePromise;
+    }
+
+    @Override
+    public Future<Void> release(Channel channel) {
+        return delegatePool.release(channel);
+    }
+
+    @Override
+    public Future<Void> release(Channel channel, Promise<Void> promise) {
+        return delegatePool.release(channel, promise);
+    }
+
+    @Override
+    public void close() {
+        delegatePool.close();
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestContext.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestContext.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
@@ -24,17 +25,26 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 public final class RequestContext {
 
     private final ChannelPool channelPool;
+    private final EventLoopGroup eventLoopGroup;
     private final AsyncExecuteRequest executeRequest;
     private final NettyConfiguration configuration;
 
-    public RequestContext(ChannelPool channelPool, AsyncExecuteRequest executeRequest, NettyConfiguration configuration) {
+    public RequestContext(ChannelPool channelPool,
+                          EventLoopGroup eventLoopGroup,
+                          AsyncExecuteRequest executeRequest,
+                          NettyConfiguration configuration) {
         this.channelPool = channelPool;
+        this.eventLoopGroup = eventLoopGroup;
         this.executeRequest = executeRequest;
         this.configuration = configuration;
     }
 
     public ChannelPool channelPool() {
         return channelPool;
+    }
+
+    public EventLoopGroup eventLoopGroup() {
+        return eventLoopGroup;
     }
 
     public AsyncExecuteRequest executeRequest() {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/CancellableAcquireChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/CancellableAcquireChannelPoolTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CancellableAcquireChannelPool}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CancellableAcquireChannelPoolTest {
+    private static final EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
+
+    private EventExecutor eventExecutor;
+
+    @Mock
+    private ChannelPool mockDelegatePool;
+
+    private Channel channel;
+
+    private CancellableAcquireChannelPool cancellableAcquireChannelPool;
+
+    @Before
+    public void setup() {
+        channel = new NioSocketChannel();
+        eventLoopGroup.register(channel);
+        eventExecutor = eventLoopGroup.next();
+        cancellableAcquireChannelPool = new CancellableAcquireChannelPool(eventExecutor, mockDelegatePool);
+    }
+
+    @After
+    public void methodTeardown() {
+        channel.close().awaitUninterruptibly();
+    }
+
+    @AfterClass
+    public static void teardown() {
+        eventLoopGroup.shutdownGracefully().awaitUninterruptibly();
+    }
+
+    @Test
+    public void promiseCancelledBeforeAcquireComplete_closesAndReleasesChannel() throws InterruptedException {
+        Promise<Channel> acquireFuture = eventExecutor.newPromise();
+        acquireFuture.setFailure(new RuntimeException("Changed my mind!"));
+
+        when(mockDelegatePool.acquire(any(Promise.class))).thenAnswer((Answer<Promise>) invocationOnMock -> {
+            Promise p = invocationOnMock.getArgumentAt(0, Promise.class);
+            p.setSuccess(channel);
+            return p;
+        });
+
+        cancellableAcquireChannelPool.acquire(acquireFuture);
+
+        Thread.sleep(500);
+        verify(mockDelegatePool).release(eq(channel));
+        assertThat(channel.closeFuture().isDone()).isTrue();
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
@@ -23,6 +23,8 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.util.DefaultAttributeMap;
 import java.io.IOException;
@@ -58,11 +60,15 @@ public class FutureCancelHandlerTest {
     @Mock
     private SdkAsyncHttpResponseHandler responseHandler;
 
+    @Mock
+    private EventLoopGroup eventLoopGroup;
+
     @Before
     public void methodSetup() {
         requestContext = new RequestContext(channelPool,
+                                            eventLoopGroup,
                                             AsyncExecuteRequest.builder().responseHandler(responseHandler).build(),
-                                null);
+                                            null);
 
         DefaultAttributeMap attrMap = new DefaultAttributeMap();
         attrMap.attr(EXECUTION_ID_KEY).set(1L);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutorTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutorTest.java
@@ -1,0 +1,86 @@
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.concurrent.Promise;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.utils.AttributeMap;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NettyRequestExecutorTest {
+
+    private ChannelPool mockChannelPool;
+
+    private EventLoopGroup eventLoopGroup;
+
+    private NettyRequestExecutor nettyRequestExecutor;
+
+    private RequestContext requestContext;
+
+    @Before
+    public void setup() {
+        mockChannelPool = mock(ChannelPool.class);
+
+        eventLoopGroup = new NioEventLoopGroup();
+
+        requestContext = new RequestContext(mockChannelPool,
+                                            eventLoopGroup,
+                                            AsyncExecuteRequest.builder().build(),
+                                            new NettyConfiguration(AttributeMap.empty()));
+        nettyRequestExecutor = new NettyRequestExecutor(requestContext);
+    }
+
+    @After
+    public void teardown() throws InterruptedException {
+        eventLoopGroup.shutdownGracefully().await();
+    }
+
+    @Test
+    public void cancelExecuteFuture_channelNotAcquired_failsAcquirePromise() {
+        ArgumentCaptor<Promise> acquireCaptor = ArgumentCaptor.forClass(Promise.class);
+        when(mockChannelPool.acquire(acquireCaptor.capture())).thenAnswer((Answer<Promise>) invocationOnMock -> {
+            return invocationOnMock.getArgumentAt(0, Promise.class);
+        });
+
+        CompletableFuture<Void> executeFuture = nettyRequestExecutor.execute();
+
+        executeFuture.cancel(true);
+
+        assertThat(acquireCaptor.getValue().isDone()).isTrue();
+        assertThat(acquireCaptor.getValue().isSuccess()).isFalse();
+    }
+
+    @Test
+    public void cancelExecuteFuture_channelAcquired_submitsRunnable() {
+        EventLoop mockEventLoop = mock(EventLoop.class);
+        Channel mockChannel = mock(Channel.class);
+        when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
+
+        when(mockChannelPool.acquire(any(Promise.class))).thenAnswer((Answer<Promise>) invocationOnMock -> {
+            Promise p = invocationOnMock.getArgumentAt(0, Promise.class);
+            p.setSuccess(mockChannel);
+            return p;
+        });
+
+        CompletableFuture<Void> executeFuture = nettyRequestExecutor.execute();
+
+        executeFuture.cancel(true);
+
+        verify(mockEventLoop).submit(any(Runnable.class));
+    }
+}

--- a/test/codegen-generated-classes-test/pom.xml
+++ b/test/codegen-generated-classes-test/pom.xml
@@ -41,6 +41,16 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-xml-protocol</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>protocol-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/query/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/query/service-2.json
@@ -2,16 +2,16 @@
   "version":"2.0",
   "metadata":{
     "apiVersion":"2016-03-11",
-    "endpointPrefix":"customresponsemetadata",
+    "endpointPrefix":"query",
     "jsonVersion":"1.1",
-    "protocol":"rest-json",
-    "serviceAbbreviation":"AmazonProtocolRestJson",
-    "serviceFullName":"Amazon Protocol Rest Json",
-    "serviceId":"AmazonProtocolRestJson",
+    "protocol":"query",
+    "serviceAbbreviation":"AmazonProtocolQuery",
+    "serviceFullName":"Amazon Protocol Query",
+    "serviceId":"AmazonProtocolQuery",
     "signatureVersion":"v4",
-    "targetPrefix":"ProtocolTestsService",
+    "targetPrefix":"QueryService",
     "timestampFormat":"unixTimestamp",
-    "uid":"restjson-2016-03-11"
+    "uid":"query-2016-03-11"
   },
   "operations":{
     "AllTypes":{
@@ -166,19 +166,6 @@
         "requestUri":"/2016-03-11/streamingOutputOperation"
       },
       "output":{"shape":"StructureWithStreamingMember"}
-    },
-    "EventStreamOperation": {
-      "name": "EventStreamOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/eventStreamOperation"
-      },
-      "input": {
-        "shape": "EventStreamOperationRequest"
-      },
-      "output": {
-        "shape": "EventStreamOutput"
-      }
     }
   },
   "shapes":{

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
@@ -2,16 +2,16 @@
   "version":"2.0",
   "metadata":{
     "apiVersion":"2016-03-11",
-    "endpointPrefix":"customresponsemetadata",
+    "endpointPrefix":"rest-xml",
     "jsonVersion":"1.1",
-    "protocol":"rest-json",
-    "serviceAbbreviation":"AmazonProtocolRestJson",
-    "serviceFullName":"Amazon Protocol Rest Json",
-    "serviceId":"AmazonProtocolRestJson",
+    "protocol":"rest-xml",
+    "serviceAbbreviation":"AmazonProtocolRestXml",
+    "serviceFullName":"Amazon Protocol Rest Xml",
+    "serviceId":"AmazonProtocolRestXml",
     "signatureVersion":"v4",
-    "targetPrefix":"ProtocolTestsService",
+    "targetPrefix":"RestXmlService",
     "timestampFormat":"unixTimestamp",
-    "uid":"restjson-2016-03-11"
+    "uid":"restxml-2016-03-11"
   },
   "operations":{
     "AllTypes":{
@@ -166,19 +166,6 @@
         "requestUri":"/2016-03-11/streamingOutputOperation"
       },
       "output":{"shape":"StructureWithStreamingMember"}
-    },
-    "EventStreamOperation": {
-      "name": "EventStreamOperation",
-      "http": {
-        "method": "POST",
-        "requestUri": "/2016-03-11/eventStreamOperation"
-      },
-      "input": {
-        "shape": "EventStreamOperationRequest"
-      },
-      "output": {
-        "shape": "EventStreamOutput"
-      }
     }
   },
   "shapes":{

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolquery/AsyncOperationCancelTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolquery/AsyncOperationCancelTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.protocolquery;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolquery.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocolquery.model.StreamingInputOperationResponse;
+import software.amazon.awssdk.services.protocolquery.model.StreamingOutputOperationResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test to ensure that cancelling the future returned for an async operation will cancel the future returned by the async HTTP client.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncOperationCancelTest {
+    @Mock
+    private SdkAsyncHttpClient mockHttpClient;
+
+    private ProtocolQueryAsyncClient client;
+
+    private CompletableFuture executeFuture;
+
+    @Before
+    public void setUp() {
+        client = ProtocolQueryAsyncClient.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("foo", "bar")))
+                .httpClient(mockHttpClient)
+                .build();
+
+        executeFuture = new CompletableFuture();
+        when(mockHttpClient.execute(any())).thenReturn(executeFuture);
+    }
+
+    @Test
+    public void testNonStreamingOperation() {
+        CompletableFuture<AllTypesResponse> responseFuture = client.allTypes(r -> {
+        });
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testStreamingInputOperation() {
+        CompletableFuture<StreamingInputOperationResponse> responseFuture = client.streamingInputOperation(r -> {}, AsyncRequestBody.empty());
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testStreamingOutputOperation() {
+        CompletableFuture<ResponseBytes<StreamingOutputOperationResponse>> responseFuture = client.streamingOutputOperation(r -> {
+        }, AsyncResponseTransformer.toBytes());
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    // TODO: Query code generation does not support event streaming operations
+    public void testEventStreamingOperation() {
+//        CompletableFuture<Void> responseFuture = client.eventStreamOperation(r -> {
+//                },
+//                subscriber -> {},
+//                new EventStreamOperationResponseHandler() {
+//                    @Override
+//                    public void responseReceived(EventStreamOperationResponse response) {
+//                    }
+//
+//                    @Override
+//                    public void onEventStream(SdkPublisher<EventStream> publisher) {
+//                    }
+//
+//                    @Override
+//                    public void exceptionOccurred(Throwable throwable) {
+//                    }
+//
+//                    @Override
+//                    public void complete() {
+//                    }
+//                });
+//        responseFuture.cancel(true);
+//        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestjson/AsyncOperationCancelTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.protocolrestjson;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.EventStream;
+import software.amazon.awssdk.services.protocolrestjson.model.EventStreamOperationResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.EventStreamOperationResponseHandler;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationResponse;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test to ensure that cancelling the future returned for an async operation will cancel the future returned by the async HTTP client.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncOperationCancelTest {
+    @Mock
+    private SdkAsyncHttpClient mockHttpClient;
+
+    private ProtocolRestJsonAsyncClient client;
+
+    private CompletableFuture executeFuture;
+
+    @Before
+    public void setUp() {
+        client = ProtocolRestJsonAsyncClient.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("foo", "bar")))
+                .httpClient(mockHttpClient)
+                .build();
+
+        executeFuture = new CompletableFuture();
+        when(mockHttpClient.execute(any())).thenReturn(executeFuture);
+    }
+
+    @Test
+    public void testNonStreamingOperation() {
+        CompletableFuture<AllTypesResponse> responseFuture = client.allTypes(r -> {});
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testStreamingOperation() {
+        CompletableFuture<StreamingInputOperationResponse> responseFuture = client.streamingInputOperation(r -> {}, AsyncRequestBody.empty());
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testStreamingOutputOperation() {
+        CompletableFuture<ResponseBytes<StreamingOutputOperationResponse>> responseFuture = client.streamingOutputOperation(r -> {
+        }, AsyncResponseTransformer.toBytes());
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testEventStreamingOperation() {
+        CompletableFuture<Void> responseFuture = client.eventStreamOperation(r -> {
+                },
+                subscriber -> {},
+                new EventStreamOperationResponseHandler() {
+                    @Override
+                    public void responseReceived(EventStreamOperationResponse response) {
+                    }
+
+                    @Override
+                    public void onEventStream(SdkPublisher<EventStream> publisher) {
+                    }
+
+                    @Override
+                    public void exceptionOccurred(Throwable throwable) {
+                    }
+
+                    @Override
+                    public void complete() {
+                    }
+                });
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestxml/AsyncOperationCancelTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/protocolrestxml/AsyncOperationCancelTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.protocolrestxml;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestxml.model.AllTypesResponse;
+import software.amazon.awssdk.services.protocolrestxml.model.StreamingInputOperationResponse;
+import software.amazon.awssdk.services.protocolrestxml.model.StreamingOutputOperationResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test to ensure that cancelling the future returned for an async operation will cancel the future returned by the async HTTP client.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncOperationCancelTest {
+    @Mock
+    private SdkAsyncHttpClient mockHttpClient;
+
+    private ProtocolRestXmlAsyncClient client;
+
+    private CompletableFuture executeFuture;
+
+    @Before
+    public void setUp() {
+        client = ProtocolRestXmlAsyncClient.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("foo", "bar")))
+                .httpClient(mockHttpClient)
+                .build();
+
+        executeFuture = new CompletableFuture();
+        when(mockHttpClient.execute(any())).thenReturn(executeFuture);
+    }
+
+    @Test
+    public void testNonStreamingOperation() {
+        CompletableFuture<AllTypesResponse> responseFuture = client.allTypes(r -> {
+        });
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testStreamingInputOperation() {
+        CompletableFuture<StreamingInputOperationResponse> responseFuture = client.streamingInputOperation(r -> {}, AsyncRequestBody.empty());
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    public void testStreamingOutputOperation() {
+        CompletableFuture<ResponseBytes<StreamingOutputOperationResponse>> responseFuture = client.streamingOutputOperation(r -> {
+        }, AsyncResponseTransformer.toBytes());
+        responseFuture.cancel(true);
+        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+        assertThat(executeFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    // TODO: RestXml code generation does not support event streaming operations
+    public void testEventStreamingOperation() {
+//        CompletableFuture<Void> responseFuture = client.eventStreamOperation(r -> {
+//                },
+//                subscriber -> {},
+//                new EventStreamOperationResponseHandler() {
+//                    @Override
+//                    public void responseReceived(EventStreamOperationResponse response) {
+//                    }
+//
+//                    @Override
+//                    public void onEventStream(SdkPublisher<EventStream> publisher) {
+//                    }
+//
+//                    @Override
+//                    public void exceptionOccurred(Throwable throwable) {
+//                    }
+//
+//                    @Override
+//                    public void complete() {
+//                    }
+//                });
+//        responseFuture.cancel(true);
+//        assertThat(executeFuture.isCompletedExceptionally()).isTrue();
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
@@ -60,4 +60,21 @@ public final class CompletableFutureUtils {
         }
         return new CompletionException(t);
     }
+
+    /**
+     * Forward the {@code Throwable} from {@code src} to {@code dst}.
+
+     * @param src The source of the {@code Throwable}.
+     * @param dst The destination where the {@code Throwable} will be forwarded to.
+     *
+     * @return {@code src}.
+     */
+    public static <T> CompletableFuture<T> forwardExceptionTo(CompletableFuture<T> src, CompletableFuture<?> dst) {
+        src.whenComplete((r, e) -> {
+            if (e != null) {
+                dst.completeExceptionally(e);
+            }
+        });
+        return src;
+    }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/CompletableFutureUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/CompletableFutureUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class CompletableFutureUtilsTest {
+
+    @Test(timeout = 1000)
+    public void testForwardException() {
+        CompletableFuture src = new CompletableFuture();
+        CompletableFuture dst = new CompletableFuture();
+
+        Exception e = new RuntimeException("BOOM");
+
+        CompletableFutureUtils.forwardExceptionTo(src, dst);
+
+        src.completeExceptionally(e);
+
+        try {
+            dst.join();
+            fail();
+        } catch (Throwable t) {
+            assertThat(t.getCause()).isEqualTo(e);
+        }
+    }
+}


### PR DESCRIPTION
 <!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Correctly pass along the cancelled signal down to the async client if the
   future returned for an async operation is cancelled.

 - Don't wait for acquire to finish to cancel; instead fail the promise if not
   complete yet

   CancellableAcquireChannelPool added to take care of closing and releasing a
   cancelled acquire.

## Motivation and Context
Bug fix.

## Testing
Added/updated tests in `codegen`, `codegen-generated-classes-test`, and `netty-nio-client`.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
