### PR TITLE
Don't call onComplete after onError in ChecksumValidatingSubscriber#o…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-8adcc2e.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-8adcc2e.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix bug in ChecksumValidatingSubscriber which results in NPE if checksum validation fails."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
@@ -138,6 +138,7 @@ public final class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffe
                     onError(SdkClientException.create(
                         String.format("Data read has a different checksum than expected. Was %d, but expected %d",
                                       computedChecksumInt, streamChecksumInt)));
+                    return; // Return after onError and not call onComplete below
                 }
             }
             wrapped.onComplete();


### PR DESCRIPTION
…nComplete method which results in NPE

* Partial fix for https://github.com/aws/aws-sdk-java-v2/issues/1225