### PR TITLE
Fix #1268

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-cb74c93.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-cb74c93.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix NPE for streaming APIs in async client if there is a failure before AsyncResponseTransformer#prepare is called for first time. See https://github.com/aws/aws-sdk-java-v2/issues/1268"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -15,7 +15,9 @@
 
 package software.amazon.awssdk.core.interceptor;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 
 /**
  * Attributes that can be applied to all sdk requests. Only SDK is allowed to set these values.
@@ -29,6 +31,13 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      * at the same time.
      */
     public static final ExecutionAttribute<Boolean> IS_FULL_DUPLEX = new ExecutionAttribute<>("IsFullDuplex");
+
+    /**
+     * The key to store the {@link CompletableFuture} returned by {@link AsyncResponseTransformer#prepare()} method
+     * in the first attempt of a request. This is used only for async streaming requests
+     */
+    public static final ExecutionAttribute<CompletableFuture<?>> ASYNC_RESPONSE_TRANSFORMER_FUTURE =
+        new ExecutionAttribute<>("AsyncResponseTransformerFuture");
 
     private SdkInternalExecutionAttribute() {
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/RequestExecutionContext.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/RequestExecutionContext.java
@@ -15,6 +15,9 @@
 
 package software.amazon.awssdk.core.internal.http;
 
+import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.ASYNC_RESPONSE_TRANSFORMER_FUTURE;
+
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkRequest;
@@ -122,6 +125,10 @@ public final class RequestExecutionContext {
      */
     public void requestProvider(AsyncRequestBody publisher) {
         requestProvider = publisher;
+    }
+
+    public CompletableFuture asyncResponseTransformerFuture() {
+        return executionAttributes().getAttribute(ASYNC_RESPONSE_TRANSFORMER_FUTURE);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -91,7 +91,10 @@ public final class MakeAsyncHttpRequestStage<OutputT>
     private CompletableFuture<Response<OutputT>> executeHttpRequest(SdkHttpFullRequest request,
                                                                     RequestExecutionContext context) {
 
-        CompletableFuture<OutputT> preparedTransformFuture = responseHandler.prepare();
+        CompletableFuture<OutputT> preparedTransformFuture =
+            context.asyncResponseTransformerFuture() != null ? context.asyncResponseTransformerFuture()
+                                                             : responseHandler.prepare();
+
         CompletableFuture<? extends SdkException> preparedErrorTransformFuture = errorResponseHandler == null ? null :
                                                                                  errorResponseHandler.prepare();
         CompletableFuture<Response<OutputT>> responseFuture = new CompletableFuture<>();

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncResponseTransformerIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncResponseTransformerIntegrationTest.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.s3.internal.handlers;
+package software.amazon.awssdk.services.s3;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
@@ -27,10 +27,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AsyncResponseTransformerTest {
+public class AsyncResponseTransformerIntegrationTest {
 
     @Mock
     private AsyncResponseTransformer asyncResponseTransformer;

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncResponseTransformerTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncResponseTransformerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.handlers;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncResponseTransformerTest {
+
+    @Mock
+    private AsyncResponseTransformer asyncResponseTransformer;
+
+    @Test
+    public void AsyncResponseTransformerPrepareCalled_BeforeCredentailsResolution() {
+        S3AsyncClient client = S3AsyncClient.builder()
+                                            .credentialsProvider(AwsCredentialsProviderChain.of(
+                                                ProfileCredentialsProvider.create("dummyprofile")))
+                                            .build();
+
+        try {
+            client.getObject(b -> b.bucket("dummy").key("key"), asyncResponseTransformer).join();
+            fail("Expected an exception during credential resolution");
+        } catch (Throwable t) {
+
+        }
+
+        verify(asyncResponseTransformer, times(1)).prepare();
+        verify(asyncResponseTransformer, times(1)).exceptionOccurred(any());
+    }
+}


### PR DESCRIPTION
* Fix for #1268
* Add an execution attribute to store the `CompletableFuture` of initial request attempt (for async streaming APIs)
* AsyncRetryableStage clear the execution attribute for retries if present so that `prepare()` method is called

**Edit:**
**Issue:**
SDK threw a ClientException as credentials cannot be resolved. In the catch block, SDK calls `asyncResponseTransformer.exceptionOccurred()` which will throw NPE as `prepare()` method is not called first which is the point the initialization. The fix moves the `prepare` call earlier into the call stack.

```
        } catch (Throwable t) {
            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                    () -> asyncResponseTransformer.exceptionOccurred(t));
            return CompletableFutureUtils.failedFuture(t);
        }
```
