### PR TITLE
Generate code to notify error for streaming operations

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-95ddbd0.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-95ddbd0.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Notify error by invoking `AsyncResponseTransformer#exceptionOccurred` for streaming operations for services using xml protocol such as S3 when the request fails and is not retriable."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -121,7 +121,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
 
     @Override
     public CodeBlock responseHandler(IntermediateModel model, OperationModel opModel) {
-        TypeName pojoResponseType = getPojoResponseType(opModel);
+        TypeName pojoResponseType = getPojoResponseType(opModel, poetExtensions);
 
         String protocolFactory = protocolFactoryLiteral(model, opModel);
         CodeBlock.Builder builder = CodeBlock.builder();
@@ -155,7 +155,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
 
     @Override
     public CodeBlock executionHandler(OperationModel opModel) {
-        TypeName responseType = getPojoResponseType(opModel);
+        TypeName responseType = getPojoResponseType(opModel, poetExtensions);
         ClassName requestType = poetExtensions.getModelClass(opModel.getInput().getVariableType());
         ClassName marshaller = poetExtensions.getRequestTransformClass(opModel.getInputShape().getShapeName() + "Marshaller");
 
@@ -191,7 +191,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
     @Override
     public CodeBlock asyncExecutionHandler(IntermediateModel intermediateModel, OperationModel opModel) {
         boolean isRestJson = isRestJson(intermediateModel);
-        TypeName pojoResponseType = getPojoResponseType(opModel);
+        TypeName pojoResponseType = getPojoResponseType(opModel, poetExtensions);
         ClassName requestType = poetExtensions.getModelClass(opModel.getInput().getVariableType());
         ClassName marshaller = poetExtensions.getRequestTransformClass(opModel.getInputShape().getShapeName() + "Marshaller");
 
@@ -230,7 +230,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
         String customerResponseHandler = opModel.hasEventStreamOutput() ? "asyncResponseHandler" : "asyncResponseTransformer";
         TypeName responseType = opModel.hasEventStreamOutput() && !isRestJson ? ClassName.get(SdkResponse.class)
                                                                               : pojoResponseType;
-        TypeName executeFutureValueType = executeFutureValueType(opModel);
+        TypeName executeFutureValueType = executeFutureValueType(opModel, poetExtensions);
 
         builder.add("\n\n$T<$T> executeFuture = clientHandler.execute(new $T<$T, $T>()\n" +
                     ".withOperationName(\"$N\")\n" +
@@ -328,20 +328,6 @@ public class JsonProtocolSpec implements ProtocolSpec {
     }
 
     /**
-     * Need to notify the response handler/response transformer if the future is completed exceptionally.
-     *
-     * @param responseHandlerName Variable name of response handler customer passed in.
-     * @return whenComplete to append to future.
-     */
-    private String streamingOutputWhenComplete(String responseHandlerName) {
-        return String.format(".whenComplete((r, e) -> {%n"
-                             + "     if (e != null) {%n"
-                             + "         %s.exceptionOccurred(e);%n"
-                             + "     }%n"
-                             + "})", responseHandlerName);
-    }
-
-    /**
      * For event streaming our future notification is a bit complicated. We create a different future that is not tied
      * to the lifecycle of the wire request. Successful completion of the future is signalled in
      * {@link EventStreamAsyncResponseTransformer}. Failure is notified via the normal future (the one returned by the client
@@ -362,14 +348,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                              + "})", responseHandlerName);
     }
 
-    /**
-     * Gets the POJO response type for the operation.
-     *
-     * @param opModel Operation to get response type for.
-     */
-    private TypeName getPojoResponseType(OperationModel opModel) {
-        return poetExtensions.getModelClass(opModel.getReturnType().getReturnType());
-    }
+
 
     @Override
     public Optional<MethodSpec> createErrorResponseHandler() {
@@ -456,15 +435,5 @@ public class JsonProtocolSpec implements ProtocolSpec {
 
     private boolean isRestJson(IntermediateModel model) {
         return Protocol.REST_JSON.equals(model.getMetadata().getProtocol());
-    }
-
-    private TypeName executeFutureValueType(OperationModel opModel) {
-        if (opModel.hasEventStreamOutput()) {
-            return ClassName.get(Void.class);
-        } else if (opModel.hasStreamingOutput()) {
-            return TypeVariableName.get("ReturnT");
-        } else {
-            return getPojoResponseType(opModel);
-        }
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
@@ -19,6 +19,8 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeVariableName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -138,5 +140,41 @@ public interface ProtocolSpec {
         builder.add(".build()");
 
         return builder.build();
+    }
+
+
+    /**
+     * Need to notify the response handler/response transformer if the future is completed exceptionally.
+     *
+     * @param responseHandlerName Variable name of response handler customer passed in.
+     * @return whenComplete to append to future.
+     */
+    default String streamingOutputWhenComplete(String responseHandlerName) {
+        return String.format(".whenComplete((r, e) -> {%n"
+                             + "     if (e != null) {%n"
+                             + "         runAndLogError(log, \"Exception thrown in exceptionOccurred callback, ignoring\", () "
+                             + "-> %s.exceptionOccurred(e));%n"
+                             + "     }%n"
+                             + "})", responseHandlerName);
+
+    }
+
+    default TypeName executeFutureValueType(OperationModel opModel, PoetExtensions poetExtensions) {
+        if (opModel.hasEventStreamOutput()) {
+            return ClassName.get(Void.class);
+        } else if (opModel.hasStreamingOutput()) {
+            return TypeVariableName.get("ReturnT");
+        } else {
+            return getPojoResponseType(opModel, poetExtensions);
+        }
+    }
+
+    /**
+     * Gets the POJO response type for the operation.
+     *
+     * @param opModel Operation to get response type for.
+     */
+    default TypeName getPojoResponseType(OperationModel opModel, PoetExtensions poetExtensions) {
+        return poetExtensions.getModelClass(opModel.getReturnType().getReturnType());
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
@@ -58,8 +58,19 @@ public class PoetClientFunctionalTests {
         assertThat(syncClientClass, generatesTo("test-query-client-class.java"));
     }
 
+
+    @Test
+    public void asyncClientClassQuery() throws Exception {
+        AsyncClientClass syncClientClass = createAsyncClientClass(ClientTestModels.queryServiceModels());
+        assertThat(syncClientClass, generatesTo("test-query-async-client-class.java"));
+    }
+
     private SyncClientClass createSyncClientClass(IntermediateModel model) {
         return new SyncClientClass(GeneratorTaskParams.create(model, "sources/", "tests/"));
+    }
+
+    private AsyncClientClass createAsyncClientClass(IntermediateModel model) {
+        return new AsyncClientClass(GeneratorTaskParams.create(model, "sources/", "tests/"));
     }
 
     @Test

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
@@ -51,6 +51,28 @@
         }
       ],
       "documentation": "<p>Performs a post operation to the query service and has modelled output</p>"
+    },
+    "StreamingInputOperation": {
+      "name": "StreamingInputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingInputOperation"
+      },
+      "input": {
+        "shape": "StructureWithStreamingMember"
+      },
+      "documentation": "Some operation with a streaming input"
+    },
+    "StreamingOutputOperation": {
+      "name": "StreamingOutputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingOutputOperation"
+      },
+      "output": {
+        "shape": "StructureWithStreamingMember"
+      },
+      "documentation": "Some operation with a streaming output"
     }
   },
   "shapes": {
@@ -143,6 +165,20 @@
     },
     "invalidInputMessage": {
       "type": "string"
+    },
+    "StreamType": {
+      "type": "blob",
+      "streaming": true
+    },
+    "StructureWithStreamingMember": {
+      "type": "structure",
+      "members": {
+        "StreamingMember": {
+          "shape": "StreamType",
+          "documentation": "This be a stream"
+        }
+      },
+      "payload": "StreamingMember"
     }
   },
   "documentation": "A service that is implemented using the query protocol"

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -833,7 +833,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     asyncResponseTransformer);
             executeFuture.whenComplete((r, e) -> {
                 if (e != null) {
-                    asyncResponseTransformer.exceptionOccurred(e);
+                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                                   () -> asyncResponseTransformer.exceptionOccurred(e));
                 }
             });
             return executeFuture;
