### PR TITLE
Add support for credential_source property on profile

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d140ae2.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d140ae2.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Support for `credential_source` property in profiles."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/CredentialSourceType.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/CredentialSourceType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public enum CredentialSourceType {
+    EC2_INSTANCE_METADATA,
+    ECS_CONTAINER,
+    ENVIRONMENT;
+
+    public static CredentialSourceType parse(String value) {
+        if (value.equalsIgnoreCase("Ec2InstanceMetadata")) {
+            return EC2_INSTANCE_METADATA;
+        } else if (value.equalsIgnoreCase("EcsContainer")) {
+            return ECS_CONTAINER;
+        } else if (value.equalsIgnoreCase("Environment")) {
+            return ENVIRONMENT;
+        }
+
+        throw new IllegalArgumentException(String.format("%s is not a valid credential_source", value));
+    }
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
@@ -26,10 +26,15 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.ChildProfileCredentialsProviderFactory;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
 import software.amazon.awssdk.profiles.Profile;
 import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
@@ -88,7 +93,19 @@ public final class ProfileCredentialsUtils {
      */
     private Optional<AwsCredentialsProvider> credentialsProvider(Set<String> children) {
         if (properties.containsKey(ProfileProperty.ROLE_ARN)) {
-            return Optional.ofNullable(roleBasedProfileCredentialsProvider(children));
+            boolean hasSourceProfile = properties.containsKey(ProfileProperty.SOURCE_PROFILE);
+            boolean hasCredentialSource = properties.containsKey(ProfileProperty.CREDENTIAL_SOURCE);
+            Validate.validState(!(hasSourceProfile && hasCredentialSource),
+                                "Invalid profile file: profile has both %s and %s.",
+                                ProfileProperty.SOURCE_PROFILE, ProfileProperty.CREDENTIAL_SOURCE);
+
+            if (hasSourceProfile) {
+                return Optional.ofNullable(roleAndSourceProfileBasedProfileCredentialsProvider(children));
+            }
+
+            if (hasCredentialSource) {
+                return Optional.ofNullable(roleAndCredentialSourceBasedProfileCredentialsProvider());
+            }
         }
 
         if (properties.containsKey(ProfileProperty.CREDENTIAL_PROCESS)) {
@@ -144,7 +161,7 @@ public final class ProfileCredentialsUtils {
      *
      * @param children The child profiles that source credentials from this profile.
      */
-    private AwsCredentialsProvider roleBasedProfileCredentialsProvider(Set<String> children) {
+    private AwsCredentialsProvider roleAndSourceProfileBasedProfileCredentialsProvider(Set<String> children) {
         requireProperties(ProfileProperty.SOURCE_PROFILE);
 
         Validate.validState(!children.contains(name),
@@ -160,6 +177,34 @@ public final class ProfileCredentialsUtils {
                                      .orElseThrow(this::noSourceCredentialsException);
 
         return stsCredentialsProviderFactory().create(sourceCredentialsProvider, profile);
+    }
+
+    /**
+     * Load an assumed-role credentials provider that has been configured in this profile. This will attempt to locate the STS
+     * module in order to generate the credentials provider. If it's not available, an illegal state exception will be raised.
+     */
+    private AwsCredentialsProvider roleAndCredentialSourceBasedProfileCredentialsProvider() {
+        requireProperties(ProfileProperty.CREDENTIAL_SOURCE);
+
+        CredentialSourceType credentialSource = CredentialSourceType.parse(properties.get(ProfileProperty.CREDENTIAL_SOURCE));
+        AwsCredentialsProvider credentialsProvider = credentialSourceCredentialProvider(credentialSource);
+        return stsCredentialsProviderFactory().create(credentialsProvider, profile);
+    }
+
+    private AwsCredentialsProvider credentialSourceCredentialProvider(CredentialSourceType credentialSource) {
+        switch (credentialSource) {
+            case ECS_CONTAINER:
+                return ContainerCredentialsProvider.builder().build();
+            case EC2_INSTANCE_METADATA:
+                return InstanceProfileCredentialsProvider.create();
+            case ENVIRONMENT:
+                return AwsCredentialsProviderChain.builder()
+                    .addCredentialsProvider(SystemPropertyCredentialsProvider.create())
+                    .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                    .build();
+            default:
+                throw noSourceCredentialsException();
+        }
     }
 
     /**

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtilsTest.java
@@ -18,6 +18,8 @@ package software.amazon.awssdk.auth.credentials.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
@@ -163,6 +165,24 @@ public class ProfileCredentialsUtilsTest {
     }
 
     @Test
+    public void profileFileWithCredentialSourceThrowsExceptionWhenRetrievingCredentialsProvider() {
+        ProfileFile profileFile = allTypesProfile();
+        List<String> profiles = Arrays.asList(
+            "profile-with-container-credential-source",
+            "profile-with-instance-credential-source",
+            "profile-with-environment-credential-source"
+        );
+        profiles.forEach(profileName -> {
+            assertThat(profileFile.profile(profileName)).hasValueSatisfying(profile -> {
+                assertThat(profile.property(ProfileProperty.REGION)).isNotPresent();
+
+                ProfileCredentialsUtils profileCredentialsUtils = new ProfileCredentialsUtils(profile, profileFile::profile);
+                Assertions.assertThatThrownBy(profileCredentialsUtils::credentialsProvider).isInstanceOf(IllegalStateException.class);
+            });
+        });
+    }
+
+    @Test
     public void profileFileWithCircularDependencyThrowsExceptionWhenResolvingCredentials() {
         ProfileFile configFile = configFile("[profile source]\n" +
                                        "aws_access_key_id=defaultAccessKey\n" +
@@ -183,6 +203,33 @@ public class ProfileCredentialsUtilsTest {
             .credentialsProvider())
                   .isInstanceOf(IllegalStateException.class)
                   .hasMessageContaining("Invalid profile file: Circular relationship detected with profiles");
+    }
+
+    @Test
+    public void profileWithBothCredentialSourceAndSourceProfileThrowsException() {
+        ProfileFile configFile = configFile("[profile test]\n" +
+                                            "source_profile=source\n" +
+                                            "credential_source=Environment\n" +
+                                            "role_arn=arn:aws:iam::123456789012:role/testRole3\n" +
+                                            "\n" +
+                                            "[profile source]\n" +
+                                            "aws_access_key_id=defaultAccessKey\n" +
+                                            "aws_secret_access_key=defaultSecretAccessKey");
+        Assertions.assertThatThrownBy(() -> new ProfileCredentialsUtils(configFile.profile("test").get(), configFile::profile)
+            .credentialsProvider())
+                  .isInstanceOf(IllegalStateException.class)
+                  .hasMessageContaining("Invalid profile file: profile has both source_profile and credential_source.");
+    }
+
+    @Test
+    public void profileWithInvalidCredentialSourceThrowsException() {
+        ProfileFile configFile = configFile("[profile test]\n" +
+                                            "credential_source=foobar\n" +
+                                            "role_arn=arn:aws:iam::123456789012:role/testRole3");
+        Assertions.assertThatThrownBy(() -> new ProfileCredentialsUtils(configFile.profile("test").get(), configFile::profile)
+            .credentialsProvider())
+                  .isInstanceOf(IllegalArgumentException.class)
+                  .hasMessageContaining("foobar is not a valid credential_source");
     }
 
     private ProfileFile credentialFile(String credentialFile) {
@@ -217,7 +264,19 @@ public class ProfileCredentialsUtilsTest {
                           "role_arn=arn:aws:iam::123456789012:role/testRole\n" +
                           "\n" +
                           "[profile profile-credential-process]\n" +
-                          "credential_process=" + scriptLocation +" defaultAccessKey defaultSecretAccessKey\n");
+                          "credential_process=" + scriptLocation +" defaultAccessKey defaultSecretAccessKey\n" +
+                          "\n" +
+                          "[profile profile-with-container-credential-source]\n" +
+                          "credential_source=ecscontainer\n" +
+                          "role_arn=arn:aws:iam::123456789012:role/testRole\n" +
+                          "\n" +
+                          "[profile profile-with-instance-credential-source]\n" +
+                          "credential_source=ec2instancemetadata\n" +
+                          "role_arn=arn:aws:iam::123456789012:role/testRole\n" +
+                          "\n" +
+                          "[profile profile-with-environment-credential-source]\n" +
+                          "credential_source=environment\n" +
+                          "role_arn=arn:aws:iam::123456789012:role/testRole\n");
     }
 
     private ProfileFile configFile(String configFile) {

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -60,6 +60,11 @@ public final class ProfileProperty {
     public static final String SOURCE_PROFILE = "source_profile";
 
     /**
+     * Property name for specifying the credential source to use when assuming a role
+     */
+    public static final String CREDENTIAL_SOURCE = "credential_source";
+
+    /**
      * AWS Region to use when creating clients.
      */
     public static final String REGION = "region";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request adds support for the `credential_source` property in profile files.
See [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#using-aws-iam-roles) for the same feature on AWS CLI.

## Description
<!--- Describe your changes in detail -->
Changed profile file parsing to understand the `credential_source` property.
If `credential_source` is `Environment`, the SDK looks at both environment variables and system in that order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I expect the profile `credential_source` to work similarly to the AWS CLI. See also feature request #1169.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There is an integration test under STS integration tests. Code changes are in profile/auth.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
