### PR TITLE
Make kinsis stability tests more reliable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,8 @@
                         <ignoredUsedUndeclaredDependency>org.hamcrest:*</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.testng:testng</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.mockito:*</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>org.junit.platform:*</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>org.opentest4j:*</ignoredUsedUndeclaredDependency>
 
                         <!-- TODO: fix this once we start to generate pom.xml for individual services -->
                         <ignoredUsedUndeclaredDependency>org.reactivestreams:reactive-streams</ignoredUsedUndeclaredDependency>

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/exceptions/StabilityTestsRetryableException.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/exceptions/StabilityTestsRetryableException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests.exceptions;
+
+/**
+ * Indicating the tests failure can be retried
+ */
+public class StabilityTestsRetryableException extends RuntimeException {
+
+    public StabilityTestsRetryableException(String message) {
+        super(message);
+    }
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3AsyncStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3AsyncStabilityTest.java
@@ -23,9 +23,10 @@ import java.util.function.IntFunction;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.stability.tests.exceptions.StabilityTestsRetryableException;
+import software.amazon.awssdk.stability.tests.utils.RetryableTest;
 import software.amazon.awssdk.stability.tests.utils.StabilityTestRunner;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.Logger;
@@ -44,7 +45,7 @@ public class S3AsyncStabilityTest extends S3BaseStabilityTest {
         deleteBucketAndAllContents(bucketName);
     }
 
-    @Test
+    @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)
     @Override
     public void putObject_getObject() {
         putObject();

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/sqs/SqsAsyncStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/sqs/SqsAsyncStabilityTest.java
@@ -23,9 +23,10 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.model.CreateQueueResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.stability.tests.exceptions.StabilityTestsRetryableException;
+import software.amazon.awssdk.stability.tests.utils.RetryableTest;
 import software.amazon.awssdk.stability.tests.utils.StabilityTestRunner;
 import software.amazon.awssdk.utils.Logger;
 
@@ -48,7 +49,7 @@ public class SqsAsyncStabilityTest extends SqsBaseStabilityTest {
         }
     }
 
-    @Test
+    @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)
     public void sendMessage_receiveMessage() {
         sendMessage();
         receiveMessage();

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/transcribestreaming/TranscribeStreamingStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/transcribestreaming/TranscribeStreamingStabilityTest.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntFunction;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.core.async.SdkPublisher;
@@ -33,6 +32,8 @@ import software.amazon.awssdk.services.transcribestreaming.model.StartStreamTran
 import software.amazon.awssdk.services.transcribestreaming.model.StartStreamTranscriptionResponseHandler;
 import software.amazon.awssdk.services.transcribestreaming.model.TranscriptEvent;
 import software.amazon.awssdk.services.transcribestreaming.model.TranscriptResultStream;
+import software.amazon.awssdk.stability.tests.exceptions.StabilityTestsRetryableException;
+import software.amazon.awssdk.stability.tests.utils.RetryableTest;
 import software.amazon.awssdk.stability.tests.utils.StabilityTestRunner;
 import software.amazon.awssdk.stability.tests.utils.TestEventStreamingResponseHandler;
 import software.amazon.awssdk.stability.tests.utils.TestTranscribeStreamingSubscription;
@@ -62,7 +63,7 @@ public class TranscribeStreamingStabilityTest extends AwsTestBase {
         }
     }
 
