### PR TITLE
Fix the bug where channel is not being released back to the pool when…

### DIFF
--- a/.changes/next-release/bugfix-NettyNioHttpClient-ed05f35.json
+++ b/.changes/next-release/bugfix-NettyNioHttpClient-ed05f35.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty Nio Http Client", 
+    "type": "bugfix", 
+    "description": "Fix a bug where the channel fails to be released if there is an exception thrown."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -312,7 +312,8 @@ public final class NettyRequestExecutor {
      */
     private void closeAndRelease(Channel channel) {
         log.trace("closing and releasing channel {}", channel.id().asLongText());
-        channel.close().addListener(ignored -> context.channelPool().release(channel));
+        channel.close();
+        context.channelPool().release(channel);
     }
 
     /**

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -165,7 +165,8 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
     private static void closeAndRelease(ChannelHandlerContext ctx) {
         Channel channel = ctx.channel();
         RequestContext requestContext = channel.attr(REQUEST_CONTEXT_KEY).get();
-        channel.close().addListener(i -> requestContext.channelPool().release(channel));
+        ctx.close();
+        requestContext.channelPool().release(channel);
     }
 
     /**

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -41,14 +41,17 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.AttributeKey;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.URI;
@@ -223,6 +226,110 @@ public class NettyNioAsyncHttpClientWireMockTest {
         assertThat(eventLoopGroup.eventLoopGroup().isTerminated()).isTrue();
         assertThat(sdkChannelPoolMap).isEmpty();
         Mockito.verify(channelPool).close();
+    }
+
+    @Test
+    public void responseConnectionReused_shouldReleaseChannel() throws Exception {
+
+        ChannelFactory channelFactory = mock(ChannelFactory.class);
+        EventLoopGroup customEventLoopGroup = new NioEventLoopGroup(1);
+        NioSocketChannel channel = new NioSocketChannel();
+
+        when(channelFactory.newChannel()).thenAnswer((Answer<NioSocketChannel>) invocationOnMock -> channel);
+        SdkEventLoopGroup eventLoopGroup = SdkEventLoopGroup.create(customEventLoopGroup, channelFactory);
+
+        NettyNioAsyncHttpClient customClient =
+            (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                             .eventLoopGroup(eventLoopGroup)
+                                                             .maxConcurrency(1)
+                                                             .build();
+
+        makeSimpleRequest(customClient);
+        verifyChannelRelease(channel);
+        assertThat(channel.isShutdown()).isFalse();
+
+        customClient.close();
+        eventLoopGroup.eventLoopGroup().shutdownGracefully().awaitUninterruptibly();
+    }
+
+    @Test
+    public void connectionInactive_shouldReleaseChannel() throws Exception {
+
+        ChannelFactory channelFactory = mock(ChannelFactory.class);
+        EventLoopGroup customEventLoopGroup = new NioEventLoopGroup(1);
+        NioSocketChannel channel = new NioSocketChannel();
+
+        when(channelFactory.newChannel()).thenAnswer((Answer<NioSocketChannel>) invocationOnMock -> channel);
+        SdkEventLoopGroup eventLoopGroup = SdkEventLoopGroup.create(customEventLoopGroup, channelFactory);
+
+        NettyNioAsyncHttpClient customClient =
+            (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                             .eventLoopGroup(eventLoopGroup)
+                                                             .maxConcurrency(1)
+                                                             .build();
+
+
+        String body = randomAlphabetic(10);
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body)
+                                                               .withStatus(500)
+                                                               .withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+
+        customClient.execute(AsyncExecuteRequest.builder()
+                                                .request(request)
+                                                .requestContentPublisher(createProvider(""))
+                                                .responseHandler(recorder).build());
+
+        verifyChannelRelease(channel);
+        assertThat(channel.isShutdown()).isTrue();
+
+        customClient.close();
+        eventLoopGroup.eventLoopGroup().shutdownGracefully().awaitUninterruptibly();
+    }
+
+    @Test
+    public void responseConnectionClosed_shouldCloseAndReleaseChannel() throws Exception {
+
+        ChannelFactory channelFactory = mock(ChannelFactory.class);
+        EventLoopGroup customEventLoopGroup = new NioEventLoopGroup(1);
+        NioSocketChannel channel = new NioSocketChannel();
+
+        when(channelFactory.newChannel()).thenAnswer((Answer<NioSocketChannel>) invocationOnMock -> channel);
+
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+        SdkEventLoopGroup eventLoopGroup = SdkEventLoopGroup.create(customEventLoopGroup, channelFactory);
+
+        NettyNioAsyncHttpClient customClient =
+            (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                             .eventLoopGroup(eventLoopGroup)
+                                                             .maxConcurrency(1)
+                                                             .build();
+
+        String body = randomAlphabetic(10);
+
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body)
+                                                               .withStatus(500)
+                                                               .withHeader("Connection", "close")
+        ));
+
+        customClient.execute(AsyncExecuteRequest.builder()
+                                                .request(request)
+                                                .requestContentPublisher(createProvider(""))
+                                                .responseHandler(recorder).build());
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+
+        verifyChannelRelease(channel);
+        assertThat(channel.isShutdown()).isTrue();
+
+        customClient.close();
+        eventLoopGroup.eventLoopGroup().shutdownGracefully().awaitUninterruptibly();
     }
 
     /**
@@ -489,6 +596,11 @@ public class NettyNioAsyncHttpClientWireMockTest {
             .hasMessageContaining(expectedErrorMsg);
 
         customClient.close();
+    }
+
+    private void verifyChannelRelease(Channel channel) throws InterruptedException {
+        Thread.sleep(1000);
+        assertThat(channel.attr(AttributeKey.valueOf("channelPool")).get()).isNull();
     }
 
     private RecordingResponseHandler makeSimpleRequestAndReturnResponseHandler(SdkAsyncHttpClient client) throws Exception {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the bug where channel is not being released back to the pool when there is an exception thrown
Originally, we had
```
 channel.close().addListener(ignored -> context.channelPool().release(channel));
```
In reality, `channelPool#release` never gets invoked.

## Testing
Local testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
