### PR TITLE
Honor request overriden content type for S3 createMultipartUpload req

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-7601ea5.json
+++ b/.changes/next-release/bugfix-AmazonS3-7601ea5.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Only set content type of S3 `CreateMultipartUploadRequest` if `Content-Type` header is not present and honor the overridden content type."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/CreateMultipartUploadRequestInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/CreateMultipartUploadRequestInterceptor.java
@@ -45,11 +45,15 @@ public class CreateMultipartUploadRequestInterceptor implements ExecutionInterce
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
                                             ExecutionAttributes executionAttributes) {
         if (context.request() instanceof CreateMultipartUploadRequest) {
-            return context.httpRequest()
-                          .toBuilder()
-                          .putHeader(CONTENT_LENGTH, String.valueOf(0))
-                          .putHeader(CONTENT_TYPE, "binary/octet-stream")
-                          .build();
+            SdkHttpRequest.Builder builder = context.httpRequest()
+                                                    .toBuilder()
+                                                    .putHeader(CONTENT_LENGTH, String.valueOf(0));
+
+            if (!context.httpRequest().firstMatchingHeader(CONTENT_TYPE).isPresent()) {
+                builder.putHeader(CONTENT_TYPE, "binary/octet-stream");
+            }
+
+            return builder.build();
         }
 
         return context.httpRequest();

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/MultipartUploadTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/MultipartUploadTest.java
@@ -79,4 +79,17 @@ public class MultipartUploadTest {
         verify(anyRequestedFor(anyUrl()).withQueryParam("uploads", containing("")));
         verify(anyRequestedFor(anyUrl()).withHeader(CONTENT_TYPE, equalTo("binary/octet-stream")));
     }
+
+    @Test
+    public void createMultipartUpload_overrideContentType() {
+        String overrideContentType = "application/html";
+        stubFor(any(urlMatching(".*"))
+                    .willReturn(aResponse().withStatus(200).withBody("<xml></xml>")));
+        s3Client.createMultipartUpload(b -> b.key("key")
+                                             .bucket("bucket")
+                                             .overrideConfiguration(c -> c.putHeader(CONTENT_TYPE, overrideContentType)));
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("uploads", containing("")));
+        verify(anyRequestedFor(anyUrl()).withHeader(CONTENT_TYPE, equalTo(overrideContentType)));
+    }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/CreateMultipartUploadRequestInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/CreateMultipartUploadRequestInterceptorTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.s3.internal.handlers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
+import static software.amazon.awssdk.services.s3.utils.InterceptorTestUtils.sdkHttpFullRequest;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -53,6 +54,20 @@ public class CreateMultipartUploadRequestInterceptorTest {
         assertThat(httpRequest).isNotEqualTo(modifyHttpRequest.httpRequest());
         assertThat(httpRequest.headers()).containsEntry(CONTENT_LENGTH, Collections.singletonList("0"));
         assertThat(httpRequest.headers()).containsEntry(CONTENT_TYPE, Collections.singletonList("binary/octet-stream"));
+    }
+
+    @Test
+    public void createMultipartRequest_contentTypePresent_shouldNotModifyContentType() {
+        String overrideContentType = "application/json";
+        Context.ModifyHttpRequest modifyHttpRequest =
+            InterceptorTestUtils.modifyHttpRequestContext(CreateMultipartUploadRequest.builder().build(),
+                                                          sdkHttpFullRequest().toBuilder()
+                                                                              .putHeader(CONTENT_TYPE, overrideContentType).build());
+
+        SdkHttpRequest httpRequest = interceptor.modifyHttpRequest(modifyHttpRequest, new ExecutionAttributes());
+        assertThat(httpRequest).isNotEqualTo(modifyHttpRequest.httpRequest());
+        assertThat(httpRequest.headers()).containsEntry(CONTENT_LENGTH, Collections.singletonList("0"));
+        assertThat(httpRequest.headers()).containsEntry(CONTENT_TYPE, Collections.singletonList(overrideContentType));
     }
 
     @Test

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/InterceptorTestUtils.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/InterceptorTestUtils.java
@@ -26,7 +26,6 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.EmptyPublisher;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -87,14 +86,17 @@ public final class InterceptorTestUtils {
     }
 
     public static Context.ModifyHttpRequest modifyHttpRequestContext(SdkRequest request) {
+        return modifyHttpRequestContext(request, sdkHttpFullRequest());
+    }
+
+    public static Context.ModifyHttpRequest modifyHttpRequestContext(SdkRequest request, SdkHttpRequest sdkHttpRequest) {
         Optional<RequestBody> requestBody = Optional.of(RequestBody.fromString("helloworld"));
         Optional<AsyncRequestBody> asyncRequestBody = Optional.of(AsyncRequestBody.fromString("helloworld"));
-        SdkHttpFullRequest sdkHttpFullRequest = sdkHttpFullRequest();
 
         return new Context.ModifyHttpRequest() {
             @Override
             public SdkHttpRequest httpRequest() {
-                return sdkHttpFullRequest;
+                return sdkHttpRequest;
             }
 
             @Override


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
## Description
We should honor request overriden content type for S3 createMultipartUpload request and only set default content type if it's absent.

## Testing
Added unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
