### PR TITLE
Bug fix #1148 - fix NPE in FileAsyncResponseTransformer

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
@@ -78,7 +78,9 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
     @Override
     public void exceptionOccurred(Throwable throwable) {
         try {
-            invokeSafely(fileChannel::close);
+            if (fileChannel != null) {
+                invokeSafely(fileChannel::close);
+            }
         } finally {
             invokeSafely(() -> Files.deleteIfExists(path));
         }


### PR DESCRIPTION
Fixes NPE if the fileChannel is null #1148 