### PR TITLE
S3: Interacting with an access point in a different region to the one…

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-0f180ea.json
+++ b/.changes/next-release/bugfix-AmazonS3-0f180ea.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "description": "Interacting with an access point in a different region to the one the S3 client is configured for will no longer result in the request being signed for the wrong region and rejected by S3."
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/AccessPointsIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/AccessPointsIntegrationTest.java
@@ -84,4 +84,25 @@ public class AccessPointsIntegrationTest extends S3IntegrationTestBase {
 
         assertThat(objectContent).isEqualTo("helloworld");
     }
+
+    @Test
+    public void transfer_Succeeds_UsingAccessPoint_CrossRegion() {
+        S3Client s3DifferentRegion =
+            s3ClientBuilder().region(Region.US_EAST_1).serviceConfiguration(c -> c.useArnRegionEnabled(true)).build();
+
+        StringJoiner apArn = new StringJoiner(":");
+        apArn.add("arn").add("aws").add("s3").add("us-west-2").add(accountId).add("accesspoint").add(AP_NAME);
+
+        s3DifferentRegion.putObject(PutObjectRequest.builder()
+                                                    .bucket(apArn.toString())
+                                                    .key(KEY)
+                                                    .build(), RequestBody.fromString("helloworld"));
+
+        String objectContent = s3DifferentRegion.getObjectAsBytes(GetObjectRequest.builder()
+                                                                                  .bucket(apArn.toString())
+                                                                                  .key(KEY)
+                                                                                  .build()).asUtf8String();
+
+        assertThat(objectContent).isEqualTo("helloworld");
+    }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Utilities.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.function.Consumer;
+
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -154,7 +155,8 @@ public final class S3Utilities {
                                                                                 getObjectRequest,
                                                                                 resolvedRegion,
                                                                                 s3Configuration,
-                                                                                endpointOverridden);
+                                                                                endpointOverridden)
+                                                    .sdkHttpRequest();
 
         try {
             return httpRequest.getUri().toURL();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/ConfiguredS3SdkHttpRequest.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/ConfiguredS3SdkHttpRequest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal;
+
+import java.util.Optional;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@SdkInternalApi
+public class ConfiguredS3SdkHttpRequest
+        implements ToCopyableBuilder<ConfiguredS3SdkHttpRequest.Builder, ConfiguredS3SdkHttpRequest> {
+    private final SdkHttpRequest sdkHttpRequest;
+    private final Region signingRegionModification;
+
+    private ConfiguredS3SdkHttpRequest(Builder builder) {
+        this.sdkHttpRequest = Validate.notNull(builder.sdkHttpRequest, "sdkHttpRequest");
+        this.signingRegionModification = builder.signingRegionModification;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public SdkHttpRequest sdkHttpRequest() {
+        return sdkHttpRequest;
+    }
+
+    public Optional<Region> signingRegionModification() {
+        return Optional.ofNullable(signingRegionModification);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().sdkHttpRequest(sdkHttpRequest).signingRegionModification(signingRegionModification);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ConfiguredS3SdkHttpRequest that = (ConfiguredS3SdkHttpRequest) o;
+
+        if (sdkHttpRequest != null ? ! sdkHttpRequest.equals(that.sdkHttpRequest) : that.sdkHttpRequest != null) {
+            return false;
+        }
+        return signingRegionModification != null ?
+            signingRegionModification.equals(that.signingRegionModification)
+            : that.signingRegionModification == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = sdkHttpRequest != null ? sdkHttpRequest.hashCode() : 0;
+        result = 31 * result + (signingRegionModification != null ? signingRegionModification.hashCode() : 0);
+        return result;
+    }
+
+    public static class Builder implements CopyableBuilder<Builder, ConfiguredS3SdkHttpRequest> {
+        private SdkHttpRequest sdkHttpRequest;
+        private Region signingRegionModification;
+
+        private Builder() {}
+
+        public Builder sdkHttpRequest(SdkHttpRequest sdkHttpRequest) {
+            this.sdkHttpRequest = sdkHttpRequest;
+            return this;
+        }
+
+        public Builder signingRegionModification(Region signingRegionModification) {
+            this.signingRegionModification = signingRegionModification;
+            return this;
+        }
+
+        @Override
+        public ConfiguredS3SdkHttpRequest build() {
+            return new ConfiguredS3SdkHttpRequest(this);
+        }
+    }
+
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/EndpointAddressInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/EndpointAddressInterceptorTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.s3.internal.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute.SIGNING_REGION;
 import static software.amazon.awssdk.awscore.AwsExecutionAttribute.AWS_REGION;
 import static software.amazon.awssdk.core.interceptor.SdkExecutionAttribute.SERVICE_CONFIG;
 import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlEncode;
@@ -24,6 +25,8 @@ import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlEncode;
 import java.net.URI;
 import java.util.Optional;
 import org.junit.Test;
+
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.interceptor.Context;
@@ -131,6 +134,7 @@ public class EndpointAddressInterceptorTest {
         verifyAccesspointArn("http",
                              "arn:aws:s3:us-future-1:12345678910:accesspoint:foobar",
                              "http://foobar-12345678910.s3-accesspoint.us-future-1.amazonaws.com",
+                             Region.of("us-future-1"),
                              S3Configuration.builder(),
                              Region.of("us-future-1"));
     }
@@ -140,6 +144,7 @@ public class EndpointAddressInterceptorTest {
         verifyAccesspointArn("http",
                              "arn:aws:s3:us-future-2:12345678910:accesspoint:foobar",
                              "http://foobar-12345678910.s3-accesspoint.us-future-2.amazonaws.com",
+                             Region.of("us-future-2"),
                              S3Configuration.builder().useArnRegionEnabled(true),
                              Region.of("us-future-1"));
     }
@@ -149,6 +154,7 @@ public class EndpointAddressInterceptorTest {
         verifyAccesspointArn("http",
                              "arn:aws-cn:s3:cn-future-1:12345678910:accesspoint:foobar",
                              "http://foobar-12345678910.s3-accesspoint.cn-future-1.amazonaws.com.cn",
+                             Region.of("cn-future-1"),
                              S3Configuration.builder(),
                              Region.of("cn-future-1"));
     }
@@ -158,6 +164,7 @@ public class EndpointAddressInterceptorTest {
         verifyAccesspointArn("http",
                              "arn:aws:s3:unknown:12345678910:accesspoint:foobar",
                              "http://foobar-12345678910.s3-accesspoint.unknown.amazonaws.com",
+                             Region.of("unknown"),
                              S3Configuration.builder(),
                              Region.of("unknown"));
     }
@@ -232,11 +239,13 @@ public class EndpointAddressInterceptorTest {
         verifyAccesspointArn("http",
                              "arn:aws-cn:s3:cn-north-1:12345678910:accesspoint:foobar",
                              "http://foobar-12345678910.s3-accesspoint.cn-north-1.amazonaws.com.cn",
+                             Region.of("cn-north-1"),
                              S3Configuration.builder(),
                              Region.of("cn-north-1"));
         verifyAccesspointArn("https",
                              "arn:aws-cn:s3:cn-north-1:12345678910:accesspoint:foobar",
                              "https://foobar-12345678910.s3-accesspoint.cn-north-1.amazonaws.com.cn",
+                             Region.of("cn-north-1"),
                              S3Configuration.builder(),
                              Region.of("cn-north-1"));
     }
@@ -246,6 +255,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                                                       "arn:aws-cn:s3:cn-north-1:12345678910:accesspoint:foobar",
                                                       "http://foobar-12345678910.s3-accesspoint.cn-north-1.amazonaws.com.cn",
+                                                      Region.of("cn-north-1"),
                                                       S3Configuration.builder().useArnRegionEnabled(true),
                                                       Region.of("us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -257,6 +267,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                              "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                             Region.of("us-east-1"),
                              S3Configuration.builder().useArnRegionEnabled(true),
                              Region.of("fips-us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -264,6 +275,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("https",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                              "https://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                             Region.of("us-east-1"),
                              S3Configuration.builder().useArnRegionEnabled(true),
                              Region.of("fips-us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -275,6 +287,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder(),
                                                       Region.of("fips-us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -282,6 +295,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("https",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "https://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder(),
                                                       Region.of("fips-us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -293,6 +307,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder().useArnRegionEnabled(true),
                                                       Region.of("us-east-1-fips")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -300,6 +315,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("https",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "https://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder().useArnRegionEnabled(true),
                                                       Region.of("us-east-1-fips")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -311,6 +327,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder(),
                                                       Region.of("us-east-1-fips")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -318,6 +335,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("https",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "https://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder(),
                                                       Region.of("us-east-1-fips")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -329,6 +347,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder().accelerateModeEnabled(true),
                                                       Region.of("us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -341,6 +360,7 @@ public class EndpointAddressInterceptorTest {
         assertThatThrownBy(() -> verifyAccesspointArn("http",
                                                       "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
                                                       "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                                                      Region.of("us-east-1"),
                                                       S3Configuration.builder().pathStyleAccessEnabled(true),
                                                       Region.of("us-east-1")))
             .isInstanceOf(IllegalArgumentException.class)
@@ -410,6 +430,7 @@ public class EndpointAddressInterceptorTest {
     }
 
     private void verifyAccesspointArn(String protocol, String accessPointArn, String expectedEndpoint,
+                                      Region expectedSigningRegion,
                                       S3Configuration.Builder builder, Region region) {
         String key = "test-key";
 
@@ -425,16 +446,19 @@ public class EndpointAddressInterceptorTest {
 
         executionAttributes.putAttribute(SERVICE_CONFIG, s3Configuration);
         executionAttributes.putAttribute(AWS_REGION, region);
+        executionAttributes.putAttribute(SIGNING_REGION, region);
 
         SdkHttpRequest sdkHttpFullRequest = interceptor.modifyHttpRequest(ctx, executionAttributes);
 
+        assertThat(executionAttributes.getAttribute(SIGNING_REGION))
+            .isEqualTo(expectedSigningRegion);
         assertThat(sdkHttpFullRequest.getUri()).isEqualTo(expectedUri);
     }
 
 
     private void verifyAccesspointArn(String protocol, String accessPointArn, String expectedEndpoint,
                                       S3Configuration.Builder builder) {
-        verifyAccesspointArn(protocol, accessPointArn, expectedEndpoint, builder, Region.US_EAST_1);
+        verifyAccesspointArn(protocol, accessPointArn, expectedEndpoint, Region.US_EAST_1, builder, Region.US_EAST_1);
     }
 
     private Context.ModifyHttpRequest context(SdkRequest request, SdkHttpRequest sdkHttpRequest) {


### PR DESCRIPTION
… the S3 client is configured for will no longer result in the request being signed for the wrong region and rejected by S3.

## Testing
Added unit test and integration test for scenario.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
