### PR TITLE
Use consistent protocol literal field except for kinesis event stream…

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddMetadata.java
@@ -85,6 +85,7 @@ final class AddMetadata {
                 .withAuthType(AuthType.fromValue(serviceMetadata.getSignatureVersion()))
                 .withRequiresApiKey(requiresApiKey(serviceModel))
                 .withUid(serviceMetadata.getUid())
+                .withServiceId(serviceMetadata.getServiceId())
                 .withSupportsH2(supportsH2(serviceMetadata));
 
         String jsonVersion = getJsonVersion(metadata, serviceMetadata);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/Metadata.java
@@ -97,6 +97,8 @@ public class Metadata {
 
     private boolean supportsH2;
 
+    private String serviceId;
+
     public String getApiVersion() {
         return apiVersion;
     }
@@ -167,12 +169,12 @@ public class Metadata {
     }
 
     public void setDefaultEndpointWithoutHttpProtocol(
-            String defaultEndpointWithoutHttpProtocol) {
+        String defaultEndpointWithoutHttpProtocol) {
         this.defaultEndpointWithoutHttpProtocol = defaultEndpointWithoutHttpProtocol;
     }
 
     public Metadata withDefaultEndpointWithoutHttpProtocol(
-            String defaultEndpointWithoutHttpProtocol) {
+        String defaultEndpointWithoutHttpProtocol) {
         setDefaultEndpointWithoutHttpProtocol(defaultEndpointWithoutHttpProtocol);
         return this;
     }
@@ -634,7 +636,25 @@ public class Metadata {
         return supportsH2;
     }
 
-    public void withSupportsH2(boolean supportsH2) {
+    public void setSupportsH2(boolean supportsH2) {
         this.supportsH2 = supportsH2;
+    }
+
+    public Metadata withSupportsH2(boolean supportsH2) {
+        setSupportsH2(supportsH2);
+        return this;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    public Metadata withServiceId(String serviceId) {
+        setServiceId(serviceId);
+        return this;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -124,7 +124,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
     public CodeBlock responseHandler(IntermediateModel model, OperationModel opModel) {
         TypeName pojoResponseType = getPojoResponseType(opModel);
 
-        String protocolFactory = protocolFactoryLiteral(opModel);
+        String protocolFactory = protocolFactoryLiteral(model, opModel);
         CodeBlock.Builder builder = CodeBlock.builder();
         builder.add("$T operationMetadata = $T.builder()\n"
                     + ".hasStreamingSuccessResponse($L)\n"
@@ -145,7 +145,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
 
     @Override
     public CodeBlock errorResponseHandler(OperationModel opModel) {
-        String protocolFactory = protocolFactoryLiteral(opModel);
+        String protocolFactory = protocolFactoryLiteral(model, opModel);
 
         return CodeBlock
             .builder()
@@ -229,7 +229,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
         }
 
         boolean isStreaming = opModel.hasStreamingOutput() || opModel.hasEventStreamOutput();
-        String protocolFactory = protocolFactoryLiteral(opModel);
+        String protocolFactory = protocolFactoryLiteral(intermediateModel, opModel);
         String customerResponseHandler = opModel.hasEventStreamOutput() ? "asyncResponseHandler" : "asyncResponseTransformer";
         TypeName responseType = opModel.hasEventStreamOutput() && !isRestJson ? ClassName.get(SdkResponse.class)
                                                                               : pojoResponseType;
@@ -449,13 +449,9 @@ public class JsonProtocolSpec implements ProtocolSpec {
                     + ".build());\n", eventStreamBaseClass);
     }
 
-    private String protocolFactoryLiteral(OperationModel opModel) {
-        // TODO Fix once below kinesis TODO is done
-        if (opModel.hasEventStreamInput() && opModel.hasEventStreamOutput()) {
-            return "protocolFactory";
-
-            // TODO remove this once kinesis supports CBOR for event streaming
-        } else if (opModel.hasEventStreamOutput()) {
+    private String protocolFactoryLiteral(IntermediateModel model, OperationModel opModel) {
+        // TODO remove this once kinesis supports CBOR for event streaming
+        if ("Kinesis".equals(model.getMetadata().getServiceId()) && opModel.hasEventStreamOutput()) {
             return "jsonProtocolFactory";
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
@@ -157,6 +157,16 @@
       "input": {
         "shape": "EventStreamOperationWithOnlyInputRequest"
       }
+    },
+    "EventStreamOperationWithOnlyOutput": {
+      "name": "EventStreamOperationWithOnlyOutput",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/EventStreamOperationWithOnlyOutput"
+      },
+      "output": {
+        "shape": "EventStreamOutput"
+      }
     }
   },
   "shapes": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -51,6 +51,9 @@ import software.amazon.awssdk.services.json.model.EventStreamOperationResponse;
 import software.amazon.awssdk.services.json.model.EventStreamOperationResponseHandler;
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputRequest;
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputResponse;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputRequest;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponse;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponseHandler;
 import software.amazon.awssdk.services.json.model.EventTwo;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
@@ -78,6 +81,7 @@ import software.amazon.awssdk.services.json.transform.APostOperationRequestMarsh
 import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.EventStreamOperationRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.EventStreamOperationWithOnlyInputRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.EventStreamOperationWithOnlyOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventOneMarshaller;
@@ -355,6 +359,83 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         }
     }
 
+    /**
+     * Invokes the EventStreamOperationWithOnlyOutput operation asynchronously.
+     *
+     * @param eventStreamOperationWithOnlyOutputRequest
+     * @return A Java Future containing the result of the EventStreamOperationWithOnlyOutput operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.EventStreamOperationWithOnlyOutput
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/EventStreamOperationWithOnlyOutput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<Void> eventStreamOperationWithOnlyOutput(
+        EventStreamOperationWithOnlyOutputRequest eventStreamOperationWithOnlyOutputRequest,
+        EventStreamOperationWithOnlyOutputResponseHandler asyncResponseHandler) {
+        try {
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                                                                           .isPayloadJson(true).build();
+
+            HttpResponseHandler<EventStreamOperationWithOnlyOutputResponse> responseHandler = new AttachHttpMetadataResponseHandler(
+                protocolFactory.createResponseHandler(operationMetadata, EventStreamOperationWithOnlyOutputResponse::builder));
+
+            HttpResponseHandler<SdkResponse> voidResponseHandler = protocolFactory.createResponseHandler(JsonOperationMetadata
+                                                                                                             .builder().isPayloadJson(false).hasStreamingSuccessResponse(true).build(), VoidSdkResponse::builder);
+
+            HttpResponseHandler<? extends EventStream> eventResponseHandler = protocolFactory.createResponseHandler(
+                JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
+                EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
+                                                  .putSdkPojoSupplier("EventTwo", EventTwo::builder).defaultSdkPojoSupplier(() -> EventStream.UNKNOWN)
+                                                  .build());
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                                                                                                       operationMetadata);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            EventStreamAsyncResponseTransformer<EventStreamOperationWithOnlyOutputResponse, EventStream> asyncResponseTransformer = EventStreamAsyncResponseTransformer
+                .<EventStreamOperationWithOnlyOutputResponse, EventStream> builder()
+                .eventStreamResponseHandler(asyncResponseHandler).eventResponseHandler(eventResponseHandler)
+                .initialResponseHandler(responseHandler).exceptionResponseHandler(errorResponseHandler).future(future)
+                .executor(executor).serviceName(serviceName()).build();
+            RestEventStreamAsyncResponseTransformer<EventStreamOperationWithOnlyOutputResponse, EventStream> restAsyncResponseTransformer = RestEventStreamAsyncResponseTransformer
+                .<EventStreamOperationWithOnlyOutputResponse, EventStream> builder()
+                .eventStreamAsyncResponseTransformer(asyncResponseTransformer)
+                .eventStreamResponseHandler(asyncResponseHandler).build();
+
+            CompletableFuture<Void> executeFuture = clientHandler
+                .execute(
+                    new ClientExecutionParams<EventStreamOperationWithOnlyOutputRequest, EventStreamOperationWithOnlyOutputResponse>()
+                        .withOperationName("EventStreamOperationWithOnlyOutput")
+                        .withMarshaller(new EventStreamOperationWithOnlyOutputRequestMarshaller(protocolFactory))
+                        .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                        .withInput(eventStreamOperationWithOnlyOutputRequest), restAsyncResponseTransformer);
+            executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    try {
+                        asyncResponseHandler.exceptionOccurred(e);
+                    } finally {
+                        future.completeExceptionally(e);
+                    }
+                }
+            });
+            return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);
+        } catch (Throwable t) {
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                           () -> asyncResponseHandler.exceptionOccurred(t));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+    
     /**
      * <p>
      * Performs a post operation to the query service and has no output

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -16,6 +16,8 @@ import software.amazon.awssdk.services.json.model.EventStreamOperationRequest;
 import software.amazon.awssdk.services.json.model.EventStreamOperationResponseHandler;
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputRequest;
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputResponse;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputRequest;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponseHandler;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InputEventStream;
@@ -297,6 +299,66 @@ public interface JsonAsyncClient extends SdkClient {
         return eventStreamOperationWithOnlyInput(
                 EventStreamOperationWithOnlyInputRequest.builder().applyMutation(eventStreamOperationWithOnlyInputRequest)
                                                         .build(), requestStream);
+    }
+
+    /**
+     * Invokes the EventStreamOperationWithOnlyOutput operation asynchronously.
+     *
+     * @param eventStreamOperationWithOnlyOutputRequest
+     * @return A Java Future containing the result of the EventStreamOperationWithOnlyOutput operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.EventStreamOperationWithOnlyOutput
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/EventStreamOperationWithOnlyOutput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<Void> eventStreamOperationWithOnlyOutput(
+        EventStreamOperationWithOnlyOutputRequest eventStreamOperationWithOnlyOutputRequest,
+        EventStreamOperationWithOnlyOutputResponseHandler asyncResponseHandler) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Invokes the EventStreamOperationWithOnlyOutput operation asynchronously.<br/>
+     * <p>
+     * This is a convenience which creates an instance of the {@link EventStreamOperationWithOnlyOutputRequest.Builder}
+     * avoiding the need to create one manually via {@link EventStreamOperationWithOnlyOutputRequest#builder()}
+     * </p>
+     *
+     * @param eventStreamOperationWithOnlyOutputRequest
+     *        A {@link Consumer} that will call methods on {@link EventStreamOperationWithOnlyOutputRequest.Builder} to
+     *        create a request.
+     * @return A Java Future containing the result of the EventStreamOperationWithOnlyOutput operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.EventStreamOperationWithOnlyOutput
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/EventStreamOperationWithOnlyOutput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    default CompletableFuture<Void> eventStreamOperationWithOnlyOutput(
+        Consumer<EventStreamOperationWithOnlyOutputRequest.Builder> eventStreamOperationWithOnlyOutputRequest,
+        EventStreamOperationWithOnlyOutputResponseHandler asyncResponseHandler) {
+        return eventStreamOperationWithOnlyOutput(
+            EventStreamOperationWithOnlyOutputRequest.builder().applyMutation(eventStreamOperationWithOnlyOutputRequest)
+                                                     .build(), asyncResponseHandler);
     }
 
     /**


### PR DESCRIPTION
* Add serviceId to IntermediateModel metadata
*  Use `jsonProtocolFactory` variable name only for kinesis. Before this fix, any service that doesn't support cbor will generate non-compilable classes if they have event stream APIs