### PR TITLE
Fix the issue where the sdk can invoke channel#read twice per request demand

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-0780cf4.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-0780cf4.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fix the issue where the SDK can invoke `channel#read` twice per request and buffer content aggressively before the subscriber is able to consume the data. This should fix [#1122](https://github.com/aws/aws-sdk-java-v2/issues/1122)."
+}

--- a/http-clients/netty-nio-client/pom.xml
+++ b/http-clients/netty-nio-client/pom.xml
@@ -142,6 +142,11 @@
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -66,15 +66,15 @@ import software.amazon.awssdk.utils.async.DelegatingSubscription;
 @SdkInternalApi
 public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
 
-    private static final Logger log = LoggerFactory.getLogger(ResponseHandler.class);
-
-    private static final ResponseHandler INSTANCE = new ResponseHandler();
-
     /**
      * {@link AttributeKey} to keep track of whether we should close the connection after this request
      * has completed.
      */
-    private static final AttributeKey<Boolean> KEEP_ALIVE = AttributeKey.newInstance("KeepAlive");
+    static final AttributeKey<Boolean> KEEP_ALIVE = AttributeKey.newInstance("KeepAlive");
+
+    private static final Logger log = LoggerFactory.getLogger(ResponseHandler.class);
+
+    private static final ResponseHandler INSTANCE = new ResponseHandler();
 
     private ResponseHandler() {
     }
@@ -200,15 +200,15 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         return ctx.channel().attr(EXECUTE_FUTURE_KEY).get();
     }
 
-    private static class PublisherAdapter implements Publisher<ByteBuffer> {
+    static class PublisherAdapter implements Publisher<ByteBuffer> {
         private final StreamedHttpResponse response;
         private final ChannelHandlerContext channelContext;
         private final RequestContext requestContext;
         private final CompletableFuture<Void> executeFuture;
         private final AtomicBoolean isDone = new AtomicBoolean(false);
 
-        private PublisherAdapter(StreamedHttpResponse response, ChannelHandlerContext channelContext,
-                                 RequestContext requestContext, CompletableFuture<Void> executeFuture) {
+        PublisherAdapter(StreamedHttpResponse response, ChannelHandlerContext channelContext,
+                         RequestContext requestContext, CompletableFuture<Void> executeFuture) {
             this.response = response;
             this.channelContext = channelContext;
             this.requestContext = requestContext;
@@ -267,8 +267,6 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                     if (byteBuffer != null) {
                         tryCatch(() -> subscriber.onNext(byteBuffer),
                                  this::notifyError);
-
-                        tryCatch(channelContext::read, this::onError);
                     }
                 }
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTE_FUTURE_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.PROTOCOL_FUTURE;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ResponseHandler.KEEP_ALIVE;
+
+import com.typesafe.netty.http.DefaultStreamedHttpResponse;
+import com.typesafe.netty.http.StreamedHttpResponse;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PublisherAdapterTest {
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    private MockChannel channel;
+
+    @Mock
+    private ChannelPool channelPool;
+
+    @Mock
+    private EventLoopGroup eventLoopGroup;
+
+    @Mock
+    private SdkAsyncHttpResponseHandler responseHandler;
+
+    private HttpContent fullHttpResponse;
+
+    private RequestContext requestContext;
+
+    private CompletableFuture<Void> executeFuture;
+
+    @Before
+    public void setUp() throws Exception {
+        executeFuture = new CompletableFuture<>();
+        fullHttpResponse = mock(DefaultHttpContent.class);
+        when(fullHttpResponse.content()).thenReturn(new EmptyByteBuf(ByteBufAllocator.DEFAULT));
+        requestContext = new RequestContext(channelPool,
+                                            eventLoopGroup,
+                                            AsyncExecuteRequest.builder().responseHandler(responseHandler).build(),
+                                            null);
+        channel = new MockChannel();
+        channel.attr(PROTOCOL_FUTURE).set(CompletableFuture.completedFuture(Protocol.HTTP1_1));
+        channel.attr(REQUEST_CONTEXT_KEY).set(requestContext);
+        channel.attr(EXECUTE_FUTURE_KEY).set(executeFuture);
+        channel.attr(KEEP_ALIVE).set(true);
+        when(ctx.channel()).thenReturn(channel);
+    }
+
+    @Test
+    public void successfulStreaming_shouldNotInvokeChannelRead() {
+        Flowable<HttpContent> testPublisher = Flowable.just(fullHttpResponse);
+
+        StreamedHttpResponse streamedHttpResponse = new DefaultStreamedHttpResponse(HttpVersion.HTTP_1_1,
+                                                                                    HttpResponseStatus.ACCEPTED,
+                                                                                    testPublisher);
+
+
+
+        ResponseHandler.PublisherAdapter publisherAdapter = new ResponseHandler.PublisherAdapter(streamedHttpResponse,
+                                                                                                 ctx,
+                                                                                                 requestContext,
+                                                                                                 executeFuture
+        );
+        TestSubscriber subscriber = new TestSubscriber();
+
+        publisherAdapter.subscribe(subscriber);
+
+        verify(ctx, times(0)).read();
+        verify(ctx, times(0)).close();
+        assertThat(subscriber.isCompleted).isEqualTo(true);
+        verify(channelPool).release(channel);
+        executeFuture.join();
+        assertThat(executeFuture).isCompleted();
+    }
+
+    @Test
+    public void errorOccurred_shouldInvokeResponseHandler() {
+        RuntimeException exception = new RuntimeException("boom");
+        Flowable<HttpContent> testPublisher = Flowable.error(exception);
+
+        StreamedHttpResponse streamedHttpResponse = new DefaultStreamedHttpResponse(HttpVersion.HTTP_1_1,
+                                                                                    HttpResponseStatus.ACCEPTED,
+                                                                                    testPublisher);
+
+
+
+        ResponseHandler.PublisherAdapter publisherAdapter = new ResponseHandler.PublisherAdapter(streamedHttpResponse,
+                                                                                                 ctx,
+                                                                                                 requestContext,
+                                                                                                 executeFuture
+        );
+        TestSubscriber subscriber = new TestSubscriber();
+
+        publisherAdapter.subscribe(subscriber);
+
+        verify(ctx, times(0)).read();
+        verify(ctx).close();
+        assertThat(subscriber.errorOccurred).isEqualTo(true);
+        verify(channelPool).release(channel);
+        assertThat(executeFuture).isCompletedExceptionally();
+        verify(responseHandler).onError(exception);
+    }
+
+    static final class TestSubscriber implements Subscriber<ByteBuffer> {
+
+        private Subscription subscription;
+        private boolean isCompleted = false;
+        private boolean errorOccurred = false;
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.subscription = s;
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            errorOccurred = true;
+        }
+
+        @Override
+        public void onComplete() {
+            isCompleted = true;
+        }
+    }
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3BaseStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3BaseStabilityTest.java
@@ -15,16 +15,20 @@
 
 package software.amazon.awssdk.stability.tests.s3;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 import software.amazon.awssdk.utils.Logger;
 
@@ -32,6 +36,8 @@ public abstract class S3BaseStabilityTest extends AwsTestBase {
     private static final Logger log = Logger.loggerFor(S3BaseStabilityTest.class);
     protected static final int CONCURRENCY = 100;
     protected static final int TOTAL_RUNS = 50;
+    protected static final String LARGE_KEY_BUCKET_NAME = "java-testing-transfermanager";
+    protected static final String LARGE_KEY_NAME = "2GB";
 
     protected static S3AsyncClient s3NettyClient;
     protected static S3Client s3ApacheClient;
@@ -41,7 +47,7 @@ public abstract class S3BaseStabilityTest extends AwsTestBase {
                                      .httpClientBuilder(NettyNioAsyncHttpClient.builder()
                                                                                .maxConcurrency(CONCURRENCY))
                                      .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
-                                     .overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMinutes(1)))
+                                     .overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMinutes(10)))
                                      .build();
 
 
@@ -49,7 +55,7 @@ public abstract class S3BaseStabilityTest extends AwsTestBase {
                                  .httpClientBuilder(ApacheHttpClient.builder()
                                                                     .maxConnections(CONCURRENCY))
                                  .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
-                                 .overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMinutes(1)))
+                                 .overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMinutes(10)))
                                  .build();
     }
 
