### PR TITLE
[Do not merge] crt benchmark

### DIFF
--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkRunner.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkRunner.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.awssdk.benchmark.apicall.httpclient.async.AwsCrtClientBenchmark;
 import software.amazon.awssdk.benchmark.apicall.httpclient.async.NettyClientH1NonTlsBenchmark;
 import software.amazon.awssdk.benchmark.apicall.httpclient.async.NettyHttpClientH1Benchmark;
 import software.amazon.awssdk.benchmark.apicall.httpclient.async.NettyHttpClientH2Benchmark;
@@ -48,7 +49,8 @@ public class BenchmarkRunner {
     private static final List<String> ASYNC_BENCHMARKS = Arrays.asList(
         NettyHttpClientH2Benchmark.class.getSimpleName(),
         NettyHttpClientH1Benchmark.class.getSimpleName(),
-        NettyClientH1NonTlsBenchmark.class.getSimpleName());
+        NettyClientH1NonTlsBenchmark.class.getSimpleName(),
+        AwsCrtClientBenchmark.class.getSimpleName());
 
     private static final List<String> SYNC_BENCHMARKS = Arrays.asList(
         ApacheHttpClientBenchmark.class.getSimpleName(),
@@ -70,10 +72,10 @@ public class BenchmarkRunner {
 
     public static void main(String... args) throws RunnerException, JsonProcessingException {
         List<String> benchmarksToRun = new ArrayList<>();
-        benchmarksToRun.addAll(SYNC_BENCHMARKS);
+        //benchmarksToRun.addAll(SYNC_BENCHMARKS);
         benchmarksToRun.addAll(ASYNC_BENCHMARKS);
-        benchmarksToRun.addAll(PROTOCOL_BENCHMARKS);
-        benchmarksToRun.addAll(COLD_START_BENCHMARKS);
+        //benchmarksToRun.addAll(PROTOCOL_BENCHMARKS);
+        //benchmarksToRun.addAll(COLD_START_BENCHMARKS);
 
         BenchmarkRunner runner = new BenchmarkRunner(benchmarksToRun);
 


### PR DESCRIPTION
```
commit 977291c

AwsCrtClientBenchmark.concurrentApiCall                        N/A  thrpt   10  6081.389
AwsCrtClientBenchmark.sequentialApiCall                        N/A  thrpt   10  2524.097 


commit ba40c05

AwsCrtClientBenchmark.concurrentApiCall                        N/A  thrpt   10  6098.988
AwsCrtClientBenchmark.sequentialApiCall                        N/A  thrpt   10  2534.842

NettyClientH1NonTlsBenchmark.concurrentApiCall                        N/A   thrpt      10   7163.717 
NettyClientH1NonTlsBenchmark.sequentialApiCall                        N/A   thrpt      10   2197.395
NettyHttpClientH1Benchmark.concurrentApiCall                          jdk   thrpt      10   6261.375
NettyHttpClientH1Benchmark.concurrentApiCall                      openssl   thrpt      10   6594.986
NettyHttpClientH1Benchmark.sequentialApiCall                          jdk   thrpt      10   1667.033
NettyHttpClientH1Benchmark.sequentialApiCall                      openssl   thrpt      10   1827.972
NettyHttpClientH2Benchmark.concurrentApiCall                          jdk   thrpt      10   4340.486
NettyHttpClientH2Benchmark.concurrentApiCall                      openssl   thrpt      10   4925.929
NettyHttpClientH2Benchmark.sequentialApiCall                          jdk   thrpt      10   1606.357
NettyHttpClientH2Benchmark.sequentialApiCall                      openssl   thrpt      10   1656.632



```