### PR TITLE
Fix flaky KinesisStabilityTest

### DIFF
--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/kinesis/KinesisStabilityTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/kinesis/KinesisStabilityTest.java
@@ -183,8 +183,10 @@ public class KinesisStabilityTest extends AwsTestBase {
                                                        .startingPosition(s -> s.type(ShardIteratorType.TRIM_HORIZON)),
                                                  responseHandler)
                                .thenAccept(b -> {
-                                   // Only verify data if all events have been received.
-                                   if (responseHandler.allEventsReceived) {
+                                   // Only verify data if all events have been received and the received data is not empty.
+                                   // It is possible the received data is empty because there is no record at the position
+                                   // event with TRIM_HORIZON.
+                                   if (responseHandler.allEventsReceived && !responseHandler.receivedData.isEmpty()) {
                                        assertThat(producedData).as(responseHandler.id + " has not received all events"
                                                                    + ".").containsSequence(responseHandler.receivedData);
                                    }
@@ -218,7 +220,7 @@ public class KinesisStabilityTest extends AwsTestBase {
         , SubscribeToShardEventStream> implements SubscribeToShardResponseHandler {
         private final List<SdkBytes> receivedData = new ArrayList<>();
         private final String id;
-        private boolean allEventsReceived = false;
+        private volatile boolean allEventsReceived = false;
 
         TestSubscribeToShardResponseHandler(int consumerIndex, int shardIndex) {
             id = "consumer_" + consumerIndex + "_shard_" + shardIndex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix flaky KinesisStabilityTest by only verifying received data if it's not empty. 
It is possible the received data is empty because there is no record at the position event with TRIM_HORIZON per https://aws.amazon.com/kinesis/data-streams/faqs/

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
