### PR TITLE
Add new profile to build tests jar in stability-tests module

### DIFF
--- a/test/stability-tests/README.md
+++ b/test/stability-tests/README.md
@@ -17,10 +17,24 @@ Any other error type, such as SdkClientException will fail the test.
 
 ## How to run
 
-You can run the tests directly from your IDE or from command line:
+- Run from your IDE
+
+- Run from maven command line
 
 ```
 mvn clean install -P stability-tests -pl :stability-tests
+```
+
+- Build JAR and use the executable JAR
+
+First add tests to TestRunner Class, then run the following command.
+
+```
+mvn clean install -pl :stability-tests --am -P quick
+mvn clean install -pl :bom-inernal
+cd test/stability-tests
+mvn package -P test-jar
+java -jar target/stability-tests-uber.jar
 ```
 
 ## Adding New Tests

--- a/test/stability-tests/pom.xml
+++ b/test/stability-tests/pom.xml
@@ -170,4 +170,47 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>test-jar</id>
+            <properties>
+                <checkstyle.skip>true</checkstyle.skip>
+                <spotbugs.skip>true</spotbugs.skip>
+                <skip.unit.tests>true</skip.unit.tests>
+                <mdep.analyze.skip>true</mdep.analyze.skip>
+            </properties>
+            <build>
+                <finalName>stability-tests</finalName>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/it/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <archive>
+                                        <manifest>
+                                            <addClasspath>true</addClasspath>
+                                            <mainClass>software.amazon.awssdk.stability.tests.TestRunner</mainClass>
+                                        </manifest>
+                                    </archive>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/test/stability-tests/src/it/assembly/assembly.xml
+++ b/test/stability-tests/src/it/assembly/assembly.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>uber</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*.class</include>
+                <include>*.properties</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/TestRunner.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/TestRunner.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests;
+
+
+public class TestRunner {
+
+    public static void main(String... args) {
+        // You can add the tests you want to run here.
+        // eg:
+//        try {
+//            S3AsyncStabilityTest s3AsyncStabilityTest = new S3AsyncStabilityTest();
+//            S3AsyncStabilityTest.setup();
+//            s3AsyncStabilityTest.putObject_getObject();
+//        } finally {
+//            S3AsyncStabilityTest.cleanup();
+//        }
+    }
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3BaseStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3BaseStabilityTest.java
@@ -36,7 +36,6 @@ public abstract class S3BaseStabilityTest extends AwsTestBase {
     private static final Logger log = Logger.loggerFor(S3BaseStabilityTest.class);
     protected static final int CONCURRENCY = 100;
     protected static final int TOTAL_RUNS = 50;
-    protected static final String LARGE_KEY_BUCKET_NAME = "java-testing-transfermanager";
     protected static final String LARGE_KEY_NAME = "2GB";
 
     protected static S3AsyncClient s3NettyClient;
@@ -99,5 +98,7 @@ public abstract class S3BaseStabilityTest extends AwsTestBase {
         }
     }
 
-    public abstract void putObject_getObject();
+    public abstract void putObject_getObject_highConcurrency();
+
+    public abstract void largeObject_put_get_usingFile();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add new profile to build tests jar in stability-tests module to make it easier to run tests on a remote instance.
- Kinesis tests: Only verify data if all events have been received.
-  S3 tests: create bucket and object instead of reusing existing one.

## Motivation and Context
Some issue can only be reproduced when running on a larger ec2 instance, and this will be handy to generate the tests jar and run the tests there.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
