### PR TITLE
S3: Add getUrl method

### DIFF
--- a/.changes/next-release/feature-AmazonS3-f2cd9dd.json
+++ b/.changes/next-release/feature-AmazonS3-f2cd9dd.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "feature", 
+    "description": "Add support for getUrl operation. The API can be used to generate a URL that represents an object in Amazon S3. The url can be used to download the object content if the object has public read permissions."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -154,6 +154,11 @@ public class CustomizationConfig {
      */
     private Map<String, String> paginationCustomization;
 
+    /**
+     * Config to generate methods in the low-level client that delegate to a hand-written client
+     */
+    private EnhancementClientConfig enhancementClientConfig;
+
     private CustomizationConfig() {
     }
 
@@ -392,5 +397,13 @@ public class CustomizationConfig {
 
     public void setPaginationCustomization(Map<String, String> paginationCustomization) {
         this.paginationCustomization = paginationCustomization;
+    }
+
+    public EnhancementClientConfig getEnhancementClientConfig() {
+        return enhancementClientConfig;
+    }
+
+    public void setEnhancementClientConfig(EnhancementClientConfig enhancementClientConfig) {
+        this.enhancementClientConfig = enhancementClientConfig;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/EnhancementClientConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/EnhancementClientConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+import java.util.List;
+
+/**
+ * Configuration to generate methods in the low-level client that delegate to a hand-written client.
+ * Includes config to generate both sync and async methods
+ */
+public class EnhancementClientConfig {
+    /** Fqcn of the sync enhanced client interface */
+    private String syncClientInterface;
+
+    /** Fqcn of the sync enhanced client implementation */
+    private String syncClientImpl;
+
+    /** Fqcn of the sync enhanced client interface */
+    private String asyncClientInterface;
+
+    /** Fqcn of the sync enhanced client implementation */
+    private String asyncClientImpl;
+
+    /** Config to generate the custom methods in low-level client */
+    private List<EnhancementMethod> enhancementMethods;
+
+    public String getSyncClientInterface() {
+        return syncClientInterface;
+    }
+
+    public void setSyncClientInterface(String syncClientInterface) {
+        this.syncClientInterface = syncClientInterface;
+    }
+
+    public String getSyncClientImpl() {
+        return syncClientImpl;
+    }
+
+    public void setSyncClientImpl(String syncClientImpl) {
+        this.syncClientImpl = syncClientImpl;
+    }
+
+    public String getAsyncClientInterface() {
+        return asyncClientInterface;
+    }
+
+    public void setAsyncClientInterface(String asyncClientInterface) {
+        this.asyncClientInterface = asyncClientInterface;
+    }
+
+    public String getAsyncClientImpl() {
+        return asyncClientImpl;
+    }
+
+    public void setAsyncClientImpl(String asyncClientImpl) {
+        this.asyncClientImpl = asyncClientImpl;
+    }
+
+    public List<EnhancementMethod> getEnhancementMethods() {
+        return enhancementMethods;
+    }
+
+    public void setEnhancementMethods(List<EnhancementMethod> enhancementMethods) {
+        this.enhancementMethods = enhancementMethods;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/EnhancementMethod.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/EnhancementMethod.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+import java.util.List;
+
+/**
+ * Config required to generate a method that delegates to a hand-written client
+ */
+public class EnhancementMethod {
+    /** Name of the operation */
+    private String name;
+
+    /** Fqcn of the return type of the operation */
+    private String returnType;
+
+    /** List of parameters of the operation */
+    private List<EnhancementMethodParam> parameters;
+
+    /** List of exceptions that are thrown by the operation */
+    private List<String> exceptions;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getReturnType() {
+        return returnType;
+    }
+
+    public void setReturnType(String returnType) {
+        this.returnType = returnType;
+    }
+
+    public List<EnhancementMethodParam> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<EnhancementMethodParam> parameters) {
+        this.parameters = parameters;
+    }
+
+    public List<String> getExceptions() {
+        return exceptions;
+    }
+
+    public void setExceptions(List<String> exceptions) {
+        this.exceptions = exceptions;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/EnhancementMethodParam.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/EnhancementMethodParam.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+public class EnhancementMethodParam {
+    /** Name of the input parameter */
+    private String name;
+
+    /** Fqcn of the input parameter */
+    private String type;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -78,6 +78,12 @@ public class AsyncClientInterface implements ClassSpec {
                                  .initializer("$S", model.getMetadata().getSigningName())
                                  .build());
 
+        if (model.getCustomizationConfig().getEnhancementClientConfig() != null) {
+            result.addSuperinterface(PoetUtils.classNameFromFqcn(model.getCustomizationConfig()
+                                                                      .getEnhancementClientConfig()
+                                                                      .getAsyncClientInterface()));
+        }
+
         PoetUtils.addJavadoc(result::addJavadoc, getJavadoc());
 
         if (!model.getCustomizationConfig().isExcludeClientCreateMethod()) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/EnhancementClientUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/EnhancementClientUtils.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.client;
+
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.codegen.model.config.customization.EnhancementClientConfig;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * Utils to generate the custom methods in the low-level client that delegate to a
+ * enhanced (hand-written) client.
+ */
+final class EnhancementClientUtils {
+    static final String ENHANCEMENT_CLIENT = "enhancementClient";
+
+    private EnhancementClientUtils() {
+    }
+
+    /**
+     * @return Field spec to declare the enhancement client
+     */
+    static FieldSpec classFieldSpec(String interfaceName) {
+        return FieldSpec.builder(PoetUtils.classNameFromFqcn(interfaceName), ENHANCEMENT_CLIENT, PRIVATE, FINAL)
+                        .build();
+    }
+
+    /**
+     * Initializes the enhancement client in the given {@link MethodSpec}.
+     */
+    static void initializeClientMember(MethodSpec.Builder builder, String classImplName, String protocolFactory) {
+        builder.addStatement("this.$1N = $2T.builder().protocolFactory($3N)"
+                             + ".sdkClientConfiguration(clientConfiguration).build()",
+                             ENHANCEMENT_CLIENT,
+                             PoetUtils.classNameFromFqcn(classImplName),
+                             protocolFactory);
+    }
+
+    /**
+     * Returns the list of {@link MethodSpec}s to generate the custom operations in sync client.
+     * All these operations delegate to the respective method in the enhancement client.
+     */
+    static List<MethodSpec> syncEnhancementMethods(EnhancementClientConfig enhancementClientConfig) {
+        return enhancementMethods(enhancementClientConfig, returnType -> PoetUtils.classNameFromFqcn(returnType));
+    }
+
+    /**
+     * Returns the list of {@link MethodSpec}s to generate the custom operations in async client.
+     * All these operations delegate to the respective method in the enhancement client.
+     */
+    static List<MethodSpec> asyncEnhancementMethods(EnhancementClientConfig enhancementClientConfig) {
+        return enhancementMethods(enhancementClientConfig, returnType -> ParameterizedTypeName.get(
+            ClassName.get(CompletableFuture.class), PoetUtils.classNameFromFqcn(returnType)));
+    }
+
+    private static List<MethodSpec> enhancementMethods(EnhancementClientConfig enhancementClientConfig,
+                                                       Function<String, TypeName> methodReturnType) {
+        if (enhancementClientConfig == null || enhancementClientConfig.getEnhancementMethods() == null) {
+            return new ArrayList<>();
+        }
+
+        return enhancementClientConfig.getEnhancementMethods()
+                                      .stream()
+                                      .map(config -> {
+                                          MethodSpec.Builder builder = MethodSpec.methodBuilder(config.getName())
+                                                                                 .addAnnotation(Override.class)
+                                                                                 .addModifiers(Modifier.PUBLIC)
+                                                                                 .returns(methodReturnType.apply(
+                                                                                     config.getReturnType()));
+
+                                          builder.addExceptions(config.getExceptions().stream()
+                                                                      .map(e -> PoetUtils.classNameFromFqcn(e))
+                                                                      .collect(Collectors.toList()));
+
+                                          config.getParameters()
+                                                .forEach(p -> builder.addParameter(PoetUtils.classNameFromFqcn(p.getType()),
+                                                                                   p.getName()));
+
+                                          builder.addStatement("return $1L.$2L($3L)",
+                                                               ENHANCEMENT_CLIENT,
+                                                               StringUtils.uncapitalize(config.getName()),
+                                                               config.getParameters().stream()
+                                                                     .map(p -> p.getName())
+                                                                     .collect(Collectors.joining(",")));
+
+                                          return builder.build();
+                                      })
+                                      .collect(Collectors.toList());
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -75,6 +75,12 @@ public final class SyncClientInterface implements ClassSpec {
                                  .initializer("$S", model.getMetadata().getSigningName())
                                  .build());
 
+        if (model.getCustomizationConfig().getEnhancementClientConfig() != null) {
+            result.addSuperinterface(PoetUtils.classNameFromFqcn(model.getCustomizationConfig()
+                                                                      .getEnhancementClientConfig()
+                                                                      .getSyncClientInterface()));
+        }
+
         PoetUtils.addJavadoc(result::addJavadoc, getJavadoc());
 
         if (!model.getCustomizationConfig().isExcludeClientCreateMethod()) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -8,5 +8,31 @@
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [
         "eventStreamOperation"
-    ]
+    ],
+    "enhancementClientConfig": {
+        "syncClientInterface": "software.amazon.awssdk.services.json.EnhancementClient",
+        "syncClientImpl": "software.amazon.awssdk.services.json.DefaultEnhancementClient",
+        "asyncClientInterface": "software.amazon.awssdk.services.json.AsyncEnhancementClient",
+        "asyncClientImpl": "software.amazon.awssdk.services.json.DefaultAsyncEnhancementClient",
+        "enhancementMethods": [
+          {
+            "name": "customOperation",
+            "returnType": "software.amazon.awssdk.services.json.customOperationResponse",
+            "parameters": [
+              {
+                "type": "software.amazon.awssdk.services.json.RequestParamOne",
+                "name": "param1"
+              },
+              {
+                "type": "software.amazon.awssdk.services.json.RequestParamTwo",
+                "name": "param2"
+              }
+            ],
+            "exceptions": [
+              "software.amazon.awssdk.awscore.exception.AwsServiceException",
+              "java.net.MalformedURLException"
+            ]
+          }
+        ]
+    }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -2,6 +2,7 @@ package software.amazon.awssdk.services.json;
 
 import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
+import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -108,11 +109,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private final Executor executor;
 
+    private final AsyncEnhancementClient enhancementClient;
+
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
         this.clientConfiguration = clientConfiguration;
         this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
         this.executor = clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
+        this.enhancementClient = DefaultAsyncEnhancementClient.builder().protocolFactory(protocolFactory)
+                                                              .sdkClientConfiguration(clientConfiguration).build();
     }
 
     @Override
@@ -809,6 +814,12 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     () -> asyncResponseTransformer.exceptionOccurred(t));
             return CompletableFutureUtils.failedFuture(t);
         }
+    }
+
+    @Override
+    public CompletableFuture<customOperationResponse> customOperation(RequestParamOne param1, RequestParamTwo param2)
+        throws AwsServiceException, MalformedURLException {
+        return enhancementClient.customOperation(param1, param2);
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithout
  * A service that is implemented using the query protocol
  */
 @Generated("software.amazon.awssdk:codegen")
-public interface JsonAsyncClient extends SdkClient {
+public interface JsonAsyncClient extends SdkClient, AsyncEnhancementClient {
     String SERVICE_NAME = "json-service";
 
     /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -1,5 +1,6 @@
 package software.amazon.awssdk.services.json;
 
+import java.net.MalformedURLException;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -68,10 +69,14 @@ final class DefaultJsonClient implements JsonClient {
 
     private final SdkClientConfiguration clientConfiguration;
 
+    private final EnhancementClient enhancementClient;
+
     protected DefaultJsonClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
         this.clientConfiguration = clientConfiguration;
         this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+        this.enhancementClient = DefaultEnhancementClient.builder().protocolFactory(protocolFactory)
+                                                         .sdkClientConfiguration(clientConfiguration).build();
     }
 
     @Override
@@ -581,6 +586,12 @@ final class DefaultJsonClient implements JsonClient {
                 .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                 .withInput(streamingOutputOperationRequest)
                 .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
+    }
+
+    @Override
+    public customOperationResponse customOperation(RequestParamOne param1, RequestParamTwo param2) throws AwsServiceException,
+                                                                                                          MalformedURLException {
+        return enhancementClient.customOperation(param1, param2);
     }
 
     private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithout
  * A service that is implemented using the query protocol
  */
 @Generated("software.amazon.awssdk:codegen")
-public interface JsonClient extends SdkClient {
+public interface JsonClient extends SdkClient, EnhancementClient {
     String SERVICE_NAME = "json-service";
 
     /**

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/DefaultS3EnhancementAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/DefaultS3EnhancementAsyncClient.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlResponse;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+
+/**
+ * Implementation of {@link S3EnhancementAsyncClient}.
+ * These APIs are exposed through {@link S3AsyncClient} and {@link DefaultS3AsyncClient}.
+ */
+@SdkInternalApi
+final class DefaultS3EnhancementAsyncClient implements S3EnhancementAsyncClient {
+
+    private final S3EnhancementClient syncClient;
+
+    DefaultS3EnhancementAsyncClient(BuilderImpl builder) {
+        this.syncClient = DefaultS3EnhancementClient.builder()
+                                                    .protocolFactory(builder.protocolFactory)
+                                                    .sdkClientConfiguration(builder.clientConfiguration)
+                                                    .build();
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link S3EnhancementAsyncClient}.
+     */
+    static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public CompletableFuture<GetUrlResponse> getUrl(GetUrlRequest getUrlRequest) throws MalformedURLException {
+        try {
+            GetUrlResponse response = syncClient.getUrl(getUrlRequest);
+
+            CompletableFuture<GetUrlResponse> future = new CompletableFuture<>();
+            future.complete(response);
+            return future;
+        } catch (Throwable t) {
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    public interface Builder {
+        Builder protocolFactory(AwsS3ProtocolFactory protocolFactory);
+
+        Builder sdkClientConfiguration(SdkClientConfiguration clientConfiguration);
+
+        DefaultS3EnhancementAsyncClient build();
+    }
+
+    private static final class BuilderImpl implements Builder {
+        private AwsS3ProtocolFactory protocolFactory;
+        private SdkClientConfiguration clientConfiguration;
+
+        @Override
+        public Builder protocolFactory(AwsS3ProtocolFactory protocolFactory) {
+            this.protocolFactory = protocolFactory;
+            return this;
+        }
+
+        @Override
+        public Builder sdkClientConfiguration(SdkClientConfiguration clientConfiguration) {
+            this.clientConfiguration = clientConfiguration;
+            return this;
+        }
+
+        @Override
+        public DefaultS3EnhancementAsyncClient build() {
+            return new DefaultS3EnhancementAsyncClient(this);
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/DefaultS3EnhancementClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/DefaultS3EnhancementClient.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import java.net.MalformedURLException;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory;
+import software.amazon.awssdk.services.s3.internal.handlers.EndpointAddressInterceptor;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlResponse;
+import software.amazon.awssdk.services.s3.transform.GetUrlRequestMarshaller;
+
+/**
+ * Implementation of {@link S3EnhancementClient}.
+ * These APIs are exposed through {@link S3Client} and {@link DefaultS3Client}.
+ */
+@SdkInternalApi
+final class DefaultS3EnhancementClient implements S3EnhancementClient {
+
+    private final AwsS3ProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    private DefaultS3EnhancementClient(BuilderImpl builder) {
+        this.protocolFactory = builder.protocolFactory;
+        this.clientConfiguration = builder.clientConfiguration;
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link S3EnhancementClient}.
+     */
+    static DefaultS3EnhancementClient.Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public GetUrlResponse getUrl(GetUrlRequest getUrlRequest) throws MalformedURLException {
+        SdkHttpFullRequest marshalledRequest = new GetUrlRequestMarshaller(protocolFactory)
+            .marshall(getUrlRequest);
+
+        SdkHttpRequest requestAfterInterceptor = applyEndpointInterceptor(marshalledRequest, getUrlRequest);
+
+        return GetUrlResponse.builder()
+                             .url(requestAfterInterceptor.getUri().toURL())
+                             .build();
+    }
+
+    private SdkHttpRequest applyEndpointInterceptor(SdkHttpFullRequest httpFullRequest, GetUrlRequest getUrlRequest) {
+        ExecutionAttributes executionAttributes = new ExecutionAttributes();
+        executionAttributes.putAttribute(AwsSignerExecutionAttribute.SERVICE_CONFIG,
+                                         clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION));
+        executionAttributes.putAttribute(AwsExecutionAttribute.AWS_REGION,
+                                         clientConfiguration.option(AwsClientOption.AWS_REGION));
+
+        EndpointAddressInterceptor interceptor = new EndpointAddressInterceptor();
+        return interceptor.modifyHttpRequest(constructModifyHttpRequest(httpFullRequest, getUrlRequest),
+                                             executionAttributes);
+    }
+
+    private static Context.ModifyHttpRequest constructModifyHttpRequest(SdkHttpFullRequest httpFullRequest,
+                                                                        GetUrlRequest getUrlRequest) {
+        return new Context.ModifyHttpRequest() {
+            @Override
+            public SdkHttpRequest httpRequest() {
+                return httpFullRequest;
+            }
+
+            @Override
+            public Optional<RequestBody> requestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<AsyncRequestBody> asyncRequestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public SdkRequest request() {
+                return getUrlRequest;
+            }
+        };
+    }
+
+    public interface Builder {
+        Builder protocolFactory(AwsS3ProtocolFactory protocolFactory);
+
+        Builder sdkClientConfiguration(SdkClientConfiguration clientConfiguration);
+
+        DefaultS3EnhancementClient build();
+    }
+
+    private static final class BuilderImpl implements Builder {
+        private AwsS3ProtocolFactory protocolFactory;
+        private SdkClientConfiguration clientConfiguration;
+
+        @Override
+        public Builder protocolFactory(AwsS3ProtocolFactory protocolFactory) {
+            this.protocolFactory = protocolFactory;
+            return this;
+        }
+
+        @Override
+        public Builder sdkClientConfiguration(SdkClientConfiguration clientConfiguration) {
+            this.clientConfiguration = clientConfiguration;
+            return this;
+        }
+
+        @Override
+        public DefaultS3EnhancementClient build() {
+            return new DefaultS3EnhancementClient(this);
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3EnhancementAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3EnhancementAsyncClient.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlResponse;
+
+/**
+ * S3 client that has custom operations not included in service model.
+ * This interface should not be used directly. Please use {@link S3AsyncClient} instead.
+ */
+@SdkProtectedApi
+interface S3EnhancementAsyncClient {
+
+    /**
+     * Returns a response with the URL for an object stored in Amazon S3.
+     *
+     * If the object identified by the given bucket and key has public read permissions,
+     * then this URL can be directly accessed to retrieve the object's data.
+     *
+     * @param getUrlRequest request to construct url
+     * @return A Java Future containing the response of the operation
+     * @throws MalformedURLException Generated Url is malformed
+     */
+    default CompletableFuture<GetUrlResponse> getUrl(GetUrlRequest getUrlRequest) throws MalformedURLException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3EnhancementClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3EnhancementClient.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import java.net.MalformedURLException;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlResponse;
+
+/**
+ * S3 client that has custom operations not included in service model.
+ * This interface should not be used directly. Please use {@link S3Client} instead.
+ */
+@SdkProtectedApi
+interface S3EnhancementClient {
+
+    /**
+     * Returns a response with the URL for an object stored in Amazon S3.
+     *
+     * If the object identified by the given bucket and key has public read permissions,
+     * then this URL can be directly accessed to retrieve the object's data.
+     *
+     * @param getUrlRequest request to construct url
+     * @return response containing the URL for an object stored in Amazon S3.
+     * @throws MalformedURLException Generated Url is malformed
+     */
+    default GetUrlResponse getUrl(GetUrlRequest getUrlRequest) throws MalformedURLException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/model/GetUrlRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/model/GetUrlRequest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * Request to generate a URL representing an object in Amazon S3.
+ *
+ * If the object identified by the given bucket and key has public read permissions,
+ * then this URL can be directly accessed to retrieve the object's data.
+ */
+@SdkPublicApi
+public final class GetUrlRequest extends S3Request implements ToCopyableBuilder<GetUrlRequest.Builder, GetUrlRequest> {
+    private static final SdkField<String> BUCKET_FIELD = SdkField
+        .<String>builder(MarshallingType.STRING)
+        .getter(getter(GetUrlRequest::bucket))
+        .setter(setter(Builder::bucket))
+        .traits(LocationTrait.builder().location(MarshallLocation.PATH).locationName("Bucket")
+                             .unmarshallLocationName("Bucket").build()).build();
+
+    private static final SdkField<String> KEY_FIELD = SdkField
+        .<String>builder(MarshallingType.STRING)
+        .getter(getter(GetUrlRequest::key))
+        .setter(setter(Builder::key))
+        .traits(LocationTrait.builder().location(MarshallLocation.GREEDY_PATH).locationName("Key")
+                             .unmarshallLocationName("Key").build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(BUCKET_FIELD, KEY_FIELD));
+
+    private final String bucket;
+
+    private final String key;
+
+    private GetUrlRequest(BuilderImpl builder) {
+        super(builder);
+        this.bucket = builder.bucket;
+        this.key = builder.key;
+    }
+
+    /**
+     * Returns the value of the Bucket property for this object.
+     *
+     * @return The value of the Bucket property for this object.
+     */
+    public String bucket() {
+        return bucket;
+    }
+
+    /**
+     * Returns the value of the Key property for this object.
+     *
+     * @return The value of the Key property for this object.
+     */
+    public String key() {
+        return key;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(bucket());
+        hashCode = 31 * hashCode + Objects.hashCode(key());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof GetUrlRequest)) {
+            return false;
+        }
+        GetUrlRequest other = (GetUrlRequest) obj;
+        return Objects.equals(bucket(), other.bucket()) && Objects.equals(key(), other.key());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("GetUrlRequest").add("Bucket", bucket()).add("Key", key()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Bucket":
+                return Optional.ofNullable(clazz.cast(bucket()));
+            case "Key":
+                return Optional.ofNullable(clazz.cast(key()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<GetUrlRequest, T> g) {
+        return obj -> g.apply((GetUrlRequest) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    public interface Builder extends S3Request.Builder, SdkPojo, CopyableBuilder<Builder, GetUrlRequest> {
+        /**
+         * Sets the value of the Bucket property for this object.
+         *
+         * @param bucket
+         *        The new value for the Bucket property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder bucket(String bucket);
+
+        /**
+         * Sets the value of the Key property for this object.
+         *
+         * @param key
+         *        The new value for the Key property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder key(String key);
+
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends S3Request.BuilderImpl implements Builder {
+        private String bucket;
+
+        private String key;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(GetUrlRequest model) {
+            super(model);
+            bucket(model.bucket);
+            key(model.key);
+        }
+
+        public String getBucket() {
+            return bucket;
+        }
+
+        @Override
+        public Builder bucket(String bucket) {
+            this.bucket = bucket;
+            return this;
+        }
+
+        public void setBucket(String bucket) {
+            this.bucket = bucket;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public Builder key(String key) {
+            this.key = key;
+            return this;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public GetUrlRequest build() {
+            return new GetUrlRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/model/GetUrlResponse.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/model/GetUrlResponse.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import java.net.URL;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * Class containing a URL representing an object in Amazon S3.
+ *
+ * If the object identified by the given bucket and key has public read permissions,
+ * then this URL can be directly accessed to retrieve the object's data.
+ */
+@SdkPublicApi
+public final class GetUrlResponse implements ToCopyableBuilder<GetUrlResponse.Builder, GetUrlResponse> {
+
+    private final URL url;
+
+    private GetUrlResponse(BuilderImpl builder) {
+        this.url = builder.url;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof GetUrlResponse)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("GetUrlResponse").build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    public interface Builder extends CopyableBuilder<Builder, GetUrlResponse> {
+        Builder url(URL url);
+    }
+
+    private static final class BuilderImpl implements Builder {
+        private URL url;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(GetUrlResponse response) {
+            url(response.url);
+        }
+
+        @Override
+        public GetUrlResponse build() {
+            return new GetUrlResponse(this);
+        }
+
+        @Override
+        public Builder url(URL url) {
+            this.url = url;
+            return this;
+        }
+
+        public URL getUrl() {
+            return url;
+        }
+
+        public void setUrl(URL url) {
+            this.url = url;
+        }
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/GetUrlRequestMarshaller.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/transform/GetUrlRequestMarshaller.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.transform;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.protocols.core.OperationInfo;
+import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
+import software.amazon.awssdk.protocols.xml.AwsXmlProtocolFactory;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * {@link GetUrlRequest} Marshaller
+ */
+@SdkInternalApi
+public class GetUrlRequestMarshaller implements Marshaller<GetUrlRequest> {
+    private static final OperationInfo SDK_OPERATION_BINDING =
+        OperationInfo.builder().requestUri("/{Bucket}/{Key+}")
+                     .httpMethod(SdkHttpMethod.HEAD).hasExplicitPayloadMember(false).hasPayloadMembers(false)
+                     .putAdditionalMetadata(AwsXmlProtocolFactory.ROOT_MARSHALL_LOCATION_ATTRIBUTE, null)
+                     .putAdditionalMetadata(AwsXmlProtocolFactory.XML_NAMESPACE_ATTRIBUTE, null).build();
+
+    private final AwsXmlProtocolFactory protocolFactory;
+
+    public GetUrlRequestMarshaller(AwsXmlProtocolFactory protocolFactory) {
+        this.protocolFactory = protocolFactory;
+    }
+
+    @Override
+    public SdkHttpFullRequest marshall(GetUrlRequest getUrlRequest) {
+        Validate.paramNotNull(getUrlRequest, "getUrlRequest");
+        try {
+            ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
+                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+            return protocolMarshaller.marshall(getUrlRequest);
+        } catch (Exception e) {
+            throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
+        }
+    }
+}

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -51,5 +51,26 @@
     "GetBucketNotification",
     "PutBucketLifecycle",
     "PutBucketNotification"
-  ]
+  ],
+  "enhancementClientConfig": {
+    "syncClientInterface": "software.amazon.awssdk.services.s3.S3EnhancementClient",
+    "syncClientImpl": "software.amazon.awssdk.services.s3.DefaultS3EnhancementClient",
+    "asyncClientInterface": "software.amazon.awssdk.services.s3.S3EnhancementAsyncClient",
+    "asyncClientImpl": "software.amazon.awssdk.services.s3.DefaultS3EnhancementAsyncClient",
+    "enhancementMethods": [
+      {
+        "name": "getUrl",
+        "returnType": "software.amazon.awssdk.services.s3.model.GetUrlResponse",
+        "parameters": [
+          {
+            "type": "software.amazon.awssdk.services.s3.model.GetUrlRequest",
+            "name": "getUrlRequest"
+          }
+        ],
+        "exceptions": [
+          "java.net.MalformedURLException"
+        ]
+      }
+    ]
+  }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3EnhancementClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3EnhancementClientTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+
+public class S3EnhancementClientTest {
+
+    private static final URI US_EAST_1_URI = URI.create("https://s3.amazonaws.com");
+    private static final URI US_WEST_2_URI = URI.create( "https://s3.us-west-2.amazonaws.com");
+
+    private static S3Configuration DEFAULT_CONFIG = S3Configuration.builder().build();
+    private static S3Configuration PATH_STYLE_CONFIG = S3Configuration.builder()
+                                                                   .pathStyleAccessEnabled(true)
+                                                                   .build();
+
+    private static S3EnhancementClient client;
+    private static S3EnhancementClient pathStyleClient;
+    private static S3EnhancementClient usEastClient;
+
+    @BeforeClass
+    public static void setup() {
+        client = defaultClient();
+        pathStyleClient = defaultPathStyleClient();
+        usEastClient = usEastOneClient();
+    }
+
+    @Test
+    public void keyWithoutSpaces() throws MalformedURLException {
+        URL url = client.getUrl(requestWithoutSpaces())
+                        .getUrl();
+
+        assertThat(url.toExternalForm()).isEqualTo("https://foo-bucket.s3.us-west-2.amazonaws.com/key-without-spaces");
+    }
+
+    @Test
+    public void keyWithSpecialCharacters() throws MalformedURLException {
+        URL url = client.getUrl(requestWithSpecialCharacters())
+                        .getUrl();
+
+        assertThat(url.toExternalForm()).isEqualTo("https://foo-bucket.s3.us-west-2.amazonaws.com/key%20with%40spaces");
+    }
+
+    @Test
+    public void keyWithoutSpaces_pathStyleAccess() throws MalformedURLException {
+        URL url = pathStyleClient.getUrl(requestWithoutSpaces())
+                        .getUrl();
+
+        assertThat(url.toExternalForm()).isEqualTo("https://s3.us-west-2.amazonaws.com/foo-bucket/key-without-spaces");
+    }
+
+    @Test
+    public void keyWithSpecialCharacters_pathStyleAccess() throws MalformedURLException {
+        URL url = pathStyleClient.getUrl(requestWithSpecialCharacters())
+                                 .getUrl();
+
+        assertThat(url.toExternalForm()).isEqualTo("https://s3.us-west-2.amazonaws.com/foo-bucket/key%20with%40spaces");
+    }
+
+    @Test
+    public void keyWithoutSpaces_usEastClient() throws MalformedURLException {
+        URL url = usEastClient.getUrl(requestWithoutSpaces())
+                              .getUrl();
+
+        assertThat(url.toExternalForm()).isEqualTo("https://foo-bucket.s3.amazonaws.com/key-without-spaces");
+    }
+
+    @Test
+    public void keyWithSpecialCharacters_usEastClient() throws MalformedURLException {
+        URL url = usEastClient.getUrl(requestWithSpecialCharacters())
+                              .getUrl();
+
+        assertThat(url.toExternalForm()).isEqualTo("https://foo-bucket.s3.amazonaws.com/key%20with%40spaces");
+    }
+
+    private static GetUrlRequest requestWithoutSpaces() {
+        return GetUrlRequest.builder()
+                            .bucket("foo-bucket")
+                            .key("key-without-spaces")
+                            .build();
+    }
+
+    private static GetUrlRequest requestWithSpecialCharacters() {
+        return GetUrlRequest.builder()
+                            .bucket("foo-bucket")
+                            .key("key with@spaces")
+                            .build();
+    }
+
+    private static S3EnhancementClient defaultClient() {
+        SdkClientConfiguration sdkClientConfiguration = clientConfig(DEFAULT_CONFIG,
+                                                                     US_WEST_2_URI);
+        return DefaultS3EnhancementClient.builder()
+                                         .protocolFactory(initProtocolFactory(sdkClientConfiguration))
+                                         .sdkClientConfiguration(sdkClientConfiguration)
+                                         .build();
+    }
+
+    private static S3EnhancementClient defaultPathStyleClient() {
+        SdkClientConfiguration sdkClientConfiguration = clientConfig(PATH_STYLE_CONFIG,
+                                                                     US_WEST_2_URI);
+        return DefaultS3EnhancementClient.builder()
+                                         .protocolFactory(initProtocolFactory(sdkClientConfiguration))
+                                         .sdkClientConfiguration(sdkClientConfiguration)
+                                         .build();
+    }
+
+    private static S3EnhancementClient usEastOneClient() {
+        SdkClientConfiguration sdkClientConfiguration = clientConfig(DEFAULT_CONFIG,
+                                                                     US_EAST_1_URI);
+        return DefaultS3EnhancementClient.builder()
+                                         .protocolFactory(initProtocolFactory(sdkClientConfiguration))
+                                         .sdkClientConfiguration(sdkClientConfiguration)
+                                         .build();
+    }
+
+    private static SdkClientConfiguration clientConfig(S3Configuration s3Configuration,
+                                                       URI endpoint) {
+        return SdkClientConfiguration.builder()
+                                     .option(SdkClientOption.SERVICE_CONFIGURATION, s3Configuration)
+                                     .option(SdkClientOption.ENDPOINT, endpoint)
+                                     .build();
+    }
+
+    private static AwsS3ProtocolFactory initProtocolFactory(SdkClientConfiguration sdkClientConfiguration) {
+        return AwsS3ProtocolFactory.builder()
+                                   .clientConfiguration(sdkClientConfiguration)
+                                   .build();
+    }
+}


### PR DESCRIPTION
* Add getUrl method similar to [v1 method](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3.java#L5558)
* Introduces a new internal hand-written (enhancement) client with the getUrl method
* Low-level client exposes the APIs and delegates them to the enhancement client
* Added unit tests