### PR TITLE
Add async calls in SimpleMethodsIntegrationTests

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-simple-methods-integ-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-simple-methods-integ-class.java
@@ -9,21 +9,28 @@ import software.amazon.awssdk.regions.Region;
 public class SimpleMethodsIntegrationTest {
     private static JsonClient client;
 
+    private static JsonAsyncClient asyncClient;
+
     @BeforeClass
     public static void setup() {
         if (JsonClient.serviceMetadata().regions().isEmpty()) {
             client = JsonClient.builder().region(Region.US_EAST_1).build();
+            asyncClient = JsonAsyncClient.builder().region(Region.US_EAST_1).build();
         } else if (JsonClient.serviceMetadata().regions().contains(Region.AWS_GLOBAL)) {
             client = JsonClient.builder().region(Region.AWS_GLOBAL).build();
+            asyncClient = JsonAsyncClient.builder().region(Region.AWS_GLOBAL).build();
         } else if (JsonClient.serviceMetadata().regions().contains(Region.US_EAST_1)) {
             client = JsonClient.builder().region(Region.US_EAST_1).build();
+            asyncClient = JsonAsyncClient.builder().region(Region.US_EAST_1).build();
         } else {
             client = JsonClient.builder().region(JsonClient.serviceMetadata().regions().get(0)).build();
+            asyncClient = JsonAsyncClient.builder().region(JsonAsyncClient.serviceMetadata().regions().get(0)).build();
         }
     }
 
     @Test
     public void paginatedOperationWithResultKey_SimpleMethod_Succeeds() throws Exception {
         client.paginatedOperationWithResultKey();
+        asyncClient.paginatedOperationWithResultKey().join();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add async calls in generated `SimpleMethodsIntegrationTests` to cover async path.

## Testing
Running simple methods integ tests now.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
