### PR TITLE
Support requiresLength trait for streaming payloads. 

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -157,6 +157,7 @@ final class AddOperations {
             operationModel.setDeprecated(op.isDeprecated());
             operationModel.setDocumentation(op.getDocumentation());
             operationModel.setIsAuthenticated(isAuthenticated(op));
+            operationModel.setAuthType(op.getAuthType());
             operationModel.setPaginated(isPaginated(op));
             operationModel.setEndpointOperation(op.isEndpointOperation());
             operationModel.setEndpointDiscovery(op.getEndpointDiscovery());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
@@ -87,6 +87,7 @@ abstract class AddShapes {
         boolean hasStatusCodeMember = false;
         boolean hasPayloadMember = false;
         boolean hasStreamingMember = false;
+        boolean hasRequiresLength = false;
 
         Map<String, Member> members = shape.getMembers();
 
@@ -112,15 +113,19 @@ abstract class AddShapes {
                     if (memberModel.getHttp().getIsStreaming()) {
                         hasStreamingMember = true;
                     }
+                    if (memberModel.getHttp().isRequiresLength()) {
+                        hasRequiresLength = true;
+                    }
                 }
 
                 shapeModel.addMember(memberModel);
             }
 
             shapeModel.withHasHeaderMember(hasHeaderMember)
-                    .withHasStatusCodeMember(hasStatusCodeMember)
-                    .withHasPayloadMember(hasPayloadMember)
-                    .withHasStreamingMember(hasStreamingMember);
+                      .withHasStatusCodeMember(hasStatusCodeMember)
+                      .withHasPayloadMember(hasPayloadMember)
+                      .withHasStreamingMember(hasStreamingMember)
+                      .withHasRequiresLengthMember(hasRequiresLength);
         }
 
         List<String> enumValues = shape.getEnumValues();
