### PR TITLE
Update buildspec to disable connection pooling for Java9+ build

### DIFF
--- a/buildspecs/build.yml
+++ b/buildspecs/build.yml
@@ -3,12 +3,13 @@ version: 0.2
 phases:
   build:
     commands:
-      - mvn clean install -D maven.wagon.httpconnectionManager.maxPerRoute=2
       - JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-1)
-      - echo $JAVA_VERSION
       - |
         if [ "$JAVA_VERSION" -ge "9" ]; then
+          mvn clean install -Dmaven.wagon.http.pool=false -T1C
           cd test/module-path-tests
           mvn package
           mvn exec:exec -P mock-tests
+        else
+          mvn clean install -D maven.wagon.httpconnectionManager.maxPerRoute=2 -T1C
         fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update buildspec to disable connection pooling for Java9+ build


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
