### PR TITLE
Workaround to fix eventloop.shutdownGracefully hanging issue

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHttpClient-91fa618.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHttpClient-91fa618.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Async Http Client", 
+    "type": "bugfix", 
+    "description": "Add workaround to await channel pools to be closed before shutting down EventLoopGroup to avoid the race condition between `channelPool.close` and `eventLoopGroup.shutdown`. See [#1109](https://github.com/aws/aws-sdk-java-v2/issues/1109)."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -30,26 +30,17 @@ import static software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration.
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
-import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
-import io.netty.channel.pool.SimpleChannelPool;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManagerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -59,20 +50,14 @@ import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
-import software.amazon.awssdk.http.nio.netty.internal.CancellableAcquireChannelPool;
-import software.amazon.awssdk.http.nio.netty.internal.ChannelPipelineInitializer;
-import software.amazon.awssdk.http.nio.netty.internal.HandlerRemovingChannelPool;
-import software.amazon.awssdk.http.nio.netty.internal.HealthCheckedChannelPool;
-import software.amazon.awssdk.http.nio.netty.internal.HonorCloseOnReleaseChannelPool;
+import software.amazon.awssdk.http.nio.netty.internal.AwaitCloseChannelPoolMap;
 import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
 import software.amazon.awssdk.http.nio.netty.internal.NettyRequestExecutor;
 import software.amazon.awssdk.http.nio.netty.internal.NonManagedEventLoopGroup;
-import software.amazon.awssdk.http.nio.netty.internal.ReleaseOnceChannelPool;
 import software.amazon.awssdk.http.nio.netty.internal.RequestContext;
 import software.amazon.awssdk.http.nio.netty.internal.SdkChannelOptions;
 import software.amazon.awssdk.http.nio.netty.internal.SdkChannelPoolMap;
 import software.amazon.awssdk.http.nio.netty.internal.SharedSdkEventLoopGroup;
-import software.amazon.awssdk.http.nio.netty.internal.http2.HttpOrHttp2ChannelPool;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.Either;
 import software.amazon.awssdk.utils.Validate;
@@ -88,35 +73,31 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
     private static final long MAX_STREAMS_ALLOWED = 4294967295L; // unsigned 32-bit, 2^32 -1
 
     private final SdkEventLoopGroup sdkEventLoopGroup;
-    private final SdkChannelPoolMap<URI, ChannelPool> pools;
-    private final SdkChannelOptions sdkChannelOptions;
+    private final SdkChannelPoolMap<URI, ? extends ChannelPool> pools;
     private final NettyConfiguration configuration;
-    private final long maxStreams;
-    private SslProvider sslProvider;
-    private Protocol protocol;
 
-    NettyNioAsyncHttpClient(DefaultBuilder builder, AttributeMap serviceDefaultsMap) {
+    private NettyNioAsyncHttpClient(DefaultBuilder builder, AttributeMap serviceDefaultsMap) {
         this.configuration = new NettyConfiguration(serviceDefaultsMap);
-        this.protocol = serviceDefaultsMap.get(SdkHttpConfigurationOption.PROTOCOL);
-        this.maxStreams = builder.maxHttp2Streams == null ? MAX_STREAMS_ALLOWED : builder.maxHttp2Streams;
+        Protocol protocol = serviceDefaultsMap.get(SdkHttpConfigurationOption.PROTOCOL);
+        long maxStreams = builder.maxHttp2Streams == null ? MAX_STREAMS_ALLOWED : builder.maxHttp2Streams;
         this.sdkEventLoopGroup = eventLoopGroup(builder);
-        this.pools = createChannelPoolMap();
-        this.sdkChannelOptions = channelOptions(builder);
-        this.sslProvider = resolveSslProvider(builder);
+        this.pools = AwaitCloseChannelPoolMap.builder()
+                                             .sdkChannelOptions(builder.sdkChannelOptions)
+                                             .configuration(configuration)
+                                             .protocol(protocol)
+                                             .maxStreams(maxStreams)
+                                             .sdkEventLoopGroup(sdkEventLoopGroup)
+                                             .sslProvider(resolveSslProvider(builder))
+                                             .build();
     }
 
     @SdkTestInternalApi
     NettyNioAsyncHttpClient(SdkEventLoopGroup sdkEventLoopGroup,
-                            SdkChannelPoolMap<URI, ChannelPool> pools,
-                            SdkChannelOptions sdkChannelOptions,
-                            NettyConfiguration configuration,
-                            long maxStreams) {
+                            SdkChannelPoolMap<URI, ? extends ChannelPool> pools,
+                            NettyConfiguration configuration) {
         this.sdkEventLoopGroup = sdkEventLoopGroup;
         this.pools = pools;
-        this.sdkChannelOptions = sdkChannelOptions;
         this.configuration = configuration;
-        this.maxStreams = maxStreams;
-        this.sslProvider = SslContext.defaultClientProvider();
     }
 
     @Override
@@ -129,10 +110,6 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         return new DefaultBuilder();
     }
 
