### PR TITLE
Reduce the pool size for asyncFutureCompletionPool 

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-045e79c.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-045e79c.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Update the pool size for default async future completion executor service. See [#1251](https://github.com/aws/aws-sdk-java-v2/issues/1251), [#994](https://github.com/aws/aws-sdk-java-v2/issues/994)"
+}

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/TestResult.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/TestResult.java
@@ -26,6 +26,8 @@ public class TestResult {
     private final int ioExceptionCount;
     private final int clientExceptionCount;
     private final int unknownExceptionCount;
+    private final int peakThreadCount;
+    private final double heapMemoryAfterGCUsage;
 
     private TestResult(Builder builder) {
         this.testName = builder.testName;
@@ -34,6 +36,8 @@ public class TestResult {
         this.ioExceptionCount = builder.ioExceptionCount;
         this.clientExceptionCount = builder.clientExceptionCount;
         this.unknownExceptionCount = builder.unknownExceptionCount;
+        this.heapMemoryAfterGCUsage = builder.heapMemoryAfterGCUsage;
+        this.peakThreadCount = builder.peakThreadCount;
     }
 
     public static Builder builder() {
@@ -64,6 +68,14 @@ public class TestResult {
         return unknownExceptionCount;
     }
 
+    public int peakThreadCount() {
+        return peakThreadCount;
+    }
+
+    public double heapMemoryAfterGCUsage() {
+        return heapMemoryAfterGCUsage;
+    }
+
     @Override
     public String toString() {
         return "{" +
@@ -73,6 +85,8 @@ public class TestResult {
                ", ioExceptionCount: " + ioExceptionCount +
                ", clientExceptionCount: " + clientExceptionCount +
                ", unknownExceptionCount: " + unknownExceptionCount +
+               ", peakThreadCount: " + peakThreadCount +
+               ", heapMemoryAfterGCUsage: " + heapMemoryAfterGCUsage +
                '}';
     }
 
@@ -83,6 +97,8 @@ public class TestResult {
         private int ioExceptionCount;
         private int clientExceptionCount;
         private int unknownExceptionCount;
+        private int peakThreadCount;
+        private double heapMemoryAfterGCUsage;
 
         private Builder() {
         }
@@ -114,6 +130,16 @@ public class TestResult {
 
         public Builder unknownExceptionCount(int unknownExceptionCount) {
             this.unknownExceptionCount = unknownExceptionCount;
+            return this;
+        }
+
+        public Builder peakThreadCount(int peakThreadCount) {
+            this.peakThreadCount = peakThreadCount;
+            return this;
+        }
+
+        public Builder heapMemoryAfterGCUsage(double heapMemoryAfterGCUsage) {
+            this.heapMemoryAfterGCUsage = heapMemoryAfterGCUsage;
             return this;
         }
 

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3AsyncStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/s3/S3AsyncStabilityTest.java
@@ -45,6 +45,7 @@ public class S3AsyncStabilityTest extends S3BaseStabilityTest {
     @AfterAll
     public static void cleanup() {
         deleteBucketAndAllContents(bucketName);
+        s3NettyClient.close();
     }
 
     @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/sqs/SqsAsyncStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/sqs/SqsAsyncStabilityTest.java
@@ -47,6 +47,7 @@ public class SqsAsyncStabilityTest extends SqsBaseStabilityTest {
         if (queueUrl != null) {
             sqsAsyncClient.deleteQueue(b -> b.queueUrl(queueUrl));
         }
+        sqsAsyncClient.close();
     }
 
     @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/transcribestreaming/TranscribeStreamingStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/transcribestreaming/TranscribeStreamingStabilityTest.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntFunction;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -61,6 +62,11 @@ public class TranscribeStreamingStabilityTest extends AwsTestBase {
         if (audioFileInputStream == null) {
             throw new RuntimeException("fail to get the audio input stream");
         }
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        transcribeStreamingClient.close();
     }
 
     @RetryableTest(maxRetries = 3, retryableException = StabilityTestsRetryableException.class)

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/RetryableTestExtension.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/RetryableTestExtension.java
@@ -104,7 +104,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     private static final class RetryExecutor implements Iterator<RetryableTestsTemplateInvocationContext> {
         private final int maxRetries;
         private int totalAttempts;
-        private static final List<Throwable> throwables = new ArrayList<>();
+        private List<Throwable> throwables = new ArrayList<>();
 
         RetryExecutor(int maxRetries) {
             this.maxRetries = maxRetries;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Reduce the pool size for asyncFutureCompletionPool 
- Add peak thread count validation in stability tests.

## Motivation and Context
#994 
#1251 

### Thread count and heap memory usage
Before the change
```json

[
  {
    testName: "KinesisStabilityTest.putRecords",
    totalRequestCount: 36,
    peakThreadCount: 65,
    heapMemoryAfterGCUsage: 0.027188731896831263
  },
  {
    testName: "KinesisStabilityTest.subscribeToShard",
    totalRequestCount: 36,
    peakThreadCount: 66,
    heapMemoryAfterGCUsage: 0.1505862277410477
  },
  {
    testName: "SqsAsyncStabilityTest.sendMessage",
    totalRequestCount: 5000,
    peakThreadCount: 67,
    heapMemoryAfterGCUsage: 0.15713969063604177
  },
  {
    testName: "SqsAsyncStabilityTest.receiveMessage",
    totalRequestCount: 5000,
    peakThreadCount: 67,
    heapMemoryAfterGCUsage: 0.16292251659230597
  },
  {
    testName: "TranscribeStreamingStabilityTest.startTranscription",
    totalRequestCount: 2,
    peakThreadCount: 31,
    heapMemoryAfterGCUsage: 0.16292251659230597
  },
  {
    testName: "S3AsyncStabilityTest.uploadLargeObjectFromFile",
    totalRequestCount: 1,
    peakThreadCount: 20,
    heapMemoryAfterGCUsage: 0.025418984017721035
  },
  {
    testName: "S3AsyncStabilityTest.downloadLargeObjectToFile",
    totalRequestCount: 1,
    peakThreadCount: 21,
    heapMemoryAfterGCUsage: 0.025418984017721035
  },
  {
    testName: "S3AsyncStabilityTest.putObject",
    totalRequestCount: 5000,
    peakThreadCount: 69,
    heapMemoryAfterGCUsage: 0.04003023000863882
  },
  {
    testName: "S3AsyncStabilityTest.getObject",
    totalRequestCount: 5000,
    peakThreadCount: 84,
    heapMemoryAfterGCUsage: 0.0562708237591911
  }

]
```

After the change
```json
[
  {
    testName: "KinesisStabilityTest.putRecords",
    totalRequestCount: 36,
    peakThreadCount: 23,
    heapMemoryAfterGCUsage: 0.026760661003672477
  },
  {
    testName: "KinesisStabilityTest.subscribeToShard",
    totalRequestCount: 36,
    peakThreadCount: 23,
    heapMemoryAfterGCUsage: 0.14375153617895672
  },
  {
    testName: "SqsAsyncStabilityTest.sendMessage",
    totalRequestCount: 5000,
    peakThreadCount: 26,
    heapMemoryAfterGCUsage: 0.14232282771620638
  },
  {
    testName: "SqsAsyncStabilityTest.receiveMessage",
    totalRequestCount: 5000,
    peakThreadCount: 25,
    heapMemoryAfterGCUsage: 0.04030660671012726
  },
  {
    testName: "TranscribeStreamingStabilityTest.startTranscription",
    totalRequestCount: 2,
    peakThreadCount: 20,
    heapMemoryAfterGCUsage: 0.04030660671012726
  },
  {
    testName: "S3AsyncStabilityTest.uploadLargeObjectFromFile",
    totalRequestCount: 1,
    peakThreadCount: 20,
    heapMemoryAfterGCUsage: 0.033353092844893295
  },
  {
    testName: "S3AsyncStabilityTest.downloadLargeObjectToFile",
    totalRequestCount: 1,
    peakThreadCount: 21,
    heapMemoryAfterGCUsage: 0.033139469798018295
  },
  {
    testName: "S3AsyncStabilityTest.putObject",
    totalRequestCount: 5000,
    peakThreadCount: 27,
    heapMemoryAfterGCUsage: 0.04231374360606564
  },
  {
    testName: "S3AsyncStabilityTest.getObject",
    totalRequestCount: 5000,
    peakThreadCount: 37,
    heapMemoryAfterGCUsage: 0.05930868754282352
  }

]
```

Note that `heapMemoryAfterGCUsage` is more like a reference  and might not be accurate.

### Performance
The throughput has increased ~4% after the change

before the change
```
                                    (sslProviderValue)    Mode     Cnt      Score     Error  Units 
s.a.a.b.apicall.httpclient.async.NettyClientH1NonTlsBenchmark.concurrentApiCall                        N/A   thrpt      10   7175.051 ± 313.624  ops/s 
s.a.a.b.apicall.httpclient.async.NettyClientH1NonTlsBenchmark.sequentialApiCall                        N/A   thrpt      10   2159.311 ±  61.802  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.concurrentApiCall                          jdk   thrpt      10   6271.857 ± 219.621  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.concurrentApiCall                      openssl   thrpt      10   6475.575 ± 352.836  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.sequentialApiCall                          jdk   thrpt      10   1666.164 ±  12.787  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.sequentialApiCall                      openssl   thrpt      10   1819.900 ±  24.139  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.concurrentApiCall                          jdk   thrpt      10   4303.621 ±  43.522  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.concurrentApiCall                      openssl   thrpt      10   4841.003 ± 151.207  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.sequentialApiCall                          jdk   thrpt      10   1590.151 ±  18.085  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.sequentialApiCall                      openssl   thrpt      10   1650.269 ±  13.517  ops/s 
s.a.a.b.apicall.httpclient.sync.ApacheHttpClientBenchmark.concurrentApiCall                            N/A   thrpt      10  12114.396 ± 720.154  ops/s 
s.a.a.b.apicall.httpclient.sync.ApacheHttpClientBenchmark.sequentialApiCall                            N/A   thrpt      10   2963.494 ±  14.767  ops/s 
s.a.a.b.apicall.httpclient.sync.UrlConnectionHttpClientBenchmark.sequentialApiCall                     N/A   thrpt      10    138.624 ±   4.863  ops/s 
s.a.a.b.apicall.protocol.Ec2ProtocolBenchmark.successfulResponse                                       N/A   thrpt      10   6773.341 ±  33.678  ops/s 
s.a.a.b.apicall.protocol.JsonProtocolBenchmark.successfulResponse                                      N/A   thrpt      10  10851.469 ± 169.554  ops/s 
s.a.a.b.apicall.protocol.QueryProtocolBenchmark.successfulResponse                                     N/A   thrpt      10   7288.177 ±  64.005  ops/s 
s.a.a.b.apicall.protocol.XmlProtocolBenchmark.successfulResponse                                       N/A   thrpt      10   6532.628 ±  95.233  ops/s
```

After the change
```
enchmark                                                                               (sslProviderValue)    Mode     Cnt      Score     Error  Units 
s.a.a.b.apicall.httpclient.async.NettyClientH1NonTlsBenchmark.concurrentApiCall                        N/A   thrpt      10   7396.302 ? 139.764  ops/s 
s.a.a.b.apicall.httpclient.async.NettyClientH1NonTlsBenchmark.sequentialApiCall                        N/A   thrpt      10   2228.084 ?   9.745  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.concurrentApiCall                          jdk   thrpt      10   6334.675 ? 229.124  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.concurrentApiCall                      openssl   thrpt      10   6776.465 ? 292.216  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.sequentialApiCall                          jdk   thrpt      10   1699.332 ?  43.800  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH1Benchmark.sequentialApiCall                      openssl   thrpt      10   1854.908 ?  37.634  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.concurrentApiCall                          jdk   thrpt      10   4467.494 ?  43.821  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.concurrentApiCall                      openssl   thrpt      10   5077.377 ?  55.295  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.sequentialApiCall                          jdk   thrpt      10   1641.146 ?  37.573  ops/s 
s.a.a.b.apicall.httpclient.async.NettyHttpClientH2Benchmark.sequentialApiCall                      openssl   thrpt      10   1699.303 ?  11.989  ops/s 
s.a.a.b.apicall.httpclient.sync.ApacheHttpClientBenchmark.concurrentApiCall                            N/A   thrpt      10  12605.827 ? 222.765  ops/s 
s.a.a.b.apicall.httpclient.sync.ApacheHttpClientBenchmark.sequentialApiCall                            N/A   thrpt      10   3051.269 ?  34.324  ops/s 
s.a.a.b.apicall.httpclient.sync.UrlConnectionHttpClientBenchmark.sequentialApiCall                     N/A   thrpt      10    144.334 ?   7.165  ops/s 
s.a.a.b.apicall.protocol.Ec2ProtocolBenchmark.successfulResponse                                       N/A   thrpt      10   6815.947 ? 136.775  ops/s 
s.a.a.b.apicall.protocol.JsonProtocolBenchmark.successfulResponse                                      N/A   thrpt      10  10909.570 ? 164.493  ops/s 
s.a.a.b.apicall.protocol.QueryProtocolBenchmark.successfulResponse                                     N/A   thrpt      10   7350.740 ?  35.965  ops/s 
s.a.a.b.apicall.protocol.XmlProtocolBenchmark.successfulResponse                                       N/A   thrpt      10   6610.649 ?  69.184  ops/s 
```


## Testing
Add peak thread count validation in stability tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
