### PR TITLE
Fix bugs in BufferingSubscriber and FlatteningSubscriber

### DIFF
--- a/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TestResponseHandlers.java
+++ b/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TestResponseHandlers.java
@@ -1,0 +1,85 @@
+package software.amazon.awssdk.services.transcribestreaming;
+
+import static software.amazon.awssdk.core.http.HttpResponseHandler.X_AMZN_REQUEST_ID_HEADER;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.services.transcribestreaming.model.StartStreamTranscriptionResponse;
+import software.amazon.awssdk.services.transcribestreaming.model.StartStreamTranscriptionResponseHandler;
+import software.amazon.awssdk.services.transcribestreaming.model.TranscriptEvent;
+import software.amazon.awssdk.services.transcribestreaming.model.TranscriptResultStream;
+
+public class TestResponseHandlers {
+
+    private static final Logger log = LoggerFactory.getLogger(TestResponseHandlers.class);
+
+    /**
+     * A simple consumer of events to subscribe
+     */
+    public static StartStreamTranscriptionResponseHandler responseHandlerBuilder_Consumer() {
+        return StartStreamTranscriptionResponseHandler.builder()
+                                                      .onResponse(r -> {
+                                                          String idFromHeader = r.sdkHttpResponse()
+                                                                                 .firstMatchingHeader(X_AMZN_REQUEST_ID_HEADER)
+                                                                                 .orElse(null);
+                                                          log.debug("Received Initial response: " + idFromHeader);
+                                                      })
+                                                      .onError(e -> {
+                                                          log.error("Error message: " + e.getMessage(), e);
+                                                      })
+                                                      .onComplete(() -> {
+                                                          log.debug("All records stream successfully");
+                                                      })
+                                                      .subscriber(event -> {
+                                                          // Do nothing
+                                                      })
+                                                      .build();
+    }
+
+
+    /**
+     * A classic way by implementing the interface and using helper method in {@link SdkPublisher}.
+     */
+    public static StartStreamTranscriptionResponseHandler responseHandlerBuilder_Classic() {
+        return new StartStreamTranscriptionResponseHandler() {
+            @Override
+            public void responseReceived(StartStreamTranscriptionResponse response) {
+                String idFromHeader = response.sdkHttpResponse()
+                                              .firstMatchingHeader(X_AMZN_REQUEST_ID_HEADER)
+                                              .orElse(null);
+                log.debug("Received Initial response: " + idFromHeader);
+            }
+
+            @Override
+            public void onEventStream(SdkPublisher<TranscriptResultStream> publisher) {
+                publisher
+                    // Filter to only SubscribeToShardEvents
+                    .filter(TranscriptEvent.class)
+                    // Flat map into a publisher of just records
+                    // Using
+                    .flatMapIterable(event -> event.transcript().results())
+                    // TODO limit is broken. After limit is reached, app fails with SdkCancellationException
+                    // instead of gracefully exiting. Limit to 1000 total records
+                    //.limit(5)
+                    // Batch records into lists of 25
+                    .buffer(25)
+                    // Print out each record batch
+                    // You won't see any data printed as the audio files we use have no voice
+                    .subscribe(batch ->  {
+                        log.debug("Record Batch - " + batch);
+                    });
+            }
+
+            @Override
+            public void exceptionOccurred(Throwable throwable) {
+                log.error("Error message: " + throwable.getMessage(), throwable);
+            }
+
+            @Override
+            public void complete() {
+                log.debug("All records stream successfully");
+            }
+        };
+    }
+}

