### PR TITLE
Expose instance signature through EC2MetadataUtils

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-461c622.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-461c622.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Expose instance signature through EC2MetadataUtils"
+}

--- a/core/regions/src/it/java/software/amazon/awssdk/regions/util/EC2MetadataUtilsIntegrationTest.java
+++ b/core/regions/src/it/java/software/amazon/awssdk/regions/util/EC2MetadataUtilsIntegrationTest.java
@@ -111,4 +111,10 @@ public class EC2MetadataUtilsIntegrationTest {
         Assert.assertEquals("bar", info.getDevpayProductCodes()[0]);
         Assert.assertEquals("qaz", info.getMarketplaceProductCodes()[0]);
     }
+
+    @Test
+    public void testInstanceSignature() {
+        String signature = EC2MetadataUtils.getInstanceSignature();
+        Assert.assertEquals("foobar", signature);
+    }
 }

--- a/core/regions/src/main/java/software/amazon/awssdk/regions/internal/util/EC2MetadataUtils.java
+++ b/core/regions/src/main/java/software/amazon/awssdk/regions/internal/util/EC2MetadataUtils.java
@@ -67,6 +67,7 @@ public final class EC2MetadataUtils {
     /** Default resource path for credentials in the Amazon EC2 Instance Metadata Service. */
     private static final String REGION = "region";
     private static final String INSTANCE_IDENTITY_DOCUMENT = "instance-identity/document";
+    private static final String INSTANCE_IDENTITY_SIGNATURE = "instance-identity/signature";
     private static final String EC2_METADATA_ROOT = "/latest/meta-data";
     private static final String EC2_USERDATA_ROOT = "/latest/user-data/";
     private static final String EC2_DYNAMICDATA_ROOT = "/latest/dynamic/";
@@ -253,6 +254,13 @@ public final class EC2MetadataUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * Get the signature of the instance.
+     */
+    public static String getInstanceSignature() {
+        return fetchData(EC2_DYNAMICDATA_ROOT + INSTANCE_IDENTITY_SIGNATURE);
     }
 
     /**

--- a/core/regions/src/test/java/software/amazon/awssdk/regions/internal/util/EC2MetadataUtilsServer.java
+++ b/core/regions/src/test/java/software/amazon/awssdk/regions/internal/util/EC2MetadataUtilsServer.java
@@ -110,6 +110,10 @@ public class EC2MetadataUtilsServer {
 
         } else if (path.equals("/latest/dynamic/instance-identity/document")) {
             outputInstanceInfo(output);
+
+        } else if (path.equals("/latest/dynamic/instance-identity/signature")) {
+            outputInstanceSignature(output);
+
         } else {
             throw new RuntimeException("Unknown path: " + path);
         }
@@ -216,6 +220,18 @@ public class EC2MetadataUtilsServer {
                + "\"devpayProductCodes\":[\"bar\"],"
                + "\"marketplaceProductCodes\":[\"qaz\"]"
                + "}";
+    }
+
+    private void outputInstanceSignature(PrintWriter output) {
+        String payload = "foobar";
+
+        output.println("HTTP/1.1 200 OK");
+        output.println("Connection: close");
+        output.println("Content-Length: " + payload.length());
+        output.println();
+
+        output.print(payload);
+        output.flush();
     }
 
 }


### PR DESCRIPTION
A method was added in aws-sdk-java to help retrieve instance identify signature. Here is a pull request to port it to v2.

See https://github.com/aws/aws-sdk-java/pull/1653