### PR TITLE
Sign events with current signing Clock time

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-f0e1099.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-f0e1099.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix a bug where events in an event stream were being signed with the request date, and not with the current system time."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsS3V4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/AwsS3V4Signer.java
@@ -155,7 +155,7 @@ public final class AwsS3V4Signer extends AbstractAws4Signer<AwsS3V4SignerParams,
         return new AwsChunkedEncodingInputStream(
                 inputStream,
                 signingKey,
-                signerRequestParams.getFormattedSigningDateTime(),
+                signerRequestParams.getFormattedRequestSigningDateTime(),
                 signerRequestParams.getScope(),
                 BinaryUtils.toHex(signature), this);
     }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -70,7 +70,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
         }
 
         addHostHeader(mutableRequest);
-        addDateHeader(mutableRequest, requestParams.getFormattedSigningDateTime());
+        addDateHeader(mutableRequest, requestParams.getFormattedRequestSigningDateTime());
 
         String contentSha256 = calculateContentHash(mutableRequest, signingParams);
         mutableRequest.firstMatchingHeader(SignerConstant.X_AMZ_CONTENT_SHA256)
@@ -112,7 +112,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
         }
 
         // Add the important parameters for v4 signing
-        String timeStamp = requestParams.getFormattedSigningDateTime();
+        String timeStamp = requestParams.getFormattedRequestSigningDateTime();
 
         addPreSignInformationToRequest(mutableRequest, sanitizedCredentials, requestParams, timeStamp, expirationInSeconds);
 
@@ -166,7 +166,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
     protected byte[] deriveSigningKey(AwsCredentials credentials, Aws4SignerRequestParams signerRequestParams) {
 
         String cacheKey = computeSigningCacheKeyName(credentials, signerRequestParams);
-        long daysSinceEpochSigningDate = numberOfDaysSinceEpoch(signerRequestParams.getSigningDateTimeMilli());
+        long daysSinceEpochSigningDate = numberOfDaysSinceEpoch(signerRequestParams.getRequestSigningDateTimeMilli());
 
         SignerKey signerKey = SIGNER_CACHE.get(cacheKey);
 
@@ -177,7 +177,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
         LOG.trace(() -> "Generating a new signing key as the signing key not available in the cache for the date: " +
             TimeUnit.DAYS.toMillis(daysSinceEpochSigningDate));
         byte[] signingKey = newSigningKey(credentials,
-            signerRequestParams.getFormattedSigningDate(),
+            signerRequestParams.getFormattedRequestSigningDate(),
             signerRequestParams.getRegionName(),
             signerRequestParams.getServiceSigningName());
         SIGNER_CACHE.add(cacheKey, new SignerKey(daysSinceEpochSigningDate, signingKey));
@@ -221,7 +221,7 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
 
         String stringToSign = requestParams.getSigningAlgorithm() +
                                     SignerConstant.LINE_SEPARATOR +
-                                    requestParams.getFormattedSigningDateTime() +
+                                    requestParams.getFormattedRequestSigningDateTime() +
                                     SignerConstant.LINE_SEPARATOR +
                                     requestParams.getScope() +
                                     SignerConstant.LINE_SEPARATOR +

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/Aws4SignerUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/Aws4SignerUtils.java
@@ -56,4 +56,8 @@ public final class Aws4SignerUtils {
     public static String formatTimestamp(long timeMilli) {
         return TIME_FORMATTER.format(Instant.ofEpochMilli(timeMilli));
     }
+
+    public static String formatTimestamp(Instant instant) {
+        return TIME_FORMATTER.format(instant);
+    }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/BaseEventStreamAsyncAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/BaseEventStreamAsyncAws4Signer.java
@@ -128,9 +128,8 @@ public abstract class BaseEventStreamAsyncAws4Signer extends BaseAsyncAws4Signer
                  * Signing Date
                  */
                 Map<String, HeaderValue> nonSignatureHeaders = new HashMap<>();
-                long signingEpochMilliSec = requestParams.getSigningDateTimeMilli();
-                Instant signingInstant = Instant.ofEpochMilli(signingEpochMilliSec);
-                String signingDate = Aws4SignerUtils.formatTimestamp(signingEpochMilliSec);
+                Instant signingInstant = requestParams.getSigningClock().instant();
+                String signingDate = Aws4SignerUtils.formatTimestamp(signingInstant);
                 nonSignatureHeaders.put(EVENT_STREAM_DATE, HeaderValue.fromTimestamp(signingInstant));
 
                 /**
@@ -144,9 +143,7 @@ public abstract class BaseEventStreamAsyncAws4Signer extends BaseAsyncAws4Signer
                 /**
                  * Add signing layer event-stream headers
                  */
-                Map<String, HeaderValue> headers = new HashMap<>();
-                //Non-signature header
-                headers.putAll(nonSignatureHeaders);
+                Map<String, HeaderValue> headers = new HashMap<>(nonSignatureHeaders);
                 //Signature headers
                 headers.put(EVENT_STREAM_SIGNATURE, HeaderValue.fromByteArray(signatureBytes));
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/Aws4SignerRequestParamsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/Aws4SignerRequestParamsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Tests for {@link Aws4SignerRequestParams}.
+ */
+public class Aws4SignerRequestParamsTest {
+
+    @Test
+    public void appliesOffset_PositiveOffset() {
+        offsetTest(5);
+    }
+
+    @Test
+    public void appliesOffset_NegativeOffset() {
+        offsetTest(-5);
+    }
+
+    private void offsetTest(int offsetSeconds) {
+        Aws4SignerParams signerParams = Aws4SignerParams.builder()
+                .awsCredentials(AwsBasicCredentials.create("akid", "skid"))
+                .doubleUrlEncode(false)
+                .signingName("test-service")
+                .signingRegion(Region.US_WEST_2)
+                .timeOffset(offsetSeconds)
+                .build();
+
+        Instant now = Instant.now();
+        Aws4SignerRequestParams requestParams = new Aws4SignerRequestParams(signerParams);
+
+        Instant requestSigningInstant = Instant.ofEpochMilli(requestParams.getRequestSigningDateTimeMilli());
+
+        // The offset is subtracted from the current time
+        if (offsetSeconds > 0) {
+            assertThat(requestSigningInstant).isBefore(now);
+        } else {
+            assertThat(requestSigningInstant).isAfter(now);
+        }
+
+        Duration diff = Duration.between(requestSigningInstant, now.minusSeconds(offsetSeconds));
+        // Allow some wiggle room in the difference since we can't use a clock
+        // override for complete accuracy as it doesn't apply the offset when
+        // using a clock override
+        assertThat(diff).isLessThanOrEqualTo(Duration.ofMillis(100));
+    }
+}


### PR DESCRIPTION
## Description
Events should be signed with the current time (as provided by the Clock), not
the initial request time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Updated unit test, ran `TranscribeStreamingIntegrationTest` to verify against service.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