--- a/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TestSubscription.java
+++ b/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TestSubscription.java
@@ -1,0 +1,85 @@
+package software.amazon.awssdk.services.transcribestreaming;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.transcribestreaming.model.AudioEvent;
+import software.amazon.awssdk.services.transcribestreaming.model.AudioStream;
+
+public class TestSubscription implements Subscription {
+    private static final int CHUNK_SIZE_IN_BYTES = 1024 * 1;
+    private ExecutorService executor = Executors.newFixedThreadPool(1);
+    private AtomicLong demand = new AtomicLong(0);
+
+    private final Subscriber<? super AudioStream> subscriber;
+    private final InputStream inputStream;
+
+    public TestSubscription(Subscriber<? super AudioStream> s, InputStream inputStream) {
+        this.subscriber = s;
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public void request(long n) {
+        if (n <= 0) {
+            subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+        }
+
+        demand.getAndAdd(n);
+
+        executor.submit(() -> {
+            try {
+                do {
+                    ByteBuffer audioBuffer = getNextEvent();
+                    if (audioBuffer.remaining() > 0) {
+                        AudioEvent audioEvent = audioEventFromBuffer(audioBuffer);
+                        subscriber.onNext(audioEvent);
+                    } else {
+                        subscriber.onComplete();
+                        break;
+                    }
+                } while (demand.decrementAndGet() > 0);
+            } catch (Exception e) {
+                subscriber.onError(e);
+            }
+        });
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    private ByteBuffer getNextEvent() {
+        ByteBuffer audioBuffer = null;
+        byte[] audioBytes = new byte[CHUNK_SIZE_IN_BYTES];
+
+        int len = 0;
+        try {
+            len = inputStream.read(audioBytes);
+
+            if (len <= 0) {
+                audioBuffer = ByteBuffer.allocate(0);
+            } else {
+                audioBuffer = ByteBuffer.wrap(audioBytes, 0, len);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return audioBuffer;
+    }
+
+    private AudioEvent audioEventFromBuffer(ByteBuffer bb) {
+        return AudioEvent.builder()
+                         .audioChunk(SdkBytes.fromByteBuffer(bb))
+                         .build();
+    }
+}

--- a/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TranscribeStreamingIntegrationTest.java
+++ b/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TranscribeStreamingIntegrationTest.java
@@ -15,38 +15,26 @@
 package software.amazon.awssdk.services.transcribestreaming;
 
 import static org.junit.Assert.assertTrue;
-import static software.amazon.awssdk.core.http.HttpResponseHandler.X_AMZN_REQUEST_ID_HEADER;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicLong;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.transcribestreaming.model.AudioEvent;
 import software.amazon.awssdk.services.transcribestreaming.model.AudioStream;
 import software.amazon.awssdk.services.transcribestreaming.model.LanguageCode;
 import software.amazon.awssdk.services.transcribestreaming.model.MediaEncoding;
 import software.amazon.awssdk.services.transcribestreaming.model.StartStreamTranscriptionRequest;
 import software.amazon.awssdk.services.transcribestreaming.model.StartStreamTranscriptionResponseHandler;
-import software.amazon.awssdk.services.transcribestreaming.model.TranscriptEvent;
 
 /**
  * An example test class to show the usage of
@@ -72,7 +60,7 @@ public class TranscribeStreamingIntegrationTest {
         CompletableFuture<Void> result = client.startStreamTranscription(getRequest(16_000),
                                                                          new AudioStreamPublisher(
                                                                              getInputStream("silence_16kHz_s16le.wav")),
-                                                                         getResponseHandler());
+                                                                         TestResponseHandlers.responseHandlerBuilder_Classic());
 
         // Blocking call to keep the main thread for shutting down
         result.get();
@@ -83,7 +71,7 @@ public class TranscribeStreamingIntegrationTest {
         CompletableFuture<Void> result = client.startStreamTranscription(getRequest(8_000),
                                                                          new AudioStreamPublisher(
                                                                              getInputStream("silence_8kHz_s16le.wav")),
-                                                                         getResponseHandler());
+                                                                         TestResponseHandlers.responseHandlerBuilder_Consumer());
 
         result.get();
     }
@@ -111,26 +99,6 @@ public class TranscribeStreamingIntegrationTest {
         }
     }
 
-    private StartStreamTranscriptionResponseHandler getResponseHandler() {
-        return StartStreamTranscriptionResponseHandler.builder()
-                                                      .onResponse(r -> {
-                                                          String idFromHeader = r.sdkHttpResponse()
-                                                                                 .firstMatchingHeader(X_AMZN_REQUEST_ID_HEADER)
-                                                                                 .orElse(null);
-                                                          System.out.println("Received Initial response: " + idFromHeader);
-                                                      })
-                                                      .onError(e -> {
-                                                          System.out.println("Error message: " + e.getMessage());
-                                                      })
-                                                      .onComplete(() -> {
-                                                          System.out.println("All records stream successfully");
-                                                      })
-                                                      .subscriber(event -> {
-                                                          System.out.println(((TranscriptEvent) event).transcript().results());
-                                                      })
-                                                      .build();
-    }
-
     private class AudioStreamPublisher implements Publisher<AudioStream> {
         private final InputStream inputStream;
 
@@ -140,78 +108,7 @@ public class TranscribeStreamingIntegrationTest {
 
         @Override
         public void subscribe(Subscriber<? super AudioStream> s) {
-            s.onSubscribe(new SubscriptionImpl(s, inputStream));
-        }
-    }
-
-    private class SubscriptionImpl implements Subscription {
-        private static final int CHUNK_SIZE_IN_BYTES = 1024 * 1;
-        private ExecutorService executor = Executors.newFixedThreadPool(1);
-        private AtomicLong demand = new AtomicLong(0);
-
-        private final Subscriber<? super AudioStream> subscriber;
-        private final InputStream inputStream;
-
-        private SubscriptionImpl(Subscriber<? super AudioStream> s, InputStream inputStream) {
-            this.subscriber = s;
-            this.inputStream = inputStream;
-        }
-
-        @Override
-        public void request(long n) {
-            if (n <= 0) {
-                subscriber.onError(new IllegalArgumentException("Demand must be positive"));
-            }
-
-            demand.getAndAdd(n);
-
-            executor.submit(() -> {
-                try {
-                    do {
-                        ByteBuffer audioBuffer = getNextEvent();
-                        if (audioBuffer.remaining() > 0) {
-                            AudioEvent audioEvent = audioEventFromBuffer(audioBuffer);
-                            subscriber.onNext(audioEvent);
-                        } else {
-                            subscriber.onComplete();
-                            break;
-                        }
-                    } while (demand.decrementAndGet() > 0);
-                } catch (Exception e) {
-                    subscriber.onError(e);
-                }
-            });
-        }
-
-        @Override
-        public void cancel() {
-
-        }
-
-        private ByteBuffer getNextEvent() {
-            ByteBuffer audioBuffer = null;
-            byte[] audioBytes = new byte[CHUNK_SIZE_IN_BYTES];
-
-            int len = 0;
-            try {
-                len = inputStream.read(audioBytes);
-
-                if (len <= 0) {
-                    audioBuffer = ByteBuffer.allocate(0);
-                } else {
-                    audioBuffer = ByteBuffer.wrap(audioBytes, 0, len);
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-
-            return audioBuffer;
-        }
-
-        private AudioEvent audioEventFromBuffer(ByteBuffer bb) {
-            return AudioEvent.builder()
-                             .audioChunk(SdkBytes.fromByteBuffer(bb))
-                             .build();
+            s.onSubscribe(new TestSubscription(s, inputStream));
         }
     }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/BufferingSubscriberTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/BufferingSubscriberTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BufferingSubscriberTest {
+
+    private static final int BUFFER_SIZE = 6;
+
+    private static final Object data = new Object();
+
+    @Mock
+    private Subscriber mockSubscriber;
+
+    @Mock
+    private Subscription mockSubscription;
+
+    private Subscriber bufferingSubscriber;
+
+    @Before
+    public void setup() {
+        doNothing().when(mockSubscriber).onSubscribe(any());
+        doNothing().when(mockSubscriber).onNext(any());
+        doNothing().when(mockSubscriber).onComplete();
+        doNothing().when(mockSubscription).request(anyLong());
+
+        bufferingSubscriber = new BufferingSubscriber(mockSubscriber, BUFFER_SIZE);
+        bufferingSubscriber.onSubscribe(mockSubscription);
+    }
+
+    @Test
+    public void onNextNotCalled_WhenCurrentSizeLessThanBufferSize() {
+        int count = 3;
+        callOnNext(count);
+
+        verify(mockSubscription, times(count)).request(1);
+        verify(mockSubscriber, times(0)).onNext(any());
+    }
+
+    @Test
+    public void onNextIsCalled_onlyWhen_BufferSizeRequirementIsMet() {
+        callOnNext(BUFFER_SIZE);
+
+        verify(mockSubscriber, times(1)).onNext(any());
+    }
+
+    @Test
+    public void onNextIsCalled_DuringOnComplete_WhenBufferNotEmpty() {
+        int count = 8;
+        callOnNext(count);
+        bufferingSubscriber.onComplete();
+
+        verify(mockSubscriber, times(count/BUFFER_SIZE + 1)).onNext(any());
+    }
+
+    private void callOnNext(int times) {
+        IntStream.range(0, times).forEach(i ->  bufferingSubscriber.onNext(data));
+    }
+
+}


### PR DESCRIPTION
**Bugs**
* BufferingSubscriber doesn't request data when current size is less than buffer size. So the application sits idle until ReadTimeoutException is thrown
* FlatteningSubscriber decrements the demand even when buffer is empty
* FlatteningSubscriber was bit complex to add unit test, so updated an integ test to use the response handler variant that was reported in the original issue (internal)