### PR TITLE
Add more options for FileAsyncResponseTransformer

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -119,6 +119,26 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
     }
 
     /**
+     * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file.
+     *
+     * @param path            Path to file to write to.
+     * @param position        The value for the data between the current end of the file and the starting position is
+     *                        undefined.
+     * @param isNewFile       Whether this is a new file. If this is {@code true} and the file already exists, the
+     *                        transformer will complete with an exception.
+     * @param deleteOnFailure Whether the file on disk should be deleted in the event of a failure when writing the
+     *                        stream.
+     * @param <ResponseT> Pojo Response type.
+     * @return AsyncResponseTransformer instance.
+     */
+    static <ResponseT> AsyncResponseTransformer<ResponseT, ResponseT> toFile(Path path,
+                                                                             long position,
+                                                                             boolean isNewFile,
+                                                                             boolean deleteOnFailure) {
+        return new FileAsyncResponseTransformer<>(path, position, isNewFile, deleteOnFailure);
+    }
+
+    /**
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file. In the event of an error,
      * the SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an
      * exception will be thrown.

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.CompletableFuture;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+
+/**
+ * Tests for {@link FileAsyncResponseTransformer}.
+ */
+public class FileAsyncResponseTransformerTest {
+    private FileSystem testFs;
+
+    @Before
+    public void setup() {
+        testFs = Jimfs.newFileSystem(Configuration.forCurrentPlatform());
+    }
+
+    @After
+    public void teardown() throws IOException {
+        testFs.close();
+    }
+
+    @Test
+    public void defaultCreatesNewWritableFile() {
+        byte[] content = "test".getBytes(StandardCharsets.UTF_8);
+        Path testFile = testFs.getPath("testFile");
+        AsyncResponseTransformer<String, String> transformer = AsyncResponseTransformer.toFile(testFile);
+        CompletableFuture<String> transformFuture = transformer.prepare();
+        transformer.onResponse("some response");
+        transformer.onStream(AsyncRequestBody.fromBytes(content));
+        transformFuture.join();
+
+        assertFileContentsEquals(testFile, "test");
+    }
+
+    @Test
+    public void honorsPosition() throws IOException {
+        byte[] content = "test".getBytes(StandardCharsets.UTF_8);
+        Path testFile = testFs.getPath("testFile");
+        AsyncResponseTransformer<String, String> transformer = AsyncResponseTransformer.toFile(testFile, content.length, true, true);
+        CompletableFuture<String> transformFuture = transformer.prepare();
+        transformer.onResponse("some response");
+        transformer.onStream(AsyncRequestBody.fromBytes(content));
+        transformFuture.join();
+
+        assertThat(Files.size(testFile)).isEqualTo(content.length * 2);
+    }
+
+    @Test
+    public void honorsNewFileFlags_False() throws IOException {
+        Path exists = testFs.getPath("exists");
+        createFileWithContents(exists, "Hello".getBytes(StandardCharsets.UTF_8));
+
+        honorsNewFileFlagTest(exists, 5, false, "Test", "HelloTest");
+    }
+
+    @Test
+    public void honorsNewFileFlag_True_FileNotExists() {
+        Path notExists = testFs.getPath("notExists");
+        honorsNewFileFlagTest(notExists, 0, true, "Test", "Test");
+    }
+
+    @Test
+    public void honorsNewFileFlag_True_FileExists() throws IOException {
+        Path exists = testFs.getPath("exists");
+        createFileWithContents(exists, "Hello".getBytes(StandardCharsets.UTF_8));
+        assertThatThrownBy(() -> honorsNewFileFlagTest(exists, 5, true, "Test", null))
+                .hasCauseInstanceOf(FileAlreadyExistsException.class);
+    }
+
+    @Test
+    public void honorsDeleteOnFailure_True_NoExistingFile() {
+        Path notExists = testFs.getPath("notExists");
+        honorsDeleteOnFailureTest(notExists, true, true);
+    }
+
+    @Test
+    public void honorsDeleteOnFailure_True_ExistingFile() throws IOException {
+        Path exists = testFs.getPath("exists");
+        createFileWithContents(exists, "Hello".getBytes(StandardCharsets.UTF_8));
+        honorsDeleteOnFailureTest(exists, false, true);
+    }
+
+    @Test
+    public void honorsDeleteOnFailure_False_NoExistingFile() {
+        Path notExists = testFs.getPath("notExists");
+        honorsDeleteOnFailureTest(notExists, true, false);
+    }
+
+    @Test
+    public void honorsDeleteOnFailure_False_ExistingFile() throws IOException {
+        Path exists = testFs.getPath("exists");
+        createFileWithContents(exists, "Hello".getBytes(StandardCharsets.UTF_8));
+        honorsDeleteOnFailureTest(exists, false, false);
+    }
+
+    private void honorsNewFileFlagTest(Path file, long position, boolean isNewFile, String streamContents, String expectedContents) {
+        AsyncResponseTransformer<String, String> transformer = AsyncResponseTransformer.toFile(file, position, isNewFile, true);
+        CompletableFuture<String> transformFuture = transformer.prepare();
+        transformer.onResponse("some response");
+        transformer.onStream(AsyncRequestBody.fromString(streamContents));
+        transformFuture.join();
+
+        if (expectedContents != null) {
+            assertFileContentsEquals(file, expectedContents);
+        }
+    }
+
+    private void honorsDeleteOnFailureTest(Path file, boolean isNewFile, boolean deleteOnFailure) {
+        AsyncResponseTransformer<String, String> transformer = AsyncResponseTransformer.toFile(file, 0, isNewFile, deleteOnFailure);
+        CompletableFuture<String> transformFuture = transformer.prepare();
+        IOException error = new IOException("Something went wrong");
+        transformer.onResponse("some response");
+        transformer.onStream(new ErrorPublisher<>(error));
+        transformer.exceptionOccurred(error);
+        assertThatThrownBy(transformFuture::join).hasCause(error);
+        if (deleteOnFailure) {
+            assertThat(Files.exists(file)).isFalse();
+        } else {
+            assertThat(Files.exists(file)).isTrue();
+        }
+    }
+
+    private static void createFileWithContents(Path file, byte[] contents) throws IOException {
+        OutputStream os = Files.newOutputStream(file, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        os.write(contents);
+        os.close();
+    }
+
+    private static void assertFileContentsEquals(Path file, String expected) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(file)));
+            String s;
+            while ((s = reader.readLine()) != null) {
+                sb.append(s);
+            }
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+        assertThat(sb.toString()).isEqualTo(expected);
+    }
+
+    private static final class ErrorPublisher<T> implements SdkPublisher<T> {
+        private final Throwable error;
+
+        private ErrorPublisher(Throwable error) {
+            this.error = error;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber) {
+            subscriber.onSubscribe(new ErrorSubscription(subscriber, error));
+        }
+    }
+
+    private static final class ErrorSubscription implements Subscription {
+        private final Subscriber<?> subscriber;
+        private final Throwable error;
+
+        public ErrorSubscription(Subscriber<?> subscriber, Throwable error) {
+            this.subscriber = subscriber;
+            this.error = error;
+        }
+
+        @Override
+        public void request(long l) {
+            subscriber.onError(error);
+        }
+
+        @Override
+        public void cancel() {
+
+        }
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/Validate.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/Validate.java
@@ -601,7 +601,30 @@ public final class Validate {
         return num;
     }
 
+    /**
+     * Asserts that the given number is non-negative.
+     *
+     * @param num Number to validate
+     * @param fieldName Field name to display in exception message if negative.
+     * @return Number if not negative.
+     */
     public static int isNotNegative(int num, String fieldName) {
+
+        if (num < 0) {
+            throw new IllegalArgumentException(String.format("%s must not be negative", fieldName));
+        }
+
+        return num;
+    }
+
+    /**
+     * Asserts that the given number is non-negative.
+     *
+     * @param num Number to validate
+     * @param fieldName Field name to display in exception message if negative.
+     * @return Number if not negative.
+     */
+    public static long isNotNegative(long num, String fieldName) {
 
         if (num < 0) {
             throw new IllegalArgumentException(String.format("%s must not be negative", fieldName));


### PR DESCRIPTION
## Description
Add the following things to control the behavior of the transformer:

 - position parameter to specify where in the file to write the stream
 - isNewFile parameter to specify whether this is a new file
 - deleteOnFailure to specify whether the file should be deleted on failure

## Motivation and Context
File opening flexibility.

## Testing
Added new tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