-    @Test
+    @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)
     public void startTranscription() {
         IntFunction<CompletableFuture<?>> futureIntFunction = i ->
             transcribeStreamingClient.startStreamTranscription(b -> b.mediaSampleRateHertz(8_000)

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/RetryableTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/RetryableTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests.utils;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Denotes that a method is a test template for a retryable test.
+ */
+@Target( {ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+
+    /**
+     * Exception to retry
+     *
+     * @return Exception that handled
+     */
+    Class<? extends Throwable> retryableException() default Throwable.class;
+
+    /**
+     * The maximum number of retries.
+     *
+     * @return the number of retries; must be greater than zero
+     */
+    int maxRetries();
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/RetryableTestExtension.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/RetryableTestExtension.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests.utils;
+
+import static java.util.Spliterator.ORDERED;
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.stream.StreamSupport.stream;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContextException;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.opentest4j.TestAbortedException;
+
+
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
+
+    private static final Namespace NAMESPACE = Namespace.create(RetryableTestExtension.class);
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext extensionContext) {
+        Method testMethod = extensionContext.getRequiredTestMethod();
+        return isAnnotated(testMethod, RetryableTest.class);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        RetryExecutor executor = retryExecutor(context);
+        return stream(spliteratorUnknownSize(executor, ORDERED), false);
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        if (!isRetryableException(context, throwable)) {
+            throw throwable;
+        }
+
+        RetryExecutor retryExecutor = retryExecutor(context);
+        retryExecutor.exceptionOccurred(throwable);
+    }
+
+    private RetryExecutor retryExecutor(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        ExtensionContext templateContext = context.getParent()
+                                                  .orElseThrow(() -> new IllegalStateException(
+                                                      "Extension context \"" + context + "\" should have a parent context."));
+
+        int maxRetries = maxRetries(context);
+        return templateContext.getStore(NAMESPACE).getOrComputeIfAbsent(method.toString(), __ -> new RetryExecutor(maxRetries),
+                                                                        RetryExecutor.class);
+
+
+    }
+
+    private boolean isRetryableException(ExtensionContext context, Throwable throwable) {
+        return retryableException(context).isAssignableFrom(throwable.getClass()) || throwable instanceof TestAbortedException;
+    }
+
+    private int maxRetries(ExtensionContext context) {
+        return retrieveAnnotation(context).maxRetries();
+    }
+
+    private Class<? extends Throwable> retryableException(ExtensionContext context) {
+        return retrieveAnnotation(context).retryableException();
+    }
+
+    private RetryableTest retrieveAnnotation(ExtensionContext context) {
+        return findAnnotation(context.getRequiredTestMethod(), RetryableTest.class)
+            .orElseThrow(() -> new ExtensionContextException("@RetryableTest Annotation not found on method"));
+    }
+
+    private static final class RetryableTestsTemplateInvocationContext implements TestTemplateInvocationContext {
+        private int maxRetries;
+        private int numAttempt;
+
+        RetryableTestsTemplateInvocationContext(int numAttempt, int maxRetries) {
+            this.numAttempt = numAttempt;
+            this.maxRetries = maxRetries;
+        }
+    }
+
+    private static final class RetryExecutor implements Iterator<RetryableTestsTemplateInvocationContext> {
+        private final int maxRetries;
+        private int totalAttempts;
+        private static final List<Throwable> throwables = new ArrayList<>();
+
+        RetryExecutor(int maxRetries) {
+            this.maxRetries = maxRetries;
+        }
+
+        private void exceptionOccurred(Throwable throwable) {
+            throwables.add(throwable);
+            if (throwables.size() == maxRetries) {
+                throw new AssertionError("All attempts failed. Last exception: ", throwable);
+            } else {
+                throw new TestAbortedException(String.format("Attempt %s failed of the retryable exception, going to retry the test", totalAttempts), throwable);
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (totalAttempts == 0) {
+                return true;
+            }
+
+            boolean previousFailed = totalAttempts == throwables.size();
+
+            if (previousFailed && totalAttempts <= maxRetries - 1) {
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        public RetryableTestsTemplateInvocationContext next() {
+            totalAttempts++;
+            return new RetryableTestsTemplateInvocationContext(totalAttempts, maxRetries);
+        }
+    }
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/StabilityTestRunner.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/StabilityTestRunner.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.stability.tests.ExceptionCounter;
 import software.amazon.awssdk.stability.tests.TestResult;
+import software.amazon.awssdk.stability.tests.exceptions.StabilityTestsRetryableException;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
@@ -260,19 +261,24 @@ public class StabilityTestRunner {
 
         double ratio = expectedExceptionCount / (double) testResult.totalRequestCount();
         if (clientExceptionCount > 0) {
-            throw new RuntimeException(String.format("%s SdkClientExceptions were thrown, failing the tests",
-                                                     clientExceptionCount));
+            String errorMessage = String.format("%s SdkClientExceptions were thrown, failing the tests",
+                                          clientExceptionCount);
+            log.error(() -> errorMessage);
+            throw new AssertionError(errorMessage);
         }
 
         if (testResult.unknownExceptionCount() > 0) {
-            throw new RuntimeException(String.format("%s unknown exceptions were thrown, failing the tests",
-                                                     unknownExceptionCount));
+            String errorMessage = String.format("%s unknown exceptions were thrown, failing the tests",
+                                          unknownExceptionCount);
+            log.error(() -> errorMessage);
+            throw new AssertionError(errorMessage);
         }
 
         if (ratio > ALLOWED_FAILURE_RATIO) {
-            throw new RuntimeException(String.format("More than %s percent requests (%s percent) failed of SdkServiceException "
-                                                     + "or IOException, failing the tests",
-                                                     ALLOWED_FAILURE_RATIO * 100, ratio * 100));
+            String errorMessage = String.format("More than %s percent requests (%s percent) failed of SdkServiceException "
+                                          + "or IOException, failing the tests",
+                                          ALLOWED_FAILURE_RATIO * 100, ratio * 100);
+            throw new StabilityTestsRetryableException(errorMessage);
         }
     }
 


### PR DESCRIPTION
## Description
- Make kinesis stability tests more reliable by increasing the waiter time and decreasing consumer count

- Create `@RetriableTest` annotation to automatically retry test if failing of certain exception

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
