### PR TITLE
Removing body on GET requests

### DIFF
--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullRequest.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullRequest.java
@@ -56,7 +56,7 @@ final class DefaultSdkHttpFullRequest implements SdkHttpFullRequest {
         this.queryParameters = deepUnmodifiableMap(builder.queryParameters, () -> new LinkedHashMap<>());
         this.httpMethod = Validate.paramNotNull(builder.httpMethod, "method");
         this.headers = deepUnmodifiableMap(builder.headers, () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
-        this.contentStreamProvider = builder.contentStreamProvider;
+        this.contentStreamProvider = standardizeBody(builder.contentStreamProvider);
     }
 
     private String standardizeProtocol(String protocol) {
@@ -95,6 +95,14 @@ final class DefaultSdkHttpFullRequest implements SdkHttpFullRequest {
         }
 
         return port;
+    }
+
+    private ContentStreamProvider standardizeBody(ContentStreamProvider contentStreamProvider) {
+        if (httpMethod.equals(SdkHttpMethod.GET)) {
+            return null;
+        }
+
+        return contentStreamProvider;
     }
 
     @Override

--- a/http-client-spi/src/test/java/software/amazon/awssdk/http/SdkHttpRequestResponseTest.java
+++ b/http-client-spi/src/test/java/software/amazon/awssdk/http/SdkHttpRequestResponseTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.ByteArrayInputStream;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +35,16 @@ import org.junit.Test;
  * interfaces.
  */
 public class SdkHttpRequestResponseTest {
+
+    @Test
+    public void contentStreamProviderNullOnGets() {
+        assertThat(validRequestBuilder().contentStreamProvider(() -> new ByteArrayInputStream("test".getBytes()))
+                                        .method(SdkHttpMethod.GET)
+                                        .build()
+                                        .contentStreamProvider())
+            .isNotPresent();
+    }
+
     @Test
     public void optionalValuesAreOptional() {
         assertThat(validRequest().contentStreamProvider()).isNotPresent();


### PR DESCRIPTION
This PR is intended for discussion on #1078 and more generally the issue of bodies on GET requests. Both our Apache client and our URL connection client don't support GET requests with bodies. 

Apache will simply silently drop the body. We can easily fix this.

The URL connection client will automatically switch any request with a body to a POST. It would not be easy to fix this without significantly forking.

Need to look into Netty.

Even without looking into Netty, the problem is clear. While GETs with bodies arent strictly disallowed, our clients don't support it by default. We probably could support it in all of our clients but this means specific code in each HTTP client. We can't support GETs with bodies generically for all clients.

This PR simply modifies the DefaultSdkHttpRequest to drop (silently) any body on a GET request. This is one option that allows us to make an easy change that would apply to all clients and any client that gets plugged in.

We could move this logic to the async and sync code paths rather than modifying the request pojo. It would likely allow us to log a little better.

We might be able to add support for this on a per client basis. Even if we could in all 3 of our clients, its not something people expect and since we are pluggable, its an edge case developers won't be aware of.
