### PR TITLE
Make `BytesWrapper`, parent of `SdkBytes` and `ResponseBytes`, public.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-914cded.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-914cded.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Make `BytesWrapper`, parent of `SdkBytes` and `ResponseBytes`, public. Fixes [#1208](https://github.com/aws/aws-sdk-java-v2/issues/1208)."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/BytesWrapper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/BytesWrapper.java
@@ -25,18 +25,27 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.Validate;
 
-@SdkInternalApi
-abstract class BytesWrapper {
+/**
+ * A base class for {@link SdkBytes} and {@link ResponseBytes} that enables retrieving an underlying byte array as multiple
+ * different types, like a byte buffer (via {@link #asByteBuffer()}, or a string (via {@link #asUtf8String()}.
+ */
+@SdkPublicApi
+public abstract class BytesWrapper {
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
     private final byte[] bytes;
 
     // Needed for serialization
+    @SdkInternalApi
     BytesWrapper() {
-        this(null);
+        this(EMPTY_BYTES);
     }
 
+    @SdkInternalApi
     BytesWrapper(byte[] bytes) {
         this.bytes = Validate.paramNotNull(bytes, "bytes");
     }


### PR DESCRIPTION
Fixes #1208.