### PR TITLE
Core: Region 'id' is now URL encoded

### DIFF
--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/RegionGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/RegionGenerator.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.codegen.lite.PoetClass;
 import software.amazon.awssdk.codegen.lite.regions.model.Partitions;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 public class RegionGenerator implements PoetClass {
 
@@ -153,7 +154,9 @@ public class RegionGenerator implements PoetClass {
                          .addParameter(boolean.class, "isGlobalRegion")
                          .returns(className())
                          .addStatement("$T.paramNotBlank($L, $S)", Validate.class, "value", "region")
-                         .addStatement("return $L.put($L, $L)", "RegionCache", "value", "isGlobalRegion")
+                         .addStatement("$T $L = $T.urlEncode($L)",
+                                       String.class, "urlEncodedValue", SdkHttpUtils.class, "value")
+                         .addStatement("return $L.put($L, $L)", "RegionCache", "urlEncodedValue", "isGlobalRegion")
                          .build();
 
     }

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/regions.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/regions.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * An Amazon Web Services region that hosts a set of Amazon services.
@@ -99,7 +100,8 @@ public final class Region {
 
     private static Region of(String value, boolean isGlobalRegion) {
         Validate.paramNotBlank(value, "region");
-        return RegionCache.put(value, isGlobalRegion);
+        String urlEncodedValue = SdkHttpUtils.urlEncode(value);
+        return RegionCache.put(urlEncodedValue, isGlobalRegion);
     }
 
     public static List<Region> regions() {

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;

--- a/core/regions/src/test/java/software/amazon/awssdk/regions/RegionTest.java
+++ b/core/regions/src/test/java/software/amazon/awssdk/regions/RegionTest.java
@@ -60,4 +60,10 @@ public class RegionTest {
 
         assertThat(someMap.get(Region.of("key"))).isEqualTo("A Value");
     }
+
+    @Test
+    public void idIsUrlEncoded() {
+        Region region = Region.of("http://my-host.com/?");
+        assertThat(region.id()).isEqualTo("http%3A%2F%2Fmy-host.com%2F%3F");
+    }
 }


### PR DESCRIPTION
## Description
Region.of(...) will now URL encode the argument passed as the 'id' of the instantiated Region.

## Testing
Added unit tests, ran all existing unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
