### PR TITLE
Update HealthCheckedChannelPool to check KEEP_ALIVE attribute

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHttpClient-9894ee4.json
+++ b/.changes/next-release/bugfix-NettyNIOHttpClient-9894ee4.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Http Client", 
+    "type": "bugfix", 
+    "description": "Update `HealthCheckedChannelPool` to check `KEEP_ALIVE` when acquiring a channel from the pool to avoid soon-to-be inactive channels being picked up by a new request. This should reduce the frequency of `IOException: Server failed to complete response` errors. See [#1380](https://github.com/aws/aws-sdk-java-v2/issues/1380), [#1466](https://github.com/aws/aws-sdk-java-v2/issues/1466)."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -67,6 +67,13 @@ public final class ChannelAttributeKey {
             "aws.http.nio.netty.async.executionId");
 
     /**
+     * {@link AttributeKey} to keep track of whether we should close the connection after this request
+     * has completed.
+     */
+    static final AttributeKey<Boolean> KEEP_ALIVE = AttributeKey.newInstance("aws.http.nio.netty.async.keepAlive");
+
+
+    /**
      * Whether the channel is still in use
      */
     static final AttributeKey<Boolean> IN_USE = AttributeKey.newInstance("aws.http.nio.netty.async.inUse");

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HealthCheckedChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HealthCheckedChannelPool.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.KEEP_ALIVE;
+
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
@@ -159,6 +161,12 @@ public class HealthCheckedChannelPool implements ChannelPool {
      * Determine whether the provided channel is 'healthy' enough to use.
      */
     private boolean isHealthy(Channel channel) {
+        // There might be cases where the channel is not reusable but still active at the moment
+        // See https://github.com/aws/aws-sdk-java-v2/issues/1380
+        if (channel.attr(KEEP_ALIVE).get() != null && !channel.attr(KEEP_ALIVE).get()) {
+            return false;
+        }
+
         return channel.isActive();
     }
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.http.nio.netty.internal;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTE_FUTURE_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.KEEP_ALIVE;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch;
@@ -38,7 +39,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.timeout.WriteTimeoutException;
-import io.netty.util.AttributeKey;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -65,12 +65,6 @@ import software.amazon.awssdk.utils.async.DelegatingSubscription;
 @Sharable
 @SdkInternalApi
 public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
-
-    /**
-     * {@link AttributeKey} to keep track of whether we should close the connection after this request
-     * has completed.
-     */
-    private static final AttributeKey<Boolean> KEEP_ALIVE = AttributeKey.newInstance("aws.http.nio.netty.async.keepAlive");
 
     private static final Logger log = LoggerFactory.getLogger(ResponseHandler.class);
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HealthCheckedChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HealthCheckedChannelPoolTest.java
@@ -18,14 +18,18 @@ package software.amazon.awssdk.http.nio.netty.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.CONNECTION_ACQUIRE_TIMEOUT;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.KEEP_ALIVE;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
+import io.netty.util.Attribute;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -52,6 +56,7 @@ public class HealthCheckedChannelPoolTest {
     private ChannelPool downstreamChannelPool = Mockito.mock(ChannelPool.class);
     private List<Channel> channels = new ArrayList<>();
     private ScheduledFuture<?> scheduledFuture = Mockito.mock(ScheduledFuture.class);
+    private Attribute<Boolean> attribute = mock(Attribute.class);
 
     private static final NettyConfiguration NETTY_CONFIGURATION =
             new NettyConfiguration(AttributeMap.builder()
@@ -64,7 +69,7 @@ public class HealthCheckedChannelPoolTest {
 
     @Before
     public void reset() {
-        Mockito.reset(eventLoopGroup, eventLoop, downstreamChannelPool, scheduledFuture);
+        Mockito.reset(eventLoopGroup, eventLoop, downstreamChannelPool, scheduledFuture, attribute);
         channels.clear();
 
         Mockito.when(eventLoopGroup.next()).thenReturn(eventLoop);
@@ -102,6 +107,39 @@ public class HealthCheckedChannelPoolTest {
         assertThat(acquire.getNow()).isEqualTo(channels.get(4));
 
         Mockito.verify(downstreamChannelPool, Mockito.times(5)).acquire(any());
+    }
+
+    @Test
+    public void acquireActiveAndKeepAliveTrue_shouldAcquireOnce() throws Exception {
+        stubForIgnoredTimeout();
+        stubAcquireActiveAndKeepAlive();
+
+        Future<Channel> acquire = channelPool.acquire();
+
+        acquire.get(5, TimeUnit.SECONDS);
+
+        assertThat(acquire.isDone()).isTrue();
+        assertThat(acquire.isSuccess()).isTrue();
+        assertThat(acquire.getNow()).isEqualTo(channels.get(0));
+
+        Mockito.verify(downstreamChannelPool, Mockito.times(1)).acquire(any());
+    }
+
+
+    @Test
+    public void acquire_firstChannelKeepAliveFalse_shouldAcquireAnother() throws Exception {
+        stubForIgnoredTimeout();
+        stubAcquireTwiceFirstTimeNotKeepAlive();
+
+        Future<Channel> acquire = channelPool.acquire();
+
+        acquire.get(5, TimeUnit.SECONDS);
+
+        assertThat(acquire.isDone()).isTrue();
+        assertThat(acquire.isSuccess()).isTrue();
+        assertThat(acquire.getNow()).isEqualTo(channels.get(1));
+
+        Mockito.verify(downstreamChannelPool, Mockito.times(2)).acquire(any());
     }
 
     @Test
@@ -154,6 +192,7 @@ public class HealthCheckedChannelPoolTest {
     public void releaseHealthyDoesNotClose() {
         Channel channel = Mockito.mock(Channel.class);
         Mockito.when(channel.isActive()).thenReturn(true);
+        stubKeepAliveAttribute(channel, null);
 
         channelPool.release(channel);
 
@@ -165,7 +204,7 @@ public class HealthCheckedChannelPoolTest {
     public void releaseHealthyCloses() {
         Channel channel = Mockito.mock(Channel.class);
         Mockito.when(channel.isActive()).thenReturn(false);
-
+        stubKeepAliveAttribute(channel, null);
         channelPool.release(channel);
 
         Mockito.verify(channel, times(1)).close();
@@ -179,11 +218,32 @@ public class HealthCheckedChannelPoolTest {
                 Promise<Channel> promise = invocation.getArgumentAt(0, Promise.class);
                 Channel channel = Mockito.mock(Channel.class);
                 Mockito.when(channel.isActive()).thenReturn(shouldAcquireBeHealthy);
+                stubKeepAliveAttribute(channel, null);
                 channels.add(channel);
                 promise.setSuccess(channel);
                 return promise;
             });
         }
+    }
+
+    private void stubAcquireActiveAndKeepAlive() {
+        OngoingStubbing<Future<Channel>> stubbing = Mockito.when(downstreamChannelPool.acquire(any()));
+        stubbing = stubbing.thenAnswer(invocation -> {
+            Promise<Channel> promise = invocation.getArgumentAt(0, Promise.class);
+            Channel channel = Mockito.mock(Channel.class);
+            Mockito.when(channel.isActive()).thenReturn(true);
+
+            stubKeepAliveAttribute(channel, true);
+
+            channels.add(channel);
+            promise.setSuccess(channel);
+            return promise;
+        });
+    }
+
+    private void stubKeepAliveAttribute(Channel channel, Boolean isKeepAlive) {
+        Mockito.when(channel.attr(KEEP_ALIVE)).thenReturn(attribute);
+        when(attribute.get()).thenReturn(isKeepAlive);
     }
 
     public void stubBadDownstreamAcquire() {
@@ -201,5 +261,28 @@ public class HealthCheckedChannelPoolTest {
     public void stubForIgnoredTimeout() {
         Mockito.when(eventLoopGroup.schedule(any(Runnable.class), anyLong(), any()))
                .thenAnswer(i -> scheduledFuture);
+    }
+
+    private void stubAcquireTwiceFirstTimeNotKeepAlive() {
+        OngoingStubbing<Future<Channel>> stubbing = Mockito.when(downstreamChannelPool.acquire(any()));
+        stubbing = stubbing.thenAnswer(invocation -> {
+            Promise<Channel> promise = invocation.getArgumentAt(0, Promise.class);
+            Channel channel = Mockito.mock(Channel.class);
+            stubKeepAliveAttribute(channel, false);
+            Mockito.when(channel.isActive()).thenReturn(true);
+            channels.add(channel);
+            promise.setSuccess(channel);
+            return promise;
+        });
+
+        stubbing.thenAnswer(invocation -> {
+            Promise<Channel> promise = invocation.getArgumentAt(0, Promise.class);
+            Channel channel = Mockito.mock(Channel.class);
+            Mockito.when(channel.isActive()).thenReturn(true);
+            channels.add(channel);
+            promise.setSuccess(channel);
+            stubKeepAliveAttribute(channel, true);
+            return promise;
+        });
     }
 }


### PR DESCRIPTION
# Description
Update `HealthCheckedChannelPool` to check `KEEP_ALIVE` when acquiring a channel from the pool to avoid soon-to-be inactive channels being picked up by a new request. This should reduce the frequency of `IOException: Server failed to complete response` errors. See #1380 #1466

## Testing
- Added unit tests.
- Manual tests 

Disabled retry and set maxIdleConnectionTimeout = 1 mins on purpose to expose the errors:

Before

```
CloudWatchAsyncStabilityTest: totalRequestCount: 4000, ioExceptionCount: 34

Based on the logs, 28 of ioExceptions were because the connections that were not reusable got picked up
```

After 

```

CloudWatchAsyncStabilityTest:, totalRequestCount: 4000, ioExceptionCount: 0

```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
