### PR TITLE
Bugfix #1145

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkBytes.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkBytes.java
@@ -77,7 +77,7 @@ public final class SdkBytes extends BytesWrapper implements Serializable {
      */
     public static SdkBytes fromString(String string, Charset charset) {
         Validate.paramNotNull(string, "string");
-        Validate.paramNotNull(string, "charset");
+        Validate.paramNotNull(charset, "charset");
         return new SdkBytes(string.getBytes(charset));
     }
 


### PR DESCRIPTION
Fixed param validation. See issue #1145.

In line 80 of SdkBytes.java there is a param validation that does not correspond to the actual param to validate. As of seen in version 2.5.10