### PR TITLE
increase processOutputLimit from 1KB to 64KB according to issue #1490…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-71c6239.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-71c6239.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "The ProcessCredentialsProvider now supports credential files up to 64 KB by default through an increase of the processOutputLimit from 1024 bytes to 64000 bytes."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
@@ -53,7 +53,7 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
  *     start to be refreshed. This allows the credentials to be refreshed *before* they are reported to expire. Default: 15
  *     seconds.</li>
  *     <li>ProcessOutputLimit - The maximum amount of data that can be returned by the external process before an exception is
- *     raised. Default: 1024 bytes.</li>
+ *     raised. Default: 64000 bytes (64KB).</li>
  * </ul>
  */
 @SdkPublicApi
@@ -222,7 +222,7 @@ public final class ProcessCredentialsProvider implements AwsCredentialsProvider 
         private Boolean asyncCredentialUpdateEnabled = false;
         private String command;
         private Duration credentialRefreshThreshold = Duration.ofSeconds(15);
-        private long processOutputLimit = 1024;
+        private long processOutputLimit = 64000;
 
         /**
          * @see #builder()
@@ -264,7 +264,7 @@ public final class ProcessCredentialsProvider implements AwsCredentialsProvider 
          * Configure the maximum amount of data that can be returned by the external process before an exception is
          * raised.
          *
-         * <p>Default: 1024 bytes.</p>
+         * <p>Default: 64000 bytes (64KB).</p>
          */
         public Builder processOutputLimit(long outputByteLimit) {
             this.processOutputLimit = outputByteLimit;

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProviderTest.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.Instant;
+
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -33,6 +35,8 @@ import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Platform;
 
 public class ProcessCredentialsProviderTest {
+
+    private final static String PROCESS_RESOURCE_PATH = "/resources/process/";
     private static String scriptLocation;
  
     @BeforeClass
@@ -132,10 +136,36 @@ public class ProcessCredentialsProviderTest {
                                   .resolveCredentials();
     }
 
+    @Test
+    public void processOutputLimitDefaultPassesLargeInput() {
+
+        String LONG_SESSION_TOKEN = "lYzvmByqdS1E69QQVEavDDHabQ2GuYKYABKRA4xLbAXpdnFtV030UH4" +
+                "bQoZWCDcfADFvBwBm3ixEFTYMjn5XQozpFV2QAsWHirCVcEJ5DC60KPCNBcDi4KLNJfbsp3r6kKTOmYOeqhEyiC4emDX33X2ppZsa5" +
+                "1iwr6ShIZPOUPmuR4WDglmWubgO2q5tZv48xA5idkcHEmtGdoL343sY24q4gMh21eeBnF6ikjZdfvZ0Mn86UQ8r05AD346rSwM5bFs" +
+                "t019ZkJIjLHD3HoKJ44EndRvSvQClXfJCmmQDH5INiXdFLLNm0dzT3ynbVIW5x1YYBWptyts4NUSy2eJ3dTPjYICpQVCkbuNVA7PqR" +
+                "ctUyE8lU7uvnrIVnx9xTgl34J6D9VJKHQkPuGvbtN6w4CVtXoPAQcE8tlkKyOQmIeqEahhaqLW15t692SI6hwBW0b8DxCQawX5ukt4" +
+                "f5gZoRFz3u8qHMSnm5oEnTgv7C5AAs0V680YvelFMNYvSoSbDnoThxfTIG9msj7WBh7iNa7mI8TXmvOegQtDWR011ZOo8dR3jnhWNH" +
+                "nSW4CRB7iSC5DMZ2y56dYS28XGBl01LYXF5ZTJJfLwQEhbRWSTdXIBJq07E0YxRu0SaLokA4uknOoicwXnD7LMCld4hFjuypYgWBuk" +
+                "3pC09CPA0MJjQNTTAvxGqDTqSWoXWDZRIMUWyGyz3FCkpPUjv4mIpVYt2bGl6cHsMBzVnpL6yXMCw2mNqJx8Rvi4gQaHH6LzvHbVKR" +
+                "w4kE53703DNOc8cA9Zc0efJa4NHOFxc4XmMOtjGW7vbWPp0CTVCJLG94ddSFJrimpamPM59bs12x2ih51EpOFR5ITIxJnd79HEkYDU" +
+                "xRIOuPIe4VpM01RnFN4g3ChDqmjQ03wQY9I8Mvh59u3MujggQfwAhCc84MAz0jVukoMfhAAhMNUPLuwRj0qpqr6B3DdKZ4KDFWF2Ga" +
+                "Iu1sEFlKvPdfF1uefbTj6YdjUciWu1UBH47VbIcTbvbwmUiu2javB21kOenyDoelK5GUM4u0uPeXIOOhtZsJb8kz88h1joWkaKr2fc" +
+                "jrIS08FM47Y4Z2Mi4zfwyN54L";
+
+        ProcessCredentialsProvider credentialsProvider = ProcessCredentialsProvider.builder()
+                .command(scriptLocation + " accessKeyId secretAccessKey " + LONG_SESSION_TOKEN)
+                .build();
+
+        AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
+
+        Assertions.assertThat(sessionCredentials.accessKeyId()).isEqualTo("accessKeyId");
+        Assertions.assertThat(sessionCredentials.sessionToken()).isNotNull();
+    }
+
     public static String copyProcessCredentialsScript() {
         String scriptClasspathFilename = Platform.isWindows() ? "windows-credentials-script.bat"
                                                               : "linux-credentials-script.sh";
-        String scriptClasspathLocation = "/resources/process/" + scriptClasspathFilename;
+        String scriptClasspathLocation = PROCESS_RESOURCE_PATH + scriptClasspathFilename;
 
         InputStream scriptInputStream = null;
         OutputStream scriptOutputStream = null;


### PR DESCRIPTION
… and test that large credentials files pass

## Description
* Added a test that should allow credential files larger than 1024 bytes (previous limit) to be successfully passed to the `ProcessCredentialsProvider`
* Increased the processOutputLimit from 1024 bytes (1KB) to 64000 bytes (64KB) 

## Motivation and Context
Some credential files have large session tokens and when using the ProcessCredentialsProvider with the default value for the processOutputLimit, an exceptions is thrown, as described in issue
[#1490 ](https://github.com/aws/aws-sdk-java-v2/issues/1490). 

This value has now been increased. Note that the builder allows code to set a custom value for `processOutputLimit`. 
 
## Testing
1. Added the new unit test with a large session token string, making the whole file > 1100 bytes. The test failed
1. Increased processOutputLimit
1. Ran test successfully

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license