### PR TITLE
Ensure host header is set by netty client.

### DIFF
--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache.internal.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.time.Duration;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.apache.internal.ApacheHttpRequestConfig;
+
+public class ApacheHttpRequestFactoryTest {
+
+    private ApacheHttpRequestConfig requestConfig;
+    private ApacheHttpRequestFactory instance;
+
+    @Before
+    public void setup() {
+        instance = new ApacheHttpRequestFactory();
+        requestConfig = ApacheHttpRequestConfig.builder()
+                .connectionAcquireTimeout(Duration.ZERO)
+                .connectionTimeout(Duration.ZERO)
+                .localAddress(InetAddress.getLoopbackAddress())
+                .socketTimeout(Duration.ZERO)
+                .build();
+    }
+
+    @Test
+    public void ceateSetsHostHeaderByDefault() {
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("http://localhost:12345/"))
+                .method(SdkHttpMethod.HEAD)
+                .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                .request(sdkRequest)
+                .build();
+        HttpRequestBase result = instance.create(request, requestConfig);
+        Header[] hostHeaders = result.getHeaders(HttpHeaders.HOST);
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.length);
+        assertEquals("localhost:12345", hostHeaders[0].getValue());
+    }
+
+    @Test
+    public void defaultHttpPortsAreNotInDefaultHostHeader() {
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("http://localhost:80/"))
+                .method(SdkHttpMethod.HEAD)
+                .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                .request(sdkRequest)
+                .build();
+        HttpRequestBase result = instance.create(request, requestConfig);
+        Header[] hostHeaders = result.getHeaders(HttpHeaders.HOST);
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.length);
+        assertEquals("localhost", hostHeaders[0].getValue());
+
+        sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("https://localhost:443/"))
+                .method(SdkHttpMethod.HEAD)
+                .build();
+        request = HttpExecuteRequest.builder()
+                .request(sdkRequest)
+                .build();
+        result = instance.create(request, requestConfig);
+        hostHeaders = result.getHeaders(HttpHeaders.HOST);
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.length);
+        assertEquals("localhost", hostHeaders[0].getValue());
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -112,6 +112,7 @@ public final class NettyRequestExecutor {
                 if (!channelPromise.isSuccess()) {
                     return;
                 }
+                log.error("Exception caught but promise was already done", t);
                 Channel ch = channelPromise.getNow();
                 try {
                     ch.eventLoop().submit(() -> {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapter.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapter.java
@@ -27,6 +27,7 @@ import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.nio.netty.internal.utils.UriUtils;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 @SdkInternalApi
@@ -37,7 +38,7 @@ public final class RequestAdapter {
     public HttpRequest adapt(SdkHttpRequest sdkRequest) {
         HttpMethod method = toNettyHttpMethod(sdkRequest.method());
         HttpHeaders headers = new DefaultHttpHeaders();
-        String uri = sdkRequest.getUri().toString();
+        String uri = UriUtils.relativize(sdkRequest.getUri()).toString();
         DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, uri, headers);
         addHeadersToRequest(request, sdkRequest);
         return request;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapter.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapter.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.http.nio.netty.internal;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
@@ -38,7 +37,8 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @SdkInternalApi
 public final class RequestAdapter {
 
-    private static final List<String> IGNORE_HEADERS = Arrays.asList(HttpHeaderNames.HOST.toString());
+    private static final String HOST = "Host"; // can't use netty's because of case
+    private static final List<String> IGNORE_HEADERS = Arrays.asList(HOST);
 
     private final Protocol protocol;
 
@@ -66,7 +66,7 @@ public final class RequestAdapter {
      */
     private void addHeadersToRequest(DefaultHttpRequest httpRequest, SdkHttpRequest request, URI originalUri) {
 
-        httpRequest.headers().add(HttpHeaderNames.HOST, getHostHeaderValue(request));
+        httpRequest.headers().add(HOST, getHostHeaderValue(request));
         if (protocol == Protocol.HTTP2 && !StringUtils.isBlank(originalUri.getScheme())) {
             httpRequest.headers().add(ExtensionHeaderNames.SCHEME.text(), originalUri.getScheme());
         }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapter.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapter.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.util.AsciiString;
 import java.util.Arrays;
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -33,7 +32,7 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @SdkInternalApi
 public final class RequestAdapter {
 
-    private static final List<AsciiString> IGNORE_HEADERS = Arrays.asList(HttpHeaderNames.HOST);
+    private static final List<String> IGNORE_HEADERS = Arrays.asList(HttpHeaderNames.HOST.toString());
 
     public HttpRequest adapt(SdkHttpRequest sdkRequest) {
         HttpMethod method = toNettyHttpMethod(sdkRequest.method());

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/UriUtils.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/UriUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * A dumbed-down version of Apache HTTP Components Client URIUtils.
+ */
+@SdkProtectedApi
+public class UriUtils {
+
+    private UriUtils() {
+    }
+
+    /**
+     * Converts an absolute URI to a relative URI by stripping out the scheme,
+     * authority, and fragment. In order to maintain compatibility with Apache
+     * HTTP Client behavior, opaque and non-absolute URIs are returned as-is.
+     * @param uri the uri
+     * @return the relativized URI
+     */
+    public static URI relativize(URI uri) {
+        Objects.requireNonNull(uri, "uri");
+        if (uri.isOpaque()) {
+            return uri;
+        }
+        try {
+            return new URI(null, null, null, -1, StringUtils.isEmpty(uri.getPath()) ? "/" : uri.getPath(), uri.getQuery(), null);
+        } catch (URISyntaxException x) {
+            throw new IllegalArgumentException(x.getMessage(), x);
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapterTest.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 
@@ -33,7 +34,7 @@ public class RequestAdapterTest {
 
     @Before
     public void setup() {
-        instance = new RequestAdapter();
+        instance = new RequestAdapter(Protocol.HTTP1_1);
     }
 
     @Test

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/RequestAdapterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+import java.net.URI;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+public class RequestAdapterTest {
+
+    private RequestAdapter instance;
+
+    @Before
+    public void setup() {
+        instance = new RequestAdapter();
+    }
+
+    @Test
+    public void adaptSetsHostHeaderByDefault() {
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("http://localhost:12345/"))
+                .method(SdkHttpMethod.HEAD)
+                .build();
+        HttpRequest result = instance.adapt(sdkRequest);
+        List<String> hostHeaders = result.headers()
+                .getAll(HttpHeaderNames.HOST.toString());
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.size());
+        assertEquals("localhost:12345", hostHeaders.get(0));
+    }
+
+    @Test
+    public void defaultHttpPortsAreNotInDefaultHostHeader() {
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("http://localhost:80/"))
+                .method(SdkHttpMethod.HEAD)
+                .build();
+        HttpRequest result = instance.adapt(sdkRequest);
+        List<String> hostHeaders = result.headers()
+                .getAll(HttpHeaderNames.HOST.toString());
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.size());
+        assertEquals("localhost", hostHeaders.get(0));
+
+        sdkRequest = SdkHttpRequest.builder()
+                .uri(URI.create("https://localhost:443/"))
+                .method(SdkHttpMethod.HEAD)
+                .build();
+        result = instance.adapt(sdkRequest);
+        hostHeaders = result.headers()
+                .getAll(HttpHeaderNames.HOST.toString());
+        assertNotNull(hostHeaders);
+        assertEquals(1, hostHeaders.size());
+        assertEquals("localhost", hostHeaders.get(0));
+    }
+}


### PR DESCRIPTION
Add test coverage for apache client setting host header.


## Description
Copies the logic from the Apache http client implementation for setting the `Host` header to the Netty implementation, and adds test cases for both implementations.

Note that I couldn't do the same for URLConnection because the underlying code ignores any attempt to set the Host header explicitly.

## Motivation and Context
Fixes #1467 for the Netty implementation.

## Testing
New JUnit test cases are added to cover the functionality for both the Apache and Netty implementations.

## Screenshots (if appropriate)
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
Sort of... The failures in `mvn install` were there when I cloned the repo, and are unrelated to the changes I've made. See #1155 for details.
- [x] My code follows the code style of this project
I think... checkstyle seems to be happy.
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
Sort of... The specific modules I touched build on my machine, but I can't vouch for other modules due to being unable to build the project as a whole (again, refer to #1155)
- [ ] A short description of the change has been added to the **CHANGELOG**
`scripts/new-change` failed with a permission denied error. Don't know if it's because I'm building on windows through git bash.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