@@ -890,7 +891,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                             .withInput(streamingOutputOperationRequest), asyncResponseTransformer);
             executeFuture.whenComplete((r, e) -> {
                 if (e != null) {
-                    asyncResponseTransformer.exceptionOccurred(e);
+                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                                   () -> asyncResponseTransformer.exceptionOccurred(e));
                 }
             });
             return executeFuture;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -1,0 +1,272 @@
+package software.amazon.awssdk.services.query;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
+import software.amazon.awssdk.protocols.core.ExceptionMetadata;
+import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
+import software.amazon.awssdk.services.query.model.APostOperationRequest;
+import software.amazon.awssdk.services.query.model.APostOperationResponse;
+import software.amazon.awssdk.services.query.model.APostOperationWithOutputRequest;
+import software.amazon.awssdk.services.query.model.APostOperationWithOutputResponse;
+import software.amazon.awssdk.services.query.model.InvalidInputException;
+import software.amazon.awssdk.services.query.model.QueryException;
+import software.amazon.awssdk.services.query.model.StreamingInputOperationRequest;
+import software.amazon.awssdk.services.query.model.StreamingInputOperationResponse;
+import software.amazon.awssdk.services.query.model.StreamingOutputOperationRequest;
+import software.amazon.awssdk.services.query.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.services.query.transform.APostOperationRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.APostOperationWithOutputRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.StreamingInputOperationRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.StreamingOutputOperationRequestMarshaller;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+
+/**
+ * Internal implementation of {@link QueryAsyncClient}.
+ *
+ * @see QueryAsyncClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultQueryAsyncClient implements QueryAsyncClient {
+    private static final Logger log = LoggerFactory.getLogger(DefaultQueryAsyncClient.class);
+
+    private final AsyncClientHandler clientHandler;
+
+    private final AwsQueryProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    protected DefaultQueryAsyncClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration;
+        this.protocolFactory = init();
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    /**
+     * <p>
+     * Performs a post operation to the query service and has no output
+     * </p>
+     *
+     * @param aPostOperationRequest
+     * @return A Java Future containing the result of the APostOperation operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>InvalidInputException The request was rejected because an invalid or out-of-range value was supplied
+     *         for an input parameter.</li>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>QueryException Base class for all service exceptions. Unknown exceptions will be thrown as an
+     *         instance of this type.</li>
+     *         </ul>
+     * @sample QueryAsyncClient.APostOperation
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/APostOperation" target="_top">AWS
+     *      API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<APostOperationResponse> aPostOperation(APostOperationRequest aPostOperationRequest) {
+        try {
+            String hostPrefix = "foo-";
+            String resolvedHostExpression = "foo-";
+
+            HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory
+                .createResponseHandler(APostOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<APostOperationResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                             .withOperationName("APostOperation")
+                             .withMarshaller(new APostOperationRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                             .hostPrefixExpression(resolvedHostExpression).withInput(aPostOperationRequest));
+            return executeFuture;
+        } catch (Throwable t) {
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * <p>
+     * Performs a post operation to the query service and has modelled output
+     * </p>
+     *
+     * @param aPostOperationWithOutputRequest
+     * @return A Java Future containing the result of the APostOperationWithOutput operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>InvalidInputException The request was rejected because an invalid or out-of-range value was supplied
+     *         for an input parameter.</li>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>QueryException Base class for all service exceptions. Unknown exceptions will be thrown as an
+     *         instance of this type.</li>
+     *         </ul>
+     * @sample QueryAsyncClient.APostOperationWithOutput
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/APostOperationWithOutput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<APostOperationWithOutputResponse> aPostOperationWithOutput(
+        APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
+        try {
+
+            HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory
+                .createResponseHandler(APostOperationWithOutputResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<APostOperationWithOutputResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                             .withOperationName("APostOperationWithOutput")
+                             .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                             .withInput(aPostOperationWithOutputRequest));
+            return executeFuture;
+        } catch (Throwable t) {
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some operation with a streaming input
+     *
+     * @param streamingInputOperationRequest
+     * @param requestBody
+     *        Functional interface that can be implemented to produce the request content in a non-blocking manner. The
+     *        size of the content is expected to be known up front. See {@link AsyncRequestBody} for specific details on
+     *        implementing this interface as well as links to precanned implementations for common scenarios like
+     *        uploading from a file. The service documentation for the request content is as follows 'This be a stream'
+     * @return A Java Future containing the result of the StreamingInputOperation operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>QueryException Base class for all service exceptions. Unknown exceptions will be thrown as an
+     *         instance of this type.</li>
+     *         </ul>
+     * @sample QueryAsyncClient.StreamingInputOperation
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/StreamingInputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<StreamingInputOperationResponse> streamingInputOperation(
+        StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestBody requestBody) {
+        try {
+
+            HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory
+                .createResponseHandler(StreamingInputOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<StreamingInputOperationResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                             .withOperationName("StreamingInputOperation")
+                             .withMarshaller(
+                                 AsyncStreamingRequestMarshaller.builder()
+                                                                .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                                                                .asyncRequestBody(requestBody).build()).withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler).withAsyncRequestBody(requestBody)
+                             .withInput(streamingInputOperationRequest));
+            return executeFuture;
+        } catch (Throwable t) {
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some operation with a streaming output
+     *
+     * @param streamingOutputOperationRequest
+     * @param asyncResponseTransformer
+     *        The response transformer for processing the streaming response in a non-blocking manner. See
+     *        {@link AsyncResponseTransformer} for details on how this callback should be implemented and for links to
+     *        precanned implementations for common scenarios like downloading to a file. The service documentation for
+     *        the response content is as follows 'This be a stream'.
+     * @return A future to the transformed result of the AsyncResponseTransformer.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>QueryException Base class for all service exceptions. Unknown exceptions will be thrown as an
+     *         instance of this type.</li>
+     *         </ul>
+     * @sample QueryAsyncClient.StreamingOutputOperation
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/StreamingOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public <ReturnT> CompletableFuture<ReturnT> streamingOutputOperation(
+        StreamingOutputOperationRequest streamingOutputOperationRequest,
+        AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
+        try {
+
+            HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory
+                .createResponseHandler(StreamingOutputOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
+                new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                    .withOperationName("StreamingOutputOperation")
+                    .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withInput(streamingOutputOperationRequest), asyncResponseTransformer);
+            executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                                   () -> asyncResponseTransformer.exceptionOccurred(e));
+                }
+            });
+            return executeFuture;
+        } catch (Throwable t) {
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                           () -> asyncResponseTransformer.exceptionOccurred(t));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+
+    private AwsQueryProtocolFactory init() {
+        return AwsQueryProtocolFactory
+            .builder()
+            .registerModeledException(
+                ExceptionMetadata.builder().errorCode("InvalidInput")
+                                 .exceptionBuilderSupplier(InvalidInputException::builder).httpStatusCode(400).build())
+            .clientConfiguration(clientConfiguration).defaultServiceExceptionSupplier(QueryException::builder).build();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -9,6 +9,9 @@ import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.runtime.transform.StreamingRequestMarshaller;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.protocols.core.ExceptionMetadata;
 import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.services.query.model.APostOperationRequest;
@@ -17,8 +20,14 @@ import software.amazon.awssdk.services.query.model.APostOperationWithOutputReque
 import software.amazon.awssdk.services.query.model.APostOperationWithOutputResponse;
 import software.amazon.awssdk.services.query.model.InvalidInputException;
 import software.amazon.awssdk.services.query.model.QueryException;
+import software.amazon.awssdk.services.query.model.StreamingInputOperationRequest;
+import software.amazon.awssdk.services.query.model.StreamingInputOperationResponse;
+import software.amazon.awssdk.services.query.model.StreamingOutputOperationRequest;
+import software.amazon.awssdk.services.query.model.StreamingOutputOperationResponse;
 import software.amazon.awssdk.services.query.transform.APostOperationRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.APostOperationWithOutputRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.StreamingInputOperationRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.StreamingOutputOperationRequestMarshaller;
 
 /**
  * Internal implementation of {@link QueryClient}.
@@ -77,10 +86,9 @@ final class DefaultQueryClient implements QueryClient {
         HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
 
         return clientHandler.execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
-                                         .withOperationName("APostOperation")
-                                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                                         .hostPrefixExpression(resolvedHostExpression).withInput(aPostOperationRequest)
-                                         .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
+                                         .withOperationName("APostOperation").withResponseHandler(responseHandler)
+                                         .withErrorResponseHandler(errorResponseHandler).hostPrefixExpression(resolvedHostExpression)
+                                         .withInput(aPostOperationRequest).withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
     }
 
     /**
@@ -115,10 +123,97 @@ final class DefaultQueryClient implements QueryClient {
 
         return clientHandler
             .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
-                         .withOperationName("APostOperationWithOutput")
-                         .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
-                         .withInput(aPostOperationWithOutputRequest)
+                         .withOperationName("APostOperationWithOutput").withResponseHandler(responseHandler)
+                         .withErrorResponseHandler(errorResponseHandler).withInput(aPostOperationWithOutputRequest)
                          .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
+    }
+
+    /**
+     * Some operation with a streaming input
+     *
+     * @param streamingInputOperationRequest
+     * @param requestBody
+     *        The content to send to the service. A {@link RequestBody} can be created using one of several factory
+     *        methods for various sources of data. For example, to create a request body from a file you can do the
+     *        following.
+     *
+     *        <pre>
+     * {@code RequestBody.fromFile(new File("myfile.txt"))}
+     * </pre>
+     *
+     *        See documentation in {@link RequestBody} for additional details and which sources of data are supported.
+     *        The service documentation for the request content is as follows 'This be a stream'
+     * @return Result of the StreamingInputOperation operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws QueryException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample QueryClient.StreamingInputOperation
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/StreamingInputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public StreamingInputOperationResponse streamingInputOperation(StreamingInputOperationRequest streamingInputOperationRequest,
+                                                                   RequestBody requestBody) throws AwsServiceException, SdkClientException, QueryException {
+
+        HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory
+            .createResponseHandler(StreamingInputOperationResponse::builder);
+
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+        return clientHandler.execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                                         .withOperationName("StreamingInputOperation")
+                                         .withResponseHandler(responseHandler)
+                                         .withErrorResponseHandler(errorResponseHandler)
+                                         .withInput(streamingInputOperationRequest)
+                                         .withRequestBody(requestBody)
+                                         .withMarshaller(
+                                             StreamingRequestMarshaller.builder()
+                                                                       .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                                                                       .requestBody(requestBody).build()));
+    }
+
+    /**
+     * Some operation with a streaming output
+     *
+     * @param streamingOutputOperationRequest
+     * @param responseTransformer
+     *        Functional interface for processing the streamed response content. The unmarshalled
+     *        StreamingInputOperationRequest and an InputStream to the response content are provided as parameters to
+     *        the callback. The callback may return a transformed type which will be the return value of this method.
+     *        See {@link software.amazon.awssdk.core.sync.ResponseTransformer} for details on implementing this
+     *        interface and for links to pre-canned implementations for common scenarios like downloading to a file. The
+     *        service documentation for the response content is as follows 'This be a stream'.
+     * @return The transformed result of the ResponseTransformer.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws QueryException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample QueryClient.StreamingOutputOperation
+     * @see <a href="http://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/StreamingOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public <ReturnT> ReturnT streamingOutputOperation(StreamingOutputOperationRequest streamingOutputOperationRequest,
+                                                      ResponseTransformer<StreamingOutputOperationResponse, ReturnT> responseTransformer) throws AwsServiceException,
+                                                                                                                                                 SdkClientException, QueryException {
+
+        HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory
+            .createResponseHandler(StreamingOutputOperationResponse::builder);
+
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+        return clientHandler.execute(
+            new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                .withOperationName("StreamingOutputOperation").withResponseHandler(responseHandler)
+                .withErrorResponseHandler(errorResponseHandler).withInput(streamingOutputOperationRequest)
+                .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
     }
 
     private AwsQueryProtocolFactory init() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -99,7 +99,9 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
     void onStream(SdkPublisher<ByteBuffer> publisher);
 
     /**
-     * Called when a error is encountered while making the request or receiving the response.
+     * Called when an error is encountered while making the request or receiving the response.
+     * Implementations should free up any resources in this method. This method may be called
+     * multiple times during the lifecycle of a request if automatic retries are enabled.
      *
      * @param error Error that occurred.
      */

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncGetObjectFaultIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncGetObjectFaultIntegrationTest.java
@@ -70,6 +70,7 @@ public class AsyncGetObjectFaultIntegrationTest extends S3IntegrationTestBase {
         assertThatThrownBy(() -> s3ClientWithTimeout.getObject(getObjectRequest(), handler).join())
                 .hasCauseInstanceOf(ApiCallTimeoutException.class);
         assertThat(handler.currentCallCount()).isEqualTo(1);
+        assertThat(handler.exceptionOccurred).isEqualTo(true);
     }
 
     private GetObjectRequest getObjectRequest() {
@@ -87,6 +88,7 @@ public class AsyncGetObjectFaultIntegrationTest extends S3IntegrationTestBase {
 
         private final AtomicInteger callCount = new AtomicInteger(0);
         private final AsyncResponseTransformer<ResponseT, ResponseBytes<ResponseT>> delegate;
+        private boolean exceptionOccurred = false;
 
         private SlowResponseTransformer() {
             this.delegate = AsyncResponseTransformer.toBytes();
@@ -95,6 +97,7 @@ public class AsyncGetObjectFaultIntegrationTest extends S3IntegrationTestBase {
         public int currentCallCount() {
             return callCount.get();
         }
+
 
         @Override
         public CompletableFuture<ResponseBytes<ResponseT>> prepare() {
@@ -123,6 +126,7 @@ public class AsyncGetObjectFaultIntegrationTest extends S3IntegrationTestBase {
         @Override
         public void exceptionOccurred(Throwable throwable) {
             delegate.exceptionOccurred(throwable);
+            exceptionOccurred = true;
         }
     }
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/query/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/query/service-2.json
@@ -58,6 +58,14 @@
         "requestUri":"/"
       },
       "input":{"shape":"StructureWithStreamingMember"}
+    },
+    "StreamingOutputOperation":{
+      "name":"StreamingOutputOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/streamingOutputOperation"
+      },
+      "output":{"shape":"StructureWithStreamingMember"}
     }
   },
   "shapes":{

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseTransformerTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseTransformerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolquery.ProtocolQueryAsyncClient;
+import software.amazon.awssdk.services.protocolquery.model.ProtocolQueryException;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
+
+public class AsyncResponseTransformerTest {
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    private ProtocolRestJsonAsyncClient jsonClient;
+    private ProtocolQueryAsyncClient xmlClient;
+
+    @Before
+    public void setupClient() {
+        jsonClient = ProtocolRestJsonAsyncClient.builder()
+                                                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                                                .region(Region.US_EAST_1)
+                                                .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                                .build();
+        xmlClient = ProtocolQueryAsyncClient.builder()
+                                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                                                "akid", "skid")))
+                                            .region(Region.US_EAST_1)
+                                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                            .build();
+    }
+
+    @Test
+    public void jsonClient_nonRetriableError_shouldNotifyAsyncResponseTransformer() {
+        stubFor(post(anyUrl())
+                    .willReturn(aResponse()
+                                    .withStatus(400)));
+        TestAsyncResponseTransformer<StreamingOutputOperationResponse> responseTransformer = new TestAsyncResponseTransformer<>();
+        assertThatThrownBy(() -> jsonClient.streamingOutputOperation(SdkBuilder::build, responseTransformer).join())
+            .hasCauseExactlyInstanceOf(ProtocolRestJsonException.class);
+        assertThat(responseTransformer.exceptionOccurred).isEqualTo(true);
+    }
+
+    @Test
+    public void xmlClient_nonRetriableError_shouldNotifyAsyncResponseTransformer() {
+        stubFor(post(anyUrl())
+                    .willReturn(aResponse()
+                                    .withStatus(400)));
+        TestAsyncResponseTransformer<software.amazon.awssdk.services.protocolquery.model.StreamingOutputOperationResponse> responseTransformer =
+            new TestAsyncResponseTransformer<>();
+        assertThatThrownBy(() -> xmlClient.streamingOutputOperation(SdkBuilder::build, responseTransformer).join())
+            .hasCauseExactlyInstanceOf(ProtocolQueryException.class);
+        assertThat(responseTransformer.exceptionOccurred).isEqualTo(true);
+    }
+
+    private class TestAsyncResponseTransformer<T extends AwsResponse> implements AsyncResponseTransformer<T, Void> {
+        private boolean exceptionOccurred = false;
+
+        @Override
+        public CompletableFuture prepare() {
+            return new CompletableFuture<Void>();
+        }
+
+        @Override
+        public void onResponse(T response) {
+
+        }
+
+        @Override
+        public void exceptionOccurred(Throwable error) {
+            exceptionOccurred = true;
+        }
+
+        @Override
+        public void onStream(SdkPublisher publisher) {
+
+        }
+    }
+}


### PR DESCRIPTION
## Description
Generating code to notify error for streaming operations.

```
            executeFuture.whenComplete((r, e) -> {
                if (e != null) {
                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                            () -> asyncResponseTransformer.exceptionOccurred(e));
                }
            });
```
Per docs,
https://github.com/aws/aws-sdk-java-v2/blob/5a799393ce9f34b07625ca5d614e5f6367ec7780/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java#L167-L170

we should invoke `AsyncResponseTransformer#exceptionOccurred` in the generated client code; we were only generating the code in json services previously, so the fix is to add the generated code for xml services.
 

## Testing
added codegen tests, unit tests, integ tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
