### PR TITLE
Add LastHttpContentHandler

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHttpClient-5af2afd.json
+++ b/.changes/next-release/bugfix-NettyNIOHttpClient-5af2afd.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO Http Client", 
+    "type": "bugfix", 
+    "description": "Fix a race condition where the channel is closed right after all content is buffered, causing `server failed to complete the response` error by adding a flag when `LastHttpContentHandler` is received."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -60,6 +61,12 @@ public final class ChannelAttributeKey {
     static final AttributeKey<Boolean> RESPONSE_COMPLETE_KEY = AttributeKey.newInstance(
         "aws.http.nio.netty.async.responseComplete");
 
+    /**
+     * {@link AttributeKey} to keep track of whether we have received the {@link LastHttpContent}.
+     */
+    static final AttributeKey<Boolean> LAST_HTTP_CONTENT_RECEIVED_KEY = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.lastHttpContentReceived");
+
     static final AttributeKey<CompletableFuture<Void>> EXECUTE_FUTURE_KEY = AttributeKey.newInstance(
             "aws.http.nio.netty.async.executeFuture");
 
@@ -71,7 +78,6 @@ public final class ChannelAttributeKey {
      * has completed.
      */
     static final AttributeKey<Boolean> KEEP_ALIVE = AttributeKey.newInstance("aws.http.nio.netty.async.keepAlive");
-
 
     /**
      * Whether the channel is still in use

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
@@ -78,6 +78,7 @@ public class HandlerRemovingChannelPool implements ChannelPool {
         if (channel.isOpen() || channel.isRegistered()) {
             removeIfExists(channel.pipeline(),
                            HttpStreamsClientHandler.class,
+                           LastHttpContentHandler.class,
                            ResponseHandler.class,
                            ReadTimeoutHandler.class,
                            WriteTimeoutHandler.class);

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/LastHttpContentHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/LastHttpContentHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.LAST_HTTP_CONTENT_RECEIVED_KEY;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.LastHttpContent;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Marks {@code ChannelAttributeKey.LAST_HTTP_CONTENT_RECEIVED_KEY} if {@link LastHttpContent} is received.
+ */
+@SdkInternalApi
+@ChannelHandler.Sharable
+public final class LastHttpContentHandler extends ChannelInboundHandlerAdapter {
+    private static final LastHttpContentHandler INSTANCE = new LastHttpContentHandler();
+    private static final Logger logger = Logger.loggerFor(LastHttpContent.class);
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (msg instanceof LastHttpContent) {
+            logger.debug(() -> "Received LastHttpContent " + ctx.channel());
+            ctx.channel().attr(LAST_HTTP_CONTENT_RECEIVED_KEY).set(true);
+        }
+
+        ctx.fireChannelRead(msg);
+    }
+
+    public static LastHttpContentHandler create() {
+        return INSTANCE;
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/LastHttpContentHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/LastHttpContentHandlerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.LAST_HTTP_CONTENT_RECEIVED_KEY;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+public class LastHttpContentHandlerTest {
+
+    private MockChannel channel;
+    private ChannelHandlerContext handlerContext;
+    private LastHttpContentHandler contentHandler = LastHttpContentHandler.create();
+
+    @Before
+    public void setup() throws Exception {
+        channel = new MockChannel();
+        channel.attr(LAST_HTTP_CONTENT_RECEIVED_KEY).set(false);
+        handlerContext = Mockito.mock(ChannelHandlerContext.class);
+        Mockito.when(handlerContext.channel()).thenReturn(channel);
+    }
+
+    @After
+    public void cleanup() {
+        channel.close();
+    }
+
+    @Test
+    public void lastHttpContentReceived_shouldSetAttribute() {
+        LastHttpContent lastHttpContent = LastHttpContent.EMPTY_LAST_CONTENT;
+        contentHandler.channelRead(handlerContext, lastHttpContent);
+
+        assertThat(channel.attr(LAST_HTTP_CONTENT_RECEIVED_KEY).get()).isTrue();
+    }
+
+    @Test
+    public void otherContentReceived_shouldNotSetAttribute() {
+        String content = "some content";
+        contentHandler.channelRead(handlerContext, content);
+
+        assertThat(channel.attr(LAST_HTTP_CONTENT_RECEIVED_KEY).get()).isFalse();
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutorTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutorTest.java
@@ -1,11 +1,18 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.util.concurrent.Promise;
+import java.util.concurrent.CompletableFuture;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,14 +20,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.utils.AttributeMap;
-
-import java.util.concurrent.CompletableFuture;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class NettyRequestExecutorTest {
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ResponseCompletionTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ResponseCompletionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
+import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.nio.netty.EmptyPublisher;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+import software.amazon.awssdk.utils.AttributeMap;
+
+
+public class ResponseCompletionTest {
+    private SdkAsyncHttpClient netty;
+    private Server server;
+
+    @After
+    public void teardown() throws InterruptedException {
+        if (server != null) {
+            server.shutdown();
+        }
+        server = null;
+
+        if (netty != null) {
+            netty.close();
+        }
+        netty = null;
+    }
+
+    @Test
+    public void connectionCloseAfterResponse_shouldNotReuseConnection() throws Exception {
+        server = new Server();
+        server.init();
+
+        netty = NettyNioAsyncHttpClient.builder()
+                                       .eventLoopGroup(SdkEventLoopGroup.builder().numberOfThreads(2).build())
+                                       .protocol(Protocol.HTTP1_1)
+                                       .buildWithDefaults(AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, true).build());
+
+        sendGetRequest().join();
+        sendGetRequest().join();
+
+        assertThat(server.channels.size()).isEqualTo(2);
+    }
+
+    private CompletableFuture<Void> sendGetRequest() {
+        AsyncExecuteRequest req = AsyncExecuteRequest.builder()
+                                                     .responseHandler(new SdkAsyncHttpResponseHandler() {
+                                                         private SdkHttpResponse headers;
+
+                                                         @Override
+                                                         public void onHeaders(SdkHttpResponse headers) {
+                                                             this.headers = headers;
+                                                         }
+
+                                                         @Override
+                                                         public void onStream(Publisher<ByteBuffer> stream) {
+                                                             Flowable.fromPublisher(stream).forEach(b -> {
+                                                             });
+                                                         }
+
+                                                         @Override
+                                                         public void onError(Throwable error) {
+                                                         }
+                                                     })
+                                                     .request(SdkHttpFullRequest.builder()
+                                                                                .method(SdkHttpMethod.GET)
+                                                                                .protocol("https")
+                                                                                .host("localhost")
+                                                                                .port(server.port())
+                                                                                .build())
+                                                     .requestContentPublisher(new EmptyPublisher())
+                                                     .build();
+
+        return netty.execute(req);
+    }
+
+
+    private static class Server extends ChannelInitializer<SocketChannel> {
+        private static final byte[] CONTENT = RandomStringUtils.randomAscii(7000).getBytes();
+        private ServerBootstrap bootstrap;
+        private ServerSocketChannel serverSock;
+        private List<SocketChannel> channels = new ArrayList<>();
+        private final NioEventLoopGroup group = new NioEventLoopGroup();
+        private SslContext sslCtx;
+
+        public void init() throws Exception {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+
+            bootstrap = new ServerBootstrap()
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(LogLevel.DEBUG))
+                .group(group)
+                .childHandler(this);
+
+            serverSock = (ServerSocketChannel) bootstrap.bind(0).sync().channel();
+        }
+
+        @Override
+        protected void initChannel(SocketChannel ch) throws Exception {
+            channels.add(ch);
+            ChannelPipeline pipeline = ch.pipeline();
+            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+            pipeline.addLast(new HttpServerCodec());
+            pipeline.addLast(new AlwaysCloseConnectionChannelHandler());
+        }
+
+        public void shutdown() throws InterruptedException {
+            group.shutdownGracefully().await();
+        }
+
+        public int port() {
+            return serverSock.localAddress().getPort();
+        }
+
+        private static class AlwaysCloseConnectionChannelHandler extends ChannelDuplexHandler {
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                if (msg instanceof HttpRequest) {
+                    FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, OK,
+                                                                            Unpooled.wrappedBuffer(CONTENT));
+
+                    response.headers()
+                            .set(CONTENT_TYPE, TEXT_PLAIN)
+                            .set(CONNECTION, CLOSE)
+                            .setInt(CONTENT_LENGTH, response.content().readableBytes());
+                    ctx.writeAndFlush(response).addListener(i -> ctx.channel().close());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `LastHttpContentHandler` to flag if the LastHttpContent has been received and don't throw "server failed to complete response" error if the content is buffered.



## Testing
Added unit tests and function tests
Tested with long running canaries tests
Integ tests and stability tests passed


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
