### PR TITLE
Remove ListPartRequest when cleaning up resources for multipart upload

### DIFF
--- a/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/internal/RequestConversionUtils.java
+++ b/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/internal/RequestConversionUtils.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListPartsRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
@@ -66,9 +65,8 @@ final class RequestConversionUtils {
                                            .sseCustomerAlgorithm(putObjectRequest.sseCustomerAlgorithm())
                                            .sseCustomerKey(putObjectRequest.sseCustomerKey())
                                            .sseCustomerKeyMD5(putObjectRequest.sseCustomerKeyMD5())
-                                           //TODO: uncomment this once #1352 is merged
-                                           //.requestPayer(putObjectRequest.requestPayer())
-                                           //.acl(putObjectRequest.acl())
+                                           .requestPayer(putObjectRequest.requestPayer())
+                                           .acl(putObjectRequest.acl())
                                            .cacheControl(putObjectRequest.cacheControl())
                                            .metadata(putObjectRequest.metadata())
                                            .contentDisposition(putObjectRequest.contentDisposition())
@@ -81,6 +79,7 @@ final class RequestConversionUtils {
                                            .grantFullControl(putObjectRequest.grantFullControl())
                                            .grantReadACP(putObjectRequest.grantReadACP())
                                            .grantWriteACP(putObjectRequest.grantWriteACP())
+                                           //TODO filter out headers
                                            //.overrideConfiguration(putObjectRequest.overrideConfiguration())
                                            .build();
     }
@@ -99,7 +98,7 @@ final class RequestConversionUtils {
                                 .sseCustomerKeyMD5(putObjectRequest.sseCustomerKeyMD5())
                                 .uploadId(uploadId)
                                 .partNumber(partNumber)
-                                //.requestPayer(putObjectRequest.requestPayer())
+                                .requestPayer(putObjectRequest.requestPayer())
                                 //.overrideConfiguration(putObjectRequest.overrideConfiguration())
                                 .build();
     }
@@ -113,21 +112,9 @@ final class RequestConversionUtils {
                                              .multipartUpload(CompletedMultipartUpload.builder()
                                                                                       .parts(parts)
                                                                                       .build())
-                                             //.requestPayer(putObjectRequest.requestPayer())
+                                             .requestPayer(putObjectRequest.requestPayer())
                                              .uploadId(uploadId)
                                              .build();
-
-    }
-
-    static ListPartsRequest toListPartsRequest(PutObjectRequest putObjectRequest,
-                                               String uploadId) {
-        return ListPartsRequest.builder()
-                               .bucket(putObjectRequest.bucket())
-                               .key(putObjectRequest.key())
-                               .uploadId(uploadId)
-                               //.partNumberMarker()
-                               //.requestPayer(putObjectRequest.requestPayer())
-                               .build();
 
     }
 
@@ -137,8 +124,7 @@ final class RequestConversionUtils {
                                           .bucket(putObjectRequest.bucket())
                                           .key(putObjectRequest.key())
                                           .uploadId(uploadId)
-                                          //.partNumberMarker()
-                                          //.requestPayer(putObjectRequest.requestPayer())
+                                          .requestPayer(putObjectRequest.requestPayer())
                                           .build();
 
     }

--- a/services-custom/s3-transfermanager/src/test/java/software/amazon/awssdk/custom/s3/transfer/internal/UploadManagerTest.java
+++ b/services-custom/s3-transfermanager/src/test/java/software/amazon/awssdk/custom/s3/transfer/internal/UploadManagerTest.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.custom.s3.transfer.UploadObjectSpecification;
 import software.amazon.awssdk.custom.s3.transfer.UploadRequest;
 import software.amazon.awssdk.custom.s3.transfer.util.SizeConstant;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
@@ -166,6 +167,7 @@ public class UploadManagerTest {
                                                    transferRequestBody);
 
         assertThatThrownBy(() -> upload.completionFuture().join()).hasCause(exception);
+        verify(s3Client).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
     }
 
     @Test
@@ -189,6 +191,7 @@ public class UploadManagerTest {
                                                    transferRequestBody);
 
         assertThatThrownBy(() -> upload.completionFuture().join()).hasCause(exception);
+        verify(s3Client).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
     }
 
     private void stubSuccessfulCreateMultipartUpload() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove ListPartRequest when cleaning up resources for multipart upload.

`listParts` after `abortMultipart` will actually throw exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