-    private SdkChannelOptions channelOptions(DefaultBuilder builder) {
-        return builder.sdkChannelOptions;
-    }
-
     private RequestContext createRequestContext(AsyncExecuteRequest request) {
         ChannelPool pool = pools.get(poolKey(request.request()));
         return new RequestContext(pool, sdkEventLoopGroup.eventLoopGroup(), request, configuration);
@@ -140,30 +117,15 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
 
     private SdkEventLoopGroup eventLoopGroup(DefaultBuilder builder) {
         Validate.isTrue(builder.eventLoopGroup == null || builder.eventLoopGroupBuilder == null,
-                "The eventLoopGroup and the eventLoopGroupFactory can't both be configured.");
+                        "The eventLoopGroup and the eventLoopGroupFactory can't both be configured.");
         return Either.fromNullable(builder.eventLoopGroup, builder.eventLoopGroupBuilder)
-                .map(e -> e.map(this::nonManagedEventLoopGroup, SdkEventLoopGroup.Builder::build))
-                .orElseGet(SharedSdkEventLoopGroup::get);
+                     .map(e -> e.map(this::nonManagedEventLoopGroup, SdkEventLoopGroup.Builder::build))
+                     .orElseGet(SharedSdkEventLoopGroup::get);
     }
 
     private static URI poolKey(SdkHttpRequest sdkRequest) {
         return invokeSafely(() -> new URI(sdkRequest.protocol(), null, sdkRequest.host(),
                                           sdkRequest.port(), null, null, null));
-    }
-
-    private SslContext sslContext(String protocol) {
-        if (!protocol.equalsIgnoreCase("https")) {
-            return null;
-        }
-        try {
-            return SslContextBuilder.forClient()
-                                    .sslProvider(sslProvider)
-                                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-                                    .trustManager(getTrustManager())
-                                    .build();
-        } catch (SSLException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private SslProvider resolveSslProvider(DefaultBuilder builder) {
@@ -172,64 +134,6 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         }
 
         return SslContext.defaultClientProvider();
-    }
-
-    private TrustManagerFactory getTrustManager() {
-        return configuration.trustAllCertificates() ? InsecureTrustManagerFactory.INSTANCE : null;
-    }
-
-    private SdkChannelPoolMap<URI, ChannelPool> createChannelPoolMap() {
-        return new SdkChannelPoolMap<URI, ChannelPool>() {
-            @Override
-            protected ChannelPool newPool(URI key) {
-                SslContext sslContext = sslContext(key.getScheme());
-                Bootstrap bootstrap =
-                    new Bootstrap()
-                        .group(sdkEventLoopGroup.eventLoopGroup())
-                        .channelFactory(sdkEventLoopGroup.channelFactory())
-                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.connectTimeoutMillis())
-                        // TODO run some performance tests with and without this.
-                        .remoteAddress(key.getHost(), key.getPort());
-                sdkChannelOptions.channelOptions().forEach(bootstrap::option);
-
-                AtomicReference<ChannelPool> channelPoolRef = new AtomicReference<>();
-                ChannelPipelineInitializer handler =
-                    new ChannelPipelineInitializer(protocol, sslContext, maxStreams, channelPoolRef, configuration, key);
-                channelPoolRef.set(createChannelPool(bootstrap, handler));
-                return channelPoolRef.get();
-            }
-        };
-    }
-
-    private ChannelPool createChannelPool(Bootstrap bootstrap, ChannelPipelineInitializer handler) {
-        // Create a simple channel pool for pooling raw TCP connections to the service.
-        ChannelPool channelPool = new SimpleChannelPool(bootstrap, handler);
-
-        // Wrap the channel pool such that the ChannelAttributeKey.CLOSE_ON_RELEASE flag is honored.
-        channelPool = new HonorCloseOnReleaseChannelPool(channelPool);
-
-        // Wrap the channel pool such that HTTP 2 channels won't be released to the underlying pool while they're still in use.
-        channelPool = new HttpOrHttp2ChannelPool(channelPool,
-                                                 bootstrap.config().group(),
-                                                 configuration.maxConnections(),
-                                                 configuration);
-
-
-        // Wrap the channel pool such that we remove request-specific handlers with each request.
-        channelPool = new HandlerRemovingChannelPool(channelPool);
-
-        // Wrap the channel pool such that an individual channel can only be released to the underlying pool once.
-        channelPool = new ReleaseOnceChannelPool(channelPool);
-
-        // Wrap the channel pool to guarantee all channels checked out are healthy, and all unhealthy channels checked in are
-        // closed.
-        channelPool = new HealthCheckedChannelPool(bootstrap.config().group(), configuration, channelPool);
-
-        // Wrap the channel pool such that if the Promise given to acquire(Promise) is done when the channel is acquired
-        // from the underlying pool, the channel is closed and released.
-        channelPool = new CancellableAcquireChannelPool(bootstrap.config().group().next(), channelPool);
-
-        return channelPool;
     }
 
     private SdkEventLoopGroup nonManagedEventLoopGroup(SdkEventLoopGroup eventLoopGroup) {
@@ -254,8 +158,8 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (TimeoutException e) {
-            throw new RuntimeException(String.format("Shutting down Netty EventLoopGroup did not complete within %s seconds",
-                                                     EVENTLOOP_SHUTDOWN_FUTURE_TIMEOUT_SECONDS));
+            log.error(String.format("Shutting down Netty EventLoopGroup did not complete within %s seconds",
+                                    EVENTLOOP_SHUTDOWN_FUTURE_TIMEOUT_SECONDS));
         }
     }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration.CHANNEL_POOL_CLOSE_TIMEOUT_SECONDS;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import java.net.URI;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+import software.amazon.awssdk.http.nio.netty.internal.http2.HttpOrHttp2ChannelPool;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Implementation of {@link SdkChannelPoolMap} that awaits channel pools to be closed upon closing.
