### PR TITLE
Add support for Polly presigning

### DIFF
--- a/.changes/next-release/feature-AmazonPolly-022a93f.json
+++ b/.changes/next-release/feature-AmazonPolly-022a93f.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "Amazon Polly",
+    "description": "Add `PollyPresigner` which enables support for presigning `SynthesizeSpeech` requests."
+}

--- a/services/polly/src/it/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerIntegrationTest.java
+++ b/services/polly/src/it/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.internal.presigner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import javax.net.ssl.HttpsURLConnection;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.polly.model.OutputFormat;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.model.VoiceId;
+import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
+import software.amazon.awssdk.services.polly.presigner.model.SynthesizeSpeechPresignRequest;
+import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
+
+/**
+ * Integration tests for {@link DefaultPollyPresigner}.
+ */
+public class DefaultPollyPresignerIntegrationTest extends AwsIntegrationTestBase {
+
+    private static PollyPresigner presigner;
+
+    @BeforeClass
+    public static void setup() {
+        presigner = DefaultPollyPresigner.builder()
+                .credentialsProvider(getCredentialsProvider())
+                .build();
+    }
+
+    @Test
+    public void presign_requestIsValid() throws IOException {
+        SynthesizeSpeechRequest request = SynthesizeSpeechRequest.builder()
+                .text("hello world!")
+                .outputFormat(OutputFormat.PCM)
+                .voiceId(VoiceId.SALLI)
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(45))
+                .synthesizeSpeechRequest(request)
+                .build();
+
+        URL presignedUrl = presigner.presignSynthesizeSpeech(presignRequest).url();
+
+        HttpsURLConnection urlConnection = null;
+        try {
+            urlConnection = ((HttpsURLConnection) presignedUrl.openConnection());
+            urlConnection.connect();
+            assertThat(urlConnection.getResponseCode()).isEqualTo(200);
+            assertThat(urlConnection.getHeaderField("Content-Type")).isEqualTo("audio/pcm");
+        } finally {
+            urlConnection.getInputStream().close();
+        }
+    }
+
+}

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.internal.presigner;
+
+import static java.util.stream.Collectors.toMap;
+import static software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute.PRESIGNER_EXPIRATION;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
+import software.amazon.awssdk.awscore.presigner.PresignRequest;
+import software.amazon.awssdk.awscore.presigner.PresignedRequest;
+import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.signer.Presigner;
+import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.regions.providers.LazyAwsRegionProvider;
+import software.amazon.awssdk.services.polly.internal.presigner.model.transform.SynthesizeSpeechRequestMarshaller;
+import software.amazon.awssdk.services.polly.model.PollyRequest;
+import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
+import software.amazon.awssdk.services.polly.presigner.model.PresignedSynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.presigner.model.SynthesizeSpeechPresignRequest;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Default implementation of {@link PollyPresigner}.
+ */
+@SdkInternalApi
+public final class DefaultPollyPresigner implements PollyPresigner {
+    private static final String SIGNING_NAME = "polly";
+    private static final String SERVICE_NAME = "polly";
+    private static final AwsRegionProvider DEFAULT_REGION_PROVIDER =
+            new LazyAwsRegionProvider(DefaultAwsRegionProviderChain::new);
+    private static final AwsCredentialsProvider DEFAULT_CREDENTIALS_PROVIDER =
+            DefaultCredentialsProvider.create();
+    private static final Aws4Signer DEFAULT_SIGNER = Aws4Signer.create();
+
+    private final Region region;
+    private final AwsCredentialsProvider credentialsProvider;
+    private final URI endpointOverride;
+
+    private DefaultPollyPresigner(BuilderImpl builder) {
+        this.region = builder.region != null ? builder.region : DEFAULT_REGION_PROVIDER.getRegion();
+        this.credentialsProvider = builder.credentialsProvider != null
+                ? builder.credentialsProvider : DEFAULT_CREDENTIALS_PROVIDER;
+        this.endpointOverride = builder.endpointOverride;
+    }
+
+    public Region region() {
+        return region;
+    }
+
+    public AwsCredentialsProvider credentialsProvider() {
+        return credentialsProvider;
+    }
+
+    public URI endpointOverride() {
+        return endpointOverride;
+    }
+
+    @Override
+    public void close() {
+        IoUtils.closeIfCloseable(credentialsProvider, null);
+    }
+
+    public static PollyPresigner.Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public PresignedSynthesizeSpeechRequest presignSynthesizeSpeech(
+            SynthesizeSpeechPresignRequest synthesizeSpeechPresignRequest) {
+        return presign(PresignedSynthesizeSpeechRequest.builder(),
+                       synthesizeSpeechPresignRequest,
+                       synthesizeSpeechPresignRequest.synthesizeSpeechRequest(),
+                       SynthesizeSpeechRequestMarshaller.getInstance()::marshall)
+                .build();
+    }
+
+    private <T extends PollyRequest> SdkHttpFullRequest marshallRequest(
+            T request, Function<T, SdkHttpFullRequest.Builder> marshalFn) {
+        SdkHttpFullRequest.Builder requestBuilder = marshalFn.apply(request);
+        applyOverrideHeadersAndQueryParams(requestBuilder, request);
+        applyEndpoint(requestBuilder);
+        return requestBuilder.build();
+    }
+
+    /**
+     * Generate a {@link PresignedRequest} from a {@link PresignedRequest} and {@link PollyRequest}.
+     */
+    private <T extends PresignedRequest.Builder, U extends PollyRequest> T presign(T presignedRequest,
+                                                              PresignRequest presignRequest,
+                                                              U requestToPresign,
+                                                              Function<U, SdkHttpFullRequest.Builder> requestMarshaller) {
+        ExecutionAttributes execAttrs = createExecutionAttributes(presignRequest, requestToPresign);
+
+        SdkHttpFullRequest marshalledRequest = marshallRequest(requestToPresign, requestMarshaller);
+        SdkHttpFullRequest signedHttpRequest = presignRequest(requestToPresign, marshalledRequest, execAttrs);
+        initializePresignedRequest(presignedRequest, execAttrs, signedHttpRequest);
+        return presignedRequest;
+    }
+
+    private void initializePresignedRequest(PresignedRequest.Builder presignedRequest,
+                                            ExecutionAttributes execAttrs,
+                                            SdkHttpFullRequest signedHttpRequest) {
+        List<String> signedHeadersQueryParam = signedHttpRequest.rawQueryParameters().get("X-Amz-SignedHeaders");
+
+        Map<String, List<String>> signedHeaders =
+                signedHeadersQueryParam.stream()
+                        .flatMap(h -> Stream.of(h.split(";")))
+                        .collect(toMap(h -> h, h -> signedHttpRequest.firstMatchingHeader(h)
+                                .map(Collections::singletonList)
+                                .orElseGet(ArrayList::new)));
+
+        boolean isBrowserExecutable = signedHttpRequest.method() == SdkHttpMethod.GET &&
+                (signedHeaders.isEmpty() ||
+                        (signedHeaders.size() == 1 && signedHeaders.containsKey("host")));
+
+        presignedRequest.expiration(execAttrs.getAttribute(PRESIGNER_EXPIRATION))
+                .isBrowserExecutable(isBrowserExecutable)
+                .httpRequest(signedHttpRequest)
+                .signedHeaders(signedHeaders);
+    }
+
+    private SdkHttpFullRequest presignRequest(PollyRequest requestToPresign,
+                                              SdkHttpFullRequest marshalledRequest,
+                                              ExecutionAttributes executionAttributes) {
+        Presigner presigner = resolvePresigner(requestToPresign);
+        SdkHttpFullRequest presigned = presigner.presign(marshalledRequest, executionAttributes);
+        List<String> signedHeadersQueryParam = presigned.rawQueryParameters().get("X-Amz-SignedHeaders");
+        Validate.validState(signedHeadersQueryParam != null,
+                "Only SigV4 presigners are supported at this time, but the configured "
+                        + "presigner (%s) did not seem to generate a SigV4 signature.", presigner);
+        return presigned;
+    }
+
+    private ExecutionAttributes createExecutionAttributes(PresignRequest presignRequest, PollyRequest requestToPresign) {
+        Instant signatureExpiration = Instant.now().plus(presignRequest.signatureDuration());
+        AwsCredentials credentials = resolveCredentialsProvider(requestToPresign).resolveCredentials();
+        Validate.validState(credentials != null, "Credential providers must never return null.");
+
+        return new ExecutionAttributes()
+                .putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, credentials)
+                .putAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME, SIGNING_NAME)
+                .putAttribute(AwsExecutionAttribute.AWS_REGION, region())
+                .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, region())
+                .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, false)
+                .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, ClientType.SYNC)
+                .putAttribute(SdkExecutionAttribute.SERVICE_NAME, SERVICE_NAME)
+                .putAttribute(PRESIGNER_EXPIRATION, signatureExpiration);
+    }
+
+    private AwsCredentialsProvider resolveCredentialsProvider(PollyRequest request) {
+        return request.overrideConfiguration().flatMap(AwsRequestOverrideConfiguration::credentialsProvider)
+                .orElse(credentialsProvider());
+    }
+
+    private Presigner resolvePresigner(PollyRequest request) {
+        Signer signer = request.overrideConfiguration().flatMap(AwsRequestOverrideConfiguration::signer)
+                .orElse(DEFAULT_SIGNER);
+
+        return Validate.isInstanceOf(Presigner.class, signer,
+                "Signer of type %s given in request override is not a Presigner", signer.getClass().getSimpleName());
+    }
+
+    private void applyOverrideHeadersAndQueryParams(SdkHttpFullRequest.Builder httpRequestBuilder, PollyRequest request) {
+        request.overrideConfiguration().ifPresent(o -> {
+            o.headers().forEach(httpRequestBuilder::putHeader);
+            o.rawQueryParameters().forEach(httpRequestBuilder::putRawQueryParameter);
+        });
+    }
+
+    private void applyEndpoint(SdkHttpFullRequest.Builder httpRequestBuilder) {
+        URI uri = resolveEndpoint();
+        httpRequestBuilder.protocol(uri.getScheme())
+                .host(uri.getHost())
+                .port(uri.getPort());
+    }
+
+    private URI resolveEndpoint() {
+        if (endpointOverride() != null) {
+            return endpointOverride();
+        }
+
+        return new DefaultServiceEndpointBuilder(SERVICE_NAME, "https")
+                .withRegion(region())
+                .getServiceEndpoint();
+    }
+
+    public static class BuilderImpl implements PollyPresigner.Builder {
+        private Region region;
+        private AwsCredentialsProvider credentialsProvider;
+        private URI endpointOverride;
+
+        @Override
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        @Override
+        public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        @Override
+        public Builder endpointOverride(URI endpointOverride) {
+            this.endpointOverride = endpointOverride;
+            return this;
+        }
+
+        @Override
+        public PollyPresigner build() {
+            return new DefaultPollyPresigner(this);
+        }
+    }
+}

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/model/transform/SynthesizeSpeechRequestMarshaller.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/model/transform/SynthesizeSpeechRequestMarshaller.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.internal.presigner.model.transform;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+
+/**
+ * Marshaller for {@link SynthesizeSpeechRequest} that marshalls the request into a form that can be presigned.
+ */
+@SdkInternalApi
+public final class SynthesizeSpeechRequestMarshaller {
+    private static final SynthesizeSpeechRequestMarshaller INSTANCE = new SynthesizeSpeechRequestMarshaller();
+
+    public SdkHttpFullRequest.Builder marshall(SynthesizeSpeechRequest synthesizeSpeechRequest) {
+        SdkHttpFullRequest.Builder builder = SdkHttpFullRequest.builder()
+                .method(SdkHttpMethod.GET)
+                .encodedPath("/v1/speech");
+
+        if (synthesizeSpeechRequest.text() != null) {
+            builder.putRawQueryParameter("Text", synthesizeSpeechRequest.text());
+        }
+
+        if (synthesizeSpeechRequest.textType() != null) {
+            builder.putRawQueryParameter("TextType", synthesizeSpeechRequest.textTypeAsString());
+        }
+
+        if (synthesizeSpeechRequest.voiceId() != null) {
+            builder.putRawQueryParameter("VoiceId", synthesizeSpeechRequest.voiceIdAsString());
+        }
+
+        if (synthesizeSpeechRequest.sampleRate() != null) {
+            builder.putRawQueryParameter("SampleRate", synthesizeSpeechRequest.sampleRate());
+        }
+
+        if (synthesizeSpeechRequest.outputFormat() != null) {
+            builder.putRawQueryParameter("OutputFormat", synthesizeSpeechRequest.outputFormatAsString());
+        }
+
+        if (synthesizeSpeechRequest.lexiconNames() != null) {
+            builder.putRawQueryParameter("LexiconNames", synthesizeSpeechRequest.lexiconNames());
+        }
+
+        if (synthesizeSpeechRequest.speechMarkTypes() != null) {
+            builder.putRawQueryParameter("SpeechMarkTypes", synthesizeSpeechRequest.speechMarkTypesAsStrings());
+        }
+
+        if (synthesizeSpeechRequest.languageCode() != null) {
+            builder.putRawQueryParameter("LanguageCode", synthesizeSpeechRequest.languageCodeAsString());
+        }
+
+        if (synthesizeSpeechRequest.engine() != null) {
+            builder.putRawQueryParameter("Engine", synthesizeSpeechRequest.engineAsString());
+        }
+
+        return builder;
+    }
+
+    public static SynthesizeSpeechRequestMarshaller getInstance() {
+        return INSTANCE;
+    }
+}

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.presigner;
+
+import java.net.URI;
+import java.net.URLConnection;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.presigner.PresignedRequest;
+import software.amazon.awssdk.awscore.presigner.SdkPresigner;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.polly.internal.presigner.DefaultPollyPresigner;
+import software.amazon.awssdk.services.polly.model.PollyRequest;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.presigner.model.PresignedSynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.presigner.model.SynthesizeSpeechPresignRequest;
+
+/**
+ * Enables signing a {@link PollyRequest} so that it can be executed without requiring any additional authentication on the
+ * part of the caller.
+ * <p/>
+ *
+ * <b>Signature Duration</b>
+ * <p/>
+ *
+ * Pre-signed requests are only valid for a finite period of time, referred to as the signature duration. This signature
+ * duration is configured when the request is generated, and cannot be longer than 7 days. Attempting to generate a signature
+ * longer than 7 days in the future will fail at generation time. Attempting to use a pre-signed request after the signature
+ * duration has passed will result in an access denied response from the service.
+ * <p/>
+ *
+ * <b>Example Usage</b>
+ * <p/>
+ *
+ * <pre>
+ * {@code
+ *     // Create a PollyPresigner using the default region and credentials.
+ *     // This is usually done at application startup, because creating a presigner can be expensive.
+ *     PollyPresigner presigner = PollyPresigner.create();
+ *
+ *     // Create a SynthesizeSpeechRequest to be pre-signed
+ *     SynthesizeSpeechRequest synthesizeSpeechRequest =
+ *             SynthesizeSpeechRequest.builder()
+ *                                    .text("Hello Polly!")
+ *                                    .voiceId(VoiceId.SALLI)
+ *                                    .outputFormat(OutputFormat.PCM)
+ *                                    .build();
+ *
+ *     // Create a SynthesizeSpeechRequest to specify the signature duration
+ *     SynthesizeSpeechPresignRequest synthesizeSpeechPresignRequest =
+ *         SynthesizeSpeechPresignRequest.builder()
+ *                                .signatureDuration(Duration.ofMinutes(10))
+ *                                .synthesizeSpeechRequest(synthesizeSpeechRequest)
+ *                                .build();
+ *
+ *     // Generate the presigned request
+ *     PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest =
+ *         presigner.presignSynthesizeSpeech(SynthesizeSpeechPresignRequest);
+ *
+ *     // Log the presigned URL, for example.
+ *     System.out.println("Presigned URL: " + presignedSynthesizeSpeechRequest.url());
+ *
+ *     // It is recommended to close the presigner when it is done being used, because some credential
+ *     // providers (e.g. if your AWS profile is configured to assume an STS role) require system resources
+ *     // that need to be freed. If you are using one presigner per application (as recommended), this
+ *     // usually is not needed.
+ *     presigner.close();
+ * }
+ * </pre>
+ * <p/>
+ *
+ * <b>Browser Compatibility</b>
+ * <p/>
+ *
+ * Some pre-signed requests can be executed by a web browser. These "browser compatible" pre-signed requests
+ * do not require the customer to send anything other than a "host" header when performing an HTTP GET against
+ * the pre-signed URL.
+ * <p/>
+ *
+ * Whether a pre-signed request is "browser compatible" can be determined by checking the
+ * {@link PresignedRequest#isBrowserExecutable()} flag. It is recommended to always check this flag when the pre-signed
+ * request needs to be executed by a browser, because some request fields will result in the pre-signed request not
+ * being browser-compatible.
+ * <p />
+ *
+ * <b>Executing a Pre-Signed Request from Java code</b>
+ * <p />
+ *
+ * Browser-compatible requests (see above) can be executed using a web browser. All pre-signed requests can be executed
+ * from Java code. This documentation describes two methods for executing a pre-signed request: (1) using the JDK's
+ * {@link URLConnection} class, (2) using an SDK synchronous {@link SdkHttpClient} class.
+ *
+ * <p />
+ * <i>Using {code URLConnection}:</i>
+ *
+ * <p />
+ * <pre>
+ *     // Create a pre-signed request using one of the "presign" methods on PollyPresigner
+ *     PresignedRequest presignedRequest = ...;
+ *
+ *     // Create a JDK HttpURLConnection for communicating with Polly
+ *     HttpURLConnection connection = (HttpURLConnection) presignedRequest.url().openConnection();
+ *
+ *     // Specify any headers that are needed by the service (not needed when isBrowserExecutable is true)
+ *     presignedRequest.httpRequest().headers().forEach((header, values) -> {
+ *         values.forEach(value -> {
+ *             connection.addRequestProperty(header, value);
+ *         });
+ *     });
+ *
+ *     // Download the result of executing the request
+ *     try (InputStream content = connection.getInputStream()) {
+ *         System.out.println("Service returned response: ");
+ *         IoUtils.copy(content, myFileOutputstream);
+ *     }
+ * </pre>
+ */
+@SdkPublicApi
+public interface PollyPresigner extends SdkPresigner {
+
+    /**
+     * Presign a {@link SynthesizeSpeechRequest} so that it can be executed at a later time without requiring additional
+     * signing or authentication.
+     *
+     * @param synthesizeSpeechPresignRequest The presign request.
+     * @return The presigned request.
+     */
+    PresignedSynthesizeSpeechRequest presignSynthesizeSpeech(SynthesizeSpeechPresignRequest synthesizeSpeechPresignRequest);
+
+    /**
+     * Create an instance of this presigner using the default region and credentials chains to resolve the region and
+     * credentials to use.
+     */
+    static PollyPresigner create() {
+        return builder().build();
+    }
+
+    /**
+     * @return the builder for a {@link PollyPresigner}.
+     */
+    static Builder builder() {
+        return DefaultPollyPresigner.builder();
+    }
+
+    interface Builder extends SdkPresigner.Builder {
+        @Override
+        Builder region(Region region);
+
+        @Override
+        Builder credentialsProvider(AwsCredentialsProvider credentialsProvider);
+
+        @Override
+        Builder endpointOverride(URI endpointOverride);
+
+        PollyPresigner build();
+    }
+}

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/model/PresignedSynthesizeSpeechRequest.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/model/PresignedSynthesizeSpeechRequest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.presigner.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.presigner.PresignedRequest;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A pre-signed a {@link SynthesizeSpeechPresignRequest} that can be executed at a later time without requiring
+ * additional signing or authentication.
+ *
+ * @see software.amazon.awssdk.services.polly.presigner.PollyPresigner#presignSynthesizeSpeech(SynthesizeSpeechPresignRequest)
+ * @see #builder()
+ */
+@SdkPublicApi
+@Immutable
+@ThreadSafe
+public final class PresignedSynthesizeSpeechRequest
+        extends PresignedRequest
+        implements ToCopyableBuilder<PresignedSynthesizeSpeechRequest.Builder, PresignedSynthesizeSpeechRequest> {
+
+
+    private PresignedSynthesizeSpeechRequest(BuilderImpl builder) {
+        super(builder);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public interface Builder extends PresignedRequest.Builder,
+            CopyableBuilder<Builder, PresignedSynthesizeSpeechRequest> {
+
+        @Override
+        Builder expiration(Instant expiration);
+
+        @Override
+        Builder isBrowserExecutable(Boolean isBrowserExecutable);
+
+        @Override
+        Builder signedHeaders(Map<String, List<String>> signedHeaders);
+
+        @Override
+        Builder signedPayload(SdkBytes signedPayload);
+
+        @Override
+        Builder httpRequest(SdkHttpRequest httpRequest);
+
+        @Override
+        PresignedSynthesizeSpeechRequest build();
+    }
+
+    private static class BuilderImpl extends PresignedRequest.DefaultBuilder<BuilderImpl> implements Builder {
+
+        BuilderImpl() {
+        }
+
+        BuilderImpl(PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest) {
+            super(presignedSynthesizeSpeechRequest);
+        }
+
+        @Override
+        public PresignedSynthesizeSpeechRequest build() {
+            return new PresignedSynthesizeSpeechRequest(this);
+        }
+    }
+}

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/model/SynthesizeSpeechPresignRequest.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/model/SynthesizeSpeechPresignRequest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.presigner.model;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.presigner.PresignRequest;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A request to pre-sign a {@link software.amazon.awssdk.services.polly.presigner.PollyPresigner} so that it can be
+ * executed at a later time without requiring additional signing or authentication.
+ *
+ * @see software.amazon.awssdk.services.polly.presigner.PollyPresigner#presignSynthesizeSpeech(SynthesizeSpeechPresignRequest)
+ * @see #builder()
+ */
+@SdkPublicApi
+@Immutable
+@ThreadSafe
+public final class SynthesizeSpeechPresignRequest
+        extends PresignRequest
+        implements ToCopyableBuilder<SynthesizeSpeechPresignRequest.Builder, SynthesizeSpeechPresignRequest> {
+
+    private final SynthesizeSpeechRequest synthesizeSpeechRequest;
+
+    private SynthesizeSpeechPresignRequest(BuilderImpl builder) {
+        super(builder);
+        this.synthesizeSpeechRequest = builder.synthesizeSpeechRequest;
+    }
+
+    public SynthesizeSpeechRequest synthesizeSpeechRequest() {
+        return synthesizeSpeechRequest;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder extends PresignRequest.Builder,
+            CopyableBuilder<SynthesizeSpeechPresignRequest.Builder, SynthesizeSpeechPresignRequest> {
+
+        Builder synthesizeSpeechRequest(SynthesizeSpeechRequest synthesizeSpeechRequest);
+
+        Builder signatureDuration(Duration signatureDuration);
+
+        /**
+         * Build the presigned request, based on the configuration on this builder.
+         */
+        SynthesizeSpeechPresignRequest build();
+    }
+
+    private static class BuilderImpl extends PresignRequest.DefaultBuilder<BuilderImpl> implements Builder {
+        private SynthesizeSpeechRequest synthesizeSpeechRequest;
+
+        BuilderImpl() {
+        }
+
+        private BuilderImpl(SynthesizeSpeechPresignRequest synthesizeSpeechPresignRequest) {
+            super(synthesizeSpeechPresignRequest);
+            this.synthesizeSpeechRequest = synthesizeSpeechPresignRequest.synthesizeSpeechRequest();
+        }
+
+        @Override
+        public Builder synthesizeSpeechRequest(SynthesizeSpeechRequest synthesizeSpeechRequest) {
+            this.synthesizeSpeechRequest = synthesizeSpeechRequest;
+            return this;
+        }
+
+        @Override
+        public SynthesizeSpeechPresignRequest build() {
+            return new SynthesizeSpeechPresignRequest(this);
+        }
+    }
+}

--- a/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerTest.java
+++ b/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresignerTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.internal.presigner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.polly.model.OutputFormat;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
+import software.amazon.awssdk.services.polly.presigner.model.PresignedSynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.presigner.model.SynthesizeSpeechPresignRequest;
+
+/**
+ * Tests for {@link DefaultPollyPresigner}.
+ */
+public class DefaultPollyPresignerTest {
+    private static final SynthesizeSpeechRequest BASIC_SYNTHESIZE_SPEECH_REQUEST = SynthesizeSpeechRequest.builder()
+            .voiceId("Salli")
+            .outputFormat(OutputFormat.PCM)
+            .text("Hello presigners!")
+            .build();
+
+    private AwsCredentialsProvider credentialsProvider;
+
+    @Before
+    public void methodSetup() {
+        credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+    }
+
+    @Test
+    public void presign_requestLevelCredentials_honored() {
+        AwsCredentials requestCredentials = AwsBasicCredentials.create("akid2", "skid2");
+
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        SynthesizeSpeechRequest synthesizeSpeechRequest = BASIC_SYNTHESIZE_SPEECH_REQUEST.toBuilder()
+                .overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                        .credentialsProvider(StaticCredentialsProvider.create(requestCredentials)).build())
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .synthesizeSpeechRequest(synthesizeSpeechRequest)
+                .signatureDuration(Duration.ofHours(3))
+                .build();
+
+        PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest = presigner.presignSynthesizeSpeech(presignRequest);
+
+        assertThat(presignedSynthesizeSpeechRequest.url().getQuery()).contains("X-Amz-Credential=akid2");
+    }
+
+    @Test
+    public void presign_requestLevelHeaders_included() {
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        SynthesizeSpeechRequest synthesizeSpeechRequest = BASIC_SYNTHESIZE_SPEECH_REQUEST.toBuilder()
+                .overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                        .putHeader("Header1", "Header1Value")
+                        .putHeader("Header2", "Header2Value")
+                        .build())
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .synthesizeSpeechRequest(synthesizeSpeechRequest)
+                .signatureDuration(Duration.ofHours(3))
+                .build();
+
+        PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest = presigner.presignSynthesizeSpeech(presignRequest);
+
+        assertThat(presignedSynthesizeSpeechRequest.httpRequest().headers().keySet()).contains("Header1", "Header2");
+    }
+
+    @Test
+    public void presign_includesRequestLevelHeaders_notBrowserCompatible() {
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        SynthesizeSpeechRequest synthesizeSpeechRequest = BASIC_SYNTHESIZE_SPEECH_REQUEST.toBuilder()
+                .overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                        .putHeader("Header1", "Header1Value")
+                        .putHeader("Header2", "Header2Value")
+                        .build())
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .synthesizeSpeechRequest(synthesizeSpeechRequest)
+                .signatureDuration(Duration.ofHours(3))
+                .build();
+
+        PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest = presigner.presignSynthesizeSpeech(presignRequest);
+
+        assertThat(presignedSynthesizeSpeechRequest.isBrowserExecutable()).isFalse();
+    }
+
+    @Test
+    public void presign_includesRequestLevelQueryParams_included() {
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        SynthesizeSpeechRequest synthesizeSpeechRequest = BASIC_SYNTHESIZE_SPEECH_REQUEST.toBuilder()
+                .overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                        .putRawQueryParameter("QueryParam1", "Param1Value")
+                        .build())
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .synthesizeSpeechRequest(synthesizeSpeechRequest)
+                .signatureDuration(Duration.ofHours(3))
+                .build();
+
+        PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest = presigner.presignSynthesizeSpeech(presignRequest);
+
+        assertThat(presignedSynthesizeSpeechRequest.httpRequest().rawQueryParameters().keySet()).contains("QueryParam1");
+    }
+
+    @Test
+    public void presign_endpointOverriden() {
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(credentialsProvider)
+                .endpointOverride(URI.create("http://some-other-polly-endpoint.aws:1234"))
+                .build();
+
+        SynthesizeSpeechPresignRequest presignRequest = SynthesizeSpeechPresignRequest.builder()
+                .synthesizeSpeechRequest(BASIC_SYNTHESIZE_SPEECH_REQUEST)
+                .signatureDuration(Duration.ofHours(3))
+                .build();
+
+        PresignedSynthesizeSpeechRequest presignedSynthesizeSpeechRequest = presigner.presignSynthesizeSpeech(presignRequest);
+
+        URL presignedUrl = presignedSynthesizeSpeechRequest.url();
+
+        assertThat(presignedUrl.getProtocol()).isEqualTo("http");
+        assertThat(presignedUrl.getHost()).isEqualTo("some-other-polly-endpoint.aws");
+        assertThat(presignedUrl.getPort()).isEqualTo(1234);
+    }
+
+    @Test
+    public void close_closesCustomCloseableCredentialsProvider() throws IOException {
+        TestCredentialsProvider mockCredentialsProvider = mock(TestCredentialsProvider.class);
+
+        PollyPresigner presigner = DefaultPollyPresigner.builder()
+                .credentialsProvider(mockCredentialsProvider)
+                .build();
+
+        presigner.close();
+
+        verify(mockCredentialsProvider).close();
+    }
+
+    private interface TestCredentialsProvider extends AwsCredentialsProvider, Closeable {
+    }
+}