@@ -200,9 +205,11 @@ abstract class AddShapes {
         boolean shapeIsStreaming = shape.isStreaming();
         boolean memberIsStreaming = c2jMemberDefinition.isStreaming();
         boolean payloadIsStreaming = shapeIsStreaming || memberIsStreaming;
+        boolean requiresLength = shape.isRequiresLength() || c2jMemberDefinition.isRequiresLength();
 
         httpMapping.withPayload(payload != null && payload.equals(c2jMemberName))
-                .withStreaming(payloadIsStreaming);
+                   .withStreaming(payloadIsStreaming)
+                   .withRequiresLength(requiresLength);
 
         memberModel.setHttp(httpMapping);
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.OperationDocs;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.internal.Utils;
+import software.amazon.awssdk.codegen.model.service.AuthType;
 import software.amazon.awssdk.codegen.model.service.EndpointTrait;
 
 public class OperationModel extends DocumentationModel {
@@ -42,6 +43,8 @@ public class OperationModel extends DocumentationModel {
     private boolean hasBlobMemberAsPayload;
 
     private boolean isAuthenticated = true;
+
+    private AuthType authType;
 
     private boolean isPaginated;
 
@@ -101,6 +104,14 @@ public class OperationModel extends DocumentationModel {
 
     public void setIsAuthenticated(boolean isAuthenticated) {
         this.isAuthenticated = isAuthenticated;
+    }
+
+    public AuthType getAuthType() {
+        return authType;
+    }
+
+    public void setAuthType(AuthType authType) {
+        this.authType = authType;
     }
 
     public ShapeModel getInputShape() {
@@ -238,6 +249,10 @@ public class OperationModel extends DocumentationModel {
      */
     public boolean hasEventStreamInput() {
         return containsEventStream(inputShape);
+    }
+
+    public boolean hasRequiresLengthInInput() {
+        return inputShape != null && inputShape.isHasRequiresLengthMember();
     }
 
     private boolean containsEventStream(ShapeModel shapeModel) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ParameterHttpMapping.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ParameterHttpMapping.java
@@ -31,6 +31,7 @@ public class ParameterHttpMapping {
     private Location location;
     private boolean flattened;
     private boolean isGreedy;
+    private boolean requiresLength;
 
     public boolean getIsPayload() {
         return isPayload;
@@ -163,6 +164,19 @@ public class ParameterHttpMapping {
 
     public ParameterHttpMapping withIsGreedy(boolean greedy) {
         setIsGreedy(greedy);
+        return this;
+    }
+
+    public boolean isRequiresLength() {
+        return requiresLength;
+    }
+
+    public void setRequiresLength(boolean requiresLength) {
+        this.requiresLength = requiresLength;
+    }
+
+    public ParameterHttpMapping withRequiresLength(boolean requiresLength) {
+        setRequiresLength(requiresLength);
         return this;
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
@@ -43,6 +43,7 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
     private boolean hasHeaderMember;
     private boolean hasStatusCodeMember;
     private boolean hasStreamingMember;
+    private boolean hasRequiresLengthMember;
     private boolean wrapper;
     private boolean simpleMethod;
     private String requestSignerClassFqcn;
@@ -236,6 +237,19 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
 
     public ShapeModel withHasStreamingMember(boolean hasStreamingMember) {
         setHasStreamingMember(hasStreamingMember);
+        return this;
+    }
+
+    public boolean isHasRequiresLengthMember() {
+        return hasRequiresLengthMember;
+    }
+
+    public void setHasRequiresLengthMember(boolean hasRequiresLengthMember) {
+        this.hasRequiresLengthMember = hasRequiresLengthMember;
+    }
+
+    public ShapeModel withHasRequiresLengthMember(boolean hasRequiresLengthMember) {
+        setHasRequiresLengthMember(hasRequiresLengthMember);
         return this;
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Member.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Member.java
@@ -29,6 +29,8 @@ public class Member {
 
     private boolean streaming;
 
+    private boolean requiresLength;
+
     private String documentation;
 
     private String queryName;
@@ -95,6 +97,14 @@ public class Member {
 
     public void setStreaming(boolean streaming) {
         this.streaming = streaming;
+    }
+
+    public boolean isRequiresLength() {
+        return requiresLength;
+    }
+
+    public void setRequiresLength(boolean requiresLength) {
+        this.requiresLength = requiresLength;
     }
 
     public String getDocumentation() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Shape.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Shape.java
@@ -40,6 +40,8 @@ public class Shape {
 
     private boolean streaming;
 
+    private boolean requiresLength;
+
     private boolean wrapper;
 
     private Member listMember;
@@ -201,6 +203,14 @@ public class Shape {
 
     public void setStreaming(boolean streaming) {
         this.streaming = streaming;
+    }
+
+    public boolean isRequiresLength() {
+        return requiresLength;
+    }
+
+    public void setRequiresLength(boolean requiresLength) {
+        this.requiresLength = requiresLength;
     }
 
     public boolean isWrapper() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -242,11 +242,11 @@ public class SyncClientClass implements ClassSpec {
         Protocol protocol = model.getMetadata().getProtocol();
         switch (protocol) {
             case QUERY:
-                return new QueryProtocolSpec(poetExtensions);
+                return new QueryProtocolSpec(model, poetExtensions);
             case REST_XML:
                 return new XmlProtocolSpec(model, poetExtensions);
             case EC2:
-                return new Ec2ProtocolSpec(poetExtensions);
+                return new Ec2ProtocolSpec(model, poetExtensions);
             case AWS_JSON:
             case REST_JSON:
             case CBOR:

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/Ec2ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/Ec2ProtocolSpec.java
@@ -15,13 +15,14 @@
 
 package software.amazon.awssdk.codegen.poet.client.specs;
 
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.protocols.query.AwsEc2ProtocolFactory;
 
 public class Ec2ProtocolSpec extends QueryProtocolSpec {
 
-    public Ec2ProtocolSpec(PoetExtensions poetExtensions) {
-        super(poetExtensions);
+    public Ec2ProtocolSpec(IntermediateModel model, PoetExtensions poetExtensions) {
+        super(model, poetExtensions);
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
@@ -30,7 +30,7 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
 
     public XmlProtocolSpec(IntermediateModel model,
                            PoetExtensions poetExtensions) {
-        super(poetExtensions);
+        super(model, poetExtensions);
         this.model = model;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHand
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
+import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.util.VersionInfo;
 import software.amazon.awssdk.protocols.core.ExceptionMetadata;
@@ -435,7 +436,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             return CompletableFutureUtils.failedFuture(t);
         }
     }
-    
+
     /**
      * <p>
      * Performs a post operation to the query service and has no output
@@ -551,7 +552,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * The following are few ways to use the response class:
      * </p>
      * 1) Using the subscribe helper method
-     * 
+     *
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
@@ -561,19 +562,19 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * </pre>
      *
      * 2) Using a custom subscriber
-     * 
+     *
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
      * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse>() {
-     * 
+     *
      * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     * 
-     * 
+     *
+     *
      * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response) { //... };
      * });}
      * </pre>
-     * 
+     *
      * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
@@ -669,7 +670,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * The following are few ways to use the response class:
      * </p>
      * 1) Using the subscribe helper method
-     * 
+     *
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
@@ -679,19 +680,19 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
      * </pre>
      *
      * 2) Using a custom subscriber
-     * 
+     *
      * <pre>
      * {@code
      * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
      * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse>() {
-     * 
+     *
      * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
-     * 
-     * 
+     *
+     *
      * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response) { //... };
      * });}
      * </pre>
-     * 
+     *
      * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
@@ -761,9 +762,12 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             CompletableFuture<StreamingInputOperationResponse> executeFuture = clientHandler
                     .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
                             .withOperationName("StreamingInputOperation")
-                            .withMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
-                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                            .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
+                            .withMarshaller(
+                                AsyncStreamingRequestMarshaller.builder()
+                                                               .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                                                               .asyncRequestBody(requestBody).build()).withResponseHandler(responseHandler)
+                            .withErrorResponseHandler(errorResponseHandler).withAsyncRequestBody(requestBody)
+                            .withInput(streamingInputOperationRequest));
             return executeFuture;
         } catch (Throwable t) {
             return CompletableFutureUtils.failedFuture(t);
@@ -818,7 +822,12 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
                     new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
                             .withOperationName("StreamingInputOutputOperation")
-                            .withMarshaller(new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
+                            .withMarshaller(
+                                AsyncStreamingRequestMarshaller
+                                    .builder()
+                                    .delegateMarshaller(
+                                        new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
+                                    .asyncRequestBody(requestBody).transferEncoding(true).build())
                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
                             .withAsyncRequestBody(requestBody).withInput(streamingInputOutputOperationRequest),
                     asyncResponseTransformer);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -472,8 +472,9 @@ final class DefaultJsonClient implements JsonClient {
                                          .withInput(streamingInputOperationRequest)
                                          .withRequestBody(requestBody)
                                          .withMarshaller(
-                                             new StreamingRequestMarshaller<StreamingInputOperationRequest>(
-                                                 new StreamingInputOperationRequestMarshaller(protocolFactory), requestBody)));
+                                             StreamingRequestMarshaller.builder()
+                                                                       .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                                                                       .requestBody(requestBody).build()));
     }
 
     /**
@@ -534,9 +535,9 @@ final class DefaultJsonClient implements JsonClient {
                 .withInput(streamingInputOutputOperationRequest)
                 .withRequestBody(requestBody)
                 .withMarshaller(
-                    new StreamingRequestMarshaller<StreamingInputOutputOperationRequest>(
-                        new StreamingInputOutputOperationRequestMarshaller(protocolFactory), requestBody)),
-            responseTransformer);
+                    StreamingRequestMarshaller.builder()
+                                              .delegateMarshaller(new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
+                                              .requestBody(requestBody).transferEncoding(true).build()), responseTransformer);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionInterceptorChain.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/ExecutionInterceptorChain.java
@@ -86,7 +86,7 @@ public class ExecutionInterceptorChain {
 
             SdkHttpFullRequest sdkHttpFullRequest = (SdkHttpFullRequest) context.httpRequest();
             if (!result.requestBody().isPresent() && sdkHttpFullRequest.contentStreamProvider().isPresent()) {
-                int contentLength = Integer.parseInt(sdkHttpFullRequest.firstMatchingHeader("Content-Length").orElse("0"));
+                long contentLength = Long.parseLong(sdkHttpFullRequest.firstMatchingHeader("Content-Length").orElse("0"));
                 String contentType = sdkHttpFullRequest.firstMatchingHeader("Content-Type").orElse("");
                 RequestBody requestBody = RequestBody.fromContentProvider(sdkHttpFullRequest.contentStreamProvider().get(),
                                                                           contentLength,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/transform/AbstractStreamingRequestMarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/transform/AbstractStreamingRequestMarshaller.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.transform;
+
+import static software.amazon.awssdk.http.Header.CHUNKED;
+import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
+import static software.amazon.awssdk.http.Header.TRANSFER_ENCODING;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+
+@SdkInternalApi
+public abstract class AbstractStreamingRequestMarshaller<T> implements Marshaller<T> {
+    protected final Marshaller<T> delegateMarshaller;
+    protected final boolean requiresLength;
+    protected final boolean transferEncoding;
+    protected final boolean useHttp2;
+
+    protected AbstractStreamingRequestMarshaller(Builder builder) {
+        this.delegateMarshaller = builder.delegateMarshaller;
+        this.requiresLength = builder.requiresLength;
+        this.transferEncoding = builder.transferEncoding;
+        this.useHttp2 = builder.useHttp2;
+    }
+
+    /**
+     * This method will run certain validations for content-length and add
+     * additional headers (like Transfer-Encoding) if necessary.
+     *
+     * If requiresLength and transferEncoding is not set to true and Content Length is missing,
+     * SDK is not required to calculate the Content-Length and delegate that behavior to the underlying http client.
+     *
+     * @param marshalled A mutable builder for {@link SdkHttpFullRequest} representing a HTTP request.
+     * @param contentLength Optional of content length
+     * @param requiresLength True if Content-Length header is required on the request
+     * @param transferEncoding True if "Transfer-Encoding: chunked" header should be set on request
+     * @param useHttp2 True if the operation uses http2
+     */
+    protected final void addHeaders(SdkHttpFullRequest.Builder marshalled,
+                                    Optional<Long> contentLength,
+                                    boolean requiresLength,
+                                    boolean transferEncoding,
+                                    boolean useHttp2) {
+        if (contentLength.isPresent()) {
+            marshalled.putHeader(CONTENT_LENGTH, Long.toString(contentLength.get()));
+            return;
+        }
+
+        if (requiresLength) {
+            throw SdkClientException.create("This API requires Content-Length header to be set. "
+                                            + "Please set the content length on the RequestBody.");
+        } else if (transferEncoding && !useHttp2) {
+            marshalled.putHeader(TRANSFER_ENCODING, CHUNKED);
+        }
+    }
+
+    protected abstract static class Builder<BuilderT extends Builder> {
+        private Marshaller delegateMarshaller;
+        private boolean requiresLength = Boolean.FALSE;
+        private boolean transferEncoding = Boolean.FALSE;
+        private boolean useHttp2 = Boolean.FALSE;
+
+        protected Builder() {
+        }
+
+        /**
+         * @param delegateMarshaller POJO marshaller (for path/query/header members)
+         * @return This object for method chaining
+         */
+        public BuilderT delegateMarshaller(Marshaller delegateMarshaller) {
+            this.delegateMarshaller = delegateMarshaller;
+            return (BuilderT) this;
+        }
+
+
+        /**
+         * @param requiresLength boolean value indicating if Content-Length header is required in the request
+         * @return This object for method chaining
+         */
+        public BuilderT requiresLength(boolean requiresLength) {
+            this.requiresLength = requiresLength;
+            return (BuilderT) this;
+        }
+
+        /**
+         * @param transferEncoding boolean value indicating if Transfer-Encoding: chunked header is required in the request
+         * @return This object for method chaining
+         */
+        public BuilderT transferEncoding(boolean transferEncoding) {
+            this.transferEncoding = transferEncoding;
+            return (BuilderT) this;
+        }
+
+        /**
+         * @param useHttp2 boolean value indicating if request uses HTTP 2 protocol
+         * @return This object for method chaining
+         */
+        public BuilderT useHttp2(boolean useHttp2) {
+            this.useHttp2 = useHttp2;
+            return (BuilderT) this;
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/AsyncStreamingRequestMarshaller.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/runtime/transform/AsyncStreamingRequestMarshaller.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.runtime.transform;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.internal.transform.AbstractStreamingRequestMarshaller;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+
+/**
+ * Augments a {@link Marshaller} to add contents for an async streamed request.
+ *
+ * @param <T> Type of POJO being marshalled.
+ */
+@SdkProtectedApi
+public final class AsyncStreamingRequestMarshaller<T> extends AbstractStreamingRequestMarshaller<T> {
+
+    private final AsyncRequestBody asyncRequestBody;
+
+    private AsyncStreamingRequestMarshaller(Builder builder) {
+        super(builder);
+        this.asyncRequestBody = builder.asyncRequestBody;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public SdkHttpFullRequest marshall(T in) {
+        SdkHttpFullRequest.Builder marshalled = delegateMarshaller.marshall(in).toBuilder();
+
+        addHeaders(marshalled, asyncRequestBody.contentLength(), requiresLength, transferEncoding, useHttp2);
+
+        return marshalled.build();
+    }
+
+    /**
+     * Builder class to build {@link AsyncStreamingRequestMarshaller} object.
+     */
+    public static final class Builder extends AbstractStreamingRequestMarshaller.Builder<Builder> {
+
+        private AsyncRequestBody asyncRequestBody;
+
+        /**
+         * @param asyncRequestBody {@link AsyncRequestBody} representing the HTTP payload
+         * @return This object for method chaining
+         */
+        public Builder asyncRequestBody(AsyncRequestBody asyncRequestBody) {
+            this.asyncRequestBody = asyncRequestBody;
+            return this;
+        }
+
+        public <T> AsyncStreamingRequestMarshaller<T> build() {
+            return new AsyncStreamingRequestMarshaller<>(this);
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/runtime/transform/AsyncStreamingRequestMarshallerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/runtime/transform/AsyncStreamingRequestMarshallerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.runtime.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.Header;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncStreamingRequestMarshallerTest {
+
+    private static final Object object = new Object();
+
+    @Mock
+    private Marshaller delegate;
+
+    @Mock
+    private AsyncRequestBody requestBody;
+
+    private SdkHttpFullRequest request = generateBasicRequest();
+
+    @Before
+    public void setup() {
+        when(delegate.marshall(any())).thenReturn(request);
+    }
+
+    @Test
+    public void contentLengthHeaderIsSet_IfPresent() {
+        long value = 5L;
+        when(requestBody.contentLength()).thenReturn(Optional.of(value));
+
+        AsyncStreamingRequestMarshaller marshaller = createMarshaller(true, true, true);
+        SdkHttpFullRequest httpFullRequest = marshaller.marshall(object);
+
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH)).isPresent();
+        assertContentLengthValue(httpFullRequest, value);
+        assertThat(httpFullRequest.firstMatchingHeader(Header.TRANSFER_ENCODING)).isEmpty();
+    }
+
+    @Test
+    public void throwsException_contentLengthHeaderIsMissing_AndRequiresLengthIsPresent() {
+        when(requestBody.contentLength()).thenReturn(Optional.empty());
+
+        AsyncStreamingRequestMarshaller marshaller = createMarshaller(true, false, false);
+        assertThatThrownBy(() -> marshaller.marshall(object)).isInstanceOf(SdkClientException.class);
+    }
+
+    @Test
+    public void transferEncodingIsUsed_OverHttp1() {
+        when(requestBody.contentLength()).thenReturn(Optional.empty());
+
+        AsyncStreamingRequestMarshaller marshaller = createMarshaller(false, true, false);
+        SdkHttpFullRequest httpFullRequest = marshaller.marshall(object);
+
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH)).isEmpty();
+        assertThat(httpFullRequest.firstMatchingHeader(Header.TRANSFER_ENCODING)).isPresent();
+    }
+
+    @Test
+    public void transferEncodingIsNotUsed_OverHttp2() {
+        when(requestBody.contentLength()).thenReturn(Optional.empty());
+
+        AsyncStreamingRequestMarshaller marshaller = createMarshaller(false, true, true);
+        SdkHttpFullRequest httpFullRequest = marshaller.marshall(object);
+
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH)).isEmpty();
+        assertThat(httpFullRequest.firstMatchingHeader(Header.TRANSFER_ENCODING)).isEmpty();
+    }
+
+    private void assertContentLengthValue(SdkHttpFullRequest httpFullRequest, long value) {
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH).get())
+            .contains(Long.toString(value));
+    }
+
+    private AsyncStreamingRequestMarshaller createMarshaller(boolean requiresLength,
+                                                             boolean transferEncoding,
+                                                             boolean useHttp2) {
+        return AsyncStreamingRequestMarshaller.builder()
+                                              .delegateMarshaller(delegate)
+                                              .asyncRequestBody(requestBody)
+                                              .requiresLength(requiresLength)
+                                              .transferEncoding(transferEncoding)
+                                              .useHttp2(useHttp2)
+                                              .build();
+    }
+
+    private SdkHttpFullRequest generateBasicRequest() {
+        return SdkHttpFullRequest.builder()
+                                 .contentStreamProvider(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
+                                 .method(SdkHttpMethod.POST)
+                                 .putHeader("Host", "demo.us-east-1.amazonaws.com")
+                                 .putHeader("x-amz-archive-description", "test  test")
+                                 .encodedPath("/")
+                                 .uri(URI.create("http://demo.us-east-1.amazonaws.com"))
+                                 .build();
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/runtime/transform/SyncStreamingRequestMarshallerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/runtime/transform/SyncStreamingRequestMarshallerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.runtime.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.Header;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+
+/**
+ * Currently RequestBody always require content length. So we always sent content-length header for all sync APIs.
+ * So this test class only tests the case when content length is present
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SyncStreamingRequestMarshallerTest {
+
+    private static final Object object = new Object();
+
+    @Mock
+    private Marshaller delegate;
+
+    private SdkHttpFullRequest request = generateBasicRequest();
+
+    @Before
+    public void setup() {
+        when(delegate.marshall(any())).thenReturn(request);
+    }
+
+    @Test
+    public void contentLengthHeaderIsSet_IfPresent() {
+        String text = "foobar";
+        StreamingRequestMarshaller marshaller = createMarshaller(RequestBody.fromString(text), true, true, true);
+        SdkHttpFullRequest httpFullRequest = marshaller.marshall(object);
+
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH)).isPresent();
+        assertContentLengthValue(httpFullRequest, text.length());
+        assertThat(httpFullRequest.firstMatchingHeader(Header.TRANSFER_ENCODING)).isEmpty();
+    }
+
+    @Test
+    public void contentLengthHeaderIsSet_forEmptyContent() {
+        StreamingRequestMarshaller marshaller = createMarshaller(RequestBody.empty(), true, true, true);
+        SdkHttpFullRequest httpFullRequest = marshaller.marshall(object);
+
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH)).isPresent();
+        assertContentLengthValue(httpFullRequest, 0L);
+        assertThat(httpFullRequest.firstMatchingHeader(Header.TRANSFER_ENCODING)).isEmpty();
+    }
+
+    private void assertContentLengthValue(SdkHttpFullRequest httpFullRequest, long value) {
+        assertThat(httpFullRequest.firstMatchingHeader(Header.CONTENT_LENGTH).get())
+            .contains(Long.toString(value));
+    }
+
+    private StreamingRequestMarshaller createMarshaller(RequestBody requestBody,
+                                                        boolean requiresLength,
+                                                        boolean transferEncoding,
+                                                        boolean useHttp2) {
+        return StreamingRequestMarshaller.builder()
+                                         .delegateMarshaller(delegate)
+                                         .requestBody(requestBody)
+                                         .requiresLength(requiresLength)
+                                         .transferEncoding(transferEncoding)
+                                         .useHttp2(useHttp2)
+                                         .build();
+    }
+
+    private SdkHttpFullRequest generateBasicRequest() {
+        return SdkHttpFullRequest.builder()
+                                 .contentStreamProvider(() -> new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
+                                 .method(SdkHttpMethod.POST)
+                                 .putHeader("Host", "demo.us-east-1.amazonaws.com")
+                                 .putHeader("x-amz-archive-description", "test  test")
+                                 .encodedPath("/")
+                                 .uri(URI.create("http://demo.us-east-1.amazonaws.com"))
+                                 .build();
+    }
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/Header.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/Header.java
@@ -29,6 +29,10 @@ public final class Header {
 
     public static final String CONTENT_MD5 = "Content-MD5";
 
+    public static final String TRANSFER_ENCODING = "Transfer-Encoding";
+
+    public static final String CHUNKED = "chunked";
+
     private Header() {
     }
 

--- a/services/mediastoredata/pom.xml
+++ b/services/mediastoredata/pom.xml
@@ -57,5 +57,17 @@
             <artifactId>protocol-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>mediastore</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/MediaStoreDataIntegrationTest.java
+++ b/services/mediastoredata/src/it/java/software/amazon/awssdk/services/mediastoredata/MediaStoreDataIntegrationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.mediastoredata;
+
+import io.reactivex.Flowable;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.internal.async.ByteArrayAsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.mediastore.MediaStoreClient;
+import software.amazon.awssdk.services.mediastore.model.Container;
+import software.amazon.awssdk.services.mediastore.model.ContainerStatus;
+import software.amazon.awssdk.services.mediastore.model.DescribeContainerResponse;
+import software.amazon.awssdk.services.mediastoredata.model.PutObjectRequest;
+import software.amazon.awssdk.testutils.Waiter;
+import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
+
+//TODO deleteContainer fails with ContainerInUseException with no error message. Needs investigation
+// The test cases work fine.
+@Ignore
+public class MediaStoreDataIntegrationTest extends AwsIntegrationTestBase {
+    private static final String CONTAINER_NAME = "java-sdk-test-" + Instant.now().toEpochMilli();
+
+    private static MediaStoreClient mediaStoreClient;
+    private static MediaStoreDataClient syncClientWithApache;
+    private static MediaStoreDataClient syncClientWithUrlConnection;
+    private static MediaStoreDataAsyncClient asyncClient;
+
+    private static Container container;
+    private static PutObjectRequest putObjectRequest;
+
+    @BeforeClass
+    public static void setup() {
+        mediaStoreClient = MediaStoreClient.builder()
+                                           .credentialsProvider(getCredentialsProvider())
+                                           .httpClient(ApacheHttpClient.builder().build())
+                                           .build();
+        container = createContainer();
+        URI uri = URI.create(container.endpoint());
+
+        syncClientWithApache = MediaStoreDataClient.builder()
+                                                   .endpointOverride(uri)
+                                                   .credentialsProvider(getCredentialsProvider())
+                                                   .httpClient(ApacheHttpClient.builder().build())
+                                                   .build();
+
+        syncClientWithUrlConnection= MediaStoreDataClient.builder()
+                                                         .endpointOverride(uri)
+                                                         .credentialsProvider(getCredentialsProvider())
+                                                         .httpClient(UrlConnectionHttpClient.create())
+                                                         .build();
+
+        asyncClient = MediaStoreDataAsyncClient.builder()
+                                               .endpointOverride(uri)
+                                               .credentialsProvider(getCredentialsProvider())
+                                               .build();
+
+        putObjectRequest = PutObjectRequest.builder()
+                                           .contentType("application/octet-stream")
+                                           .path("/foo")
+                                           .build();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        waitContainerToBeActive();
+        // Randomly this method is throwing ContainerInUseException
+        Thread.sleep(2000);
+        mediaStoreClient.deleteContainer(r -> r.containerName(CONTAINER_NAME));
+    }
+
+    @org.junit.Test
+    public void putObject_sync_apacheHttpClient() {
+        syncClientWithApache.putObject(putObjectRequest, RequestBody.fromString("foobar"));
+    }
+
+    @org.junit.Test
+    public void putObject_sync_urlConnectionHttpClient() {
+        syncClientWithUrlConnection.putObject(putObjectRequest,
+                                              RequestBody.fromInputStream(
+                                                  new ByteArrayInputStream("foobar".getBytes()), 6));
+    }
+
+    @org.junit.Test
+    public void putObject_asyncClient_withContentLength() {
+        asyncClient.putObject(putObjectRequest, AsyncRequestBody.fromString("foobar")).join();
+    }
+
+    @org.junit.Test
+    public void putObject_asyncClient_withoutContentLength() {
+        asyncClient.putObject(putObjectRequest, customAsyncRequestBody()).join();
+    }
+
+    private static Container createContainer() {
+        mediaStoreClient.createContainer(r -> r.containerName(CONTAINER_NAME));
+
+        DescribeContainerResponse response = waitContainerToBeActive();
+        return response.container();
+    }
+
+    private static DescribeContainerResponse waitContainerToBeActive() {
+        return Waiter.run(() -> mediaStoreClient.describeContainer(r -> r.containerName(CONTAINER_NAME)))
+                     .until(r -> ContainerStatus.ACTIVE.equals(r.container().status()))
+                     .orFailAfter(Duration.ofMinutes(3));
+    }
+
+    private AsyncRequestBody customAsyncRequestBody() {
+        return new AsyncRequestBody() {
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.empty();
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                Flowable.fromPublisher(new ByteArrayAsyncRequestBody("Random text".getBytes()))
+                        .subscribe(s);
+            }
+        };
+    }
+}

--- a/services/mediastoredata/src/it/resources/log4j.properties
+++ b/services/mediastoredata/src/it/resources/log4j.properties
@@ -1,0 +1,32 @@
+#
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+log4j.rootLogger=INFO, A1
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+
+# Print the date in ISO 8601 format
+log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+# Adjust to see more / less logging
+#log4j.logger.com.amazonaws.ec2=DEBUG
+
+# HttpClient 3 Wire Logging
+#log4j.logger.httpclient.wire=DEBUG
+
+# HttpClient 4 Wire Logging
+#log4j.logger.org.apache.http.wire=DEBUG
+#log4j.logger.org.apache.http=DEBUG
+#log4j.logger.software.amazon.awssdk=DEBUG

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/query-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/query-input.json
@@ -21,6 +21,30 @@
     }
   },
   {
+    "description": "Streaming payload member is marshalled correctly",
+    "given": {
+      "input": {
+        "StreamingMember": "contents"
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "StreamingInputOperation"
+    },
+    "then": {
+      "serializedAs": {
+        "headers": {
+          "contains": {
+            "Content-Length": "8"
+          }
+        },
+        "body": {
+          "equals": "contents"
+        }
+      }
+    }
+  },
+  {
     "description": "Scalar Members are marshalled correctly into the query params",
     "given": {
       "input": {

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-input.json
@@ -91,6 +91,11 @@
     },
     "then": {
       "serializedAs": {
+        "headers": {
+          "contains": {
+            "Content-Length": "8"
+          }
+        },
         "body": {
           "equals": "contents"
         }

--- a/test/protocol-tests/src/main/resources/codegen-resources/query/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/query/service-2.json
@@ -50,6 +50,14 @@
         "shape":"QueryTypesInput",
         "resultWrapper":"QueryTypesResult"
       }
+    },
+    "StreamingInputOperation":{
+      "name":"StreamingInputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"StructureWithStreamingMember"}
     }
   },
   "shapes":{
@@ -224,6 +232,18 @@
       },
       "exception":true
     },
-    "Timestamp":{"type":"timestamp"}
+    "Timestamp":{"type":"timestamp"},
+    "StructureWithStreamingMember":{
+      "type":"structure",
+      "members":{
+        "StreamingMember":{"shape":"StreamType"}
+      },
+      "payload":"StreamingMember"
+    },
+    "StreamType":{
+      "type":"blob",
+      "streaming":true,
+      "requiresLength":true
+    }
   }
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -690,7 +690,8 @@
     },
     "StreamType":{
       "type":"blob",
-      "streaming":true
+      "streaming":true,
+      "requiresLength":true
     },
     "String":{"type":"string"},
     "StructWithNestedBlobType":{

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ExecutionInterceptorTest.java
@@ -65,6 +65,7 @@ import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.Header;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
@@ -134,6 +135,8 @@ public class ExecutionInterceptorTest {
         // Expect
         Context.BeforeTransmission beforeTransmissionArg = captureBeforeTransmissionArg(interceptor, false);
         assertThat(beforeTransmissionArg.requestBody().get().contentStreamProvider().newStream().read()).isEqualTo(0);
+        assertThat(beforeTransmissionArg.httpRequest().firstMatchingHeader(Header.CONTENT_LENGTH).get())
+            .contains(Long.toString(1L));
     }
 
     @Test
@@ -156,6 +159,8 @@ public class ExecutionInterceptorTest {
         // the MoveParametersToBodyStage, but we can move the logic from there into the query marshallers (why the hack exists)
         // and then everything should be good for JSON.
         assertThat(beforeTransmissionArg.requestBody().get().contentStreamProvider().newStream().read()).isEqualTo(-1);
+        assertThat(beforeTransmissionArg.httpRequest().firstMatchingHeader(Header.CONTENT_LENGTH).get())
+            .contains(Long.toString(0L));
     }
 
     @Test


### PR DESCRIPTION
~~**This is a draft. Ignore any missing tests, formatting issues**~~
PR is ready for review.

* Support requiresLength trait for streaming payloads. 
* Set request headers based on requiresLength and authType trait
* Core logic is in `StreamingRequestMarshaller` and `AsyncStreamingRequestMarshaller`

**Header resolution logic:** 

-  If content-length is present, always use Content-Length header
- If content-length is not present:
    - If `requiresLength` is present, throw an exception to fail-fast and let user know Content-Length is required. This can only happen for async requests when custom publisher is used. Based on our team discussion, we didn't want to compute the Content-Length in this case to avoid complexity of wrapping publisher and computing content-length
    - If `transferEncoding` (determined at generation based on `v4-unsigned-body`Auth type) is present and not `http2`, set `transfer-encoding: chunked` header
    - For all other cases, keep the behavior same as now. Underlying http clients can determine whether to send `Content-Length` or `Transfer-Encoding` and this is fine as services accept both headers. This is better than computing Content-Length as there will be performance impact if SDK has to read data to find content length. (More information on this in internal doc)