### PR TITLE
Add maven commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Once you check out the code from GitHub, you can build it using Maven.
 
 ```sh
 mvn clean install
+
+# Skip tests, checkstyles, findbugs, etc for quick build
+mvn clean install -P quick
+
+# Build a specific service module
+mvn clean install -pl :s3 -P quick --am
 ```
 
 ## Sample Code


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add maven commands in README so that customers are aware that they can skip tests and not blocked for failed tests.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
