### PR TITLE
Update HandlerRemovingChannelPool to only remove per request handlers…

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHttpClient-b229ef8.json
+++ b/.changes/next-release/bugfix-NettyNIOHttpClient-b229ef8.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Http Client", 
+    "type": "bugfix", 
+    "description": "Update `HandlerRemovingChannelPool` to only remove per request handlers if the channel is open or registered to avoid the race condition when the DefaultChannelPipeline is trying to removing the handler at the same time, causing `NoSuchElementException`."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
@@ -70,10 +70,17 @@ public class HandlerRemovingChannelPool implements ChannelPool {
 
     private void removePerRequestHandlers(Channel channel) {
         channel.attr(IN_USE).set(false);
-        removeIfExists(channel.pipeline(),
-                       HttpStreamsClientHandler.class,
-                       ResponseHandler.class,
-                       ReadTimeoutHandler.class,
-                       WriteTimeoutHandler.class);
+
+        // Only remove per request handler if the channel is registered
+        // or open since DefaultChannelPipeline would remove handlers if
+        // channel is closed and unregistered
+        // See DefaultChannelPipeline.java#L1403
+        if (channel.isOpen() || channel.isRegistered()) {
+            removeIfExists(channel.pipeline(),
+                           HttpStreamsClientHandler.class,
+                           ResponseHandler.class,
+                           ReadTimeoutHandler.class,
+                           WriteTimeoutHandler.class);
+        }
     }
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/ChannelUtils.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/ChannelUtils.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
@@ -37,7 +38,13 @@ public final class ChannelUtils {
     public static void removeIfExists(ChannelPipeline pipeline, Class<? extends ChannelHandler>... handlers) {
         for (Class<? extends ChannelHandler> handler : handlers) {
             if (pipeline.get(handler) != null) {
-                pipeline.remove(handler);
+                try {
+                    pipeline.remove(handler);
+                } catch (NoSuchElementException exception) {
+                    // There could still be race condition when channel gets
+                    // closed right after removeIfExists is invoked. Ignoring
+                    // NoSuchElementException for that edge case.
+                }
             }
         }
     }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPoolTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.IN_USE;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
+
+import com.typesafe.netty.http.HttpStreamsClientHandler;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HandlerRemovingChannelPoolTest {
+    @Mock
+    private ChannelPool channelPool;
+
+    @Mock
+    private SdkAsyncHttpResponseHandler responseHandler;
+
+    private Channel mockChannel;
+    private ChannelPipeline pipeline;
+    private NioEventLoopGroup nioEventLoopGroup;
+    private HandlerRemovingChannelPool handlerRemovingChannelPool;
+
+    @Before
+    public void setup() throws Exception {
+        mockChannel = new MockChannel();
+        pipeline = mockChannel.pipeline();
+        pipeline.addLast(new LoggingHandler(LogLevel.DEBUG));
+        nioEventLoopGroup = new NioEventLoopGroup();
+        nioEventLoopGroup.register(mockChannel);
+        RequestContext requestContext = new RequestContext(channelPool,
+                                                           nioEventLoopGroup,
+                                                           AsyncExecuteRequest.builder().responseHandler(responseHandler).build(),
+                                                           null);
+
+        mockChannel.attr(IN_USE).set(true);
+        mockChannel.attr(REQUEST_CONTEXT_KEY).set(requestContext);
+        mockChannel.attr(RESPONSE_COMPLETE_KEY).set(true);
+
+        pipeline.addLast(new HttpStreamsClientHandler());
+        pipeline.addLast(ResponseHandler.getInstance());
+        pipeline.addLast(new ReadTimeoutHandler(10));
+        pipeline.addLast(new WriteTimeoutHandler(10));
+        handlerRemovingChannelPool = new HandlerRemovingChannelPool(channelPool);
+    }
+
+    @After
+    public void tearDown() {
+        nioEventLoopGroup.shutdownGracefully();
+    }
+
+    @Test
+    public void release_openChannel_handlerShouldBeRemovedFromChannelPool() {
+        assertHandlersNotRemoved();
+        handlerRemovingChannelPool.release(mockChannel);
+
+        assertHandlersRemoved();
+    }
+
+    @Test
+    public void release_closedChannel_handlerShouldBeRemovedFromPipeline() {
+        mockChannel.close().awaitUninterruptibly();
+
+        // CLOSE -> INACTIVE -> UNREGISTERED: channel handlers should be removed at this point
+        assertHandlersRemoved();
+        handlerRemovingChannelPool.release(mockChannel);
+        assertHandlersRemoved();
+    }
+
+    @Test
+    public void release_deregisteredOpenChannel_handlerShouldBeRemovedFromChannelPool() {
+        mockChannel.deregister().awaitUninterruptibly();
+        assertHandlersNotRemoved();
+        handlerRemovingChannelPool.release(mockChannel);
+
+        assertHandlersRemoved();
+    }
+
+    private void assertHandlersRemoved() {
+        assertThat(pipeline.get(HttpStreamsClientHandler.class)).isNull();
+        assertThat(pipeline.get(ResponseHandler.class)).isNull();
+        assertThat(pipeline.get(ReadTimeoutHandler.class)).isNull();
+        assertThat(pipeline.get(WriteTimeoutHandler.class)).isNull();
+    }
+
+    private void assertHandlersNotRemoved() {
+        assertThat(pipeline.get(HttpStreamsClientHandler.class)).isNotNull();
+        assertThat(pipeline.get(ResponseHandler.class)).isNotNull();
+        assertThat(pipeline.get(ReadTimeoutHandler.class)).isNotNull();
+        assertThat(pipeline.get(WriteTimeoutHandler.class)).isNotNull();
+    }
+}


### PR DESCRIPTION
## Description
Update `HandlerRemovingChannelPool` to only remove per request handlers if the channel is open or registered to avoid the race condition when the DefaultChannelPipeline is trying to removing the handler at the same time, causing `NoSuchElementException`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Added unit tests.  Will run integ tests and stability tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
