### PR TITLE
Increase javadoc max memory config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,7 +611,7 @@
                         <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <minmemory>128m</minmemory>
-                            <maxmemory>4g</maxmemory>
+                            <maxmemory>8g</maxmemory>
                             <includeDependencySources>false</includeDependencySources>
                             <show>public</show>
                             <author>false</author>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase javadoc max memory config, fixing `javadoc: error - java.lang.OutOfMemoryError: Please increase memory.`


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
