### PR TITLE
Fixed the issue where AsyncStreamingResponseHandler#prepare was not i…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-d2b1b51.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-d2b1b51.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fixed the issue where `AsyncResponseHandler#prepare` was not invoked before `#onHeaders`. See [#1343](https://github.com/aws/aws-sdk-java-v2/issues/1343)."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseAsyncClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/BaseAsyncClientHandler.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.client.handler;
 
 import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.ASYNC_RESPONSE_TRANSFORMER_FUTURE;
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -39,9 +40,11 @@ import software.amazon.awssdk.core.internal.util.ThrowableUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.Logger;
 
 @SdkProtectedApi
 public abstract class BaseAsyncClientHandler extends BaseClientHandler implements AsyncClientHandler {
+    private static final Logger log = Logger.loggerFor(BaseAsyncClientHandler.class);
     private final SdkClientConfiguration clientConfiguration;
     private final AmazonAsyncHttpClient client;
     private final Function<SdkHttpFullResponse, SdkHttpFullResponse> crc32Validator;
@@ -77,16 +80,16 @@ public abstract class BaseAsyncClientHandler extends BaseClientHandler implement
 
         // For streaming requests, prepare() should be called as early as possible to avoid NPE in client
         // See https://github.com/aws/aws-sdk-java-v2/issues/1268
-        CompletableFuture<ReturnT> asyncTransformerFuture = asyncResponseTransformer.prepare();
+        AsyncStreamingResponseHandler<OutputT, ReturnT> asyncStreamingResponseHandler =
+            new AsyncStreamingResponseHandler<>(asyncResponseTransformer);
+        CompletableFuture<ReturnT> asyncTransformerFuture = asyncStreamingResponseHandler.prepare();
 
         ExecutionContext context = createExecutionContext(executionParams);
         context.executionAttributes().putAttribute(ASYNC_RESPONSE_TRANSFORMER_FUTURE, asyncTransformerFuture);
 
         HttpResponseHandler<OutputT> decoratedResponseHandlers =
             decorateResponseHandlers(executionParams.getResponseHandler(), context);
-
-        AsyncStreamingResponseHandler<OutputT, ReturnT> asyncStreamingResponseHandler =
-            new AsyncStreamingResponseHandler<>(asyncResponseTransformer, decoratedResponseHandlers);
+        asyncStreamingResponseHandler.responseHandler(decoratedResponseHandlers);
 
         return doExecute(executionParams, context, asyncStreamingResponseHandler);
     }
@@ -143,6 +146,10 @@ public abstract class BaseAsyncClientHandler extends BaseClientHandler implement
 
             return CompletableFutureUtils.forwardExceptionTo(exceptionTranslatedFuture, invokeFuture);
         } catch (Throwable t) {
+            runAndLogError(
+                log.logger(),
+                "Error thrown from TransformingAsyncResponseHandler#onError, ignoring.",
+                () -> asyncResponseHandler.onError(t));
             return CompletableFutureUtils.failedFuture(ThrowableUtils.asSdkException(t));
         }
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/AsyncStreamingResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/AsyncStreamingResponseHandler.java
@@ -31,16 +31,17 @@ import software.amazon.awssdk.http.SdkHttpResponse;
  * Response handler for asynchronous streaming operations.
  */
 @SdkInternalApi
-public class AsyncStreamingResponseHandler<OutputT extends SdkResponse, ReturnT>
+public final class AsyncStreamingResponseHandler<OutputT extends SdkResponse, ReturnT>
     implements TransformingAsyncResponseHandler<ReturnT> {
 
     private final AsyncResponseTransformer<OutputT, ReturnT> asyncResponseTransformer;
-    private final HttpResponseHandler<OutputT> responseHandler;
-    private volatile CompletableFuture<ReturnT> transformFuture;
+    private volatile HttpResponseHandler<OutputT> responseHandler;
 
-    public AsyncStreamingResponseHandler(AsyncResponseTransformer<OutputT, ReturnT> asyncResponseTransformer,
-                                         HttpResponseHandler<OutputT> responseHandler) {
+    public AsyncStreamingResponseHandler(AsyncResponseTransformer<OutputT, ReturnT> asyncResponseTransformer) {
         this.asyncResponseTransformer = asyncResponseTransformer;
+    }
+
+    public void responseHandler(HttpResponseHandler<OutputT> responseHandler) {
         this.responseHandler = responseHandler;
     }
 
@@ -53,7 +54,7 @@ public class AsyncStreamingResponseHandler<OutputT extends SdkResponse, ReturnT>
 
             asyncResponseTransformer.onResponse(resp);
         } catch (Exception e) {
-            transformFuture.completeExceptionally(e);
+            asyncResponseTransformer.exceptionOccurred(e);
         }
     }
 
