### PR TITLE
Expose Apache HttpRoutePlanner and CredentialProvider on the Apache c…

### DIFF
--- a/.changes/next-release/feature-ApacheHttpClient-3dec1688.json
+++ b/.changes/next-release/feature-ApacheHttpClient-3dec1688.json
@@ -1,0 +1,5 @@
+{
+  "category": "Apache Http Client",
+  "type": "feature",
+  "description": "Add the ability to set a custom Apache HttpRoutePlanner and CredentialProvider"
+}

--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientTest.java
@@ -15,17 +15,112 @@
 
 package software.amazon.awssdk.http.apache;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * @see ApacheHttpClientWireMockTest
  */
 public class ApacheHttpClientTest {
+    @After
+    public void cleanup() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.proxyUser");
+        System.clearProperty("http.proxyPassword");
+    }
+
     @Test
     public void connectionReaperCanBeManuallyEnabled() {
         ApacheHttpClient.builder()
                         .useIdleConnectionReaper(true)
                         .build()
                         .close();
+    }
+
+    @Test
+    public void httpRoutePlannerCantBeUsedWithProxy() {
+        ProxyConfiguration proxyConfig = ProxyConfiguration.builder()
+                                                      .endpoint(URI.create("http://localhost:1234"))
+                                                      .useSystemPropertyValues(Boolean.FALSE)
+                                                      .build();
+        assertThatThrownBy(() -> {
+            ApacheHttpClient.builder()
+                            .proxyConfiguration(proxyConfig)
+                            .httpRoutePlanner(Mockito.mock(HttpRoutePlanner.class))
+                            .build();
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void httpRoutePlannerCantBeUsedWithProxy_SystemPropertiesEnabled() {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "1234");
+
+        assertThatThrownBy(() -> {
+            ApacheHttpClient.builder()
+                            .httpRoutePlanner(Mockito.mock(HttpRoutePlanner.class))
+                            .build();
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void httpRoutePlannerCantBeUsedWithProxy_SystemPropertiesDisabled() {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "1234");
+
+        ProxyConfiguration proxyConfig = ProxyConfiguration.builder()
+                                                           .useSystemPropertyValues(Boolean.FALSE)
+                                                           .build();
+
+        ApacheHttpClient.builder()
+                        .proxyConfiguration(proxyConfig)
+                        .httpRoutePlanner(Mockito.mock(HttpRoutePlanner.class))
+                        .build();
+    }
+
+    @Test
+    public void credentialProviderCantBeUsedWithProxyCredentials() {
+        ProxyConfiguration proxyConfig = ProxyConfiguration.builder()
+                                                           .endpoint(URI.create("http://localhost:1234"))
+                                                           .username("foo")
+                                                           .password("bar")
+                                                           .build();
+        assertThatThrownBy(() -> {
+            ApacheHttpClient.builder()
+                            .proxyConfiguration(proxyConfig)
+                            .credentialsProvider(Mockito.mock(CredentialsProvider.class))
+                            .build();
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void credentialProviderCantBeUsedWithProxyCredentials_SystemProperties() {
+        System.setProperty("http.proxyUser", "foo");
+        System.setProperty("http.proxyPassword", "bar");
+
+        assertThatThrownBy(() -> {
+            ApacheHttpClient.builder()
+                            .credentialsProvider(Mockito.mock(CredentialsProvider.class))
+                            .build();
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
+    public void credentialProviderCanBeUsedWithProxy() {
+        ProxyConfiguration proxyConfig = ProxyConfiguration.builder()
+                                                           .endpoint(URI.create("http://localhost:1234"))
+                                                           .build();
+        ApacheHttpClient.builder()
+                        .proxyConfiguration(proxyConfig)
+                        .credentialsProvider(Mockito.mock(CredentialsProvider.class))
+                        .build();
     }
 }

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
@@ -19,10 +19,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -149,7 +147,7 @@ public abstract class SdkHttpClientTestSuite {
             responseBuilder.withHeader("Location", "Some New Location");
         }
 
-        stubFor(any(urlPathEqualTo("/")).willReturn(responseBuilder));
+        mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(responseBuilder));
     }
 
     private void validateResponse(HttpExecuteResponse response, int returnCode, SdkHttpMethod method) throws IOException {
@@ -165,7 +163,7 @@ public abstract class SdkHttpClientTestSuite {
             patternBuilder.withRequestBody(equalTo("Body"));
         }
 
-        verify(1, patternBuilder);
+        mockServer.verify(1, patternBuilder);
 
         if (method == SdkHttpMethod.HEAD) {
             assertThat(response.responseBody()).isEmpty();


### PR DESCRIPTION
…lient builder

<!--- Provide a general summary of your changes in the Title above -->

## Description
Expose Apache's HTTP route builder and credential provider interfaces so custom ones can be used

## Motivation and Context
Allows the proxy settings to be altered without having to tear down all of the AWS SDK clients

## Testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
