### PR TITLE
Set correct Content-Type for APIs support input event streams.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-05caf1d.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-05caf1d.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "For APIs that support input event streams, set the `Content-Type` to `application/vnd.amazon.eventstream` on the request."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
@@ -161,4 +161,20 @@ public class EventStreamUtils {
         return doesShapeContainsEventStream(opModel.getInputShape(), eventStreamShape) ||
                doesShapeContainsEventStream(opModel.getOutputShape(), eventStreamShape);
     }
+
+    /**
+     * @return true if the provide model is a request/response shape model that contains event stream shape.
+     * Otherwise return false.
+     */
+    public static boolean isEventStreamParentModel(ShapeModel shapeModel) {
+        return containsEventStream(shapeModel);
+    }
+
+    private static boolean containsEventStream(ShapeModel shapeModel) {
+        return shapeModel != null
+               && shapeModel.getMembers() != null
+               && shapeModel.getMembers().stream()
+                            .filter(m -> m.getShape() != null)
+                            .anyMatch(m -> m.getShape().isEventStream());
+    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
@@ -73,6 +73,7 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
                      .add(".hasPayloadMembers($L)", shapeModel.hasPayloadMembers())
                      // Adding httpMethod to avoid validation failure while creating the SdkHttpFullRequest
                      .add(".httpMethod($T.GET)", SdkHttpMethod.class)
+                     .add(".hasEvent(true)")
                      .add(".build()");
 
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/JsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/JsonMarshallerSpec.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.codegen.poet.transform.protocols;
 
+import static software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils.isEventStreamParentModel;
+
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -101,6 +103,10 @@ public class JsonMarshallerSpec implements MarshallerProtocolSpec {
 
         if (shapeModel.isHasStreamingMember()) {
             initializationCodeBlockBuilder.add(".hasStreamingInput(true)");
+        }
+
+        if (isEventStreamParentModel(shapeModel)) {
+            initializationCodeBlockBuilder.add(".hasEventStreamingInput(true)");
         }
 
         CodeBlock codeBlock = initializationCodeBlockBuilder.add(".build()").build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventOneMarshaller implements Marshaller<EventOne> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).build();
+                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationrequestmarshaller.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.utils.Validate;
 public class EventStreamOperationRequestMarshaller implements Marshaller<EventStreamOperationRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
                                                                             .requestUri("/2016-03-11/eventStreamOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(true)
-                                                                            .hasPayloadMembers(true).build();
+                                                                            .hasPayloadMembers(true).hasEventStreamingInput(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationwithonlyinputrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationwithonlyinputrequestmarshaller.java
@@ -21,7 +21,7 @@ public class EventStreamOperationWithOnlyInputRequestMarshaller implements
                                                                 Marshaller<EventStreamOperationWithOnlyInputRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
                                                                             .requestUri("/2016-03-11/EventStreamOperationWithOnlyInput").httpMethod(SdkHttpMethod.POST)
-                                                                            .hasExplicitPayloadMember(false).hasPayloadMembers(true).build();
+                                                                            .hasExplicitPayloadMember(false).hasPayloadMembers(true).hasEventStreamingInput(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
@@ -19,8 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventThreeMarshaller implements Marshaller<EventThree> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).build();
-
+                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
     public EventThreeMarshaller(BaseAwsJsonProtocolFactory protocolFactory) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventTwoMarshaller implements Marshaller<EventTwo> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).build();
+                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventmarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class InputEventMarshaller implements Marshaller<InputEvent> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(true)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).build();
+                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class InputEventTwoMarshaller implements Marshaller<InputEventTwo> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).build();
+                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.protocols.json.internal.marshall;
 
+import static software.amazon.awssdk.core.internal.util.Mimetype.MIMETYPE_EVENT_STREAM;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
 
@@ -59,6 +60,8 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
     private final boolean hasStreamingInput;
 
     private final JsonMarshallerContext marshallerContext;