@@ -69,7 +70,6 @@ public class AsyncStreamingResponseHandler<OutputT extends SdkResponse, ReturnT>
 
     @Override
     public CompletableFuture<ReturnT> prepare() {
-        this.transformFuture = asyncResponseTransformer.prepare();
-        return transformFuture;
+        return asyncResponseTransformer.prepare();
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/AsyncClientHandlerExceptionTest.java
@@ -15,10 +15,13 @@
 
 package software.amazon.awssdk.core.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.fail;
 
@@ -32,6 +35,7 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.EmptyPublisher;
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -119,6 +123,21 @@ public class AsyncClientHandlerExceptionTest {
         final SdkClientException e = SdkClientException.create("Could not handle response");
         when(responseHandler.handle(any(SdkHttpFullResponse.class), any(ExecutionAttributes.class))).thenThrow(e);
         doVerify(() -> clientHandler.execute(executionParams), e);
+    }
+
+    @Test
+    public void streamingRequest_marshallingException_shouldInvokeExceptionOccurred() throws Exception {
+        AsyncResponseTransformer asyncResponseTransformer = mock(AsyncResponseTransformer.class);
+        CompletableFuture<?> future = new CompletableFuture<>();
+        when(asyncResponseTransformer.prepare()).thenReturn(future);
+
+        SdkClientException exception = SdkClientException.create("Could not handle response");
+        when(marshaller.marshall(any(SdkRequest.class))).thenThrow(exception);
+
+        doVerify(() -> clientHandler.execute(executionParams, asyncResponseTransformer), exception);
+
+        verify(asyncResponseTransformer, times(1)).prepare();
+        verify(asyncResponseTransformer, times(1)).exceptionOccurred(exception);
     }
 
     private void doVerify(Supplier<CompletableFuture<?>> s, final Throwable expectedException) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTransformerVerificationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/AsyncClientHandlerTransformerVerificationTest.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +43,7 @@ import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
@@ -100,6 +102,22 @@ public class AsyncClientHandlerTransformerVerificationTest {
 
         when(responseHandler.handle(any(SdkHttpFullResponse.class), any(ExecutionAttributes.class)))
                 .thenReturn(VoidSdkResponse.builder().build());
+    }
+
+    @Test
+    public void marshallerThrowsException_shouldTriggerExceptionOccurred() {
+        SdkClientException exception = SdkClientException.create("Could not handle response");
+        when(marshaller.marshall(any(SdkRequest.class))).thenThrow(exception);
+        AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
+        executeAndWaitError(new TestTransformer<SdkResponse, Void>(){
+            @Override
+            public void exceptionOccurred(Throwable error) {
+                exceptionOccurred.set(true);
+                super.exceptionOccurred(error);
+            }
+        });
+
+        assertThat(exceptionOccurred.get()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
…nvoked

<!--- Provide a general summary of your changes in the Title above -->

## Description
The issue is that `AsyncStreamingResponseHandler#prepare` is never invoked before `#onHeaders` in the first attempt as described on javadoc, so `transformFuture` will be null and when there is an exception thrown from `onHeaders` , NPE will be thrown when it is trying to complete the `transformFuture`

https://github.com/aws/aws-sdk-java-v2/blob/393687dc177a3c94814490a9847b1abaaf2fed9d/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/AsyncStreamingResponseHandler.java#L55-L56

## Motivation and Context
Related to #1343 

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
