### PR TITLE
Added tests to the new JavaHttpClientNioAsyncHttpClient and Implemented new configurations

### DIFF
--- a/codegen-lite-maven-plugin/pom.xml
+++ b/codegen-lite-maven-plugin/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>

--- a/codegen-maven-plugin/pom.xml
+++ b/codegen-maven-plugin/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>default-descriptor</id>

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -129,6 +129,11 @@
             <artifactId>rxjava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
@@ -59,12 +59,13 @@ public final class ByteArrayAsyncRequestBody implements AsyncRequestBody {
 
                         @Override
                         public void request(long n) {
+                            if (done) {
+                                return;
+                            }
                             if (n > 0) {
-                                if (!done) {
-                                    s.onNext(ByteBuffer.wrap(bytes));
-                                    done = true;
-                                    s.onComplete();
-                                }
+                                done = true;
+                                s.onNext(ByteBuffer.wrap(bytes));
+                                s.onComplete();
                             } else {
                                 s.onError(new IllegalArgumentException("§3.9: non-positive requests are not allowed!"));
                             }
@@ -72,6 +73,11 @@ public final class ByteArrayAsyncRequestBody implements AsyncRequestBody {
 
                         @Override
                         public void cancel() {
+                            synchronized (this) {
+                                if (!done) {
+                                    done = true;
+                                }
+                            }
                         }
                     }
             );

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
@@ -98,7 +98,7 @@ public class AsyncClientHandlerExceptionTest {
                 .thenReturn(VoidSdkResponse.builder().build());
 
         when(asyncHttpClient.execute(any(AsyncExecuteRequest.class))).thenAnswer((Answer<CompletableFuture<Void>>) invocationOnMock -> {
-            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgument(0, AsyncExecuteRequest.class).responseHandler();
             handler.onHeaders(SdkHttpFullResponse.builder()
                     .statusCode(200)
                     .build());

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerInterceptorExceptionTest.java
@@ -119,7 +119,7 @@ public class AsyncClientHandlerInterceptorExceptionTest {
         Answer<CompletableFuture<Void>> prepareRequestAnswer;
         if (hook != Hook.ON_EXECUTION_FAILURE) {
             prepareRequestAnswer = invocationOnMock -> {
-                SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+                SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgument(0, AsyncExecuteRequest.class).responseHandler();
                 handler.onHeaders(SdkHttpFullResponse.builder()
                         .statusCode(200)
                         .build());
@@ -128,7 +128,7 @@ public class AsyncClientHandlerInterceptorExceptionTest {
             };
         } else {
             prepareRequestAnswer = invocationOnMock -> {
-                SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+                SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgument(0, AsyncExecuteRequest.class).responseHandler();
                 RuntimeException error = new RuntimeException("Something went horribly wrong!");
                 handler.onError(error);
                 return CompletableFutureUtils.failedFuture(error);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTransformerVerificationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTransformerVerificationTest.java
@@ -174,7 +174,7 @@ public class AsyncClientHandlerTransformerVerificationTest {
 
     private void mockSuccessfulResponse() {
         Answer<CompletableFuture<Void>> executeAnswer = invocationOnMock -> {
-            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgument(0, AsyncExecuteRequest.class).responseHandler();
             handler.onHeaders(SdkHttpFullResponse.builder()
                     .statusCode(200)
                     .build());
@@ -191,7 +191,7 @@ public class AsyncClientHandlerTransformerVerificationTest {
      */
     private void mockSuccessfulResponse_NonSignalingStream() {
         Answer<CompletableFuture<Void>> executeAnswer = invocationOnMock -> {
-            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+            SdkAsyncHttpResponseHandler handler = invocationOnMock.getArgument(0, AsyncExecuteRequest.class).responseHandler();
             handler.onHeaders(SdkHttpFullResponse.builder()
                     .statusCode(200)
                     .build());

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http;
 
 import java.time.Duration;
+import javax.net.ssl.SSLParameters;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -97,6 +98,19 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
     public static final SdkHttpConfigurationOption<Boolean> REAP_IDLE_CONNECTIONS =
             new SdkHttpConfigurationOption<>("ReapIdleConnections", Boolean.class);
 
+    /**
+     * SSLParameters of the SSLSocket, could be set in HttpClient.
+     */
+    public static final SdkHttpConfigurationOption<SSLParameters> SSL_PARAMETERS =
+            new SdkHttpConfigurationOption<>("SslParameters", SSLParameters.class);
+
+    /**
+     * Timeout for waiting for a response.
+     */
+    public static final SdkHttpConfigurationOption<Duration> RESPONSE_TIMEOUT =
+            new SdkHttpConfigurationOption<>("ResponseTimeout", Duration.class);
+
+
     private static final Duration DEFAULT_SOCKET_READ_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration DEFAULT_SOCKET_WRITE_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(2);
@@ -107,6 +121,8 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
     private static final int DEFAULT_MAX_CONNECTIONS = 50;
     private static final int DEFAULT_MAX_CONNECTION_ACQUIRES = 10_000;
     private static final Boolean DEFAULT_TRUST_ALL_CERTIFICATES = Boolean.FALSE;
+    private static final SSLParameters DEFAULT_SSL_PARAMETERS = new SSLParameters();
+    private static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofSeconds(30);
 
     private static final Protocol DEFAULT_PROTOCOL = Protocol.HTTP1_1;
 
@@ -123,6 +139,8 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
             .put(PROTOCOL, DEFAULT_PROTOCOL)
             .put(TRUST_ALL_CERTIFICATES, DEFAULT_TRUST_ALL_CERTIFICATES)
             .put(REAP_IDLE_CONNECTIONS, DEFAULT_REAP_IDLE_CONNECTIONS)
+            .put(SSL_PARAMETERS, DEFAULT_SSL_PARAMETERS)
+            .put(RESPONSE_TIMEOUT, DEFAULT_RESPONSE_TIMEOUT)
             .build();
 
     private final String name;

--- a/http-clients/java-nio-client/pom.xml
+++ b/http-clients/java-nio-client/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>java-nio-client</artifactId>
     <name>AWS Java SDK :: HTTP Clients :: Java Non-Blocking I/O</name>
 
+    <properties>
+        <jre.version>11</jre.version>
+    </properties>
+
 
     <dependencies>
         <!--SDK dependencies-->
@@ -46,7 +50,6 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
 
-
         <!--org.reactivestreams dependencies-->
         <dependency>
             <groupId>org.reactivestreams</groupId>
@@ -57,25 +60,81 @@
             <artifactId>reactive-streams-flow-adapters</artifactId>
             <version>1.0.2</version>
         </dependency>
-
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
             <version>3.0.0-RC0</version>
         </dependency>
 
-
+        <!--Test dependencies-->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.23.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!-- Disabling because it does not support analyzing Java 11 compiled classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>software.amazon.awssdk.java.nio.netty</Automatic-Module-Name>
+                            <Automatic-Module-Name>software.amazon.awssdk.http.nio.java</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/JavaSdkAsyncHttpService.java
+++ b/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/JavaSdkAsyncHttpService.java
@@ -27,7 +27,7 @@ public class JavaSdkAsyncHttpService implements SdkAsyncHttpService {
 
     @Override
     public SdkAsyncHttpClient.Builder createAsyncHttpClientFactory() {
-        return JavaNioAsyncHttpClient.builder();
+        return JavaHttpClientNioAsyncHttpClient.builder();
     }
 
 }

--- a/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpClientConfiguration.java
+++ b/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpClientConfiguration.java
@@ -15,10 +15,10 @@
 
 package software.amazon.awssdk.http.nio.java.internal;
 
-import static software.amazon.awssdk.http.SdkHttpConfigurationOption.CONNECTION_TIMEOUT;
 import static software.amazon.awssdk.utils.NumericUtils.saturatedCast;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.utils.AttributeMap;
 
 /**
@@ -27,19 +27,22 @@ import software.amazon.awssdk.utils.AttributeMap;
 @SdkInternalApi
 public final class JavaHttpClientConfiguration {
 
-    private final AttributeMap configuration;
+    private final AttributeMap sdkConfiguration;
 
-
-    public JavaHttpClientConfiguration(AttributeMap configuration) {
-        this.configuration = configuration;
+    public JavaHttpClientConfiguration(AttributeMap sdkConfiguration) {
+        this.sdkConfiguration = sdkConfiguration;
     }
 
     public <T> T attribute(AttributeMap.Key<T> key) {
-        return configuration.get(key);
+        return sdkConfiguration.get(key);
     }
 
     public int connectionTimeoutMillis() {
-        return saturatedCast(configuration.get(CONNECTION_TIMEOUT).toMillis());
+        return saturatedCast(sdkConfiguration.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toMillis());
+    }
+
+    public int responseTimeoutMillis() {
+        return saturatedCast(sdkConfiguration.get(SdkHttpConfigurationOption.RESPONSE_TIMEOUT).toMillis());
     }
 
 }

--- a/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpResponseBodyHandler.java
+++ b/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpResponseBodyHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java.internal;
+
+import java.net.http.HttpResponse;
+import org.reactivestreams.FlowAdapters;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+/**
+ * An implementation of {@link HttpResponse.BodyHandler}, connecting the ListToByteBufferProcessor and
+ * SdkAsyncHttpResponseHandler.
+ */
+@SdkProtectedApi
+final class JavaHttpResponseBodyHandler implements HttpResponse.BodyHandler<Void> {
+    private SdkAsyncHttpResponseHandler responseHandler;
+    private ListToByteBufferProcessor listToByteBufferProcessor;
+
+    JavaHttpResponseBodyHandler(SdkAsyncHttpResponseHandler responseHandler,
+                                ListToByteBufferProcessor listToByteBufferProcessor) {
+        this.responseHandler = responseHandler;
+        this.listToByteBufferProcessor = listToByteBufferProcessor;
+    }
+
+    @Override
+    public HttpResponse.BodySubscriber<Void> apply(HttpResponse.ResponseInfo responseInfo) {
+        SdkHttpResponse headers = SdkHttpFullResponse.builder()
+                .headers(responseInfo.headers().map())
+                .statusCode(responseInfo.statusCode())
+                .build(); // get the headers from responseInfo
+        responseHandler.onHeaders(headers);
+        responseHandler.onStream(listToByteBufferProcessor.getPublisherToSdk());
+        return HttpResponse.BodySubscribers.fromSubscriber(FlowAdapters.toFlowSubscriber(listToByteBufferProcessor));
+    }
+
+}

--- a/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/internal/ListToByteBufferProcessor.java
+++ b/http-clients/java-nio-client/src/main/java/software/amazon/awssdk/http/nio/java/internal/ListToByteBufferProcessor.java
@@ -39,15 +39,17 @@ public final class ListToByteBufferProcessor implements Subscriber<List<ByteBuff
 
     private final CompletableFuture<Void> terminated = new CompletableFuture<>();
 
+    public ListToByteBufferProcessor() {
+        this.processor = PublishProcessor.create();
+        this.publisherToSdk = processor.map(ListToByteBufferProcessor::convertListToByteBuffer);
+    }
 
-    ListToByteBufferProcessor() {
-        processor = PublishProcessor.create();
-        publisherToSdk = processor.map(list -> {
-            int bodyPartSize = list.stream().mapToInt(Buffer::remaining).sum();
-            ByteBuffer processedByteBuffer = ByteBuffer.allocate(bodyPartSize);
-            list.forEach(processedByteBuffer::put);
-            return processedByteBuffer;
-        });
+    public static ByteBuffer convertListToByteBuffer(List<ByteBuffer> list) {
+        int bodyPartSize = list.stream().mapToInt(Buffer::remaining).sum();
+        ByteBuffer processedByteBuffer = ByteBuffer.allocate(bodyPartSize);
+        list.forEach(processedByteBuffer::put);
+        processedByteBuffer.flip();
+        return processedByteBuffer;
     }
 
     @Override

--- a/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/JavaHttpClientNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/JavaHttpClientNioAsyncHttpClientWireMockTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static junit.framework.TestCase.assertEquals;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import com.github.jknack.handlebars.internal.lang3.StringUtils;
+import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.reactivex.Flowable;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.net.ssl.SSLParameters;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+
+public class JavaHttpClientNioAsyncHttpClientWireMockTest {
+    private final RecordingNetworkTrafficListener wiremockTrafficListener = new RecordingNetworkTrafficListener();
+    private static SdkAsyncHttpClient client = JavaHttpClientNioAsyncHttpClient.builder().build();
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort()
+            .networkTrafficListener(wiremockTrafficListener));
+
+    @Before
+    public void methodSetup() {
+        System.setProperty("jdk.internal.httpclient.debug", "true");
+        wiremockTrafficListener.reset();
+    }
+
+    @After
+    public void tearDownSetup() {
+        System.clearProperty("jdk.internal.httpclient.debug");
+    }
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(10);
+
+    public class RetryRule implements TestRule {
+        private int retryCount;
+
+        public RetryRule (int retryCount) {
+            this.retryCount = retryCount;
+        }
+
+        public Statement apply(Statement base, Description description) {
+            return statement(base, description);
+        }
+
+        private Statement statement(final Statement base, final Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    Throwable caughtThrowable = null;
+
+                    for (int i = 0; i < retryCount; i++) {
+                        try {
+                            base.evaluate();
+                            return;
+                        } catch (Throwable t) {
+                            caughtThrowable = t;
+                        }
+                        System.out.println("Test failed after 10 attemps!");
+                    }
+                    throw caughtThrowable;
+                }
+            };
+        }
+    }
+
+    private void makeSimpleRequest(SdkAsyncHttpClient client) throws Exception {
+        String body = randomAlphabetic(10);
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        stubFor(any(urlPathEqualTo("/"))
+                .willReturn(aResponse().withBody(body)));
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .requestContentPublisher(createProvider(""))
+                .responseHandler(recorder)
+                .build());
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void simpleMockTest() throws Exception {
+        makeSimpleRequest(client);
+    }
+
+    @Test
+    public void simpleMockPostTest() throws InterruptedException, ExecutionException, TimeoutException {
+        // Tests whether the HttpClient really only takes content in length of that demanded in "Content-Length"
+        final String content = randomAlphabetic(10);
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        stubFor(any(urlEqualTo("/echo?reversed=true"))
+                .withRequestBody(equalTo(content))
+                .willReturn(aResponse().withBody(StringUtils.reverse(content))));
+
+        SdkHttpFullRequest request = createRequest(uri, "/echo", content, SdkHttpMethod.POST, singletonMap("reversed", "true"), emptyMap());
+        request = request.toBuilder().putHeader("Content-Length", Integer.toString(content.length())).build();
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+        SdkHttpContentPublisher contentPublisher = createProvider(content);
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .requestContentPublisher(contentPublisher)
+                .responseHandler(recorder)
+                .build()).join();
+
+        recorder.completeFuture.get(2, TimeUnit.SECONDS);
+        assertThat(wiremockTrafficListener.response.toString().endsWith(content));
+
+    }
+
+    private SdkHttpFullRequest createRequest(URI uri) {
+        return createRequest(uri, "/", "", SdkHttpMethod.GET, emptyMap(), emptyMap());
+    }
+
+    private SdkHttpFullRequest createRequest(URI uri,
+                                             String resourcePath,
+                                             String body,
+                                             SdkHttpMethod method,
+                                             Map<String, String> params,
+                                             Map<String, List<String>> headers) {
+        String contentLength = body == null ? null : String.valueOf(body.getBytes(UTF_8).length);
+        return SdkHttpFullRequest.builder()
+                .uri(uri)
+                .method(method)
+                .encodedPath(resourcePath)
+                .applyMutation(b -> params.forEach(b::putRawQueryParameter))
+                .applyMutation(b -> {
+                    b.putHeader("Host", uri.getHost());
+                    if (contentLength != null) {
+                        b.putHeader("Content-Length", contentLength);
+                    }
+                })
+                .applyMutation(b -> headers.forEach(b::putHeader))
+                .build();
+    }
+
+
+    private SdkHttpContentPublisher createProvider(String body) {
+
+        return new SdkHttpContentPublisher() {
+            Flowable<ByteBuffer> flowable = Flowable.just(ByteBuffer.wrap(body.getBytes()));
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of((long) body.length());
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                flowable.subscribeWith(s);
+            }
+        };
+    }
+
+
+    @Test
+    public void testConnectionTimeoutError() throws Exception{
+        try{
+            String expectedErrorMsg = "java.net.http.HttpConnectTimeoutException: HTTP connect timed out";
+            SdkAsyncHttpClient customClient = JavaHttpClientNioAsyncHttpClient.builder()
+                    .connectionTimeout(Duration.ofMillis(1))
+                    .build();
+
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                futures.add(makeSimpleRequestAndReturnResponseHandler(customClient).completeFuture);
+            }
+
+            assertThatThrownBy(() -> CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join())
+                    .hasMessageContaining(expectedErrorMsg);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void protocolChangedTest() {
+        JavaHttpClientNioAsyncHttpClient customClient = (JavaHttpClientNioAsyncHttpClient)
+                                                        JavaHttpClientNioAsyncHttpClient.builder()
+                                                        .protocol(Protocol.HTTP2)
+                                                        .build();
+        assertEquals(customClient.getHttpClient().version(), HttpClient.Version.HTTP_2);
+    }
+
+    @Test
+    public void sslParametersTest() {
+        SSLParameters sslParameters = new SSLParameters();
+        String[] protocols = new String[] { "TLSv1.2" };
+        String[] cipherSuites = new String[] { "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" };
+        String[] applicationProtocols = new String[] { "h2", "http/1.1" };
+        sslParameters.setProtocols(protocols);
+        sslParameters.setCipherSuites(cipherSuites);
+        sslParameters.setApplicationProtocols(applicationProtocols);
+
+        JavaHttpClientNioAsyncHttpClient customClient = (JavaHttpClientNioAsyncHttpClient)
+                                                        JavaHttpClientNioAsyncHttpClient.builder()
+                                                        .configureSsl(sslParameters)
+                                                        .build();
+        SSLParameters testSslParameters = customClient.getHttpClient().sslParameters();
+        assertThat(testSslParameters.getProtocols().equals(protocols));
+        assertThat(testSslParameters.getCipherSuites().equals(cipherSuites));
+        assertThat(testSslParameters.getApplicationProtocols().equals(applicationProtocols));
+    }
+
+    @Test
+    public void testResponseTimeoutError() throws Exception {
+        try {
+            String expectedErrorMsg = "java.net.http.HttpTimeoutException: request timed out";
+            SdkAsyncHttpClient customClient = JavaHttpClientNioAsyncHttpClient.builder()
+                    .responseTimeout(Duration.ofMillis(500))
+                    .build();
+
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                futures.add(makeSimpleRequestAndReturnResponseHandler(customClient).completeFuture);
+            }
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+            assertThatThrownBy(() -> CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join())
+                    .hasMessageContaining(expectedErrorMsg);
+
+            customClient.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private RecordingResponseHandler makeSimpleRequestAndReturnResponseHandler(SdkAsyncHttpClient client) throws Exception {
+        String body = randomAlphabetic(10);
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body).withFixedDelay(1000)));
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .requestContentPublisher(createProvider(""))
+                .responseHandler(recorder)
+                .build());
+        return recorder;
+    }
+
+    private static class RecordingNetworkTrafficListener implements WiremockNetworkTrafficListener {
+        private final StringBuilder requests = new StringBuilder();
+        private final StringBuilder response = new StringBuilder();
+
+        @Override
+        public void opened(Socket socket) {
+
+        }
+
+        @Override
+        public void incoming(Socket socket, ByteBuffer byteBuffer) {
+            requests.append(StandardCharsets.UTF_8.decode(byteBuffer));
+        }
+
+        @Override
+        public void outgoing(Socket socket, ByteBuffer byteBuffer) {
+            response.append(UTF_8.decode(byteBuffer));
+        }
+
+        @Override
+        public void closed(Socket socket) {
+
+        }
+
+        public void reset() {
+            requests.setLength(0);
+        }
+    }
+
+
+
+}

--- a/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/RecordingResponseHandler.java
+++ b/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/RecordingResponseHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
+
+public final class RecordingResponseHandler implements SdkAsyncHttpResponseHandler {
+
+    List<SdkHttpResponse> responses = new ArrayList<>();
+    private StringBuilder bodyParts = new StringBuilder();
+    CompletableFuture<Void> completeFuture = new CompletableFuture<>();
+
+    @Override
+    public void onHeaders(SdkHttpResponse response) {
+        responses.add(response);
+    }
+
+    @Override
+    public void onStream(Publisher<ByteBuffer> publisher) {
+        publisher.subscribe(new SimpleSubscriber(byteBuffer -> {
+            byte[] b = new byte[byteBuffer.remaining()];
+            byteBuffer.duplicate().get(b);
+            bodyParts.append(new String(b, StandardCharsets.UTF_8));
+        }) {
+
+            @Override
+            public void onError(Throwable t) {
+                completeFuture.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completeFuture.complete(null);
+            }
+        });
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        completeFuture.completeExceptionally(error);
+    }
+
+    public String fullResponseAsString() {
+        return bodyParts.toString();
+    }
+}
+

--- a/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpRequestExecutorTest.java
+++ b/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpRequestExecutorTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java.internal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.reactivex.Flowable;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+import software.amazon.awssdk.http.nio.java.RecordingResponseHandler;
+import software.amazon.awssdk.utils.AttributeMap;
+
+public class JavaHttpRequestExecutorTest {
+
+    private final RecordingNetworkTrafficListener wiremockTrafficListener = new RecordingNetworkTrafficListener();
+
+    @Test
+    public void methodGetTest() {
+        RequestCheck(SdkHttpMethod.GET, "");
+    }
+
+    @Test
+    public void methodPutTest() {
+        String body = randomAlphabetic(10);
+        RequestCheck(SdkHttpMethod.PUT, body);
+    }
+
+    @Test
+    public void methodPostTest() {
+        String body = randomAlphabetic(32);
+        RequestCheck(SdkHttpMethod.POST, body);
+    }
+
+    @Test
+    public void methodDeleteTest() {
+        RequestCheck(SdkHttpMethod.DELETE, "");
+    }
+
+    @Test
+    public void methodHeadTest() {
+        RequestCheck(SdkHttpMethod.HEAD, "");
+    }
+
+    @Test
+    public void methodPatchTest() {
+        String body = randomAlphabetic(10);
+        RequestCheck(SdkHttpMethod.PATCH, body);
+    }
+
+    @Test
+    public void methodOptionTest() {
+        RequestCheck(SdkHttpMethod.OPTIONS, "");
+    }
+
+    private void RequestCheck(SdkHttpMethod method, String body) {
+        // Given
+        URI uri = URI.create("http://localhost:" + 8080);
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("foo", Collections.singletonList("bar"));
+        SdkHttpRequest request = createRequest(uri, "", body, method, emptyMap(), headers);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+        // Mock the HttpClient to capture the request flows into this client
+        MyHttpClient mockJavaHttpClient = mock(MyHttpClient.class);
+
+        JavaHttpRequestExecutor javaHttpRequestExecutor = new JavaHttpRequestExecutor(mockJavaHttpClient,
+                AttributeMap.builder().build().merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
+        CompletableFuture<HttpResponse<Void>> responseFuture = new CompletableFuture();
+        when(mockJavaHttpClient.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                                                                                        .thenReturn(responseFuture);
+        javaHttpRequestExecutor.requestExecution(AsyncExecuteRequest.builder()
+                .request(request)
+                .requestContentPublisher(createProvider(body))
+                .responseHandler(recorder).build());
+
+        // Then, check whether the request passed to the executor has been generated correctly
+        Mockito.verify(mockJavaHttpClient).sendAsync(argThat((HttpRequest httpRequest) ->
+                httpRequest.uri().toString().equals(uri.toString())
+                && httpRequest.method().equals(method.toString())
+                && httpRequest.headers().map().toString().equals(headers.toString())),
+                any(HttpResponse.BodyHandler.class));
+    }
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort()
+            .networkTrafficListener(wiremockTrafficListener), false);
+
+    @Test
+    public void handlerReceiveSuccessfullyTest() {
+        String body = randomAlphabetic(32);
+        successfullyExecuteTest(SdkHttpMethod.POST, body);
+    }
+
+    @Test
+    public void handlerReceiveFailedTest() {
+        String body = randomAlphabetic(32);
+        unsuccessfullyExecuteTest(SdkHttpMethod.POST, body);
+    }
+
+    private void successfullyExecuteTest(SdkHttpMethod method, String body) throws CompletionException {
+        // Check the CompletableFuture when the request is executed successfully
+        stubFor(WireMock.any(urlPathEqualTo("/")).willReturn(aResponse()
+                .withBody(body)
+                .withHeader("Some-Header", "With Value")
+                .withFixedDelay(2)));
+
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("foo", Collections.singletonList("bar"));
+        SdkHttpRequest request = createRequest(uri, "/", body, method, emptyMap(), headers);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+        HttpClient javaHttpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(20))
+                .build();
+        JavaHttpRequestExecutor javaHttpRequestExecutor = new JavaHttpRequestExecutor(javaHttpClient,
+                AttributeMap.builder().build().merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
+
+        javaHttpRequestExecutor.requestExecution(AsyncExecuteRequest.builder()
+                .request(request)
+                .requestContentPublisher(createProvider(body))
+                .responseHandler(recorder)
+                .build()).join();
+
+        assertThat(wiremockTrafficListener.response.toString().endsWith(body));
+    }
+
+
+    private void unsuccessfullyExecuteTest(SdkHttpMethod method, String body) throws CompletionException {
+        // Check the CompletableFuture when the request is executed unsuccessfully
+        try{
+            stubFor(WireMock.any(urlPathEqualTo("/")).willReturn(aResponse()
+                    .withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+            URI uri = URI.create("http://localhost:" + mockServer.port());
+            Map<String, List<String>> headers = new HashMap<>();
+            headers.put("foo", Collections.singletonList("bar"));
+            SdkHttpRequest request = createRequest(uri, "/", body, method, emptyMap(), headers);
+            RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+            HttpClient javaHttpClient = HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .connectTimeout(Duration.ofSeconds(20))
+                    .build();
+
+            JavaHttpRequestExecutor javaHttpRequestExecutor = new JavaHttpRequestExecutor(javaHttpClient,
+                    AttributeMap.builder().build().merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
+
+            javaHttpRequestExecutor.requestExecution(AsyncExecuteRequest.builder()
+                    .request(request)
+                    .requestContentPublisher(createProvider(body))
+                    .responseHandler(recorder).build()).join();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    private SdkHttpFullRequest createRequest(URI uri) {
+        return createRequest(uri, "/", "", SdkHttpMethod.GET, emptyMap(), emptyMap());
+    }
+
+    private SdkHttpFullRequest createRequest(URI uri,
+                                             String resourcePath,
+                                             String body,
+                                             SdkHttpMethod method,
+                                             Map<String, String> params,
+                                             Map<String, List<String>> headers) {
+        String contentLength = body == null ? null : String.valueOf(body.getBytes(UTF_8).length);
+        return SdkHttpFullRequest.builder()
+                .uri(uri)
+                .method(method)
+                .encodedPath(resourcePath)
+                .applyMutation(b -> params.forEach(b::putRawQueryParameter))
+                .applyMutation(b -> {
+                    b.putHeader("Host", uri.getHost());
+                    if (contentLength != null) {
+                        b.putHeader("Content-Length", contentLength);
+                    }
+                })
+                .applyMutation(b -> headers.forEach(b::putHeader))
+                .build();
+    }
+
+
+    private SdkHttpContentPublisher createProvider(String body) {
+
+        return new SdkHttpContentPublisher() {
+            Flowable<ByteBuffer> flowable = Flowable.just(ByteBuffer.wrap(body.getBytes()));
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of((long) body.length());
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                flowable.subscribeWith(s);
+            }
+        };
+    }
+
+
+    private static class RecordingNetworkTrafficListener implements WiremockNetworkTrafficListener {
+        private final StringBuilder requests = new StringBuilder();
+        private final StringBuilder response = new StringBuilder();
+
+        @Override
+        public void opened(Socket socket) {
+
+        }
+
+        @Override
+        public void incoming(Socket socket, ByteBuffer byteBuffer) {
+            requests.append(StandardCharsets.UTF_8.decode(byteBuffer));
+        }
+
+        @Override
+        public void outgoing(Socket socket, ByteBuffer byteBuffer) {
+            response.append(UTF_8.decode(byteBuffer));
+        }
+
+        @Override
+        public void closed(Socket socket) {
+
+        }
+
+        public void reset() {
+            requests.setLength(0);
+        }
+    }
+
+    // The constructor of HttpClient is protected, so to mock it here an auxiliary class is added
+    private static abstract class MyHttpClient extends HttpClient {
+        public MyHttpClient() {
+            super();
+        }
+    }
+}

--- a/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpResponseBodyHandlerTest.java
+++ b/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/JavaHttpResponseBodyHandlerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java.internal;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.*;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+public class JavaHttpResponseBodyHandlerTest {
+
+    @Test
+    public void BodyHandlerCreatedSuccessfullyTest() {
+        SdkAsyncHttpResponseHandler mockSdkHttpResponseHandler = mock(SdkAsyncHttpResponseHandler.class);
+        HttpResponse.ResponseInfo responseInfo = mock(HttpResponse.ResponseInfo.class);
+
+        ListToByteBufferProcessor listToByteBufferProcessor = new ListToByteBufferProcessor();
+
+        JavaHttpResponseBodyHandler javaBodyHandler = new JavaHttpResponseBodyHandler(mockSdkHttpResponseHandler, listToByteBufferProcessor);
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("foo", Collections.singletonList("bar"));
+
+        HttpHeaders httpHeaders = HttpHeaders.of(headers, (s, s2) -> false);
+
+        when(responseInfo.headers()).thenReturn(httpHeaders);
+        when(responseInfo.statusCode()).thenReturn(200);
+
+
+        javaBodyHandler.apply(responseInfo);
+
+        ArgumentCaptor<SdkHttpResponse> capturedResponse = ArgumentCaptor.forClass(SdkHttpResponse.class);
+        verify(mockSdkHttpResponseHandler).onHeaders(capturedResponse.capture());
+        verify(mockSdkHttpResponseHandler).onStream(listToByteBufferProcessor.getPublisherToSdk());
+
+        assertEquals(responseInfo.statusCode(), capturedResponse.getValue().statusCode());
+        assertEquals(httpHeaders.map(), capturedResponse.getValue().headers());
+    }
+
+}

--- a/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/ListToByteBufferProcessorTest.java
+++ b/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/ListToByteBufferProcessorTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java.internal;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.processors.ReplayProcessor;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Flow;
+import org.junit.Test;
+import org.reactivestreams.FlowAdapters;
+import org.reactivestreams.Subscription;
+
+public class ListToByteBufferProcessorTest {
+
+    private ListToByteBufferProcessor listToByteBufferProcessor = new ListToByteBufferProcessor();
+    private PublishProcessor<List<ByteBuffer>> publishProcessor = PublishProcessor.create();
+    private ErrorPublisher errorPublisher = new ErrorPublisher();
+    private CompletePublisher completePublisher = new CompletePublisher();
+
+    private final int byteBufferSize1 = 20;
+    private final int byteBufferSize2 = 20;
+
+    private FlowableSubscriber<ByteBuffer> simSdkSubscriber = new FlowableSubscriber<ByteBuffer>() {
+        private Subscription subscription;
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(ByteBuffer byteBuffer) {
+            assertEquals(byteBuffer.capacity(), byteBufferSize1+byteBufferSize2);
+            subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            throwable.printStackTrace();
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    };
+
+    @Test
+    public void publisherTest() {
+        List<ByteBuffer> list1 = new ArrayList<>();
+        List<ByteBuffer> list2 = new ArrayList<>();
+        String tempString1 = "Hello";
+        String tempString2 = " World";
+        String tempString3 = "!";
+        ByteBuffer tempBuffer1 = ByteBuffer.wrap(tempString1.getBytes(StandardCharsets.UTF_8));
+        ByteBuffer tempBuffer2 = ByteBuffer.wrap(tempString2.getBytes(StandardCharsets.UTF_8));
+        ByteBuffer tempBuffer3 = ByteBuffer.wrap(tempString3.getBytes(StandardCharsets.UTF_8));
+        list1.add(tempBuffer1);
+        list1.add(tempBuffer2);
+        list2.add(tempBuffer3);
+
+        Flowable<List<ByteBuffer>> bufferListPublisher = Flowable.just(list1, list2);
+
+        ListToByteBufferProcessor listToByteBufferProcessor = new ListToByteBufferProcessor();
+
+        ReplayProcessor<ByteBuffer> replayProcessor = ReplayProcessor.create();
+
+        listToByteBufferProcessor.getPublisherToSdk().subscribe(replayProcessor);
+        bufferListPublisher.subscribe(listToByteBufferProcessor);
+        List<ByteBuffer> resultList = Flowable.fromPublisher(replayProcessor).toList().blockingGet();
+        assertThat(resultList.get(0).toString().equals("Hello World") && resultList.get(1).toString().equals("!"));
+    }
+
+    @Test
+    public void mapperTest() {
+        List<ByteBuffer> list = new ArrayList<>();
+        String tempString1 = "Hello";
+        String tempString2 = " World!";
+        ByteBuffer tempBuffer1 = ByteBuffer.wrap(tempString1.getBytes(StandardCharsets.UTF_8));
+        ByteBuffer tempBuffer2 = ByteBuffer.wrap(tempString2.getBytes(StandardCharsets.UTF_8));
+        list.add(tempBuffer1);
+        list.add(tempBuffer2);
+        ByteBuffer buffer = ListToByteBufferProcessor.convertListToByteBuffer(list);
+        assertEquals(tempString1+tempString2, new String(buffer.array()));
+    }
+
+    @Test
+    public void onErrorTest() {
+        errorPublisher.subscribe(FlowAdapters.toFlowSubscriber(listToByteBufferProcessor));
+        listToByteBufferProcessor.getPublisherToSdk().subscribe(simSdkSubscriber);
+        listToByteBufferProcessor.onComplete();
+    }
+
+    @Test
+    public void onCompleteTest() {
+        completePublisher.subscribe(FlowAdapters.toFlowSubscriber(listToByteBufferProcessor));
+        listToByteBufferProcessor.getPublisherToSdk().subscribe(simSdkSubscriber);
+        listToByteBufferProcessor.onComplete();
+    }
+
+    @Test
+    public void ProcessorTest() {
+        List<ByteBuffer> testList1 = new ArrayList<>();
+        ByteBuffer buf1 = ByteBuffer.allocate(byteBufferSize1);
+        ByteBuffer buf2 = ByteBuffer.allocate(byteBufferSize2);
+
+        testList1.add(buf1);
+        testList1.add(buf2);
+
+        publishProcessor.subscribe(listToByteBufferProcessor);
+        listToByteBufferProcessor.getPublisherToSdk().subscribe(simSdkSubscriber);
+        publishProcessor.onNext(testList1);
+        publishProcessor.onComplete();
+        listToByteBufferProcessor.onComplete();
+    }
+
+    public static class ErrorPublisher implements Flow.Publisher<List<ByteBuffer>> {
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super List<ByteBuffer>> subscriber) {
+            subscriber.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(long n) {
+                }
+
+                @Override
+                public void cancel() {
+                }
+            });
+
+            subscriber.onError(new RuntimeException("onError: invoked successfully, something went wrong!"));
+        }
+
+    }
+
+    public static class CompletePublisher implements Flow.Publisher<List<ByteBuffer>> {
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super List<ByteBuffer>> subscriber) {
+            subscriber.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(long n) {
+                }
+
+                @Override
+                public void cancel() {
+                }
+            });
+
+            subscriber.onComplete();
+        }
+
+    }
+}

--- a/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/S3JavaHttpClientIntegratedTest.java
+++ b/http-clients/java-nio-client/src/test/java/software/amazon/awssdk/http/nio/java/internal/S3JavaHttpClientIntegratedTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.java.internal;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import java.util.concurrent.CompletableFuture;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.java.JavaHttpClientNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.*;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class S3JavaHttpClientIntegratedTest {
+
+    private static final String BUCKET = "zhouquas3testbucketjava";
+    private static final String KEY = "smalltestkey";
+    private static final String LARGEKEY = "largetestkey";
+    private static final String VALUE = "Hello World!";
+    private static String LARGESTRING = randomAlphabetic(25000);
+
+    private S3AsyncClient s3Async;
+    private S3Client s3Client;
+
+    private void createS3AsyncClient(SdkAsyncHttpClient myClient) {
+        this.s3Async = S3AsyncClient.builder()
+                .httpClient(myClient)
+                .overrideConfiguration(b -> b.retryPolicy(RetryPolicy.none()))
+                .serviceConfiguration(S3Configuration.builder().checksumValidationEnabled(false).build())
+                .region(Region.US_WEST_2)
+                .build();
+    }
+
+    private void createS3Client() {
+        this.s3Client = S3Client.create();
+    }
+
+    private void createAsyncClientWithJavaHttpClientHTTP1() {
+        SdkAsyncHttpClient javaHttpCient = JavaHttpClientNioAsyncHttpClient.builder().protocol(Protocol.HTTP1_1).build();
+        createS3AsyncClient(javaHttpCient);
+    }
+
+    private void createAsyncClientWithJavaHttpClientHTTP2() {
+        SdkAsyncHttpClient javaHttpCient = JavaHttpClientNioAsyncHttpClient.builder().protocol(Protocol.HTTP2).build();
+        createS3AsyncClient(javaHttpCient);
+    }
+
+    /* To run the tests in order, here alphabets are added at the beginning of the names of tests. */
+    @Test
+    public void As3createBucketWithJavaHttpClientHTTP1Test() {
+        createAsyncClientWithJavaHttpClientHTTP1();
+        createBucketTest(s3Async);
+    }
+
+    @Test
+    public void Bs3createBucketWithJavaHttpClientHTTP2Test() {
+        createAsyncClientWithJavaHttpClientHTTP2();
+        createBucketTest(s3Async);
+    }
+
+    @Test
+    public void Cs3PutSmallObjectWithJavaHttpClientHTTP1Test() {
+        createAsyncClientWithJavaHttpClientHTTP1();
+        putObjectTest(s3Async, KEY, VALUE);
+    }
+
+    @Test
+    public void Ds3PutSmallObjectWithJavaHttpClientHTTP2Test() {
+        createAsyncClientWithJavaHttpClientHTTP2();
+        putObjectTest(s3Async, KEY, VALUE);
+    }
+
+    @Test
+    public void Es3PutLargeObjectWithJavaHttpClientHTTP1Test() {
+        createAsyncClientWithJavaHttpClientHTTP1();
+        putObjectTest(s3Async, LARGEKEY, LARGESTRING);
+    }
+
+    @Test
+    public void Fs3PutLargeObjectWithJavaHttpClientHTTP2Test() {
+        createAsyncClientWithJavaHttpClientHTTP2();
+        putObjectTest(s3Async, LARGEKEY, LARGESTRING);
+    }
+
+    @Test
+    public void Gs3GetObjectWithJavaHttpClientHTTP1Test() {
+        createAsyncClientWithJavaHttpClientHTTP1();
+        getObjectTest(s3Async);
+    }
+
+    @Test
+    public void Hs3GetObjectWithJavaHttpClientHTTP2Test() {
+        createAsyncClientWithJavaHttpClientHTTP2();
+        getObjectTest(s3Async);
+    }
+
+    @Test
+    public void Is3GetObjectWithSyncHttpClient() {
+        createS3Client();
+        ResponseBytes responseBytes = s3Client.getObject(GetObjectRequest.builder().bucket(BUCKET).key(KEY).build(),
+                ResponseTransformer.toBytes());
+        assertEquals(responseBytes.asUtf8String(), VALUE);
+    }
+
+    @Test
+    public void Js3DeleteObjectWithJavaHttpClientHTTP1Test() {
+        createAsyncClientWithJavaHttpClientHTTP1();
+        deleteObjectTest(s3Async);
+    }
+
+
+    private static void createBucketTest(S3AsyncClient s3Async) {
+        try (s3Async) {
+            s3Async.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build()).join();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void putObjectTest(S3AsyncClient s3Async, String key, String value) {
+        try (s3Async) {
+            CompletableFuture<PutObjectResponse> future = s3Async.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(BUCKET)
+                            .key(key)
+                            .build(),
+                    AsyncRequestBody.fromString(value)
+            );
+            future.join();
+        }
+    }
+
+    private static void getObjectTest(S3AsyncClient s3Async) {
+        ResponseBytes responseBytes = s3Async.getObject(
+                GetObjectRequest.builder()
+                        .bucket(BUCKET)
+                        .key(KEY)
+                        .build(),
+                AsyncResponseTransformer.toBytes()).join();
+        assertEquals(responseBytes.asUtf8String(), VALUE);
+    }
+
+    private static void deleteObjectTest(S3AsyncClient s3Async) {
+        try (s3Async) {
+            CompletableFuture<DeleteObjectResponse> future = s3Async.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(BUCKET)
+                            .key(KEY)
+                            .build());
+            future.join();
+        }
+    }
+}

--- a/http-clients/java-nio-client/src/test/resources/jetty-logging.properties
+++ b/http-clients/java-nio-client/src/test/resources/jetty-logging.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+# Set up logging implementation
+
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+org.eclipse.jetty.LEVEL=OFF

--- a/http-clients/java-nio-client/src/test/resources/log4j.properties
+++ b/http-clients/java-nio-client/src/test/resources/log4j.properties
@@ -20,15 +20,5 @@ log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 # Print the date in ISO 8601 format
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 
-# Adjust to see more / less logging
-#log4j.logger.com.amazonaws.ec2=DEBUG
-
-# HttpClient 3 Wire Logging
-#log4j.logger.httpclient.wire=DEBUG
-
-# HttpClient 4 Wire Logging
-#log4j.logger.org.apache.http.wire=DEBUG
-#log4j.logger.org.apache.http=DEBUG
-#log4j.logger.org.apache.http.wire=WARN
-log4j.logger.software.amazon.awssdk=INFO
-log4j.logger.jdk.internal.httpclient.debug=INFO
+log4j.jdk.internal.httpclient.debug=INFO
+jdk.httpclient.HttpClient.log=requests

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/CancellableAcquireChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/CancellableAcquireChannelPoolTest.java
@@ -15,6 +15,11 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -30,12 +35,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link CancellableAcquireChannelPool}.
@@ -77,7 +76,7 @@ public class CancellableAcquireChannelPoolTest {
         acquireFuture.setFailure(new RuntimeException("Changed my mind!"));
 
         when(mockDelegatePool.acquire(any(Promise.class))).thenAnswer((Answer<Promise>) invocationOnMock -> {
-            Promise p = invocationOnMock.getArgumentAt(0, Promise.class);
+            Promise p = invocationOnMock.getArgument(0, Promise.class);
             p.setSuccess(channel);
             return p;
         });

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HealthCheckedChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HealthCheckedChannelPoolTest.java
@@ -176,7 +176,7 @@ public class HealthCheckedChannelPoolTest {
         OngoingStubbing<Future<Channel>> stubbing = Mockito.when(downstreamChannelPool.acquire(any()));
         for (boolean shouldAcquireBeHealthy : acquireHealthySequence) {
             stubbing = stubbing.thenAnswer(invocation -> {
-                Promise<Channel> promise = invocation.getArgumentAt(0, Promise.class);
+                Promise<Channel> promise = invocation.getArgument(0, Promise.class);
                 Channel channel = Mockito.mock(Channel.class);
                 Mockito.when(channel.isActive()).thenReturn(shouldAcquireBeHealthy);
                 channels.add(channel);
@@ -188,14 +188,14 @@ public class HealthCheckedChannelPoolTest {
 
     public void stubBadDownstreamAcquire() {
         Mockito.when(downstreamChannelPool.acquire(any())).thenAnswer(invocation -> {
-            Promise<Channel> promise = invocation.getArgumentAt(0, Promise.class);
+            Promise<Channel> promise = invocation.getArgument(0, Promise.class);
             promise.setFailure(new IOException());
             return promise;
         });
     }
 
     public void stubIncompleteDownstreamAcquire() {
-        Mockito.when(downstreamChannelPool.acquire(any())).thenAnswer(invocation -> invocation.getArgumentAt(0, Promise.class));
+        Mockito.when(downstreamChannelPool.acquire(any())).thenAnswer(invocation -> invocation.getArgument(0, Promise.class));
     }
 
     public void stubForIgnoredTimeout() {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutorTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutorTest.java
@@ -1,11 +1,15 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.util.concurrent.Promise;
+import java.util.concurrent.CompletableFuture;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,14 +17,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.utils.AttributeMap;
-
-import java.util.concurrent.CompletableFuture;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class NettyRequestExecutorTest {
 
@@ -54,7 +50,7 @@ public class NettyRequestExecutorTest {
     public void cancelExecuteFuture_channelNotAcquired_failsAcquirePromise() {
         ArgumentCaptor<Promise> acquireCaptor = ArgumentCaptor.forClass(Promise.class);
         when(mockChannelPool.acquire(acquireCaptor.capture())).thenAnswer((Answer<Promise>) invocationOnMock -> {
-            return invocationOnMock.getArgumentAt(0, Promise.class);
+            return invocationOnMock.getArgument(0, Promise.class);
         });
 
         CompletableFuture<Void> executeFuture = nettyRequestExecutor.execute();
@@ -72,7 +68,7 @@ public class NettyRequestExecutorTest {
         when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
 
         when(mockChannelPool.acquire(any(Promise.class))).thenAnswer((Answer<Promise>) invocationOnMock -> {
-            Promise p = invocationOnMock.getArgumentAt(0, Promise.class);
+            Promise p = invocationOnMock.getArgument(0, Promise.class);
             p.setSuccess(mockChannel);
             return p;
         });

--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,13 @@
         <junit.version>4.12</junit.version>
         <junit5.version>5.4.2</junit5.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>2.28.1</mockito.version>
         <assertj.version>3.8.0</assertj.version>
         <guava.version>26.0-jre</guava.version>
         <jimfs.version>1.1</jimfs.version>
         <commons-lang.verson>2.3</commons-lang.verson>
         <netty-open-ssl-version>2.0.20.Final</netty-open-ssl-version>
+        <wiremock-jre8.version>2.23.2</wiremock-jre8.version>
 
         <!-- build plugin dependencies-->
         <maven.surefire.version>2.21.0</maven.surefire.version>
@@ -144,7 +145,7 @@
         <freemarker.version>2.3.9</freemarker.version>
         <aspectj.version>1.8.2</aspectj.version>
 
-        <jre.version>1.8</jre.version>
+        <jre.version>8</jre.version>
         <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.10</httpcomponents.httpcore.version>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Summary
First of all, the name of JavaNioAsyncHttpClient has been changed into JavaHttoClientNioAsyncHttpClient.
Then in this pull request, unit tests and functional tests to the basic version of JavaHttpClientNioAsyncHttpClient implementation were added, through which the methods and integrated functionality of the basic implementation are tested. And a new class named JavaHttpResponseBodyHandler is added.

#### 7/17 Updated
New features(configurations) are added, including: connectionTimeout, protocol, configureSsl and responseTimeout. Tests for these configurations are also added.

## Description
<!--- Describe your changes in detail -->
A new class named JavaHttpResponseBodyHandler is added, in this class the BodyHandler of the JavaHttpClientNioAsyncHttpClient is defined based on the HttpResponse.BodyHandler provided by Jdk 11. And descriptions related to the tests will be added in Testing part below.

#### 7/17 Updated
Four new features and corresponding setters are added in a new commit. Among these features, connectionTimeout and protocol are just similar to the ones in NettyNioAsyncHttpClient, while configureSsl is newly added in a similar way. New configuration responseTimeout is added in the SdkHttpConfigurationOption too, but it will be set in JavaHttpRequestFactory as an argument of the HttpRequest.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The name has been changed considering the customer experience. And there were no tests for the basic version of implementation in last pull requests, so they have been completed in this one.

#### 7/17 updated
There were no configuration setting parts in the basic version of JavaHttpClientNioAsyncHttpClient, to let the customers customize the HttpClient as the way they want, here setters of specific configurations are added.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Mockito and WireMock are used in this pull request to test the basic version of the implementation of the client, and the former one is for unit tests, and latter one for functional test.

1. In JavaHttpClientNioAsyncHttpClientTest class, a trivial test is added, to test whether the object of this client is created correctly. And more tests to test the configurations of the client will be added in this class later;
2. In JavaHttpRequestFactoryTest class, a trivial test is added, to test whether the object of the request is created correctly;
3. In JavaHttpRequestExecutorTest class, multiple tests aiming at the Http methods are added, to test whether each of these http methods can be executed correctly with this client; And in the method RequestCheck(), the request been passed to the HttpClient is checked, making sure the uri, http method, and http headers are just the same as that we set in the request; In successfullyExecuteTest() and unsuccessfullyExecuteTest(), the invocation of onHeaders(), onStream() and onError() are tested to check whether these methods are invoked correctly in different situation;
4. In JavaHttpResponseBodyHandler class, a test checking whether the status code and headers are correct is added. This test confirms the response we get from the server will be passed to the JavaHttpResponseBodyHandler correctly.
5. In ListToByteBufferProcessorTest class, a simulation of publisher and subscriber for the processor is added, to simulate the publisher publishing List<ByteBuffer> to the processor and the subscriber subscribing ByteBuffer object from the processor. And a test checking whether the conversion from List<ByteBuffer> to ByteBuffer through the processor succeed is added. Also two test checking whether onError() and onComplete() will be invoked correctly are also added.

#### 7/17 Updated
For the new added features, connectionTimeout() and responseTimeout() are tested via WireMock tests, setting different timeout for the HttpClient and checking whether their performances are correct. For configureSsl() and protocol(), since there are no APIs for SdkAsyncHttpClient to get access to the internal HttpClient object, so we can't directly check the protocol and SslParameters, but through debug mode of IntelliJ these fields are confirmed.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license