### PR TITLE
Modify the types of ObjectVersion#Size and Part#Size

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-31779a7.json
+++ b/.changes/next-release/bugfix-AmazonS3-31779a7.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Modify the types of Part#size and ObjectVersion#size from Integer to Long. This is a breaking change for customers who are using the size() method."
+}

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -16,6 +16,24 @@
         }
       ]
     },
+    "ObjectVersion": {
+      "modify": [
+        {
+          "Size": {
+            "emitAsType": "long"
+          }
+        }
+      ]
+    },
+    "Part": {
+      "modify": [
+        {
+          "Size": {
+            "emitAsType": "long"
+          }
+        }
+      ]
+    },
     "FilterRuleName": {
       "modify": [
         {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify the types of `ObjectVersion#Size` and `Part#Size` from Integer to Long.

`S3Object`, `ObjectVersion` and `Part` are the only shapes using `Size`.

## Motivation and Context
Related to #1299 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Bug fix (breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