+    private final boolean hasEventStreamingInput;
+    private final boolean hasEvent;
 
     JsonProtocolMarshaller(URI endpoint,
                            StructuredJsonGenerator jsonGenerator,
@@ -69,6 +72,8 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
         this.contentType = contentType;
         this.hasExplicitPayloadMember = operationInfo.hasExplicitPayloadMember();
         this.hasStreamingInput = operationInfo.hasStreamingInput();
+        this.hasEventStreamingInput = operationInfo.hasEventStreamingInput();
+        this.hasEvent = operationInfo.hasEvent();
         this.request = fillBasicRequestParams(operationInfo);
         this.marshallerContext = JsonMarshallerContext.builder()
                                                       .jsonGenerator(jsonGenerator)
@@ -204,9 +209,16 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
 
         // We skip setting the default content type if the request is streaming as
         // content-type is determined based on the body of the stream
-        if (!request.headers().containsKey(CONTENT_TYPE) && contentType != null && !hasStreamingInput) {
-            request.putHeader(CONTENT_TYPE, contentType);
+        // TODO: !request.headers().containsKey(CONTENT_TYPE) does not work because request is created from line 77
+        // and not from the original request
+        if (!request.headers().containsKey(CONTENT_TYPE) && !hasEvent) {
+            if (hasEventStreamingInput) {
+                request.putHeader(CONTENT_TYPE, MIMETYPE_EVENT_STREAM);
+            } else if (contentType != null && !hasStreamingInput) {
+                request.putHeader(CONTENT_TYPE, contentType);
+            }
         }
+
         return request.build();
     }
 

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationInfo.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationInfo.java
@@ -32,6 +32,8 @@ public final class OperationInfo {
     private final boolean hasExplicitPayloadMember;
     private final boolean hasPayloadMembers;
     private final boolean hasStreamingInput;
+    private final boolean hasEventStreamingInput;
+    private final boolean hasEvent;
     private final AttributeMap additionalMetadata;
 
     private OperationInfo(Builder builder) {
@@ -43,6 +45,8 @@ public final class OperationInfo {
         this.hasPayloadMembers = builder.hasPayloadMembers;
         this.hasStreamingInput = builder.hasStreamingInput;
         this.additionalMetadata = builder.additionalMetadata.build();
+        this.hasEventStreamingInput = builder.hasEventStreamingInput;
+        this.hasEvent = builder.hasEvent;
     }
 
     /**
@@ -99,6 +103,20 @@ public final class OperationInfo {
     }
 
     /**
+     * @return True if the operation has event streaming input.
+     */
+    public boolean hasEventStreamingInput() {
+        return hasEventStreamingInput;
+    }
+
+    /**
+     * @return True if the operation has event.
+     */
+    public boolean hasEvent() {
+        return hasEvent;
+    }
+
+    /**
      * Gets an unmodeled piece of metadata. Useful for protocol specific options.
      *
      * @param key Key the metadata was registered under.
@@ -128,6 +146,8 @@ public final class OperationInfo {
         private boolean hasExplicitPayloadMember;
         private boolean hasPayloadMembers;
         private boolean hasStreamingInput;
+        private boolean hasEventStreamingInput;
+        private boolean hasEvent;
         private AttributeMap.Builder additionalMetadata = AttributeMap.builder();
 
         private Builder() {
@@ -165,6 +185,16 @@ public final class OperationInfo {
 
         public Builder hasStreamingInput(boolean hasStreamingInput) {
             this.hasStreamingInput = hasStreamingInput;
+            return this;
+        }
+
+        public Builder hasEventStreamingInput(boolean hasEventStreamingInput) {
+            this.hasEventStreamingInput = hasEventStreamingInput;
+            return this;
+        }
+
+        public Builder hasEvent(boolean hasEvent) {
+            this.hasEvent = hasEvent;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/Mimetype.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/Mimetype.java
@@ -67,6 +67,8 @@ public final class Mimetype {
 
     public static final String MIMETYPE_TEXT_PLAIN = "text/plain; charset=UTF-8";
 
+    public static final String MIMETYPE_EVENT_STREAM = "application/vnd.amazon.eventstream";
+
     private static final Logger LOG = LoggerFactory.getLogger(Mimetype.class);
 
     private static final String MIME_TYPE_PATH = "software/amazon/awssdk/core/util/mime.types";

--- a/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TranscribeStreamingIntegrationTest.java
+++ b/services/transcribestreaming/src/it/java/software/amazon/awssdk/services/transcribestreaming/TranscribeStreamingIntegrationTest.java
@@ -14,13 +14,16 @@
  */
 package software.amazon.awssdk.services.transcribestreaming;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.BeforeClass;
@@ -29,6 +32,10 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.transcribestreaming.model.AudioStream;
 import software.amazon.awssdk.services.transcribestreaming.model.LanguageCode;
@@ -51,6 +58,7 @@ public class TranscribeStreamingIntegrationTest {
     public static void setup() throws URISyntaxException {
         client = TranscribeStreamingAsyncClient.builder()
                                                .region(Region.US_EAST_1)
+                                               .overrideConfiguration(b -> b.addExecutionInterceptor(new VerifyHeaderInterceptor()))
                                                .credentialsProvider(getCredentials())
                                                .build();
     }
@@ -109,6 +117,16 @@ public class TranscribeStreamingIntegrationTest {
         @Override
         public void subscribe(Subscriber<? super AudioStream> s) {
             s.onSubscribe(new TestSubscription(s, inputStream));
+        }
+    }
+
+    private static class VerifyHeaderInterceptor implements ExecutionInterceptor {
+
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            List<String> contentTypeHeader = context.httpRequest().headers().get(CONTENT_TYPE);
+            assertThat(contentTypeHeader.size()).isEqualTo(1);
+            assertThat(contentTypeHeader.get(0)).isEqualTo(Mimetype.MIMETYPE_EVENT_STREAM);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Setting `Content-Type` to `application/vnd.amazon.eventstream` for APIs accepting input event streams.

## Testing
Added unit tests and integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