+ */
+@SdkInternalApi
+public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI,
+    AwaitCloseChannelPoolMap.SimpleChannelPoolAwareChannelPool> {
+
+    private static final Logger log = Logger.loggerFor(AwaitCloseChannelPoolMap.class);
+
+    private final SdkChannelOptions sdkChannelOptions;
+    private final SdkEventLoopGroup sdkEventLoopGroup;
+    private final NettyConfiguration configuration;
+    private final Protocol protocol;
+    private final long maxStreams;
+    private final SslProvider sslProvider;
+
+    private AwaitCloseChannelPoolMap(Builder builder) {
+        this.sdkChannelOptions = builder.sdkChannelOptions;
+        this.sdkEventLoopGroup = builder.sdkEventLoopGroup;
+        this.configuration = builder.configuration;
+        this.protocol = builder.protocol;
+        this.maxStreams = builder.maxStreams;
+        this.sslProvider = builder.sslProvider;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected SimpleChannelPoolAwareChannelPool newPool(URI key) {
+        SslContext sslContext = sslContext(key.getScheme());
+        Bootstrap bootstrap =
+            new Bootstrap()
+                .group(sdkEventLoopGroup.eventLoopGroup())
+                .channelFactory(sdkEventLoopGroup.channelFactory())
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.connectTimeoutMillis())
+                // TODO run some performance tests with and without this.
+                .remoteAddress(key.getHost(), key.getPort());
+        sdkChannelOptions.channelOptions().forEach(bootstrap::option);
+
+        AtomicReference<ChannelPool> channelPoolRef = new AtomicReference<>();
+        ChannelPipelineInitializer handler =
+            new ChannelPipelineInitializer(protocol, sslContext, maxStreams, channelPoolRef, configuration, key);
+
+        BetterSimpleChannelPool simpleChannelPool = new BetterSimpleChannelPool(bootstrap, handler);
+
+        channelPoolRef.set(wrapSimpleChannelPool(bootstrap, simpleChannelPool));
+        return new SimpleChannelPoolAwareChannelPool(simpleChannelPool, channelPoolRef.get());
+    }
+
+    @Override
+    public void close() {
+        log.trace(() -> "Closing channel pools");
+        // If there is a new pool being added while we are iterating the pools, there might be a
+        // race condition between the close call of the newly acquired pool and eventLoopGroup.shutdown and it
+        // could cause the eventLoopGroup#shutdownGracefully to hang before it times out.
+        // If a new pool is being added while super.close() is running, it might be left open because
+        // the underlying pool map is a ConcurrentHashMap and it doesn't guarantee strong consistency for retrieval
+        // operations. See https://github.com/aws/aws-sdk-java-v2/pull/1200#discussion_r277906715
+        Collection<SimpleChannelPoolAwareChannelPool> channelPools = pools().values();
+        super.close();
+
+        try {
+            CompletableFuture.allOf(channelPools.stream()
+                                                .map(pool -> pool.underlyingSimpleChannelPool.closeFuture())
+                                                .toArray(CompletableFuture[]::new))
+                             .get(CHANNEL_POOL_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ChannelPool wrapSimpleChannelPool(Bootstrap bootstrap, ChannelPool channelPool) {
+
+        // Wrap the channel pool such that the ChannelAttributeKey.CLOSE_ON_RELEASE flag is honored.
+        channelPool = new HonorCloseOnReleaseChannelPool(channelPool);
+
+        // Wrap the channel pool such that HTTP 2 channels won't be released to the underlying pool while they're still in use.
+        channelPool = new HttpOrHttp2ChannelPool(channelPool,
+                                                 bootstrap.config().group(),
+                                                 configuration.maxConnections(),
+                                                 configuration);
+
+
+        // Wrap the channel pool such that we remove request-specific handlers with each request.
+        channelPool = new HandlerRemovingChannelPool(channelPool);
+
+        // Wrap the channel pool such that an individual channel can only be released to the underlying pool once.
+        channelPool = new ReleaseOnceChannelPool(channelPool);
+
+        // Wrap the channel pool to guarantee all channels checked out are healthy, and all unhealthy channels checked in are
+        // closed.
+        channelPool = new HealthCheckedChannelPool(bootstrap.config().group(), configuration, channelPool);
+
+        // Wrap the channel pool such that if the Promise given to acquire(Promise) is done when the channel is acquired
+        // from the underlying pool, the channel is closed and released.
+        channelPool = new CancellableAcquireChannelPool(bootstrap.config().group().next(), channelPool);
+
+        return channelPool;
+    }
+
+    private SslContext sslContext(String protocol) {
+        if (!protocol.equalsIgnoreCase("https")) {
+            return null;
+        }
+        try {
+            return SslContextBuilder.forClient()
+                                    .sslProvider(sslProvider)
+                                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                                    .trustManager(getTrustManager())
+                                    .build();
+        } catch (SSLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private TrustManagerFactory getTrustManager() {
+        return configuration.trustAllCertificates() ? InsecureTrustManagerFactory.INSTANCE : null;
+    }
+
+    static final class SimpleChannelPoolAwareChannelPool implements ChannelPool {
+        private final BetterSimpleChannelPool underlyingSimpleChannelPool;
+        private final ChannelPool actualChannelPool;
+
+        private SimpleChannelPoolAwareChannelPool(BetterSimpleChannelPool underlyingSimpleChannelPool,
+                                                  ChannelPool actualChannelPool) {
+            this.underlyingSimpleChannelPool = underlyingSimpleChannelPool;
+            this.actualChannelPool = actualChannelPool;
+        }
+
+        @Override
+        public Future<Channel> acquire() {
+            return actualChannelPool.acquire();
+        }
+
+        @Override
+        public Future<Channel> acquire(Promise<Channel> promise) {
+            return actualChannelPool.acquire(promise);
+        }
+
+        @Override
+        public Future<Void> release(Channel channel) {
+            return actualChannelPool.release(channel);
+        }
+
+        @Override
+        public Future<Void> release(Channel channel, Promise<Void> promise) {
+            return actualChannelPool.release(channel, promise);
+        }
+
+        @Override
+        public void close() {
+            actualChannelPool.close();
+        }
+
+        @SdkTestInternalApi
+        BetterSimpleChannelPool underlyingSimpleChannelPool() {
+            return underlyingSimpleChannelPool;
+        }
+    }
+
+    public static class Builder {
+
+        private SdkChannelOptions sdkChannelOptions;
+        private SdkEventLoopGroup sdkEventLoopGroup;
+        private NettyConfiguration configuration;
+        private Protocol protocol;
+        private long maxStreams;
+        private SslProvider sslProvider;
+
+        private Builder() {
+        }
+
+        public Builder sdkChannelOptions(SdkChannelOptions sdkChannelOptions) {
+            this.sdkChannelOptions = sdkChannelOptions;
+            return this;
+        }
+
+        public Builder sdkEventLoopGroup(SdkEventLoopGroup sdkEventLoopGroup) {
+            this.sdkEventLoopGroup = sdkEventLoopGroup;
+            return this;
+        }
+
+        public Builder configuration(NettyConfiguration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public Builder protocol(Protocol protocol) {
+            this.protocol = protocol;
+            return this;
+        }
+
+        public Builder maxStreams(long maxStreams) {
+            this.maxStreams = maxStreams;
+            return this;
+        }
+
+        public Builder sslProvider(SslProvider sslProvider) {
+            this.sslProvider = sslProvider;
+            return this;
+        }
+
+        public AwaitCloseChannelPoolMap build() {
+            return new AwaitCloseChannelPoolMap(this);
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/BetterSimpleChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/BetterSimpleChannelPool.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.pool.ChannelPoolHandler;
+import io.netty.channel.pool.SimpleChannelPool;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Extension of {@link SimpleChannelPool} to add an asynchronous close method
+ */
+@SdkInternalApi
+public final class BetterSimpleChannelPool extends SimpleChannelPool {
+    private final CompletableFuture<Boolean> closeFuture;
+
+    BetterSimpleChannelPool(Bootstrap bootstrap, ChannelPoolHandler handler) {
+        super(bootstrap, handler);
+        closeFuture = new CompletableFuture<>();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        closeFuture.complete(true);
+    }
+
+    CompletableFuture<Boolean> closeFuture() {
+        return closeFuture;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyConfiguration.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.utils.AttributeMap;
 @SdkInternalApi
 public final class NettyConfiguration {
 
+    public static final int CHANNEL_POOL_CLOSE_TIMEOUT_SECONDS = 5;
     public static final int EVENTLOOP_SHUTDOWN_QUIET_PERIOD_SECONDS = 2;
     public static final int EVENTLOOP_SHUTDOWN_TIMEOUT_SECONDS = 15;
     public static final int EVENTLOOP_SHUTDOWN_FUTURE_TIMEOUT_SECONDS = 16;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SdkChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SdkChannelPoolMap.java
@@ -20,6 +20,8 @@ import static software.amazon.awssdk.utils.Validate.paramNotNull;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.ChannelPoolMap;
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -87,8 +89,12 @@ public abstract class SdkChannelPoolMap<K, P extends ChannelPool>
     protected abstract P newPool(K key);
 
     @Override
-    public final void close() {
+    public void close() {
         map.keySet().forEach(this::remove);
+    }
+
+    public final Map<K, P> pools() {
+        return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     /**

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -90,7 +90,6 @@ import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
-import software.amazon.awssdk.http.nio.netty.internal.SdkChannelOptions;
 import software.amazon.awssdk.http.nio.netty.internal.SdkChannelPoolMap;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -237,11 +236,10 @@ public class NettyNioAsyncHttpClientWireMockTest {
         };
 
         sdkChannelPoolMap.get(URI.create("http://blah"));
-        SdkChannelOptions channelOptions = new SdkChannelOptions();
         NettyConfiguration nettyConfiguration = new NettyConfiguration(AttributeMap.empty());
 
         SdkAsyncHttpClient customerClient =
-            new NettyNioAsyncHttpClient(eventLoopGroup, sdkChannelPoolMap, channelOptions, nettyConfiguration, 1);
+            new NettyNioAsyncHttpClient(eventLoopGroup, sdkChannelPoolMap, nettyConfiguration);
 
         customerClient.close();
         assertThat(eventLoopGroup.eventLoopGroup().isShuttingDown()).isTrue();

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS;
+
+import io.netty.handler.ssl.SslProvider;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+import software.amazon.awssdk.http.nio.netty.internal.AwaitCloseChannelPoolMap.SimpleChannelPoolAwareChannelPool;
+
+public class AwaitCloseChannelPoolMapTest {
+
+    private static AwaitCloseChannelPoolMap channelPoolMap;
+
+
+    @BeforeClass
+    public static void setup() {
+        channelPoolMap = AwaitCloseChannelPoolMap.builder()
+                                                 .sdkChannelOptions(new SdkChannelOptions())
+                                                 .sdkEventLoopGroup(SdkEventLoopGroup.builder().build())
+                                                 .configuration(new NettyConfiguration(GLOBAL_HTTP_DEFAULTS))
+                                                 .protocol(Protocol.HTTP1_1)
+                                                 .maxStreams(100)
+                                                 .sslProvider(SslProvider.OPENSSL)
+                                                 .build();
+    }
+
+    @Test
+    public void close_underlyingPoolsShouldBeClosed() throws ExecutionException, InterruptedException {
+
+        int numberOfChannelPools = 5;
+        List<SimpleChannelPoolAwareChannelPool> channelPools = new ArrayList<>();
+
+        for (int i = 0; i < numberOfChannelPools; i++) {
+            channelPools.add(
+                channelPoolMap.get(URI.create("http://" + RandomStringUtils.randomAlphabetic(2) + i + "localhost:" + numberOfChannelPools)));
+        }
+
+        assertThat(channelPoolMap.pools().size()).isEqualTo(numberOfChannelPools);
+
+        channelPoolMap.close();
+        channelPools.forEach(channelPool -> {
+            assertThat(channelPool.underlyingSimpleChannelPool().closeFuture()).isDone();
+            assertThat(channelPool.underlyingSimpleChannelPool().closeFuture().join()).isTrue();
+        });
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update `NettyNioAsyncHttpClient#close` to wait for `pools#close` before shutting down eventloop

The root cause is a race condition in Netty where the event loop gets terminated before channel is closed so `globalEventExecutor` will be stuck forever waiting for eventloop to notify the `channel.close` future.

```
"globalEventExecutor-1-1" #62 prio=5 os_prio=31 tid=0x00007ff34abb8800 nid=0x8c0b in Object.wait() [0x0000700003023000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	- waiting on <0x000000076b1b6a30> (a io.netty.channel.DefaultChannelPromise)
	at java.lang.Object.wait(Object.java:502)
	at io.netty.util.concurrent.DefaultPromise.awaitUninterruptibly(DefaultPromise.java:253)
	- locked <0x000000076b1b6a30> (a io.netty.channel.DefaultChannelPromise)
	at io.netty.channel.DefaultChannelPromise.awaitUninterruptibly(DefaultChannelPromise.java:137)
	at io.netty.channel.DefaultChannelPromise.awaitUninterruptibly(DefaultChannelPromise.java:30)
	at io.netty.channel.pool.SimpleChannelPool.close(SimpleChannelPool.java:398)
	at software.amazon.awssdk.http.nio.netty.internal.HonorCloseOnReleaseChannelPool.close(HonorCloseOnReleaseChannelPool.java:75)
	at software.amazon.awssdk.http.nio.netty.internal.utils.BetterFixedChannelPool$6.run(BetterFixedChannelPool.java:382)
	at io.netty.util.concurrent.GlobalEventExecutor$TaskRunner.run(GlobalEventExecutor.java:248)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```

See https://github.com/aws/aws-sdk-java-v2/issues/1109

~~This is a workaround to wait for 2 seconds before shutting down eventloop to avoid the race condition~~

The new better workaround is creating a `BetterSimpleChannelPool` to extend `SimpleChannelPool` and provide an asynchronous close method and then make `AwaitCloseChannelPoolMap` to wait to make sure all channels are being closed before we invoke `EventLoopGroup.shutdownGracefully`

~~**NOTE**
The unit tests are still pending because I wanted to make sure this approach is okay before I spend time adding the tests.~~

## Testing
Tested with the spring-boot app I wrote to replicate the issue and verified the issue was fixed with this change.

All integration tests passed

~~TODO: add more unit tests.~~(done)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
