### PR TITLE
Fix flaky tests and print thread info when thread count exceeds

### DIFF
--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/StabilityTestRunner.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/utils/StabilityTestRunner.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
+import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.time.Duration;
 import java.util.Arrays;
@@ -296,7 +297,7 @@ public class StabilityTestRunner {
      *
      * @param testResult the result to process.
      */
-    private static void processResult(TestResult testResult) {
+    private void processResult(TestResult testResult) {
         log.info(() -> "TestResult: " + testResult);
 
         int clientExceptionCount = testResult.clientExceptionCount();
@@ -330,7 +331,25 @@ public class StabilityTestRunner {
         if (testResult.peakThreadCount() > ALLOWED_PEAK_THREAD_COUNT) {
             String errorMessage = String.format("The number of peak thread exceeds the allowed peakThread threshold %s",
                                                 ALLOWED_PEAK_THREAD_COUNT);
+
+
+            threadDump(testResult.testName());
             throw new AssertionError(errorMessage);
         }
+    }
+
+    private void threadDump(String testName) {
+        StringBuilder threadDump = new StringBuilder("\n============").append(testName)
+                                                                      .append(" Thread Dump:=============\n");
+        ThreadInfo[] threadInfoList = threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 100);
+        for (ThreadInfo threadInfo : threadInfoList) {
+            threadDump.append('"');
+            threadDump.append(threadInfo.getThreadName());
+            threadDump.append("\":");
+            threadDump.append(threadInfo.getThreadState());
+            threadDump.append("\n");
+        }
+        threadDump.append("==================================");
+        log.info(threadDump::toString);
     }
 }


### PR DESCRIPTION
## Description 

Fix flaky tests and print thread info when thread count exceeds threshold

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
