### PR TITLE
Fix race condition in sync client timers

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallAttemptTimeoutTrackingStage.java
@@ -17,16 +17,22 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.resolveTimeoutInMillis;
 import static software.amazon.awssdk.core.internal.http.timers.TimerUtils.timeSyncTaskIfNeeded;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.core.exception.SdkInterruptedException;
 import software.amazon.awssdk.core.internal.Response;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestPipeline;
 import software.amazon.awssdk.core.internal.http.pipeline.RequestToResponsePipeline;
+import software.amazon.awssdk.core.internal.http.timers.SyncTimeoutTask;
 import software.amazon.awssdk.core.internal.http.timers.TimeoutTracker;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 
@@ -40,8 +46,9 @@ public final class ApiCallAttemptTimeoutTrackingStage<OutputT> implements Reques
     private final Duration apiCallAttemptTimeout;
     private final ScheduledExecutorService timeoutExecutor;
 
-    public ApiCallAttemptTimeoutTrackingStage(HttpClientDependencies dependencies, RequestPipeline<SdkHttpFullRequest,
-        Response<OutputT>> wrapped) {
+    public ApiCallAttemptTimeoutTrackingStage(HttpClientDependencies dependencies,
+                                              RequestPipeline<SdkHttpFullRequest,
+                                              Response<OutputT>> wrapped) {
         this.wrapped = wrapped;
         this.timeoutExecutor = dependencies.clientConfiguration().option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
         this.apiCallAttemptTimeout = dependencies.clientConfiguration().option(SdkClientOption.API_CALL_ATTEMPT_TIMEOUT);
@@ -55,15 +62,88 @@ public final class ApiCallAttemptTimeoutTrackingStage<OutputT> implements Reques
      */
     @Override
     public Response<OutputT> execute(SdkHttpFullRequest request, RequestExecutionContext context) throws Exception {
-        long timeoutInMillis = resolveTimeoutInMillis(context.requestConfig()::apiCallAttemptTimeout, apiCallAttemptTimeout);
-
-        TimeoutTracker timeoutTracker = timeSyncTaskIfNeeded(timeoutExecutor, timeoutInMillis, Thread.currentThread());
-
         try {
-            context.apiCallAttemptTimeoutTracker(timeoutTracker);
-            return wrapped.execute(request, context);
-        } finally {
-            timeoutTracker.cancel();
+            long timeoutInMillis = resolveTimeoutInMillis(context.requestConfig()::apiCallAttemptTimeout, apiCallAttemptTimeout);
+
+            TimeoutTracker timeoutTracker = timeSyncTaskIfNeeded(timeoutExecutor, timeoutInMillis, Thread.currentThread());
+
+            Response<OutputT> response;
+            try {
+                context.apiCallAttemptTimeoutTracker(timeoutTracker);
+                response = wrapped.execute(request, context);
+            } finally {
+                // Cancel the timeout tracker, guaranteeing that if it hasn't already executed and set this thread's
+                // interrupt flag, it won't do so later. Every code path executed after this line *must* call
+                // timeoutTracker.hasExecuted() and appropriately clear the interrupt flag if it returns true.
+                timeoutTracker.cancel();
+            }
+
+            if (timeoutTracker.hasExecuted()) {
+                // The timeout tracker executed before the call to cancel(), which means it set this thread's interrupt
+                // flag. However, the execute() call returned before we raised an InterruptedException, so just clear
+                // the interrupt flag and return the result we got back.
+                Thread.interrupted();
+            }
+            return response;
+
+        } catch (Exception e) {
+            throw translatePipelineException(context, e);
         }
+    }
+
+
+
+    /**
+     * Take the given exception thrown from the wrapped pipeline and return a more appropriate
+     * timeout related exception based on its type and the the execution status.
+     *
+     * @param context The execution context.
+     * @param e The exception thrown from the inner pipeline.
+     * @return The translated exception.
+     */
+    private Exception translatePipelineException(RequestExecutionContext context, Exception e) {
+        if (e instanceof InterruptedException) {
+            return handleInterruptedException(context, (InterruptedException) e);
+        }
+
+        // Timeout tracker finished and interrupted this thread after wrapped.execute() last checked the interrupt flag,
+        // but before we called timeoutTracker.cancel(). Note that if hasExecuted() returns true, its guaranteed that
+        // the timeout tracker has set the interrupt flag, and if it returns false, it guarantees that it did not and
+        // will never set the interrupt flag.
+        if (context.apiCallAttemptTimeoutTracker().hasExecuted()) {
+            // Clear the interrupt flag. Since we already have an exception from the call, which may contain information
+            // that's useful to the caller, just return that instead of an ApiCallTimeoutException.
+            Thread.interrupted();
+        }
+
+        return e;
+    }
+
+    /**
+     * Determine if an interrupted exception is caused by the api call timeout task
+     * interrupting the current thread or some other task interrupting the thread for another
+     * purpose.
+     *
+     * @return {@link ApiCallTimeoutException} if the {@link InterruptedException} was
+     * caused by the {@link SyncTimeoutTask}. Otherwise re-interrupts the current thread
+     * and returns a {@link AbortedException} wrapping an {@link InterruptedException}
+     */
+    private RuntimeException handleInterruptedException(RequestExecutionContext context, InterruptedException e) {
+        if (e instanceof SdkInterruptedException) {
+            ((SdkInterruptedException) e).getResponseStream().ifPresent(r -> invokeSafely(r::close));
+        }
+        if (context.apiCallAttemptTimeoutTracker().hasExecuted()) {
+            // Clear the interrupt status
+            Thread.interrupted();
+            return generateApiCallAttemptTimeoutException(context);
+        }
+
+        Thread.currentThread().interrupt();
+        return AbortedException.create("Thread was interrupted", e);
+    }
+
+    private ApiCallAttemptTimeoutException generateApiCallAttemptTimeoutException(RequestExecutionContext context) {
+        return ApiCallAttemptTimeoutException.create(
+                resolveTimeoutInMillis(context.requestConfig()::apiCallAttemptTimeout, apiCallAttemptTimeout));
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallTimeoutTrackingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApiCallTimeoutTrackingStage.java
@@ -70,17 +70,36 @@ public final class ApiCallTimeoutTrackingStage<OutputT> implements RequestToResp
      * doesn't leak out to the callers code
      */
     private Response<OutputT> executeWithTimer(SdkHttpFullRequest request, RequestExecutionContext context) throws Exception {
-
         long timeoutInMillis = resolveTimeoutInMillis(context.requestConfig()::apiCallTimeout, apiCallTimeout);
 
+        // XXX: I think there's another class of bug here, with an analog in ApiCallAttemptTimeoutTrackingStage: This
+        // call schedules a future, and it's possible that the future will execute (interrupting the current thread)
+        // before we get into the try/finally, and before we call context.apiCallTimeoutTracker(timeoutTracker).
+        // However, I *think* this bug is harmless (perhaps by design, in which case its not a bug, just undocumented,
+        // subtle behavior), because nothing between this line and the call to wrapped.execute() will check the
+        // interrupt flag, the call to execute() will (in my testing) raise an AbortedException with the interrupt flag
+        // still set, and our exception-handling will see that timeoutTask.hasExecuted() returns true, clearing the flag
+        // and returning an appropriate call.
         TimeoutTracker timeoutTracker = timeSyncTaskIfNeeded(timeoutExecutor, timeoutInMillis, Thread.currentThread());
 
+        Response<OutputT> response;
         try {
             context.apiCallTimeoutTracker(timeoutTracker);
-            return wrapped.execute(request, context);
+            response = wrapped.execute(request, context);
         } finally {
+            // Cancel the timeout tracker, guaranteeing that if it hasn't already executed and set this thread's
+            // interrupt flag, it won't do so later. Every code path executed after this line *must* call
+            // timeoutTracker.hasExecuted() and appropriately clear the interrupt flag if it returns true.
             timeoutTracker.cancel();
         }
+
+        if (timeoutTracker.hasExecuted()) {
+            // The timeout tracker executed before the call to cancel(), which means it set this thread's interrupt
+            // flag. However, the execute() call returned before we raised an InterruptedException, so just clear the
+            // interrupt flag and return the result we got back.
+            Thread.interrupted();
+        }
+        return response;
     }
 
     /**
@@ -96,10 +115,18 @@ public final class ApiCallTimeoutTrackingStage<OutputT> implements RequestToResp
             return handleInterruptedException(context, (InterruptedException) e);
         }
 
-        // InterruptedException was not rethrown and instead the interrupted flag was set
-        if (Thread.currentThread().isInterrupted() && context.apiCallTimeoutTracker().hasExecuted()) {
+        // Timeout tracker finished and interrupted this thread after wrapped.execute() last checked the interrupt flag,
+        // but before we called timeoutTracker.cancel(). Note that if hasExecuted() returns true, its guaranteed that
+        // the timeout tracker has set the interrupt flag, and if it returns false, it guarantees that it did not and
+        // will never set the interrupt flag.
+        if (context.apiCallTimeoutTracker().hasExecuted()) {
+            // Clear the interrupt flag. Since we already have an exception from the call, which may contain information
+            // that's useful to the caller, just return that instead of an ApiCallTimeoutException.
+            // XXX: In the edge case described further up, it's possible that wrapped.execute() will throw an
+            // AbortedException caused by this timeout, so in that case raising an ApiCallTimeoutException would
+            // actually be the right thing, I think. Not sure if there's a good way to distinguish all exceptions
+            // possibly raised due to interrupts (such as AbortedException) from other ones.
             Thread.interrupted();
-            return generateApiCallTimeoutException(context);
         }
 
         return e;
@@ -130,6 +157,6 @@ public final class ApiCallTimeoutTrackingStage<OutputT> implements RequestToResp
 
     private ApiCallTimeoutException generateApiCallTimeoutException(RequestExecutionContext context) {
         return ApiCallTimeoutException.create(
-            resolveTimeoutInMillis(context.requestConfig()::apiCallTimeout, apiCallTimeout));
+                resolveTimeoutInMillis(context.requestConfig()::apiCallTimeout, apiCallTimeout));
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/ApiCallTimeoutTracker.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/ApiCallTimeoutTracker.java
@@ -47,7 +47,10 @@ public final class ApiCallTimeoutTracker implements TimeoutTracker {
 
     @Override
     public void cancel() {
+        // Best-effort attempt to ensure that if the future hasn't started running already, don't run it.
         future.cancel(false);
+        // Ensure that if the future hasn't executed its timeout logic already, it won't do so.
+        timeoutTask.cancel();
     }
 
     @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/SyncTimeoutTask.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/SyncTimeoutTask.java
@@ -26,6 +26,11 @@ import software.amazon.awssdk.utils.Validate;
 public final class SyncTimeoutTask implements TimeoutTask {
     private final Thread threadToInterrupt;
     private volatile boolean hasExecuted;
+    private volatile boolean isCancelled;
+
+    // Synchronize calls to run(), cancel(), and hasExecuted(). XXX: We could just use synchronized methods instead of
+    // this.
+    private final Object lock = new Object();
 
     private Abortable abortable;
 
@@ -38,18 +43,49 @@ public final class SyncTimeoutTask implements TimeoutTask {
         this.abortable = abortable;
     }
 
+    /**
+     * Runs this task. If cancel() was called prior to this invocation, has no side effects. Otherwise, behaves with the
+     * following post-conditions: (1) threadToInterrupt's interrupt flag is set to true (unless a concurrent process
+     * clears it); (2) hasExecuted() will return true.
+     *
+     * Note that run(), cancel(), and hasExecuted() behave atomically - calls to these methods operate with strict
+     * happens-before relationships to one another.
+     */
     @Override
     public void run() {
-        hasExecuted = true;
-        threadToInterrupt.interrupt();
+        synchronized (this.lock) {
+            if (isCancelled) {
+                return;
+            }
+            hasExecuted = true;
+            threadToInterrupt.interrupt();
 
-        if (abortable != null) {
-            abortable.abort();
+            if (abortable != null) {
+                abortable.abort();
+            }
         }
     }
 
+    /**
+     * Cancels this task. Once this returns, it's guaranteed that hasExecuted() will not change its value, and that this
+     * task won't interrupt the threadToInterrupt this task was created with.
+     */
+    @Override
+    public void cancel() {
+        synchronized (this.lock) {
+            isCancelled = true;
+        }
+    }
+
+    /**
+     * Returns whether this task has finished executing its timeout behavior. The interrupt flag set by this task will
+     * only be set if hasExecuted() returns true, and is guaranteed not to be set at the time hasExecuted() returns
+     * false.
+     */
     @Override
     public boolean hasExecuted() {
-        return hasExecuted;
+        synchronized (this.lock) {
+            return hasExecuted;
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/TimeoutTask.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/timers/TimeoutTask.java
@@ -27,6 +27,9 @@ public interface TimeoutTask extends Runnable {
     default void abortable(Abortable abortable) {
     }
 
+    default void cancel() {
+    }
+
     /**
      * @return True if timeout task has executed. False otherwise
      */

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/InterruptFlagAlwaysClearsTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/InterruptFlagAlwaysClearsTest.java
@@ -1,0 +1,156 @@
+package software.amazon.awssdk.core.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.time.Duration;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.client.handler.SdkSyncClientHandler;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.runtime.transform.Marshaller;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import utils.HttpTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InterruptFlagAlwaysClearsTest {
+    private static final Duration SERVICE_LATENCY = Duration.ofMillis(10);
+
+    private static SdkSyncClientHandler syncHttpClient;
+
+    @Mock
+    private Marshaller<SdkRequest> marshaller;
+
+    @Mock
+    private HttpResponseHandler<SdkResponse> responseHandler;
+
+    @Mock
+    private HttpResponseHandler<SdkServiceException> errorResponseHandler;
+
+    @BeforeClass
+    public static void setup() {
+        SdkClientConfiguration clientConfiguration = HttpTestUtils.testClientConfiguration()
+                .toBuilder()
+                .option(SdkClientOption.SYNC_HTTP_CLIENT, new SleepyHttpClient())
+                .option(SdkClientOption.API_CALL_ATTEMPT_TIMEOUT, SERVICE_LATENCY)
+                .build();
+
+        syncHttpClient = new TestClientHandler(clientConfiguration);
+    }
+
+    @Before
+    public void methodSetup() throws Exception {
+        when(marshaller.marshall(any(NoopTestRequest.class)))
+                .thenReturn(SdkHttpFullRequest.builder()
+                        .protocol("http")
+                        .host("some-host.aws")
+                        .method(SdkHttpMethod.GET)
+                        .build());
+
+        when(errorResponseHandler.handle(any(SdkHttpFullResponse.class), any(ExecutionAttributes.class)))
+                .thenReturn(SdkServiceException.builder().message("BOOM").statusCode(400).build());
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        syncHttpClient.close();
+    }
+
+    @Test
+    public void interruptFlagClearsWithTimeoutCloseToLatency() {
+        int numRuns = 100;
+
+        int interruptCount = 0;
+
+        for (int i = 0; i < numRuns; ++i) {
+            // This request is expected to time out for some number of iterations
+            executeRequestIgnoreErrors(syncHttpClient);
+
+            // Check and clear interrupt flag
+            if (Thread.interrupted()) {
+                ++interruptCount;
+            }
+        }
+
+        assertThat(interruptCount)
+                .withFailMessage("Interrupt flags are leaking: %d of %d runs leaked interrupt flags.",
+                                 interruptCount, numRuns)
+                .isEqualTo(0);
+    }
+
+    private void executeRequestIgnoreErrors(SdkSyncClientHandler syncHttpClient) {
+        try {
+            syncHttpClient.execute(new ClientExecutionParams<SdkRequest, SdkResponse>()
+                    .withOperationName("SomeOperation")
+                    .withResponseHandler(responseHandler)
+                    .withErrorResponseHandler(errorResponseHandler)
+                    .withInput(NoopTestRequest.builder().build())
+                    .withMarshaller(marshaller));
+            Assert.fail();
+        } catch (AbortedException | ApiCallAttemptTimeoutException | SdkServiceException e) {
+            // Ignored
+        }
+    }
+
+    private static class SleepyHttpClient implements SdkHttpClient {
+        private static final HttpExecuteResponse RESPONSE = HttpExecuteResponse.builder()
+                .response(SdkHttpResponse.builder()
+                        .statusCode(400)
+                        .build())
+                .build();
+        @Override
+        public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+            return new ExecutableHttpRequest() {
+                @Override
+                public HttpExecuteResponse call() throws IOException {
+                    try {
+                        Thread.sleep(SERVICE_LATENCY.toMillis());
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted!", e);
+                    }
+
+                    return RESPONSE;
+                }
+
+                @Override
+                public void abort() {
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+
+    private static class TestClientHandler extends SdkSyncClientHandler {
+        protected TestClientHandler(SdkClientConfiguration clientConfiguration) {
+            super(clientConfiguration);
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/SyncTimeoutTaskTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/timers/SyncTimeoutTaskTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.timers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+public class SyncTimeoutTaskTest {
+    private static final ExecutorService EXEC = Executors.newSingleThreadExecutor();
+
+    @AfterClass
+    public static void teardown() {
+        EXEC.shutdown();
+    }
+
+    @Test
+    public void taskInProgress_hasExecutedReturnsTrue() throws InterruptedException {
+        Thread mockThread = mock(Thread.class);
+        SyncTimeoutTask task = new SyncTimeoutTask(mockThread);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        task.abortable(() -> {
+            try {
+                latch.countDown();
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+            }
+        });
+
+        EXEC.submit(task);
+
+        latch.await();
+
+        assertThat(task.hasExecuted()).isTrue();
+    }
+
+    @Test
+    public void taskInProgress_cancelCalled_abortableIsNotInterrupted() throws InterruptedException {
+        Thread mockThread = mock(Thread.class);
+        SyncTimeoutTask task = new SyncTimeoutTask(mockThread);
+
+        AtomicBoolean interrupted = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+        task.abortable(() -> {
+            try {
+                latch.countDown();
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+
+        EXEC.submit(task);
+
+        latch.await();
+        task.cancel();
+        assertThat(interrupted.get()).isFalse();
+    }
+}


### PR DESCRIPTION
## Description
Fix a bug where the interrupted flag set by the API call and attempt timers can
leak outside of the client if the timeout is very small and approximately equal
to the response latency.

## Motivation and Context
See description.

## Testing
New unit tests, also ran stability tests and benchmarks.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
