### PR TITLE
Lazily initializing exceptions

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-03971fc.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-03971fc.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Lazily initialize `ApiCallTimeoutException` and `ApiCallAttemptTimeoutException`. This change would improve performance of async api calls."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallTimeoutTrackingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncApiCallTimeoutTrackingStage.java
@@ -20,10 +20,12 @@ import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.timeAs
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
@@ -52,9 +54,10 @@ public class AsyncApiCallTimeoutTrackingStage<OutputT>
         long apiCallTimeoutInMillis = resolveTimeoutInMillis(() -> context.requestConfig().apiCallTimeout(),
                                                              clientConfig.option(SdkClientOption.API_CALL_TIMEOUT));
 
+        Supplier<SdkClientException> exceptionSupplier = () -> ApiCallTimeoutException.create(apiCallTimeoutInMillis);
         TimeoutTracker timeoutTracker = timeAsyncTaskIfNeeded(future,
                                                               scheduledExecutor,
-                                                              ApiCallTimeoutException.create(apiCallTimeoutInMillis),
+                                                              exceptionSupplier,
                                                               apiCallTimeoutInMillis);
         context.apiCallTimeoutTracker(timeoutTracker);
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
@@ -165,9 +167,11 @@ public final class MakeAsyncHttpRequestStage<OutputT>
 
     private TimeoutTracker setupAttemptTimer(CompletableFuture<Response<OutputT>> executeFuture, RequestExecutionContext ctx) {
         long timeoutMillis = resolveTimeoutInMillis(ctx.requestConfig()::apiCallAttemptTimeout, apiCallAttemptTimeout);
+        Supplier<SdkClientException> exceptionSupplier = () -> ApiCallAttemptTimeoutException.create(timeoutMillis);
+
         return TimerUtils.timeAsyncTaskIfNeeded(executeFuture,
                                                 timeoutExecutor,
-                                                ApiCallAttemptTimeoutException.create(timeoutMillis),
+                                                exceptionSupplier,
                                                 timeoutMillis);
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/TimerUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/TimerUtils.java
@@ -38,20 +38,20 @@ public final class TimerUtils {
      *
      * @param completableFuture the completableFuture to be timed
      * @param timeoutExecutor the executor to execute the {@link TimeoutTask}
-     * @param exceptionToThrow the exception to thrown after timeout
+     * @param exceptionSupplier the exception to thrown after timeout
      * @param timeoutInMills the timeout in milliseconds.
      * @param <T> the type of the {@link CompletableFuture}
      * @return a {@link TimeoutTracker}
      */
     public static <T> TimeoutTracker timeAsyncTaskIfNeeded(CompletableFuture<T> completableFuture,
                                                            ScheduledExecutorService timeoutExecutor,
-                                                           SdkClientException exceptionToThrow,
+                                                           Supplier<SdkClientException> exceptionSupplier,
                                                            long timeoutInMills) {
         if (timeoutInMills <= 0) {
             return NoOpTimeoutTracker.INSTANCE;
         }
 
-        TimeoutTask timeoutTask = new AsyncTimeoutTask(completableFuture, exceptionToThrow);
+        TimeoutTask timeoutTask = new AsyncTimeoutTask(completableFuture, exceptionSupplier);
 
         ScheduledFuture<?> scheduledFuture =
             timeoutExecutor.schedule(timeoutTask,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Delay the creation of `ApiCallTimeoutException` and `ApiCallAttemptTimeoutException` as they are not necessary and costly to create. This would improve performance in async path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Benchmark comparison (throughput ops/s)

Benchmark  |  before | after |     
------------ | -------------  | -----------                              
NettyClientH1NonTlsBenchmark.concurrentApiCall  |  7119 | 8453
NettyClientH1NonTlsBenchmark.sequentialApiCall |  2303 | 2393
NettyHttpClientH1Benchmark.concurrentApiCall (jdk) |  6390 | 7260
NettyHttpClientH1Benchmark.sequentialApiCall (jdk) |  1775 |  1827
NettyHttpClientH2Benchmark.concurrentApiCall (jdk) | 4513 | 4655
NettyHttpClientH2Benchmark.sequentialApiCall (jdk) | 1687 | 1723



## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
