### PR TITLE
Update to 0.3.35 of the CRT with minor API changes

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-9a322a2.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-9a322a2.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Common Runtime Client", 
+    "type": "bugfix", 
+    "description": "Upgrade to the latest version (0.3.35) of the AWS Common Runtime."
+}

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.22</version>
+            <version>0.3.35</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
@@ -143,11 +143,8 @@ public class AwsCrtClientCallingPatternIntegrationTest {
                                      @FromDataPoints("SharedClient") boolean useSharedClient) throws Exception {
 
         try {
-            if (CrtResource.getAllocatedNativeResourceCount() > 0) {
-                System.err.println("Leaked Resources: " + String.join(", ", CrtResource.getAllocatedNativeResources()));
-            }
-            Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
 
+            CrtResource.waitForNoResources();
             String testName = String.format("Testing with eventLoopSize %d, connectionPoolSize %d, numberOfRequests %d, " +
                             "numberOfParallelJavaClients %d, useSharedClient %b", eventLoopSize, connectionPoolSize,
                     numberOfRequests, numberOfParallelClients, useSharedClient);
@@ -197,11 +194,7 @@ public class AwsCrtClientCallingPatternIntegrationTest {
             awsCrtHttpClient.close();
             Assert.assertFalse(failed.get());
 
-            if (CrtResource.getAllocatedNativeResourceCount() > 0) {
-                System.err.println("Leaked Resources: " + String.join(", ", CrtResource.getAllocatedNativeResources()));
-            }
-
-            Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+            CrtResource.waitForNoResources();
 
             float numSeconds = (float) ((System.currentTimeMillis() - start) / 1000.0);
             String timeElapsed = String.format("%.2f sec", numSeconds);

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
@@ -35,7 +35,7 @@ public class AwsCrtClientKmsIntegrationTest {
 
     @Before
     public void setup() {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
 
         // Create an Http Client for each TLS Cipher Preference supported on the current platform
         for (TlsCipherPreference pref: TlsCipherPreference.values()) {
@@ -55,7 +55,7 @@ public class AwsCrtClientKmsIntegrationTest {
 
     @After
     public void tearDown() {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
     }
 
     private boolean doesKeyExist(KmsAsyncClient kms, String keyAlias) {

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
@@ -56,7 +56,7 @@ public class AwsCrtClientS3IntegrationTest {
 
     @Before
     public void setup() {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
 
         crtClient = AwsCrtAsyncHttpClient.builder()
                 .eventLoopSize(4)
@@ -74,7 +74,7 @@ public class AwsCrtClientS3IntegrationTest {
         s3.close();
         crtClient.close();
 
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
     }
 
     @Test

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.http.CrtHttpStreamHandler;
-import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpException;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.HttpStream;
@@ -38,7 +38,7 @@ import software.amazon.awssdk.utils.Validate;
 public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpStreamAdapter.class);
 
-    private final HttpConnection connection;
+    private final HttpClientConnection connection;
     private final CompletableFuture<Void> responseComplete;
     private final AsyncExecuteRequest sdkRequest;
     private final SdkHttpResponse.Builder respBuilder = SdkHttpResponse.builder();
@@ -46,7 +46,7 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     private final AwsCrtRequestBodySubscriber requestBodySubscriber;
     private AwsCrtResponseBodyPublisher respBodyPublisher = null;
 
-    public AwsCrtAsyncHttpStreamAdapter(HttpConnection connection, CompletableFuture<Void> responseComplete,
+    public AwsCrtAsyncHttpStreamAdapter(HttpClientConnection connection, CompletableFuture<Void> responseComplete,
                                         AsyncExecuteRequest sdkRequest, int windowSize) {
         Validate.notNull(connection, "HttpConnection is null");
         Validate.notNull(responseComplete, "reqComplete Future is null");
@@ -69,7 +69,7 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     }
 
     @Override
-    public void onResponseHeaders(HttpStream stream, int responseStatusCode, HttpHeader[] nextHeaders) {
+    public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType, HttpHeader[] nextHeaders) {
         initRespBodyPublisherIfNeeded(stream);
 
         respBuilder.statusCode(responseStatusCode);

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -28,7 +28,7 @@ import java.util.function.LongUnaryOperator;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -41,7 +41,7 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
     private static final Logger log = Logger.loggerFor(AwsCrtResponseBodyPublisher.class);
     private static final LongUnaryOperator DECREMENT_IF_GREATER_THAN_ZERO = x -> ((x > 0) ? (x - 1) : (x));
 
-    private final HttpConnection connection;
+    private final HttpClientConnection connection;
     private final HttpStream stream;
     private final CompletableFuture<Void> responseComplete;
     private final AtomicLong outstandingRequests = new AtomicLong(0);
@@ -62,7 +62,7 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
      * @param windowSize The max allowed bytes to be queued. The sum of the sizes of all queued ByteBuffers should
      *                   never exceed this value.
      */
-    public AwsCrtResponseBodyPublisher(HttpConnection connection, HttpStream stream,
+    public AwsCrtResponseBodyPublisher(HttpClientConnection connection, HttpStream stream,
                                        CompletableFuture<Void> responseComplete, int windowSize) {
         Validate.notNull(connection, "HttpConnection must not be null");
         Validate.notNull(stream, "Stream must not be null");

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -68,7 +68,7 @@ public class AwsCrtHttpClientSpiVerificationTest {
 
     @Before
     public void setup() throws Exception {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
 
         client = AwsCrtAsyncHttpClient.builder()
                 .build();
@@ -77,7 +77,7 @@ public class AwsCrtHttpClientSpiVerificationTest {
     @After
     public void tearDown() {
         client.close();
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
     }
 
     private byte[] generateRandomBody(int size) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.http.crt.internal.AwsCrtResponseBodyPublisher;
 import software.amazon.awssdk.utils.Logger;
@@ -37,7 +37,7 @@ public class AwsCrtResponseBodyPublisherReactiveStreamCompatTest extends Publish
 
     @Override
     public Publisher<ByteBuffer> createPublisher(long elements) {
-        HttpConnection connection = mock(HttpConnection.class);
+        HttpClientConnection connection = mock(HttpClientConnection.class);
         HttpStream stream = mock(HttpStream.class);
         AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(connection, stream, new CompletableFuture<>(), Integer.MAX_VALUE);
 

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.22</version>
+            <version>0.3.35</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the version of the CRT with their latest changes.

## Motivation and Context
This is required to to upgrade past the memory leak in the earlier versions of the CRT.

## Testing
`mvn install`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