@@ -72,6 +78,24 @@ public abstract class S3BaseStabilityTest extends AwsTestBase {
             s3NettyClient.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build()).join();
         } catch (Exception e) {
             log.error(() -> "Failed to delete bucket: " +bucketName);
+        }
+    }
+
+    protected void verifyObjectExist(String bucketName, String keyName, long size) throws IOException {
+        try {
+            s3ApacheClient.headBucket(b -> b.bucket(bucketName));
+        } catch (NoSuchBucketException e) {
+            log.info(() -> "NoSuchBucketException was thrown, staring to create the bucket");
+            s3ApacheClient.createBucket(b -> b.bucket(bucketName));
+        }
+
+        try {
+            s3ApacheClient.headObject(b -> b.key(keyName).bucket(bucketName));
+        } catch (NoSuchKeyException e) {
+            log.info(() -> "NoSuchKeyException was thrown, starting to upload the object");
+            RandomTempFile file = new RandomTempFile(size);
+            s3ApacheClient.putObject(b -> b.bucket(bucketName).key(keyName), RequestBody.fromFile(file));
+            file.delete();
         }
     }
 

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/StabilityTestRunner.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/StabilityTestRunner.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.stability.tests.utils;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -91,6 +92,11 @@ public class StabilityTestRunner {
 
     public StabilityTestRunner futures(List<CompletableFuture<?>> futures) {
         this.futures = futures;
+        return this;
+    }
+
+    public StabilityTestRunner futures(CompletableFuture<?>... futures) {
+        this.futures = Arrays.asList(futures);
         return this;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the issue where the sdk can invoke channel#read twice per request demand. When the subscriber invokes `subscription#request`, the underlying `HandlerPublisher` would trigger `ChannelHandlerContext#read`; the SDK was invoking `ChannelHandlerContext#read` again in `PublisherAdapter#onNext`. 

This would be an issue with "slow" subscriber such as `FileAsyncResponseTransformer` and cause unnecessary message buffering.



## Motivation and Context
See #1122 

## Testing
Added unit tests
Added stability tests. (verified the test failed before the fix and succeeded after the fix.)
Tested downloading a 2g object on an instance with NVMe local storage.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
