### PR TITLE
Add provide method in AwsCredentialsProvider

### DIFF
--- a/core/auth/pom.xml
+++ b/core/auth/pom.xml
@@ -135,6 +135,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProvider.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.auth.credentials;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
+import java.util.function.Supplier;
+
 /**
  * Interface for loading {@link AwsCredentials} that are used for authentication.
  *
@@ -39,4 +41,32 @@ public interface AwsCredentialsProvider {
      * @return AwsCredentials which the caller can use to authorize an AWS request.
      */
     AwsCredentials resolveCredentials();
+
+    /**
+     * Returns {@link AwsCredentialsProvider} that can be used to load {@link AwsCredentials} used for authentication.
+     *
+     * @param accessKeyIdSupplier     The supplier of access key idt to use.
+     * @param secretAccessKeySupplier The supplier of secret access key to use.
+     * @return AwsCredentialsProvider  which the caller can use to resolve AwsCredentials
+     */
+    static AwsCredentialsProvider provide(final Supplier<String> accessKeyIdSupplier, final Supplier<String> secretAccessKeySupplier) {
+        final String accessKeyId = accessKeyIdSupplier.get();
+        final String secretAccessKey = secretAccessKeySupplier.get();
+        if (accessKeyId == null || accessKeyId.isBlank() || secretAccessKey == null || secretAccessKey.isBlank()) {
+            return DefaultCredentialsProvider.create();
+        } else {
+            return () ->
+                    new AwsCredentials() {
+                        @Override
+                        public String accessKeyId() {
+                            return accessKeyId;
+                        }
+
+                        @Override
+                        public String secretAccessKey() {
+                            return secretAccessKey;
+                        }
+                    };
+        }
+    }
 }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderTest.java
@@ -1,0 +1,21 @@
+package software.amazon.awssdk.auth.credentials;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AwsCredentialsProviderTest {
+
+    @Test
+    public void provide() {
+        final String testAccessKeyId = "test-access-key-id";
+        final String testSecretAccessKey = "test-secret-access-key";
+        final AwsCredentialsProvider awsCredentialsProvider = AwsCredentialsProvider.provide(() -> testAccessKeyId, () -> testSecretAccessKey);
+        assertNotNull(awsCredentialsProvider);
+        final AwsCredentials awsCredentials = awsCredentialsProvider.resolveCredentials();
+        assertNotNull(awsCredentials);
+        assertEquals(testAccessKeyId, awsCredentials.accessKeyId());
+        assertEquals(testSecretAccessKey, awsCredentials.secretAccessKey());
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- added a simple `provide` method to `AwsCredentialsProvider` in order to create a provider directly from a `Supplier` of `accessKeyId` and a `Supplier` of `secretAccessKey`
- added unit test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently the code to instantiate a `AwsCredentialsProvider` from simple configuration is quite verbose. With this change the caller can actually instantiate a provider simply like that:
```java
AwsCredentialsProvider.provide(() -> testAccessKeyId, () -> testSecretAccessKey);
```
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test has been added in `AwsCredentialsProviderTest`.
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
