### PR TITLE
Bypass SSL validation when TRUST_ALL_CERTIFICATES is set to true

### DIFF
--- a/.changes/next-release/bugfix-URLConnectionHttpClient-8ae3a85.json
+++ b/.changes/next-release/bugfix-URLConnectionHttpClient-8ae3a85.json
@@ -1,0 +1,5 @@
+{
+    "category": "URL Connection Http Client", 
+    "type": "bugfix", 
+    "description": "Bypass ssl validations when `TRUST_ALL_CERTIFICATES` is set to true."
+}

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -26,10 +26,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
@@ -120,10 +130,34 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
     }
 
     private HttpURLConnection createDefaultConnection(URI uri) {
+
+        if (options.get(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES)) {
+            trustAllCertificates();
+        }
+
         HttpURLConnection connection = invokeSafely(() -> (HttpURLConnection) uri.toURL().openConnection());
         connection.setConnectTimeout(saturatedCast(options.get(CONNECTION_TIMEOUT).toMillis()));
         connection.setReadTimeout(saturatedCast(options.get(READ_TIMEOUT).toMillis()));
         return connection;
+    }
+
+    /**
+     * Should only be used in testing
+     */
+    private static void trustAllCertificates() {
+        HttpsURLConnection.setDefaultHostnameVerifier(NoOpHostNameVerifier.INSTANCE);
+
+        TrustManager[] trustManagers = new TrustManager[]{TrustAllManager.INSTANCE};
+        SSLContext context;
+
+        try {
+            context = SSLContext.getInstance("TLS");
+            context.init(null, trustManagers, null);
+        } catch (NoSuchAlgorithmException | KeyManagementException ex) {
+            throw new RuntimeException(ex.getMessage(), ex);
+        }
+
+        HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
     }
 
     private static class RequestCallable implements ExecutableHttpRequest {
@@ -249,6 +283,39 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
                                                               .merge(serviceDefaults)
                                                               .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS),
                                                null);
+        }
+    }
+
+    private static class NoOpHostNameVerifier implements HostnameVerifier {
+
+        static final NoOpHostNameVerifier INSTANCE = new NoOpHostNameVerifier();
+
+        @Override
+        public boolean verify(String s, SSLSession sslSession) {
+            return true;
+        }
+    }
+
+    /**
+     * Insecure trust manager to trust all certs. Should only be used for testing.
+     */
+    private static class TrustAllManager implements X509TrustManager {
+
+        private static final TrustAllManager INSTANCE = new TrustAllManager();
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+            // no op
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+            // no op
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
         }
     }
 }

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
@@ -14,12 +14,37 @@
  */
 package software.amazon.awssdk.http.urlconnection;
 
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+
+import java.net.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.After;
+import org.junit.Test;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpClientTestSuite;
+import software.amazon.awssdk.utils.AttributeMap;
 
 public final class UrlConnectionHttpClientWireMockTest extends SdkHttpClientTestSuite {
+
     @Override
     protected SdkHttpClient createSdkHttpClient(SdkHttpClientOptions options) {
         return UrlConnectionHttpClient.create();
+    }
+
+    @After
+    public void reset() {
+        HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+    }
+
+    @Test
+    public void trustAllCertificates_shouldWork() throws Exception {
+        try (SdkHttpClient client = UrlConnectionHttpClient.builder()
+                                                           .buildWithDefaults(AttributeMap.builder()
+                                                                                          .put(TRUST_ALL_CERTIFICATES,
+                                                                                               Boolean.TRUE)
+                                                                                          .build())) {
+            testForResponseCodeUsingHttps(client, HttpURLConnection.HTTP_OK);
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bypass SSL validation when `TRUST_ALL_CERTIFICATES` is set to true in `UrlConnectionHttpClient`

## Motivation and Context
fix #1163 

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
