### PR TITLE
Update baseline due to jdk version change

### DIFF
--- a/test/sdk-benchmarks/src/main/resources/software/amazon/awssdk/benchmark/baseline.json
+++ b/test/sdk-benchmarks/src/main/resources/software/amazon/awssdk/benchmark/baseline.json
@@ -2,361 +2,361 @@
   {
     "id": "apicall.httpclient.async.NettyClientH1NonTlsBenchmark.concurrentApiCall-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.801"
+      "date": "2019-10-01T20:07:52.539"
     },
     "statistics": {
-      "mean": 7364.196759313598,
-      "variance": 14933.656525355855,
-      "standardDeviation": 122.20334089277533,
-      "max": 7602.467305679072,
-      "min": 7222.792224268672,
+      "mean": 11953.741893432696,
+      "variance": 47530.034301188265,
+      "standardDeviation": 218.01383970103427,
+      "max": 12372.362415239815,
+      "min": 11719.587724827139,
       "n": 10,
-      "sum": 73641.96759313598
+      "sum": 119537.41893432697
     }
   },
   {
     "id": "apicall.httpclient.async.NettyClientH1NonTlsBenchmark.sequentialApiCall-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.806"
+      "date": "2019-10-01T20:07:52.544"
     },
     "statistics": {
-      "mean": 2221.2872113564904,
-      "variance": 1218.7488626723098,
-      "standardDeviation": 34.91058382027304,
-      "max": 2258.7177589570374,
-      "min": 2132.9555713926898,
+      "mean": 3474.8929618663287,
+      "variance": 712.0377962331736,
+      "standardDeviation": 26.684036355716007,
+      "max": 3505.5433448106787,
+      "min": 3415.4832560499217,
       "n": 10,
-      "sum": 22212.872113564903
+      "sum": 34748.929618663286
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH1Benchmark.concurrentApiCall-Throughput-sslProviderValue-jdk",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.807"
+      "date": "2019-10-01T20:07:52.544"
     },
     "statistics": {
-      "mean": 6296.90974288793,
-      "variance": 89420.4318661426,
-      "standardDeviation": 299.0324929938929,
-      "max": 6675.545217088489,
-      "min": 5592.085642067786,
+      "mean": 9699.896431884776,
+      "variance": 76032.40025479376,
+      "standardDeviation": 275.73973281845645,
+      "max": 10206.843184671103,
+      "min": 9468.303441931195,
       "n": 10,
-      "sum": 62969.09742887931
+      "sum": 96998.96431884775
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH1Benchmark.concurrentApiCall-Throughput-sslProviderValue-openssl",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.807"
+      "date": "2019-10-01T20:07:52.544"
     },
     "statistics": {
-      "mean": 6671.994088086753,
-      "variance": 20643.699497150585,
-      "standardDeviation": 143.67915470641725,
-      "max": 6950.699050611882,
-      "min": 6528.581224396909,
+      "mean": 10446.03380714306,
+      "variance": 66413.66363464146,
+      "standardDeviation": 257.7084857637432,
+      "max": 10923.23707364524,
+      "min": 10204.627718853411,
       "n": 10,
-      "sum": 66719.94088086754
+      "sum": 104460.3380714306
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH1Benchmark.sequentialApiCall-Throughput-sslProviderValue-jdk",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.807"
+      "date": "2019-10-01T20:07:52.544"
     },
     "statistics": {
-      "mean": 1706.3486946941637,
-      "variance": 40.44757621063699,
-      "standardDeviation": 6.359840895072533,
-      "max": 1717.3087657393187,
-      "min": 1696.8362983897875,
+      "mean": 2512.7905373200633,
+      "variance": 91.50695734966303,
+      "standardDeviation": 9.565926894434382,
+      "max": 2526.984094567836,
+      "min": 2495.5718551901746,
       "n": 10,
-      "sum": 17063.486946941637
+      "sum": 25127.905373200632
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH1Benchmark.sequentialApiCall-Throughput-sslProviderValue-openssl",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.807"
+      "date": "2019-10-01T20:07:52.544"
     },
     "statistics": {
-      "mean": 1859.1429364109122,
-      "variance": 597.4803221148496,
-      "standardDeviation": 24.44341060725466,
-      "max": 1878.0800291867756,
-      "min": 1793.1335692427201,
+      "mean": 2784.4975432258934,
+      "variance": 450.46863826270305,
+      "standardDeviation": 21.22424647102231,
+      "max": 2818.4210467256917,
+      "min": 2744.7963740556124,
       "n": 10,
-      "sum": 18591.42936410912
+      "sum": 27844.975432258936
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH2Benchmark.concurrentApiCall-Throughput-sslProviderValue-jdk",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.808"
+      "date": "2019-10-01T20:07:52.544"
     },
     "statistics": {
-      "mean": 4463.662283130101,
-      "variance": 6625.965700233274,
-      "standardDeviation": 81.40003501371037,
-      "max": 4514.7539188229,
-      "min": 4239.462308147566,
+      "mean": 7283.504799574257,
+      "variance": 2940.452504351831,
+      "standardDeviation": 54.22593940497325,
+      "max": 7341.573192234993,
+      "min": 7160.770039331679,
       "n": 10,
-      "sum": 44636.62283130101
+      "sum": 72835.04799574257
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH2Benchmark.concurrentApiCall-Throughput-sslProviderValue-openssl",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.808"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 5112.7257098357795,
-      "variance": 802.2818760333253,
-      "standardDeviation": 28.324580774184906,
-      "max": 5147.924245234365,
-      "min": 5050.790341008115,
+      "mean": 8384.82208375372,
+      "variance": 916.1282854797893,
+      "standardDeviation": 30.267611162425574,
+      "max": 8426.604455073824,
+      "min": 8321.092978907209,
       "n": 10,
-      "sum": 51127.2570983578
+      "sum": 83848.22083753718
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH2Benchmark.sequentialApiCall-Throughput-sslProviderValue-jdk",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.808"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 1640.7592542891784,
-      "variance": 69.71008247843469,
-      "standardDeviation": 8.349256402724418,
-      "max": 1656.104250511042,
-      "min": 1630.7164376867986,
+      "mean": 2477.2975472033204,
+      "variance": 840.2618882518038,
+      "standardDeviation": 28.987271141861626,
+      "max": 2521.960405726022,
+      "min": 2428.703690483765,
       "n": 10,
-      "sum": 16407.592542891784
+      "sum": 24772.975472033202
     }
   },
   {
     "id": "apicall.httpclient.async.NettyHttpClientH2Benchmark.sequentialApiCall-Throughput-sslProviderValue-openssl",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.808"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 1676.67681381348,
-      "variance": 1039.9414664927494,
-      "standardDeviation": 32.24812345691993,
-      "max": 1700.692626771009,
-      "min": 1594.6062017550792,
+      "mean": 2590.8112289580376,
+      "variance": 454.61212848034586,
+      "standardDeviation": 21.321635220600363,
+      "max": 2616.8156380507344,
+      "min": 2540.5786144254553,
       "n": 10,
-      "sum": 16766.7681381348
+      "sum": 25908.11228958038
     }
   },
   {
     "id": "apicall.httpclient.sync.ApacheHttpClientBenchmark.concurrentApiCall-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.808"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 12466.210539861848,
-      "variance": 5312.815115782836,
-      "standardDeviation": 72.88906032994825,
-      "max": 12564.442387533953,
-      "min": 12321.305153545603,
+      "mean": 16866.337334610893,
+      "variance": 101462.03409398827,
+      "standardDeviation": 318.531056718161,
+      "max": 17190.064649926695,
+      "min": 16269.141724682142,
       "n": 10,
-      "sum": 124662.10539861849
+      "sum": 168663.37334610894
     }
   },
   {
     "id": "apicall.httpclient.sync.ApacheHttpClientBenchmark.sequentialApiCall-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.808"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 3021.5270620547926,
-      "variance": 538.0504173293807,
-      "standardDeviation": 23.19591380673287,
-      "max": 3049.5359594398983,
-      "min": 2976.2272479106614,
+      "mean": 4226.017857222098,
+      "variance": 3066.661807525882,
+      "standardDeviation": 55.37744854655081,
+      "max": 4305.988492552596,
+      "min": 4134.085450279892,
       "n": 10,
-      "sum": 30215.270620547926
+      "sum": 42260.17857222098
     }
   },
   {
     "id": "apicall.httpclient.sync.UrlConnectionHttpClientBenchmark.sequentialApiCall-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.809"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 140.443125437716,
-      "variance": 8.721059053065806,
-      "standardDeviation": 2.9531439269134525,
-      "max": 143.73567607142863,
-      "min": 134.5555106870464,
+      "mean": 174.7664801674713,
+      "variance": 12.515295546405632,
+      "standardDeviation": 3.5376963615332553,
+      "max": 178.6770241537442,
+      "min": 166.3421471658005,
       "n": 10,
-      "sum": 1404.4312543771598
+      "sum": 1747.6648016747129
     }
   },
   {
     "id": "apicall.protocol.Ec2ProtocolBenchmark.successfulResponse-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.809"
+      "date": "2019-10-01T20:07:52.545"
     },
     "statistics": {
-      "mean": 6898.29329334776,
-      "variance": 12450.746690163985,
-      "standardDeviation": 111.58291397057161,
-      "max": 7022.630245470391,
-      "min": 6783.090612775874,
+      "mean": 9841.459076464273,
+      "variance": 10949.247996138049,
+      "standardDeviation": 104.63865440714558,
+      "max": 9965.24912712474,
+      "min": 9722.623015204204,
       "n": 10,
-      "sum": 68982.9329334776
+      "sum": 98414.59076464272
     }
   },
   {
     "id": "apicall.protocol.JsonProtocolBenchmark.successfulResponse-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.809"
+      "date": "2019-10-01T20:07:52.546"
     },
     "statistics": {
-      "mean": 10920.33311838949,
-      "variance": 61481.868230783715,
-      "standardDeviation": 247.9553754827342,
-      "max": 11157.596527879317,
-      "min": 10549.978250007163,
+      "mean": 16430.407523053836,
+      "variance": 29331.706560699487,
+      "standardDeviation": 171.26501849677152,
+      "max": 16638.092602848086,
+      "min": 16262.768049018146,
       "n": 10,
-      "sum": 109203.3311838949
+      "sum": 164304.07523053835
     }
   },
   {
     "id": "apicall.protocol.QueryProtocolBenchmark.successfulResponse-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.809"
+      "date": "2019-10-01T20:07:52.546"
     },
     "statistics": {
-      "mean": 7449.261722431135,
-      "variance": 1664.7140802728582,
-      "standardDeviation": 40.80090783638102,
-      "max": 7499.727895494281,
-      "min": 7405.119207717104,
+      "mean": 10599.011117216372,
+      "variance": 975.0013823076044,
+      "standardDeviation": 31.225012126620616,
+      "max": 10644.281296039415,
+      "min": 10551.650476781753,
       "n": 10,
-      "sum": 74492.61722431135
+      "sum": 105990.11117216373
     }
   },
   {
     "id": "apicall.protocol.XmlProtocolBenchmark.successfulResponse-Throughput",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "Throughput",
-      "date": "2019-09-27T20:26:56.809"
+      "date": "2019-10-01T20:07:52.546"
     },
     "statistics": {
-      "mean": 6591.030764142568,
-      "variance": 200.42459103773166,
-      "standardDeviation": 14.157139225059971,
-      "max": 6608.540390532487,
-      "min": 6567.667335090131,
+      "mean": 9303.178155788462,
+      "variance": 21561.58218389355,
+      "standardDeviation": 146.83862633480862,
+      "max": 9463.863235819606,
+      "min": 9137.897225156119,
       "n": 10,
-      "sum": 65910.30764142568
+      "sum": 93031.78155788462
     }
   },
   {
     "id": "coldstart.V2OptimizedClientCreationBenchmark.createClient-SampleTime",
     "params": {
-      "sdkVersion": "2.9.9",
-      "jdkVersion": "1.8.0_212",
+      "sdkVersion": "2.9.11",
+      "jdkVersion": "1.8.0_222",
       "jvmName": "OpenJDK 64-Bit Server VM",
-      "jvmVersion": "25.212-b03",
+      "jvmVersion": "25.222-b10",
       "mode": "SampleTime",
-      "date": "2019-09-27T20:26:56.82"
+      "date": "2019-10-01T20:07:52.56"
     },
     "statistics": {
-      "mean": 0.8036448885038757,
-      "variance": 145.4839076833385,
-      "standardDeviation": 12.061671015383336,
-      "max": 2810.18368,
-      "min": 0.67584,
-      "n": 189316,
-      "sum": 152142.83571199974
+      "mean": 0.11715317741749746,
+      "variance": 24.391494667328747,
+      "standardDeviation": 4.9387746119183,
+      "max": 3544.1868799999997,
+      "min": 0.09088,
+      "n": 1293869,
+      "sum": 151580.86451200003
     }
   }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Looks like the jdk version change (`1.8.0_212` -> `1.8.0_222`) has increased the throughput a lot.
Might be related to https://bugs.openjdk.java.net/browse/JDK-8222206

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
