### PR TITLE
Add progress listener APIs

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/AbstractProgressEventListenerBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/AbstractProgressEventListenerBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.progress.ProgressEventHandler.ByteCountEventHandler;
+import software.amazon.awssdk.core.progress.ProgressEventHandler.RequestLifeCycleEventHandler;
+
+/**
+ * Builder for an {@link ProgressEventListener}.
+ * @param <B>
+ */
+@SdkProtectedApi
+public abstract class AbstractProgressEventListenerBuilder<B extends ProgressEventListener.Builder> implements ProgressEventListener.Builder<B> {
+
+    private ByteCountEventHandler byteCountEventHandler;
+    private RequestLifeCycleEventHandler requestLifeCycleEventHandler;
+    private ProgressEventHandler defaultEventHandler;
+
+    @Override
+    public B onDefault(ProgressEventHandler defaultEventHandler) {
+        this.defaultEventHandler = defaultEventHandler;
+        return (B) this;
+    }
+
+    @Override
+    public B onByteCountEvent(ByteCountEventHandler byteCountEventHandler) {
+        this.byteCountEventHandler = byteCountEventHandler;
+        return (B) this;
+    }
+
+    @Override
+    public B onRequestLifeCycleEvent(RequestLifeCycleEventHandler requestLifeCycleEventHandler) {
+        this.requestLifeCycleEventHandler = requestLifeCycleEventHandler;
+        return (B) this;
+    }
+
+    static final class DefaultProgressEventListenerBuilder extends AbstractProgressEventListenerBuilder implements ProgressEventListener.Builder {
+        @Override
+        public ProgressEventListener build() {
+            return new DefaultProgressEventListener(this);
+        }
+    }
+
+    final class DefaultProgressEventListener implements ProgressEventListener {
+        private final ByteCountEventHandler byteCountEventHandler;
+        private final RequestLifeCycleEventHandler requestLifeCycleEventHandler;
+        private final ProgressEventHandler defaultEventHandler;
+
+        DefaultProgressEventListener(AbstractProgressEventListenerBuilder builder) {
+            this.defaultEventHandler = builder.defaultEventHandler == null ? ProgressEventListener.super::onDefault : builder.defaultEventHandler;
+            this.byteCountEventHandler = builder.byteCountEventHandler == null ? ProgressEventListener.super::onDefault :
+                                         builder.byteCountEventHandler;
+            this.requestLifeCycleEventHandler = builder.requestLifeCycleEventHandler == null ?
+                                                ProgressEventListener.super::onDefault :
+                                                builder.requestLifeCycleEventHandler;
+        }
+
+        @Override
+        public CompletableFuture<? extends ProgressEventResult>  onDefault(ProgressEvent progressEventHandler) {
+            return defaultEventHandler.onDefault(progressEventHandler);
+        }
+
+        @Override
+        public CompletableFuture<? extends ProgressEventResult> onRequestLifeCycleEvent(RequestCycleEvent progressEvent) {
+            return requestLifeCycleEventHandler.onRequestLifeCycleEvent(progressEvent);
+        }
+
+        @Override
+        public CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent) {
+            return byteCountEventHandler.onByteCountEvent(progressEvent);
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ByteCountEvent.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ByteCountEvent.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.ToString;
+
+/**
+ * The Byte count {@link ProgressEvent} indicating the number of bytes in the execution of a single http request-response.
+ */
+@SdkPublicApi
+public final class ByteCountEvent implements ProgressEvent {
+    private final ByteCountEventType eventType;
+    private final ByteCountEventData eventData;
+
+    public ByteCountEvent(ByteCountEventType eventType,
+                          ByteCountEventData eventData) {
+        this.eventType = eventType;
+        this.eventData = eventData;
+    }
+
+    /**
+     * @return the type of the progress event
+     */
+    public ByteCountEventType eventType() {
+        return eventType;
+    }
+
+    @Override
+    public ByteCountEventData eventData() {
+        return eventData;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("ProgressEvent")
+                       .add("eventType", eventType)
+                       .add("eventData", eventData)
+                       .build();
+    }
+
+    public static final class ByteCountEventData implements ProgressEventData {
+        private final EventContext context;
+        private final long bytes;
+
+        public ByteCountEventData(EventContext context, long bytes) {
+            this.context = context;
+            this.bytes = bytes;
+        }
+
+        @Override
+        public EventContext eventContext() {
+            return context;
+        }
+
+        /**
+         * @return number of bytes associated with the event.
+         */
+        public long bytes() {
+            return bytes;
+        }
+    }
+
+
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ByteCountEventType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ByteCountEventType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Byte counting progress events
+ */
+@SdkPublicApi
+public enum ByteCountEventType implements ProgressEventType {
+    /**
+     * Event of the content length to be sent in a request.
+     */
+    REQUEST_CONTENT_LENGTH_EVENT,
+    /**
+     * Event of the content length received in a response.
+     */
+    RESPONSE_CONTENT_LENGTH_EVENT,
+
+    /**
+     * Used to indicate the number of bytes to be sent to the services.
+     */
+    REQUEST_BYTE_TRANSFER_EVENT,
+
+    /**
+     * Used to indicate the number of bytes received from services.
+     */
+    RESPONSE_BYTE_TRANSFER_EVENT
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/EventContext.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/EventContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkRequest;
+
+/**
+ * Context associated with an {@link ProgressEvent}.
+ */
+@SdkPublicApi
+public interface EventContext {
+
+    SdkRequest request();
+
+    final class SdkEventContext implements EventContext {
+        private final SdkRequest request;
+
+        public SdkEventContext(SdkRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public SdkRequest request() {
+            return request;
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEvent.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * A progress event. Typically this is used to notify a chunk of bytes has been
+ * transferred. This can also used to notify other types of progress events such as a
+ * transfer starting, or failing.
+ *
+ * @see ProgressEventListener
+ * @see ProgressEventType
+ */
+@SdkPublicApi
+public interface ProgressEvent {
+
+    /**
+     * @return the type of the progress event
+     */
+    ProgressEventType eventType();
+
+    /**
+     * @return the optional event data
+     */
+    ProgressEventData eventData();
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventData.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventData.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * The event data in a {@link software.amazon.awssdk.core.progress.ProgressEvent}.
+ */
+@SdkPublicApi
+public interface ProgressEventData {
+
+    /**
+     * @return the context associated with the progress event.
+     */
+    EventContext eventContext();
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Generic handler to handle {@link ProgressEvent}.
+ */
+@SdkPublicApi
+@FunctionalInterface
+public interface ProgressEventHandler {
+
+    /**
+     * Handles default {@link ProgressEvent}
+     *
+     * @param progressEvent the progress event
+     * @return the future containing the {@link ProgressEventResult}
+     */
+    CompletableFuture<? extends ProgressEventResult> onDefault(ProgressEvent progressEvent);
+
+
+    /**
+     * Event handler to handle {@link ByteCountEvent}.
+     */
+    @FunctionalInterface
+    interface ByteCountEventHandler {
+
+        /**
+         * Handles a {@link ByteCountEvent}
+         *
+         * @param progressEvent the progress event
+         * @return the future containing the {@link ProgressEventResult}
+         */
+        CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent);
+    }
+
+    /**
+     * Event handler to handle {@link RequestCycleEvent}.
+     */
+    @FunctionalInterface
+    interface RequestLifeCycleEventHandler {
+
+        /**
+         * Handles a {@link RequestCycleEvent}
+         *
+         * @param progressEvent the progress event
+         * @return the future containing the {@link ProgressEventResult}
+         */
+        CompletableFuture<? extends ProgressEventResult> onRequestLifeCycleEvent(RequestCycleEvent progressEvent);
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventListener.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventListener.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.progress.AbstractProgressEventListenerBuilder.DefaultProgressEventListenerBuilder;
+import software.amazon.awssdk.core.progress.ProgressEventHandler.ByteCountEventHandler;
+import software.amazon.awssdk.core.progress.ProgressEventHandler.RequestLifeCycleEventHandler;
+
+/**
+ * Listener interface to listen to the progress events.
+ *
+ * <T> Type of progress event
+ *
+ * @see ProgressEvent the progress event
+ */
+@SdkPublicApi
+public interface ProgressEventListener extends ProgressEventHandler, ByteCountEventHandler, RequestLifeCycleEventHandler {
+
+    Set<Class<? extends ProgressEvent>> SUPPORTED_TYPES =
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(RequestCycleEvent.class, ByteCountEvent.class)));
+
+    /**
+     * Check if the provided event is supported by this listener or not.
+     *
+     * <p>
+     * Sub classes can override {@link #extendedTypes()} to provided additional supported {@link ProgressEvent}.
+     *
+     * @param event the event
+     * @return true if the event is supported by this listener, otherwise false.
+     */
+    default boolean isSupported(ProgressEvent event) {
+        return SUPPORTED_TYPES.contains(event.getClass()) || extendedTypes().contains(event.getClass());
+    }
+
+    /**
+     * Data notification when a {@link ProgressEvent} is available.
+     *
+     * @param progressEvent a progress event
+     * @return the future containing the {@link ProgressEventResult}
+     */
+    default CompletableFuture<? extends ProgressEventResult> onProgressEvent(ProgressEvent progressEvent) {
+
+        ProgressEventType progressEventType = progressEvent.eventType();
+
+        if (progressEventType instanceof ByteCountEventType) {
+            return onByteCountEvent((ByteCountEvent) progressEvent);
+        }
+
+        if (progressEventType instanceof RequestCycleEventType) {
+            return onRequestLifeCycleEvent((RequestCycleEvent) progressEvent);
+        }
+
+        return onExtendedEvents(progressEvent);
+    }
+
+    @Override
+    default CompletableFuture<? extends ProgressEventResult> onRequestLifeCycleEvent(RequestCycleEvent progressEvent) {
+        return onDefault(progressEvent);
+    }
+
+    @Override
+    default CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent) {
+        return onDefault(progressEvent);
+    }
+
+    @Override
+    default CompletableFuture<? extends ProgressEventResult> onDefault(ProgressEvent progressEvent) {
+        return CompletableFuture.completedFuture(ProgressEventResult.empty());
+    }
+
+    /**
+     * Can be overridden by sub interfaces to provide additional supported types
+     *
+     * @return the future containing the progress event result.
+     */
+    default Set<Class<? extends ProgressEvent>> extendedTypes() {
+        return Collections.EMPTY_SET;
+    }
+
+    /**
+     * Can be overridden by sub interfaces to provide notifications on extended events
+     *
+     * @return the future containing the progress event result.
+     */
+    default CompletableFuture<? extends ProgressEventResult> onExtendedEvents(ProgressEvent progressEvent) {
+        return CompletableFuture.completedFuture(ProgressEventResult.empty());
+    }
+
+    static Builder builder() {
+        return new DefaultProgressEventListenerBuilder();
+    }
+
+    interface Builder<B extends Builder> {
+        B onDefault(ProgressEventHandler progressEvent);
+
+        B onByteCountEvent(ByteCountEventHandler transferEventHandler);
+
+        B onRequestLifeCycleEvent(RequestLifeCycleEventHandler requestLifeCycleEventVisitor);
+
+        ProgressEventListener build();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventListenerChain.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventListenerChain.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+
+
+/**
+ * An implementation of ProgressListener interface that dipatch
+ * progressEvents to multiple listeners.
+ */
+@SdkInternalApi
+public final class ProgressEventListenerChain implements ProgressEventListener {
+    private static final Logger log = Logger.loggerFor(ProgressEventListenerChain.class);
+
+    private final List<ProgressEventListener> listeners;
+
+    public ProgressEventListenerChain(Collection<ProgressEventListener> listeners) {
+        this.listeners = new ArrayList<>(Validate.paramNotNull(listeners, "listeners"));
+    }
+
+    @Override
+    public CompletableFuture<? extends ProgressEventResult> onProgressEvent(software.amazon.awssdk.core.progress.ProgressEvent progressEvent) {
+        log.debug(() -> "dispatching event " + progressEvent.eventType());
+        CompletableFuture[] completableFutures =
+            listeners.stream()
+                     .filter(l -> l.isSupported(progressEvent))
+                     .map(l -> l.onProgressEvent(progressEvent))
+                     .toArray(CompletableFuture[]::new);
+
+        return CompletableFuture.allOf(completableFutures).thenApply(ignore -> ProgressEventResult.empty());
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventResult.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Progress event result.
+ */
+@SdkPublicApi
+public interface ProgressEventResult {
+
+    /**
+     * @return an empty result
+     */
+    static ProgressEventResult empty() {
+        return EmptyProgressEventResult.instance();
+    }
+
+    final class EmptyProgressEventResult implements ProgressEventResult {
+        private static final EmptyProgressEventResult INSTANCE = new EmptyProgressEventResult();
+
+        private EmptyProgressEventResult() {
+        }
+
+        static ProgressEventResult instance() {
+            return INSTANCE;
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/ProgressEventType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * The type of the {@link software.amazon.awssdk.core.progress.ProgressEvent}.
+ */
+@SdkPublicApi
+public interface ProgressEventType {
+
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/RequestCycleEvent.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/RequestCycleEvent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.ToString;
+
+/**
+ * The request cycle {@link ProgressEvent} related to the execution of a single http request-response.
+ */
+@SdkPublicApi
+public final class RequestCycleEvent implements ProgressEvent {
+    private final RequestCycleEventType eventType;
+    private final RequestCycleEventData eventData;
+
+    public RequestCycleEvent(RequestCycleEventType eventType, RequestCycleEventData eventData) {
+        this.eventType = eventType;
+        this.eventData = eventData;
+    }
+
+    /**
+     * Create a {@link ProgressEvent} with event type and {@link ProgressEventData}.
+     *
+     * @param eventType the type of the event
+     * @param eventData the progress event data
+     * @return an instance of ProgressEvent
+     */
+    public static RequestCycleEvent create(RequestCycleEventType eventType, RequestCycleEventData eventData) {
+        return new RequestCycleEvent(eventType, eventData);
+    }
+
+    /**
+     * @return the type of the progress event
+     */
+    public RequestCycleEventType eventType() {
+        return eventType;
+    }
+
+    /**
+     * @return the optional event data
+     */
+    public RequestCycleEventData eventData() {
+        return eventData;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("ProgressEvent")
+                       .add("eventType", eventType)
+                       .add("eventData", eventData)
+                       .build();
+    }
+
+    public static final class RequestCycleEventData implements ProgressEventData {
+        private final EventContext context;
+
+        public RequestCycleEventData(EventContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public EventContext eventContext() {
+            return context;
+        }
+
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/RequestCycleEventType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/progress/RequestCycleEventType.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Request life cycle events
+ */
+@SdkPublicApi
+public enum RequestCycleEventType implements ProgressEventType {
+
+    ////////////////////////////////////////
+    // Generic Request/Response progress events
+    ////////////////////////////////////////
+    /**
+     * Event indicating that the client has started sending the AWS API request.
+     * This type of event is guaranteed to be only fired once during a
+     * request-response cycle, even when the request is retried.
+     */
+    CLIENT_REQUEST_STARTED_EVENT,
+
+    /**
+     * Event indicating that the client has started sending the HTTP request.
+     * The request progress listener will be notified of multiple instances of
+     * this type of event if the request gets retried.
+     */
+    HTTP_REQUEST_STARTED_EVENT,
+
+    /**
+     * Event indicating that the client has finished sending the HTTP request.
+     * The request progress listener will be notified of multiple instances of
+     * this type of event if the request gets retried.
+     */
+    HTTP_REQUEST_COMPLETED_EVENT,
+
+    /**
+     * Event indicating that a failed request is detected as retryable and is
+     * ready for the next retry.
+     */
+    CLIENT_REQUEST_RETRY_EVENT,
+
+    /**
+     * Event indicating that the client has started reading the HTTP response.
+     * The request progress listener will be notified of this event only if the
+     * client receives a successful service response (i.e. 2XX status code).
+     */
+    HTTP_RESPONSE_STARTED_EVENT,
+
+    /**
+     * Event indicating that the client has finished reading the HTTP response.
+     * The request progress listener will be notified of this event only if the
+     * client receives a successful service response (i.e. 2XX status code).
+     */
+    HTTP_RESPONSE_COMPLETED_EVENT,
+
+    /**
+     * Event indicating that the client has received a successful service
+     * response and has finished parsing the response data.
+     */
+    CLIENT_REQUEST_SUCCESS_EVENT,
+
+    /**
+     * Event indicating that a client request has failed (after retries have
+     * been conducted).
+     */
+    CLIENT_REQUEST_FAILED_EVENT,
+
+    /**
+     * Used to indicate the request body has been cancelled.
+     */
+    REQUEST_BODY_CANCEL_EVENT,
+
+    /**
+     * Used to indicate the request body is complete.
+     */
+    REQUEST_BODY_COMPLETE_EVENT,
+
+    /**
+     * Used to indicate the request has been reset.
+     */
+    REQUEST_BODY_RESET_EVENT,
+
+
+    RESPONSE_BODY_CANCEL_EVENT,
+
+    RESPONSE_BODY_COMPLETE_EVENT,
+
+    RESPONSE_BODY_RESET_EVENT,
+}

--- a/docs/design/core/progress-listeners/README.md
+++ b/docs/design/core/progress-listeners/README.md
@@ -1,0 +1,113 @@
+**Design:** New Feature, **Status:** [In Development](../../../README.md)
+
+# Project Goals
+
+1. Capturing progress events should have minimal impact on the application performance.
+
+2. Progress events and listeners should be extensible.
+
+# Introduction
+
+This project provides Progress Listeners feature, which allows customers to track the progress of executions for streaming operations and execute callbacks
+on different progress events. 
+
+# Progress Event
+
+A progress event contains the progress type and progress data.
+
+```
+@SdkPublicApi
+public interface ProgressEvent {
+
+    /**
+     * @return the type of the progress event
+     */
+    ProgressEventType eventType();
+
+    /**
+     * @return the optional event data
+     */
+    ProgressEventData eventData();
+}
+```
+
+## Progress Event Types
+
+Currently, there are two core ProgressEventTypes and one TransferManager event type
+
+`ByteCountEvent`: The Byte count events indicating the number of bytes in the execution of a single http request-response.
+
+`RequestCycleEvent`: The request cycle events related to the execution of a single http request-response.
+
+`S3TransferEvent`: The events related to a S3 {@link Transfer}.
+
+# Configuration
+
+Customers can provide `ProgressEventListener`s on client level as well as request level and the provided progress listeners will be merged.
+
+A `ProgressEventListener` can be created by implementing the interface or from the `ProgressEventListener#builder`.
+
+## Low level client
+
+```java
+
+        ProgressEventListener eventListener = new ProgressEventListener() {
+            @Override
+            public CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent) {
+                System.out.println("received ByteCountEvent");
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        // Client level progress listener
+        S3AsyncClient s3AsyncClient = S3AsyncClient.builder()
+                                                   .overrideConfiguration(b -> b.progressListeners(Collections.singletonList(eventListener)))
+                                                   .build();
+
+        // Request level progress listener
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                                                            .bucket("bucket")
+                                                            .key("key")
+                                                            .overrideConfiguration(o -> o.addProgressListener(eventListener))
+                                                            .build();
+
+```
+
+
+## High level libraries
+
+```java
+        transferManager = S3TransferManager.builder()
+                                           .s3client(s3Async)
+                                           // Implement interface
+                                           .addProgressListener(new S3TransferProgressEventListener() {
+                                               @Override
+                                               public CompletableFuture<? extends ProgressEventResult> onTransferEvent(S3TransferEvent progressEvent) {
+                                                   System.out.println("received S3TransferEvent");
+                                                   return CompletableFuture.completedFuture(null);
+                                               }
+
+                                               @Override
+                                               public CompletableFuture<? extends ProgressEventResult> onRequestLifeCycleEvent(RequestCycleEvent progressEvent) {
+                                                   System.out.println("received RequestLifeCycleEvent");
+                                                   return CompletableFuture.completedFuture(null);
+                                               }
+
+                                               @Override
+                                               public CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent) {
+                                                   System.out.println("received ByteCountEvent");
+                                                   return CompletableFuture.completedFuture(null);
+                                               }
+                                           })
+                                           // Using builder
+                                           .addProgressListener(S3TransferProgressEventListener.builder()
+                                                                                               .onTransferEvent(t -> CompletableFuture.completedFuture(null))
+                                                                                               .onByteCountEvent(t -> CompletableFuture.completedFuture(null))
+                                                                                               .onTransferEvent(t -> CompletableFuture.completedFuture(null))
+                                                                                               .build())
+        
+            
+```
+
+
+

--- a/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferEvent.java
+++ b/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.custom.s3.transfer.progress;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.progress.EventContext;
+import software.amazon.awssdk.core.progress.ProgressEvent;
+import software.amazon.awssdk.core.progress.ProgressEventData;
+import software.amazon.awssdk.custom.s3.transfer.Transfer;
+
+/**
+ * The {@link ProgressEvent}s related to a {@link Transfer}.
+ */
+@SdkPublicApi
+public final class S3TransferEvent implements ProgressEvent {
+
+    private final S3TransferEventType eventType;
+    private final TransferProgressEventData eventData;
+
+    public S3TransferEvent(S3TransferEventType eventType, TransferProgressEventData eventData) {
+        this.eventType = eventType;
+        this.eventData = eventData;
+    }
+
+    @Override
+    public S3TransferEventType eventType() {
+        return eventType;
+    }
+
+    @Override
+    public TransferProgressEventData eventData() {
+        return null;
+    }
+
+    public static class TransferProgressEventData implements ProgressEventData {
+
+        @Override
+        public TransferProgressContext eventContext() {
+            return null;
+        }
+    }
+
+
+    public final class TransferProgressContext implements EventContext {
+        private final Transfer transfer;
+
+        public TransferProgressContext(Transfer transfer) {
+            this.transfer = transfer;
+        }
+
+        /**
+         * @return
+         */
+        public Transfer transfer() {
+            return transfer;
+        }
+
+        @Override
+        public SdkRequest request() {
+            return null;
+        }
+    }
+}

--- a/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferEventHandler.java
+++ b/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferEventHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.custom.s3.transfer.progress;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.progress.ProgressEventResult;
+
+/**
+ * Handler of s3 transfer related events.
+ */
+@SdkPublicApi
+@FunctionalInterface
+public interface S3TransferEventHandler {
+
+    /**
+     * Handles a {@link S3TransferEvent}
+     *
+     * @param progressEvent the progress event
+     * @return the future containing the {@link ProgressEventResult}
+     */
+    CompletableFuture<? extends ProgressEventResult> onTransferEvent(S3TransferEvent progressEvent);
+}

--- a/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferEventType.java
+++ b/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferEventType.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.custom.s3.transfer.progress;
+
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.progress.ProgressEventType;
+
+/**
+ * Progress event types that are used to track the transfer progress.
+ */
+@SdkPublicApi
+public enum  S3TransferEventType implements ProgressEventType {
+
+    /**
+     *
+     */
+     TRANSFER_PREPARING_EVENT,
+
+    /**
+     *
+     */
+     TRANSFER_STARTED_EVENT,
+
+    /**
+     *
+     */
+     TRANSFER_COMPLETED_EVENT,
+
+    /**
+     *
+     */
+     TRANSFER_FAILED_EVENT,
+    /**
+     *
+     */
+     TRANSFER_CANCELED_EVENT,
+
+    /**
+     * A transfer event denotes the transfer has completed.
+     */
+      TRANSFER_PART_STARTED_EVENT,
+
+    /**
+     * A transfer event denotes the transfer has completed.
+     */
+     TRANSFER_PART_COMPLETED_EVENT,
+
+    /**
+     * A transfer event denotes the transfer has failed.
+     */
+     TRANSFER_PART_FAILED_EVENT
+}

--- a/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferProgressEventListener.java
+++ b/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferProgressEventListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.custom.s3.transfer.progress;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.progress.ProgressEvent;
+import software.amazon.awssdk.core.progress.ProgressEventListener;
+import software.amazon.awssdk.core.progress.ProgressEventResult;
+import software.amazon.awssdk.core.progress.ProgressEventType;
+
+
+/**
+ * Extended listener to listen to additional {@link S3TransferEvent}s.
+ */
+@SdkPublicApi
+public interface S3TransferProgressEventListener extends ProgressEventListener, S3TransferEventHandler {
+    Set<Class<? extends ProgressEvent>> SUPPORTED_TYPES =
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(S3TransferEvent.class)));
+
+    @Override
+    default Set<Class<? extends ProgressEvent>> extendedTypes() {
+        return SUPPORTED_TYPES;
+    }
+
+    @Override
+    default CompletableFuture<? extends ProgressEventResult> onExtendedEvents(ProgressEvent progressEvent) {
+
+        ProgressEventType progressEventType = progressEvent.eventType();
+        if (progressEventType instanceof S3TransferEventType) {
+
+            return onTransferEvent((S3TransferEvent) progressEvent);
+        }
+
+        return onDefault(progressEvent);
+    }
+
+    @Override
+    default CompletableFuture<? extends ProgressEventResult> onTransferEvent(S3TransferEvent progressEvent) {
+        return onDefault(progressEvent);
+    }
+
+    static Builder builder() {
+        return new S3TransferProgressEventListenerBuilder();
+    }
+
+    interface Builder extends ProgressEventListener.Builder<Builder> {
+        Builder onTransferEvent(S3TransferEventHandler transferEventHandler);
+
+        S3TransferProgressEventListener build();
+    }
+}

--- a/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferProgressEventListenerBuilder.java
+++ b/services-custom/s3-transfermanager/src/main/java/software/amazon/awssdk/custom/s3/transfer/progress/S3TransferProgressEventListenerBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.custom.s3.transfer.progress;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.progress.AbstractProgressEventListenerBuilder;
+import software.amazon.awssdk.core.progress.ProgressEventResult;
+
+
+/**
+ * Extended listener to listen to {@link S3TransferEvent}s.
+ */
+@SdkInternalApi
+public final class S3TransferProgressEventListenerBuilder extends AbstractProgressEventListenerBuilder<S3TransferProgressEventListener.Builder> implements S3TransferProgressEventListener.Builder {
+
+    private S3TransferEventHandler transferEventHandler;
+
+    S3TransferProgressEventListenerBuilder() {
+    }
+
+    @Override
+    public S3TransferProgressEventListenerBuilder onTransferEvent(S3TransferEventHandler transferEventHandler) {
+        this.transferEventHandler = transferEventHandler;
+        return this;
+    }
+
+    @Override
+    public S3TransferProgressEventListener build() {
+        return new DefaultS3TransferProgressEventListener(this);
+    }
+
+    static final class DefaultS3TransferProgressEventListener implements S3TransferProgressEventListener {
+        private final S3TransferEventHandler transferEventHandler;
+
+        DefaultS3TransferProgressEventListener(S3TransferProgressEventListenerBuilder builder) {
+            this.transferEventHandler = builder.transferEventHandler == null ?
+                                        S3TransferProgressEventListener.super::onDefault : builder.transferEventHandler;
+        }
+
+        @Override
+        public CompletableFuture<? extends ProgressEventResult> onTransferEvent(S3TransferEvent progressEvent) {
+            return transferEventHandler.onTransferEvent(progressEvent);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add progress listener APIs. I still need to clean up the code(adding javadoc and stuff), but wanted to get feedback first.

***TODOs***
- More javadocs.
- Constructors -> static factory method 
- checkstyle fixes.

##  Details

When dispatching events, the "event bus" `ProgressEventListenerChain` would check if the event type is supported by each listener, and only dispatch the event if it's supported.

### Low level client

```java
        ProgressEventListener eventListener = new ProgressEventListener() {
            @Override
            public CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent) {
                System.out.println("received ByteCountEvent");
                return CompletableFuture.completedFuture(null);
            }
        };
        // Client level progress listener
        S3AsyncClient s3AsyncClient = S3AsyncClient.builder()
                                                   .overrideConfiguration(b -> b.progressListeners(Collections.singletonList(eventListener)))
                                                   .build();
        // Request level progress listener
        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                                                            .bucket("bucket")
                                                            .key("key")
                                                            .overrideConfiguration(o -> o.addProgressListener(eventListener))
                                                            .build();
```


### High level libraries

```java
        transferManager = S3TransferManager.builder()
                                           .s3client(s3Async)
                                           // Implement interface
                                           .addProgressListener(new S3TransferProgressEventListener() {
                                               @Override
                                               public CompletableFuture<? extends ProgressEventResult> onTransferEvent(S3TransferEvent progressEvent) {
                                                   System.out.println("received S3TransferEvent");
                                                   return CompletableFuture.completedFuture(null);
                                               }
                                               @Override
                                               public CompletableFuture<? extends ProgressEventResult> onRequestLifeCycleEvent(RequestCycleEvent progressEvent) {
                                                   System.out.println("received RequestLifeCycleEvent");
                                                   return CompletableFuture.completedFuture(null);
                                               }
                                               @Override
                                               public CompletableFuture<? extends ProgressEventResult> onByteCountEvent(ByteCountEvent progressEvent) {
                                                   System.out.println("received ByteCountEvent");
                                                   return CompletableFuture.completedFuture(null);
                                               }
                                           })
                                           // Using builder
                                           .addProgressListener(S3TransferProgressEventListener.builder()
                                                                                               .onTransferEvent(t -> CompletableFuture.completedFuture(null))
                                                                                               .onByteCountEvent(t -> CompletableFuture.completedFuture(null))
                                                                                               .onTransferEvent(t -> CompletableFuture.completedFuture(null))
                                                                                               .build())
        
            
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
