### PR TITLE
Allow use of Apache version < 4.5.9

### DIFF
--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/utils/ApacheUtils.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/utils/ApacheUtils.java
@@ -33,10 +33,16 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.ReflectionMethodInvoker;
 
 @SdkInternalApi
 public final class ApacheUtils {
     private static final Logger logger = Logger.loggerFor(ApacheUtils.class);
+    private static final ReflectionMethodInvoker<RequestConfig.Builder, RequestConfig.Builder> NORMALIZE_URI_INVOKER =
+            new ReflectionMethodInvoker<>(RequestConfig.Builder.class,
+                                          RequestConfig.Builder.class,
+                                          "setNormalizeUri",
+                                          boolean.class);
 
     private ApacheUtils() {
     }
@@ -86,10 +92,10 @@ public final class ApacheUtils {
      */
     public static void disableNormalizeUri(RequestConfig.Builder requestConfigBuilder) {
         try {
-            requestConfigBuilder.setNormalizeUri(false);
-        } catch (NoSuchMethodError error) {
+            NORMALIZE_URI_INVOKER.invoke(requestConfigBuilder, false);
+        } catch (NoSuchMethodException error) {
             // setNormalizeUri method was added in httpclient 4.5.8
-            logger.warn(() -> "NoSuchMethodError was thrown when disabling normalizeUri. This indicates you are using an old "
+            logger.warn(() -> "NoSuchMethodException was thrown when disabling normalizeUri. This indicates you are using an old "
                               + "version (< 4.5.8) of Apache http "
                               + "client. It is recommended to use http client version >= 4.5.9 to avoid the breaking change "
                               + "introduced in apache client 4.5.7 and the latency in exception handling. "

--- a/utils/src/main/java/software/amazon/awssdk/utils/ReflectionMethodInvoker.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ReflectionMethodInvoker.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * This class acts as a proxy to invoke a specific method on objects of a specific class. It will use the JDK's
+ * reflection library to find and invoke the method.
+ * <p>
+ * The relatively expensive call to find the correct method on the class is lazy and will not be performed until the
+ * first invocation. The result of that getMethod() call is cached for subsequent invocations. If a
+ * NoSuchMethodException is thrown, the exception will be cached instead and all subsequent calls to invoke will
+ * immediately throw the cached exception.
+ * <p>
+ * Example:
+ * {@code
+ * ReflectionMethodInvoker<String, Integer> invoker =
+ *       new ReflectionMethodInvoker<String, Integer>(String.class, Integer.class, "indexOf", String.class, int.class);
+ * invoker.invoke("ababab", "ab", 1);     // This is equivalent to calling "ababab".indexOf("ab", 1);
+ * }
+ * @param <T> The class type that has the method to be invoked.
+ * @param <R> The expected return type of the method invocation.
+ */
+@SdkProtectedApi
+public class ReflectionMethodInvoker<T, R> {
+    private final Class<T> clazz;
+    private final String methodName;
+    private final Class<R> returnType;
+    private final Class<?>[] parameterTypes;
+
+    private Method targetMethod;
+    private NoSuchMethodException cachedException;
+
+    /**
+     * Construct an instance of {@code ReflectionMethodInvoker}.
+     * <p>
+     * This constructor will not make any reflection calls as part of initialization; i.e. no validation of the
+     * existence of the given method signature will occur.
+     * @param clazz The class that has the method to be invoked.
+     * @param returnType The expected return class of the method invocation. The object returned by the invocation
+     *                   will be cast to this class.
+     * @param methodName The name of the method to invoke.
+     * @param parameterTypes The classes of the parameters of the method to invoke.
+     */
+    public ReflectionMethodInvoker(Class<T> clazz,
+                                   Class<R> returnType,
+                                   String methodName,
+                                   Class<?>... parameterTypes) {
+        this.clazz = clazz;
+        this.methodName = methodName;
+        this.returnType = returnType;
+        this.parameterTypes = parameterTypes;
+    }
+
+    /**
+     * Attempt to invoke the method this proxy was initialized for on the given object with the given arguments.
+     * @param obj The object to invoke the method on.
+     * @param args The arguments to pass to the method. These arguments must match the signature of the method.
+     * @return The returned value of the method cast to the 'returnType' class that this proxy was initialized with.
+     * @throws NoSuchMethodException if the JVM could not find a method matching the signature specified in the
+     * initialization of this proxy.
+     * @throws RuntimeException if any other exception is thrown when attempting to invoke the method or by the
+     * method itself. The cause of this exception will be the exception that was actually thrown.
+     */
+    public R invoke(T obj, Object... args) throws NoSuchMethodException {
+        Method targetMethod = getTargetMethod();
+
+        try {
+            Object rawResult = targetMethod.invoke(obj, args);
+            return returnType.cast(rawResult);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(createInvocationErrorMessage(), e);
+        }
+    }
+
+    private synchronized Method getTargetMethod() throws NoSuchMethodException {
+        if (cachedException != null) {
+            throw cachedException;
+        }
+
+        if (targetMethod != null) {
+            return targetMethod;
+        }
+
+        try {
+            targetMethod = clazz.getMethod(methodName, parameterTypes);
+            return targetMethod;
+        } catch (NoSuchMethodException e) {
+            cachedException = e;
+            throw e;
+        } catch (NullPointerException e) {
+            throw new RuntimeException(createInvocationErrorMessage(), e);
+        }
+    }
+
+    private String createInvocationErrorMessage() {
+        return String.format("Failed to reflectively invoke method %s on %s", methodName, clazz.getName());
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/ReflectionMethodInvokerTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/ReflectionMethodInvokerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.utils;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReflectionMethodInvokerTest {
+    private final InvokeTestClass invokeTestInstance = new InvokeTestClass();
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void invokeCanInvokeMethodAndReturnsCorrectResult() throws Exception {
+        ReflectionMethodInvoker<String, Integer> invoker =
+                new ReflectionMethodInvoker<>(String.class,
+                                              Integer.class,
+                                              "indexOf",
+                                              String.class,
+                                              int.class);
+
+        assertThat(invoker.invoke("ababab", "ab", 1), is(2));
+    }
+
+    @Test
+    public void invokeCanReturnVoid() throws Exception {
+        ReflectionMethodInvoker<InvokeTestClass, Void> invoker =
+                new ReflectionMethodInvoker<>(InvokeTestClass.class,
+                                              Void.class,
+                                              "happyVoid");
+
+        invoker.invoke(invokeTestInstance);
+    }
+
+    @Test
+    public void invokeThrowsNoSuchMethodExceptionWhenMethodSignatureNotFound() throws Exception {
+        ReflectionMethodInvoker<String, Integer> invoker =
+                new ReflectionMethodInvoker<>(String.class,
+                                              Integer.class,
+                                              "foo",
+                                              String.class,
+                                              int.class);
+
+        exception.expect(NoSuchMethodException.class);
+        invoker.invoke("ababab", "ab", 1);
+    }
+
+    @Test
+    public void invoke_callThrowsNullPointerException_throwsAsRuntimeException() throws Exception {
+        ReflectionMethodInvoker<String, Integer> invoker =
+                new ReflectionMethodInvoker<>(String.class,
+                                              Integer.class,
+                                              null,
+                                              String.class,
+                                              int.class);
+
+        exception.expect(RuntimeException.class);
+        exception.expectCause(Matchers.<NullPointerException>instanceOf(NullPointerException.class));
+        exception.expectMessage("String");
+        invoker.invoke("ababab", "ab", 1);
+    }
+
+    @Test
+    public void invoke_invokedMethodThrowsException_throwsAsRuntimeException() throws Exception {
+        ReflectionMethodInvoker<InvokeTestClass, Void> invoker =
+                new ReflectionMethodInvoker<>(InvokeTestClass.class,
+                                              Void.class,
+                                              "throwsException");
+        exception.expect(RuntimeException.class);
+        exception.expectMessage("InvokeTestClass");
+        exception.expectMessage("throwsException");
+        exception.expectCause(Matchers.<InvocationTargetException>instanceOf(InvocationTargetException.class));
+        invoker.invoke(invokeTestInstance);
+    }
+
+    @Test
+    public void invoke_invokePrivateMethod_throwsNoSuchMethodException() throws Exception {
+        ReflectionMethodInvoker<InvokeTestClass, Void> invoker =
+                new ReflectionMethodInvoker<>(InvokeTestClass.class,
+                                              Void.class,
+                                              "illegalAccessException");
+        exception.expect(NoSuchMethodException.class);
+        invoker.invoke(invokeTestInstance);
+    }
+
+    // This test assumes that the result of getMethod() may have been cached, and therefore asserts the correctness of
+    // a simple cache put and get.
+    @Test
+    public void invoke_canBeCalledMultipleTimes() throws Exception {
+        ReflectionMethodInvoker<String, Integer> invoker =
+                new ReflectionMethodInvoker<>(String.class,
+                                              Integer.class,
+                                              "indexOf",
+                                              String.class,
+                                              int.class);
+
+        assertThat(invoker.invoke("ababab", "ab", 1), is(2));
+        assertThat(invoker.invoke("ababab", "ab", 1), is(2));
+    }
+
+    @Test
+    public void invoke_methodNotFound_throwsCachedExceptionOnSecondAttempt() throws Exception {
+        ReflectionMethodInvoker<String, Integer> invoker =
+                new ReflectionMethodInvoker<>(String.class,
+                                              Integer.class,
+                                              "foo",
+                                              String.class,
+                                              int.class);
+
+        NoSuchMethodException thrownException = null;
+
+        try {
+            invoker.invoke("ababab", "ab", 1);
+            fail("Expected NoSuchMethodException to be thrown");
+        } catch (NoSuchMethodException e) {
+            thrownException = e;
+        }
+
+        try {
+            invoker.invoke("ababab", "ab", 1);
+            fail("Expected NoSuchMethodException to be thrown");
+        } catch (NoSuchMethodException e) {
+            assertThat(e, sameInstance(thrownException));
+        }
+    }
+
+    public static class InvokeTestClass {
+        public void throwsException() {
+            throw new RuntimeException();
+        }
+
+        private void illegalAccessException() {
+            // should never get here
+        }
+
+        public void happyVoid() {
+        }
+    }
+}


### PR DESCRIPTION
## Description
Use reflection to call the RequestConfig.Builder.setNormalizeUri() function so
that customers can to continue to use older versions of Apache that do not have
this method on the builder.

## Motivation and Context


## Testing
Unit tests for new class, all existing Apache tests pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
