### PR TITLE
Allow service names to include reserved keywords in their shape or field names...

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -216,7 +216,7 @@ public class DefaultNamingStrategy implements NamingStrategy {
     public String getVariableName(String name) {
         // Exclude keywords because they will not compile, and exclude reserved method names because they're frequently
         // used for local variable names.
-        if (RESERVED_KEYWORDS.contains(name) ||
+        if (isJavaKeyword(name) ||
             RESERVED_STRUCTURE_METHOD_NAMES.contains(name) ||
             RESERVED_EXCEPTION_METHOD_NAMES.contains(name)) {
             return unCapitalize(name + CONFLICTING_NAME_SUFFIX);

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/reservedwords/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/reservedwords/service-2.json
@@ -36,6 +36,7 @@
         "create":{"shape":"String"},
         "int":{"shape":"String"},
         "return":{"shape":"String"},
+        "Long":{"shape":"String"},
         "overrideConfiguration":{"shape":"String"},
         "toBuilder":{"shape":"String"},
         "innerStructure":{"shape":"BadNamesStructure"}


### PR DESCRIPTION
... even if they differ in capitalization.