--- a/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/model/transform/SynthesizeSpeechRequestMarshallerTest.java
+++ b/services/polly/src/test/java/software/amazon/awssdk/services/polly/internal/presigner/model/transform/SynthesizeSpeechRequestMarshallerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.polly.internal.presigner.model.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+
+public class SynthesizeSpeechRequestMarshallerTest {
+    private static Map<String, Object> properties;
+
+    @BeforeClass
+    public static void setup() {
+        properties = new HashMap<>();
+
+        properties.put("Engine", "engine");
+        properties.put("LanguageCode", "languageCode");
+        properties.put("LexiconNames", Arrays.asList("Lexicon1", "Lexicon2", "Lexicon3"));
+        properties.put("OutputFormat", "outputFormat");
+        properties.put("SampleRate", "sampleRate");
+        properties.put("SpeechMarkTypes", Arrays.asList("SpeechMark1", "SpeechMark2"));
+        properties.put("Text", "text");
+        properties.put("TextType", "textType");
+        properties.put("VoiceId", "voiceId");
+    }
+
+    // Test to ensure that we are testing with all the known properties for
+    // this request. If this test fails, it means Polly added a new field to
+    // SynthesizeSpeechRequest and the marshaller and/or properties map above
+    // wasn't updated.
+    @Test
+    public void marshall_allPropertiesAccountedFor() {
+        SynthesizeSpeechRequest request = SynthesizeSpeechRequest.builder().build();
+        request.sdkFields().forEach(f -> assertThat(properties.containsKey(f.locationName())).isTrue());
+    }
+
+    @Test
+    public void marshall_allPropertiesMarshalled() {
+        SynthesizeSpeechRequest.Builder builder = setAllProperties(SynthesizeSpeechRequest.builder());
+
+        SdkHttpFullRequest.Builder marshalled = SynthesizeSpeechRequestMarshaller.getInstance().marshall(builder.build());
+
+        Map<String, List<String>> queryParams = marshalled.rawQueryParameters();
+
+        properties.keySet().forEach(k -> {
+            Object expected = properties.get(k);
+            List<String> actual = queryParams.get(k);
+            if (expected instanceof List) {
+                assertThat(actual).isEqualTo(expected);
+            } else {
+                assertThat(actual).containsExactly((String) expected);
+            }
+        });
+
+        assertThat(marshalled.contentStreamProvider()).isNull();
+    }
+
+    @Test
+    public void marshall_correctPath() {
+        SdkHttpFullRequest.Builder marshalled = SynthesizeSpeechRequestMarshaller.getInstance()
+                .marshall(SynthesizeSpeechRequest.builder().build());
+        assertThat(marshalled.encodedPath()).isEqualTo("/v1/speech");
+    }
+
+    @Test
+    public void marshall_correctMethod() {
+        SdkHttpFullRequest.Builder marshalled = SynthesizeSpeechRequestMarshaller.getInstance()
+                .marshall(SynthesizeSpeechRequest.builder().build());
+        assertThat(marshalled.method()).isEqualTo(SdkHttpMethod.GET);
+    }
+
+    private SynthesizeSpeechRequest.Builder setAllProperties(SynthesizeSpeechRequest.Builder builder) {
+        SynthesizeSpeechRequest request = SynthesizeSpeechRequest.builder().build();
+        List<SdkField<?>> sdkFields = request.sdkFields();
+        sdkFields.forEach(f -> f.set(builder, properties.get(f.locationName())));
+        return builder;
+    }
+}


### PR DESCRIPTION
## Description
Supports presigning for SynthesizeSpeechRequest.

## Motivation and Context
Part of #203 

## Testing
Unit and integration tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
