### PR TITLE
Expose the Byte Array from ByteArrayAsyncRequestBody

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
@@ -33,13 +33,13 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 @SdkInternalApi
 public final class ByteArrayAsyncRequestBody implements AsyncRequestBody {
 
-    private final byte[] bytes;
+    public final byte[] bytes;
 
     public ByteArrayAsyncRequestBody(byte[] bytes) {
         this.bytes = bytes.clone();
     }
     
-    public byte[] getBytes() { return bytes; }
+    // public byte[] getBytes() { return bytes; }
 
     @Override
     public Optional<Long> contentLength() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
@@ -38,6 +38,8 @@ public final class ByteArrayAsyncRequestBody implements AsyncRequestBody {
     public ByteArrayAsyncRequestBody(byte[] bytes) {
         this.bytes = bytes.clone();
     }
+    
+    public byte[] getBytes = { return bytes; }
 
     @Override
     public Optional<Long> contentLength() {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBody.java
@@ -39,7 +39,7 @@ public final class ByteArrayAsyncRequestBody implements AsyncRequestBody {
         this.bytes = bytes.clone();
     }
     
-    public byte[] getBytes = { return bytes; }
+    public byte[] getBytes() { return bytes; }
 
     @Override
     public Optional<Long> contentLength() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
@@ -62,7 +62,7 @@ public class ByteArrayAsyncRequestBodyTest {
     @Test
     public void getBytes_shouldReturnBytesArray() {
         ByteArrayAsyncRequestBody byteArrayReq = new ByteArrayAsyncRequestBody("Hello World!".getBytes());
-        assertTrue(byteArrayReq.getBytes == "Hello World!".getBytes());
+        assertArrayEquals(byteArrayReq.getBytes, "Hello World!".getBytes());
     }
 
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
@@ -62,7 +62,7 @@ public class ByteArrayAsyncRequestBodyTest {
     @Test
     public void getBytes_shouldReturnBytesArray() {
         ByteArrayAsyncRequestBody byteArrayReq = new ByteArrayAsyncRequestBody("Hello World!".getBytes());
-        assertArrayEquals(byteArrayReq.getBytes, "Hello World!".getBytes());
+        assertArrayEquals(byteArrayReq.getBytes(), "Hello World!".getBytes());
     }
 
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
@@ -58,11 +58,5 @@ public class ByteArrayAsyncRequestBodyTest {
         byteArrayReq.subscribe(subscriber);
         assertTrue(subscriber.onCompleteCalled.get());
     }
-    
-    @Test
-    public void getBytes_shouldReturnBytesArray() {
-        ByteArrayAsyncRequestBody byteArrayReq = new ByteArrayAsyncRequestBody("Hello World!".getBytes());
-        assertArrayEquals(byteArrayReq.getBytes(), "Hello World!".getBytes());
-    }
 
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteArrayAsyncRequestBodyTest.java
@@ -58,5 +58,11 @@ public class ByteArrayAsyncRequestBodyTest {
         byteArrayReq.subscribe(subscriber);
         assertTrue(subscriber.onCompleteCalled.get());
     }
+    
+    @Test
+    public void getBytes_shouldReturnBytesArray() {
+        ByteArrayAsyncRequestBody byteArrayReq = new ByteArrayAsyncRequestBody("Hello World!".getBytes());
+        assertTrue(byteArrayReq.getBytes == "Hello World!".getBytes());
+    }
 
 }


### PR DESCRIPTION
Ability to expose the byte array from AsyncRequestBody using a getter would help in certain scenarios and compatibility when testing frameworks rely on AWS SDK version 1.

## Description
The byte array in the AsyncRequestBody, if extractable, could help generate an inputstream that could be used to create a PutObjectRequest compatible with AWS SDK V1 for testing purposes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
