### PR TITLE
Adding Java vendor to user agent and using it everywhere

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-caed172.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-caed172.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Adds the Java vendor the user agent as well as using the updated user agent for all HTTP calls"
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProviderTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.auth.credentials;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -30,6 +31,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.internal.util.UserAgentUtils;
 import software.amazon.awssdk.regions.util.ResourcesEndpointProvider;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
@@ -93,6 +95,7 @@ public class ContainerCredentialsProviderTest {
     private void stubForSuccessResponse() {
         stubFor(
             get(urlPathEqualTo(CREDENTIALS_PATH))
+                .withHeader("User-Agent", equalTo(UserAgentUtils.getUserAgent()))
                 .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/HttpCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/HttpCredentialsProviderTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.auth.credentials;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -34,6 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.internal.util.UserAgentUtils;
 import software.amazon.awssdk.regions.util.ResourcesEndpointProvider;
 import software.amazon.awssdk.utils.DateUtils;
 import software.amazon.awssdk.utils.IoUtils;
@@ -130,6 +132,7 @@ public class HttpCredentialsProviderTest {
     private void stubForSuccessResponseWithCustomBody(String body) {
         stubFor(
             get(urlPathEqualTo(CREDENTIALS_PATH))
+                .withHeader("User-Agent", equalTo(UserAgentUtils.getUserAgent()))
                 .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/util/ResourcesEndpointProvider.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/util/ResourcesEndpointProvider.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.core.util.VersionInfo;
+import software.amazon.awssdk.core.internal.util.UserAgentUtils;
 
 /**
  * <p>
@@ -57,7 +57,7 @@ public interface ResourcesEndpointProvider {
      */
     default Map<String, String> headers() {
         Map<String, String> requestHeaders = new HashMap<>();
-        requestHeaders.put("User-Agent", String.format("aws-sdk-java/%s", VersionInfo.SDK_VERSION));
+        requestHeaders.put("User-Agent", UserAgentUtils.getUserAgent());
         requestHeaders.put("Accept", "*/*");
         requestHeaders.put("Connection", "keep-alive");
 

--- a/core/regions/src/test/java/software/amazon/awssdk/regions/util/HttpCredentialsUtilsTest.java
+++ b/core/regions/src/test/java/software/amazon/awssdk/regions/util/HttpCredentialsUtilsTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.internal.util.UserAgentUtils;
 import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.regions.internal.util.ConnectionUtils;
 import software.amazon.awssdk.regions.internal.util.SocketUtils;
@@ -52,7 +53,7 @@ public class HttpCredentialsUtilsTest {
     private static Map<String, String> headers = new HashMap<String, String>()
     {
         {
-            put("User-Agent", String.format("aws-sdk-java/%s", VersionInfo.SDK_VERSION));
+            put("User-Agent", UserAgentUtils.getUserAgent());
             put("Accept", "*/*");
             put("Connection", "keep-alive");
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/UserAgentUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/UserAgentUtils.java
@@ -33,7 +33,8 @@ import software.amazon.awssdk.utils.JavaSystemSetting;
 public final class UserAgentUtils {
 
     private static final String UA_STRING = "aws-sdk-{platform}/{version} {os.name}/{os.version} {java.vm.name}/{java.vm"
-                                            + ".version} Java/{java.version}{language.and.region}{additional.languages}";
+                                            + ".version} Java/{java.version}{language.and.region}{additional.languages} "
+                                            + "vendor/{java.vendor}";
 
     /** Disallowed characters in the user agent token: @see <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">RFC 7230</a> */
     private static final String UA_BLACKLIST_REGEX = "[() ,/:;<=>?@\\[\\]{}\\\\]";
@@ -84,6 +85,7 @@ public final class UserAgentUtils {
                 .replace("{java.vm.name}", sanitizeInput(JavaSystemSetting.JAVA_VM_NAME.getStringValue().orElse(null)))
                 .replace("{java.vm.version}", sanitizeInput(JavaSystemSetting.JAVA_VM_VERSION.getStringValue().orElse(null)))
                 .replace("{java.version}", sanitizeInput(JavaSystemSetting.JAVA_VERSION.getStringValue().orElse(null)))
+                .replace("{java.vendor}", sanitizeInput(JavaSystemSetting.JAVA_VENDOR.getStringValue().orElse(null)))
                 .replace("{additional.languages}", getAdditionalJvmLanguages());
 
         Optional<String> language = JavaSystemSetting.USER_LANGUAGE.getStringValue();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/UserAgentUtilsTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/UserAgentUtilsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Arrays;
 import org.junit.Test;
 import software.amazon.awssdk.core.internal.util.UserAgentUtils;
+import software.amazon.awssdk.utils.JavaSystemSetting;
 
 public class UserAgentUtilsTest {
 
@@ -29,6 +30,21 @@ public class UserAgentUtilsTest {
         String userAgent = UserAgentUtils.userAgent();
         assertNotNull(userAgent);
         Arrays.stream(userAgent.split(" ")).forEach(str -> assertThat(isValidInput(str)).isTrue());
+    }
+
+    @Test
+    public void userAgent_HasVendor() {
+        System.setProperty(JavaSystemSetting.JAVA_VENDOR.property(), "finks");
+        String userAgent = UserAgentUtils.userAgent();
+        System.clearProperty(JavaSystemSetting.JAVA_VENDOR.property());
+        assertThat(userAgent).contains("vendor/finks");
+    }
+
+    @Test
+    public void userAgent_HasUnknownVendor() {
+        System.clearProperty(JavaSystemSetting.JAVA_VENDOR.property());
+        String userAgent = UserAgentUtils.userAgent();
+        assertThat(userAgent).contains("vendor/unknown");
     }
 
     private boolean isValidInput(String input) {

--- a/utils/src/main/java/software/amazon/awssdk/utils/JavaSystemSetting.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/JavaSystemSetting.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 @SdkProtectedApi
 public enum JavaSystemSetting implements SystemSetting {
     JAVA_VERSION("java.version"),
+    JAVA_VENDOR("java.vendor"),
     TEMP_DIRECTORY("java.io.tmpdir"),
     JAVA_VM_NAME("java.vm.name"),
     JAVA_VM_VERSION("java.vm.version"),


### PR DESCRIPTION
Adds Java vendor to the user agent:

aws-sdk-java/2.5.1-SNAPSHOT Mac_OS_X/10.12.6 Java_HotSpot_TM__64-Bit_Server_VM/25.202-b08 Java/1.8.0_202 vendor/Oracle_Corporation

aws-sdk-java/2.5.1-SNAPSHOT Mac_OS_X/10.12.6 OpenJDK_64-Bit_Server_VM/25.202-b08 Java/1.8.0_202 vendor/Amazon.com_Inc.

## Testing
Updated/added tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
