### PR TITLE
Add list/map existence check (#867)

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-a67e196.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-a67e196.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Adds a `has*` method to requests and responses that have a List or Map property."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
@@ -179,6 +179,7 @@ abstract class AddShapes {
                 .withFluentEnumGetterMethodName(namingStrategy.getFluentEnumGetterMethodName(c2jMemberName, parentShape, shape))
                 .withFluentSetterMethodName(namingStrategy.getFluentSetterMethodName(c2jMemberName, parentShape, shape))
                 .withFluentEnumSetterMethodName(namingStrategy.getFluentEnumSetterMethodName(c2jMemberName, parentShape, shape))
+                .withExistenceCheckMethodName(namingStrategy.getExistenceCheckMethodName(c2jMemberName, parentShape))
                 .withBeanStyleGetterMethodName(namingStrategy.getBeanStyleGetterMethodName(c2jMemberName, parentShape, shape))
                 .withBeanStyleSetterMethodName(namingStrategy.getBeanStyleSetterMethodName(c2jMemberName, parentShape, shape));
         memberModel.setIdempotencyToken(c2jMemberDefinition.isIdempotencyToken());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DocumentationUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DocumentationUtils.java
@@ -36,6 +36,11 @@ public final class DocumentationUtils {
 
     private static final String DEFAULT_GETTER_PARAM = "The value of the %s property for this object.";
 
+    private static final String DEFAULT_EXISTENCE_CHECK = "Returns true if the %s property was specified by the sender "
+                                                          + "(it may be empty), or false if the sender did not specify "
+                                                          + "the value (it will be empty). For responses returned by the SDK, "
+                                                          + "the sender is the AWS service.";
+
     private static final String DEFAULT_FLUENT_RETURN =
             "Returns a reference to this object so that method calls can be chained together.";
 
@@ -163,5 +168,9 @@ public final class DocumentationUtils {
 
     public static String defaultFluentReturn() {
         return DEFAULT_FLUENT_RETURN;
+    }
+
+    public static String defaultExistenceCheck() {
+        return DEFAULT_EXISTENCE_CHECK;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -293,6 +293,13 @@ public class DefaultNamingStrategy implements NamingStrategy {
     }
 
     @Override
+    public String getExistenceCheckMethodName(String memberName, Shape parentShape) {
+        String existenceCheckMethodName = Utils.unCapitalize(memberName);
+        existenceCheckMethodName = rewriteInvalidMemberName(existenceCheckMethodName, parentShape);
+        return String.format("has%s", Utils.capitalize(existenceCheckMethodName));
+    }
+
+    @Override
     public String getBeanStyleGetterMethodName(String memberName, Shape parentShape, Shape c2jShape) {
         String fluentGetterMethodName = getFluentGetterMethodName(memberName, parentShape, c2jShape);
         return String.format("get%s", Utils.capitalize(fluentGetterMethodName));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/NamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/NamingStrategy.java
@@ -146,4 +146,13 @@ public interface NamingStrategy {
      * @return Name of field for {@link SdkField} pojo.
      */
     String getSdkFieldFieldName(MemberModel memberModel);
+
+    /**
+     * Names a method that would check for existence of the member in the response.
+     *
+     * @param memberName The member name to get the method name for.
+     * @param parentShape The shape containing the member.
+     * @return Name of an existence check method.
+     */
+    String getExistenceCheckMethodName(String memberName, Shape parentShape);
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -27,6 +27,8 @@ import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -36,344 +38,344 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class AllTypesRequest extends JsonProtocolTestsRequest implements
-        ToCopyableBuilder<AllTypesRequest.Builder, AllTypesRequest> {
+                                                                    ToCopyableBuilder<AllTypesRequest.Builder, AllTypesRequest> {
     private static final SdkField<String> STRING_MEMBER_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesRequest::stringMember)).setter(setter(Builder::stringMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
+        .getter(getter(AllTypesRequest::stringMember)).setter(setter(Builder::stringMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
 
     private static final SdkField<Integer> INTEGER_MEMBER_FIELD = SdkField.<Integer> builder(MarshallingType.INTEGER)
-            .getter(getter(AllTypesRequest::integerMember)).setter(setter(Builder::integerMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
+        .getter(getter(AllTypesRequest::integerMember)).setter(setter(Builder::integerMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
 
     private static final SdkField<Boolean> BOOLEAN_MEMBER_FIELD = SdkField.<Boolean> builder(MarshallingType.BOOLEAN)
-            .getter(getter(AllTypesRequest::booleanMember)).setter(setter(Builder::booleanMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
+        .getter(getter(AllTypesRequest::booleanMember)).setter(setter(Builder::booleanMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
 
     private static final SdkField<Float> FLOAT_MEMBER_FIELD = SdkField.<Float> builder(MarshallingType.FLOAT)
-            .getter(getter(AllTypesRequest::floatMember)).setter(setter(Builder::floatMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
+        .getter(getter(AllTypesRequest::floatMember)).setter(setter(Builder::floatMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
 
     private static final SdkField<Double> DOUBLE_MEMBER_FIELD = SdkField.<Double> builder(MarshallingType.DOUBLE)
-            .getter(getter(AllTypesRequest::doubleMember)).setter(setter(Builder::doubleMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
+        .getter(getter(AllTypesRequest::doubleMember)).setter(setter(Builder::doubleMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
 
     private static final SdkField<Long> LONG_MEMBER_FIELD = SdkField.<Long> builder(MarshallingType.LONG)
-            .getter(getter(AllTypesRequest::longMember)).setter(setter(Builder::longMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
+        .getter(getter(AllTypesRequest::longMember)).setter(setter(Builder::longMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
 
     private static final SdkField<List<String>> SIMPLE_LIST_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::simpleList))
-            .setter(setter(Builder::simpleList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::simpleList))
+        .setter(setter(Builder::simpleList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<String>> LIST_OF_ENUMS_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfEnumsAsStrings))
-            .setter(setter(Builder::listOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfEnumsAsStrings))
+        .setter(setter(Builder::listOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAPS_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfMaps))
-            .setter(setter(Builder::listOfMaps))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfMaps))
+        .setter(setter(Builder::listOfMaps))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<List<SimpleStruct>> LIST_OF_STRUCTS_FIELD = SdkField
-            .<List<SimpleStruct>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfStructs))
-            .setter(setter(Builder::listOfStructs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SimpleStruct>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfStructs))
+        .setter(setter(Builder::listOfStructs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                            .constructor(SimpleStruct::builder)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfMapOfEnumToStringAsStrings))
-            .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfMapOfEnumToStringAsStrings))
+        .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<Integer>>> MAP_OF_STRING_TO_INTEGER_LIST_FIELD = SdkField
-            .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToIntegerList))
-            .setter(setter(Builder::mapOfStringToIntegerList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<Integer>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<Integer> builder(MarshallingType.INTEGER)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToIntegerList))
+        .setter(setter(Builder::mapOfStringToIntegerList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<Integer>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<Integer> builder(MarshallingType.INTEGER)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToString))
-            .setter(setter(Builder::mapOfStringToString))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToString))
+        .setter(setter(Builder::mapOfStringToString))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToSimpleStruct))
-            .setter(setter(Builder::mapOfStringToSimpleStruct))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToSimpleStruct))
+        .setter(setter(Builder::mapOfStringToSimpleStruct))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToStringAsStrings))
-            .setter(setter(Builder::mapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToStringAsStrings))
+        .setter(setter(Builder::mapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToSimpleStructAsStrings))
-            .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToSimpleStructAsStrings))
+        .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<String>>> MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD = SdkField
-            .<Map<String, List<String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToListOfEnumsAsStrings))
-            .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToListOfEnumsAsStrings))
+        .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<String>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, Map<String, String>>> MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToMapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
-                    .build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToMapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
+                             .build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        MapTrait.builder()
+                                                .keyLocationName("key")
+                                                .valueLocationName("value")
+                                                .valueFieldInfo(
+                                                    SdkField.<String> builder(MarshallingType.STRING)
+                                                        .traits(LocationTrait.builder()
+                                                                             .location(MarshallLocation.PAYLOAD)
+                                                                             .locationName("value").build()).build())
+                                                .build()).build()).build()).build();
 
     private static final SdkField<Instant> TIMESTAMP_MEMBER_FIELD = SdkField.<Instant> builder(MarshallingType.INSTANT)
-            .getter(getter(AllTypesRequest::timestampMember)).setter(setter(Builder::timestampMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
+        .getter(getter(AllTypesRequest::timestampMember)).setter(setter(Builder::timestampMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
 
     private static final SdkField<StructWithTimestamp> STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD = SdkField
-            .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesRequest::structWithNestedTimestampMember))
-            .setter(setter(Builder::structWithNestedTimestampMember))
-            .constructor(StructWithTimestamp::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
-                    .build()).build();
+        .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesRequest::structWithNestedTimestampMember))
+        .setter(setter(Builder::structWithNestedTimestampMember))
+        .constructor(StructWithTimestamp::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
+                             .build()).build();
 
     private static final SdkField<SdkBytes> BLOB_ARG_FIELD = SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-            .getter(getter(AllTypesRequest::blobArg)).setter(setter(Builder::blobArg))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
+        .getter(getter(AllTypesRequest::blobArg)).setter(setter(Builder::blobArg))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
 
     private static final SdkField<StructWithNestedBlobType> STRUCT_WITH_NESTED_BLOB_FIELD = SdkField
-            .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::structWithNestedBlob))
-            .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
-            .build();
+        .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::structWithNestedBlob))
+                                                                     .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
+                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
+                                                                     .build();
 
     private static final SdkField<Map<String, SdkBytes>> BLOB_MAP_FIELD = SdkField
-            .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::blobMap))
-            .setter(setter(Builder::blobMap))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::blobMap))
+        .setter(setter(Builder::blobMap))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<List<SdkBytes>> LIST_OF_BLOBS_FIELD = SdkField
-            .<List<SdkBytes>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfBlobs))
-            .setter(setter(Builder::listOfBlobs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SdkBytes>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfBlobs))
+        .setter(setter(Builder::listOfBlobs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<RecursiveStructType> RECURSIVE_STRUCT_FIELD = SdkField
-            .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::recursiveStruct))
-            .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
+        .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::recursiveStruct))
+                                                                .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
+                                                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
 
     private static final SdkField<BaseType> POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD = SdkField
-            .<BaseType> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesRequest::polymorphicTypeWithSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithSubTypes))
-            .constructor(BaseType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
-                    .build()).build();
+        .<BaseType> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesRequest::polymorphicTypeWithSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithSubTypes))
+        .constructor(BaseType::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
+                             .build()).build();
 
     private static final SdkField<SubTypeOne> POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD = SdkField
-            .<SubTypeOne> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesRequest::polymorphicTypeWithoutSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
-            .constructor(SubTypeOne::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
-                    .build()).build();
+        .<SubTypeOne> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesRequest::polymorphicTypeWithoutSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
+        .constructor(SubTypeOne::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
+                             .build()).build();
 
     private static final SdkField<String> ENUM_TYPE_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesRequest::enumTypeAsString)).setter(setter(Builder::enumType))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
+        .getter(getter(AllTypesRequest::enumTypeAsString)).setter(setter(Builder::enumType))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(STRING_MEMBER_FIELD,
-            INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
-            SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
-            LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
-            MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
-            BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
-            POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
+                                                                                                   INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
+                                                                                                   SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
+                                                                                                   LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
+                                                                                                   MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
+                                                                                                   BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
+                                                                                                   POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
 
     private final String stringMember;
 
@@ -471,7 +473,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the StringMember property for this object.
-     * 
+     *
      * @return The value of the StringMember property for this object.
      */
     public String stringMember() {
@@ -480,7 +482,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the IntegerMember property for this object.
-     * 
+     *
      * @return The value of the IntegerMember property for this object.
      */
     public Integer integerMember() {
@@ -489,7 +491,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the BooleanMember property for this object.
-     * 
+     *
      * @return The value of the BooleanMember property for this object.
      */
     public Boolean booleanMember() {
@@ -498,7 +500,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the FloatMember property for this object.
-     * 
+     *
      * @return The value of the FloatMember property for this object.
      */
     public Float floatMember() {
@@ -507,7 +509,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the DoubleMember property for this object.
-     * 
+     *
      * @return The value of the DoubleMember property for this object.
      */
     public Double doubleMember() {
@@ -516,7 +518,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the LongMember property for this object.
-     * 
+     *
      * @return The value of the LongMember property for this object.
      */
     public Long longMember() {
@@ -524,11 +526,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the SimpleList property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSimpleList() {
+        return simpleList != null && !(simpleList instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the SimpleList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasSimpleList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the SimpleList property for this object.
      */
     public List<String> simpleList() {
@@ -540,7 +553,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<EnumType> listOfEnums() {
@@ -548,11 +564,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfEnums property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfEnums() {
+        return listOfEnums != null && !(listOfEnums instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<String> listOfEnumsAsStrings() {
@@ -560,11 +587,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfMaps property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfMaps() {
+        return listOfMaps != null && !(listOfMaps instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMaps property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMaps()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMaps property for this object.
      */
     public List<Map<String, String>> listOfMaps() {
@@ -572,11 +610,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfStructs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfStructs() {
+        return listOfStructs != null && !(listOfStructs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfStructs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfStructs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfStructs property for this object.
      */
     public List<SimpleStruct> listOfStructs() {
@@ -588,7 +637,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<EnumType, String>> listOfMapOfEnumToString() {
@@ -596,11 +648,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfMapOfEnumToString property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfMapOfEnumToString() {
+        return listOfMapOfEnumToString != null && !(listOfMapOfEnumToString instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<String, String>> listOfMapOfEnumToStringAsStrings() {
@@ -608,11 +672,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToIntegerList property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToIntegerList() {
+        return mapOfStringToIntegerList != null && !(mapOfStringToIntegerList instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToIntegerList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToIntegerList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToIntegerList property for this object.
      */
     public Map<String, List<Integer>> mapOfStringToIntegerList() {
@@ -620,11 +696,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToString() {
+        return mapOfStringToString != null && !(mapOfStringToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToString property for this object.
      */
     public Map<String, String> mapOfStringToString() {
@@ -632,11 +720,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToSimpleStruct() {
+        return mapOfStringToSimpleStruct != null && !(mapOfStringToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfStringToSimpleStruct() {
@@ -648,7 +748,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<EnumType, EnumType> mapOfEnumToEnum() {
@@ -656,11 +759,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToEnum() {
+        return mapOfEnumToEnum != null && !(mapOfEnumToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<String, String> mapOfEnumToEnumAsStrings() {
@@ -672,7 +787,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<EnumType, String> mapOfEnumToString() {
@@ -680,11 +798,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToString() {
+        return mapOfEnumToString != null && !(mapOfEnumToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<String, String> mapOfEnumToStringAsStrings() {
@@ -696,7 +826,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, EnumType> mapOfStringToEnum() {
@@ -704,11 +837,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToEnum() {
+        return mapOfStringToEnum != null && !(mapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, String> mapOfStringToEnumAsStrings() {
@@ -720,7 +865,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct() {
@@ -728,11 +876,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToSimpleStruct() {
+        return mapOfEnumToSimpleStruct != null && !(mapOfEnumToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfEnumToSimpleStructAsStrings() {
@@ -744,7 +904,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<EnumType, List<EnumType>> mapOfEnumToListOfEnums() {
@@ -752,11 +915,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToListOfEnums property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToListOfEnums() {
+        return mapOfEnumToListOfEnums != null && !(mapOfEnumToListOfEnums instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<String, List<String>> mapOfEnumToListOfEnumsAsStrings() {
@@ -768,7 +943,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum() {
@@ -776,11 +954,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToMapOfStringToEnum property was specified by the sender (it may be empty), or false
+     * if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the
+     * AWS service.
+     */
+    public boolean hasMapOfEnumToMapOfStringToEnum() {
+        return mapOfEnumToMapOfStringToEnum != null && !(mapOfEnumToMapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToMapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumAsStrings() {
@@ -789,7 +979,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the TimestampMember property for this object.
-     * 
+     *
      * @return The value of the TimestampMember property for this object.
      */
     public Instant timestampMember() {
@@ -798,7 +988,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the StructWithNestedTimestampMember property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedTimestampMember property for this object.
      */
     public StructWithTimestamp structWithNestedTimestampMember() {
@@ -807,7 +997,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * 
+     *
      * @return The value of the BlobArg property for this object.
      */
     public SdkBytes blobArg() {
@@ -816,7 +1006,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the StructWithNestedBlob property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedBlob property for this object.
      */
     public StructWithNestedBlobType structWithNestedBlob() {
@@ -824,11 +1014,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the BlobMap property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBlobMap() {
+        return blobMap != null && !(blobMap instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the BlobMap property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasBlobMap()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the BlobMap property for this object.
      */
     public Map<String, SdkBytes> blobMap() {
@@ -836,11 +1037,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfBlobs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfBlobs() {
+        return listOfBlobs != null && !(listOfBlobs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfBlobs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfBlobs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfBlobs property for this object.
      */
     public List<SdkBytes> listOfBlobs() {
@@ -849,7 +1061,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the RecursiveStruct property for this object.
-     * 
+     *
      * @return The value of the RecursiveStruct property for this object.
      */
     public RecursiveStructType recursiveStruct() {
@@ -858,7 +1070,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the PolymorphicTypeWithSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithSubTypes property for this object.
      */
     public BaseType polymorphicTypeWithSubTypes() {
@@ -867,7 +1079,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the PolymorphicTypeWithoutSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithoutSubTypes property for this object.
      */
     public SubTypeOne polymorphicTypeWithoutSubTypes() {
@@ -881,7 +1093,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -896,7 +1108,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -972,30 +1184,30 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
         AllTypesRequest other = (AllTypesRequest) obj;
         return Objects.equals(stringMember(), other.stringMember()) && Objects.equals(integerMember(), other.integerMember())
-                && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
-                && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
-                && Objects.equals(simpleList(), other.simpleList())
-                && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
-                && Objects.equals(listOfMaps(), other.listOfMaps()) && Objects.equals(listOfStructs(), other.listOfStructs())
-                && Objects.equals(listOfMapOfEnumToStringAsStrings(), other.listOfMapOfEnumToStringAsStrings())
-                && Objects.equals(mapOfStringToIntegerList(), other.mapOfStringToIntegerList())
-                && Objects.equals(mapOfStringToString(), other.mapOfStringToString())
-                && Objects.equals(mapOfStringToSimpleStruct(), other.mapOfStringToSimpleStruct())
-                && Objects.equals(mapOfEnumToEnumAsStrings(), other.mapOfEnumToEnumAsStrings())
-                && Objects.equals(mapOfEnumToStringAsStrings(), other.mapOfEnumToStringAsStrings())
-                && Objects.equals(mapOfStringToEnumAsStrings(), other.mapOfStringToEnumAsStrings())
-                && Objects.equals(mapOfEnumToSimpleStructAsStrings(), other.mapOfEnumToSimpleStructAsStrings())
-                && Objects.equals(mapOfEnumToListOfEnumsAsStrings(), other.mapOfEnumToListOfEnumsAsStrings())
-                && Objects.equals(mapOfEnumToMapOfStringToEnumAsStrings(), other.mapOfEnumToMapOfStringToEnumAsStrings())
-                && Objects.equals(timestampMember(), other.timestampMember())
-                && Objects.equals(structWithNestedTimestampMember(), other.structWithNestedTimestampMember())
-                && Objects.equals(blobArg(), other.blobArg())
-                && Objects.equals(structWithNestedBlob(), other.structWithNestedBlob())
-                && Objects.equals(blobMap(), other.blobMap()) && Objects.equals(listOfBlobs(), other.listOfBlobs())
-                && Objects.equals(recursiveStruct(), other.recursiveStruct())
-                && Objects.equals(polymorphicTypeWithSubTypes(), other.polymorphicTypeWithSubTypes())
-                && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
-                && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
+               && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
+               && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
+               && Objects.equals(simpleList(), other.simpleList())
+               && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
+               && Objects.equals(listOfMaps(), other.listOfMaps()) && Objects.equals(listOfStructs(), other.listOfStructs())
+               && Objects.equals(listOfMapOfEnumToStringAsStrings(), other.listOfMapOfEnumToStringAsStrings())
+               && Objects.equals(mapOfStringToIntegerList(), other.mapOfStringToIntegerList())
+               && Objects.equals(mapOfStringToString(), other.mapOfStringToString())
+               && Objects.equals(mapOfStringToSimpleStruct(), other.mapOfStringToSimpleStruct())
+               && Objects.equals(mapOfEnumToEnumAsStrings(), other.mapOfEnumToEnumAsStrings())
+               && Objects.equals(mapOfEnumToStringAsStrings(), other.mapOfEnumToStringAsStrings())
+               && Objects.equals(mapOfStringToEnumAsStrings(), other.mapOfStringToEnumAsStrings())
+               && Objects.equals(mapOfEnumToSimpleStructAsStrings(), other.mapOfEnumToSimpleStructAsStrings())
+               && Objects.equals(mapOfEnumToListOfEnumsAsStrings(), other.mapOfEnumToListOfEnumsAsStrings())
+               && Objects.equals(mapOfEnumToMapOfStringToEnumAsStrings(), other.mapOfEnumToMapOfStringToEnumAsStrings())
+               && Objects.equals(timestampMember(), other.timestampMember())
+               && Objects.equals(structWithNestedTimestampMember(), other.structWithNestedTimestampMember())
+               && Objects.equals(blobArg(), other.blobArg())
+               && Objects.equals(structWithNestedBlob(), other.structWithNestedBlob())
+               && Objects.equals(blobMap(), other.blobMap()) && Objects.equals(listOfBlobs(), other.listOfBlobs())
+               && Objects.equals(recursiveStruct(), other.recursiveStruct())
+               && Objects.equals(polymorphicTypeWithSubTypes(), other.polymorphicTypeWithSubTypes())
+               && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
+               && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
     }
 
     /**
@@ -1005,88 +1217,88 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     @Override
     public String toString() {
         return ToString.builder("AllTypesRequest").add("StringMember", stringMember()).add("IntegerMember", integerMember())
-                .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
-                .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
-                .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
-                .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
-                .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
-                .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
-                .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
-                .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
-                .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
-                .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
-                .add("TimestampMember", timestampMember())
-                .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
-                .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
-                .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
-                .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
-                .build();
+                       .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
+                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
+                       .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
+                       .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
+                       .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
+                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
+                       .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
+                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
+                       .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
+                       .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
+                       .add("TimestampMember", timestampMember())
+                       .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
+                       .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
+                       .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
+                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
+                       .build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "StringMember":
-            return Optional.ofNullable(clazz.cast(stringMember()));
-        case "IntegerMember":
-            return Optional.ofNullable(clazz.cast(integerMember()));
-        case "BooleanMember":
-            return Optional.ofNullable(clazz.cast(booleanMember()));
-        case "FloatMember":
-            return Optional.ofNullable(clazz.cast(floatMember()));
-        case "DoubleMember":
-            return Optional.ofNullable(clazz.cast(doubleMember()));
-        case "LongMember":
-            return Optional.ofNullable(clazz.cast(longMember()));
-        case "SimpleList":
-            return Optional.ofNullable(clazz.cast(simpleList()));
-        case "ListOfEnums":
-            return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
-        case "ListOfMaps":
-            return Optional.ofNullable(clazz.cast(listOfMaps()));
-        case "ListOfStructs":
-            return Optional.ofNullable(clazz.cast(listOfStructs()));
-        case "ListOfMapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
-        case "MapOfStringToIntegerList":
-            return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
-        case "MapOfStringToString":
-            return Optional.ofNullable(clazz.cast(mapOfStringToString()));
-        case "MapOfStringToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
-        case "MapOfEnumToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
-        case "MapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
-        case "MapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
-        case "MapOfEnumToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
-        case "MapOfEnumToListOfEnums":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
-        case "MapOfEnumToMapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
-        case "TimestampMember":
-            return Optional.ofNullable(clazz.cast(timestampMember()));
-        case "StructWithNestedTimestampMember":
-            return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
-        case "BlobArg":
-            return Optional.ofNullable(clazz.cast(blobArg()));
-        case "StructWithNestedBlob":
-            return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
-        case "BlobMap":
-            return Optional.ofNullable(clazz.cast(blobMap()));
-        case "ListOfBlobs":
-            return Optional.ofNullable(clazz.cast(listOfBlobs()));
-        case "RecursiveStruct":
-            return Optional.ofNullable(clazz.cast(recursiveStruct()));
-        case "PolymorphicTypeWithSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
-        case "PolymorphicTypeWithoutSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
-        case "EnumType":
-            return Optional.ofNullable(clazz.cast(enumTypeAsString()));
-        default:
-            return Optional.empty();
+            case "StringMember":
+                return Optional.ofNullable(clazz.cast(stringMember()));
+            case "IntegerMember":
+                return Optional.ofNullable(clazz.cast(integerMember()));
+            case "BooleanMember":
+                return Optional.ofNullable(clazz.cast(booleanMember()));
+            case "FloatMember":
+                return Optional.ofNullable(clazz.cast(floatMember()));
+            case "DoubleMember":
+                return Optional.ofNullable(clazz.cast(doubleMember()));
+            case "LongMember":
+                return Optional.ofNullable(clazz.cast(longMember()));
+            case "SimpleList":
+                return Optional.ofNullable(clazz.cast(simpleList()));
+            case "ListOfEnums":
+                return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
+            case "ListOfMaps":
+                return Optional.ofNullable(clazz.cast(listOfMaps()));
+            case "ListOfStructs":
+                return Optional.ofNullable(clazz.cast(listOfStructs()));
+            case "ListOfMapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
+            case "MapOfStringToIntegerList":
+                return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
+            case "MapOfStringToString":
+                return Optional.ofNullable(clazz.cast(mapOfStringToString()));
+            case "MapOfStringToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
+            case "MapOfEnumToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
+            case "MapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
+            case "MapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
+            case "MapOfEnumToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
+            case "MapOfEnumToListOfEnums":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
+            case "MapOfEnumToMapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
+            case "TimestampMember":
+                return Optional.ofNullable(clazz.cast(timestampMember()));
+            case "StructWithNestedTimestampMember":
+                return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
+            case "BlobArg":
+                return Optional.ofNullable(clazz.cast(blobArg()));
+            case "StructWithNestedBlob":
+                return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
+            case "BlobMap":
+                return Optional.ofNullable(clazz.cast(blobMap()));
+            case "ListOfBlobs":
+                return Optional.ofNullable(clazz.cast(listOfBlobs()));
+            case "RecursiveStruct":
+                return Optional.ofNullable(clazz.cast(recursiveStruct()));
+            case "PolymorphicTypeWithSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
+            case "PolymorphicTypeWithoutSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
+            case "EnumType":
+                return Optional.ofNullable(clazz.cast(enumTypeAsString()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -1256,7 +1468,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link List<SimpleStruct>.Builder#build()} is called immediately and its
          * result is passed to {@link #listOfStructs(List<SimpleStruct>)}.
-         * 
+         *
          * @param listOfStructs
          *        a consumer that will call methods on {@link List<SimpleStruct>.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1443,7 +1655,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link StructWithTimestamp.Builder#build()} is called immediately and
          * its result is passed to {@link #structWithNestedTimestampMember(StructWithTimestamp)}.
-         * 
+         *
          * @param structWithNestedTimestampMember
          *        a consumer that will call methods on {@link StructWithTimestamp.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1451,7 +1663,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          */
         default Builder structWithNestedTimestampMember(Consumer<StructWithTimestamp.Builder> structWithNestedTimestampMember) {
             return structWithNestedTimestampMember(StructWithTimestamp.builder().applyMutation(structWithNestedTimestampMember)
-                    .build());
+                                                                      .build());
         }
 
         /**
@@ -1480,7 +1692,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link StructWithNestedBlobType.Builder#build()} is called immediately
          * and its result is passed to {@link #structWithNestedBlob(StructWithNestedBlobType)}.
-         * 
+         *
          * @param structWithNestedBlob
          *        a consumer that will call methods on {@link StructWithNestedBlobType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1534,7 +1746,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
          * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
-         * 
+         *
          * @param recursiveStruct
          *        a consumer that will call methods on {@link RecursiveStructType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1561,7 +1773,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link BaseType.Builder#build()} is called immediately and its result is
          * passed to {@link #polymorphicTypeWithSubTypes(BaseType)}.
-         * 
+         *
          * @param polymorphicTypeWithSubTypes
          *        a consumer that will call methods on {@link BaseType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1588,7 +1800,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link SubTypeOne.Builder#build()} is called immediately and its result
          * is passed to {@link #polymorphicTypeWithoutSubTypes(SubTypeOne)}.
-         * 
+         *
          * @param polymorphicTypeWithoutSubTypes
          *        a consumer that will call methods on {@link SubTypeOne.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1887,7 +2099,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Collection<SimpleStruct.Builder> getListOfStructs() {
             return listOfStructs != null ? listOfStructs.stream().map(SimpleStruct::toBuilder).collect(Collectors.toList())
-                    : null;
+                                         : null;
         }
 
         @Override
@@ -1907,7 +2119,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
-                    .collect(Collectors.toList()));
+                                .collect(Collectors.toList()));
             return this;
         }
 
@@ -1966,7 +2178,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
             return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
-                    SimpleStruct::toBuilder) : null;
+                                                                                 SimpleStruct::toBuilder) : null;
         }
 
         @Override
@@ -2041,7 +2253,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
-                    : null;
+                                                   : null;
         }
 
         @Override
@@ -2126,7 +2338,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                    .build() : null;
+                .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {
@@ -2159,7 +2371,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Map<String, ByteBuffer> getBlobMap() {
             return blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
@@ -2170,7 +2382,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
             blobMap(blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
         public final List<ByteBuffer> getListOfBlobs() {
@@ -2192,7 +2404,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
             listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
-                    .collect(Collectors.toList()));
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {
@@ -2235,7 +2447,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setPolymorphicTypeWithoutSubTypes(SubTypeOne.BuilderImpl polymorphicTypeWithoutSubTypes) {
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes != null ? polymorphicTypeWithoutSubTypes.build()
-                    : null;
+                                                                                         : null;
         }
 
         public final String getEnumTypeAsString() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -35,344 +37,344 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class AllTypesResponse extends JsonProtocolTestsResponse implements
-        ToCopyableBuilder<AllTypesResponse.Builder, AllTypesResponse> {
+                                                                      ToCopyableBuilder<AllTypesResponse.Builder, AllTypesResponse> {
     private static final SdkField<String> STRING_MEMBER_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesResponse::stringMember)).setter(setter(Builder::stringMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
+        .getter(getter(AllTypesResponse::stringMember)).setter(setter(Builder::stringMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
 
     private static final SdkField<Integer> INTEGER_MEMBER_FIELD = SdkField.<Integer> builder(MarshallingType.INTEGER)
-            .getter(getter(AllTypesResponse::integerMember)).setter(setter(Builder::integerMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
+        .getter(getter(AllTypesResponse::integerMember)).setter(setter(Builder::integerMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
 
     private static final SdkField<Boolean> BOOLEAN_MEMBER_FIELD = SdkField.<Boolean> builder(MarshallingType.BOOLEAN)
-            .getter(getter(AllTypesResponse::booleanMember)).setter(setter(Builder::booleanMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
+        .getter(getter(AllTypesResponse::booleanMember)).setter(setter(Builder::booleanMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
 
     private static final SdkField<Float> FLOAT_MEMBER_FIELD = SdkField.<Float> builder(MarshallingType.FLOAT)
-            .getter(getter(AllTypesResponse::floatMember)).setter(setter(Builder::floatMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
+        .getter(getter(AllTypesResponse::floatMember)).setter(setter(Builder::floatMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
 
     private static final SdkField<Double> DOUBLE_MEMBER_FIELD = SdkField.<Double> builder(MarshallingType.DOUBLE)
-            .getter(getter(AllTypesResponse::doubleMember)).setter(setter(Builder::doubleMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
+        .getter(getter(AllTypesResponse::doubleMember)).setter(setter(Builder::doubleMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
 
     private static final SdkField<Long> LONG_MEMBER_FIELD = SdkField.<Long> builder(MarshallingType.LONG)
-            .getter(getter(AllTypesResponse::longMember)).setter(setter(Builder::longMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
+        .getter(getter(AllTypesResponse::longMember)).setter(setter(Builder::longMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
 
     private static final SdkField<List<String>> SIMPLE_LIST_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::simpleList))
-            .setter(setter(Builder::simpleList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::simpleList))
+        .setter(setter(Builder::simpleList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<String>> LIST_OF_ENUMS_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfEnumsAsStrings))
-            .setter(setter(Builder::listOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfEnumsAsStrings))
+        .setter(setter(Builder::listOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAPS_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfMaps))
-            .setter(setter(Builder::listOfMaps))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfMaps))
+        .setter(setter(Builder::listOfMaps))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<List<SimpleStruct>> LIST_OF_STRUCTS_FIELD = SdkField
-            .<List<SimpleStruct>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfStructs))
-            .setter(setter(Builder::listOfStructs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SimpleStruct>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfStructs))
+        .setter(setter(Builder::listOfStructs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                            .constructor(SimpleStruct::builder)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfMapOfEnumToStringAsStrings))
-            .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfMapOfEnumToStringAsStrings))
+        .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<Integer>>> MAP_OF_STRING_TO_INTEGER_LIST_FIELD = SdkField
-            .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToIntegerList))
-            .setter(setter(Builder::mapOfStringToIntegerList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<Integer>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<Integer> builder(MarshallingType.INTEGER)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToIntegerList))
+        .setter(setter(Builder::mapOfStringToIntegerList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<Integer>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<Integer> builder(MarshallingType.INTEGER)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToString))
-            .setter(setter(Builder::mapOfStringToString))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToString))
+        .setter(setter(Builder::mapOfStringToString))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToSimpleStruct))
-            .setter(setter(Builder::mapOfStringToSimpleStruct))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToSimpleStruct))
+        .setter(setter(Builder::mapOfStringToSimpleStruct))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToStringAsStrings))
-            .setter(setter(Builder::mapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToStringAsStrings))
+        .setter(setter(Builder::mapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToSimpleStructAsStrings))
-            .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToSimpleStructAsStrings))
+        .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<String>>> MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD = SdkField
-            .<Map<String, List<String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToListOfEnumsAsStrings))
-            .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToListOfEnumsAsStrings))
+        .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<String>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, Map<String, String>>> MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToMapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
-                    .build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToMapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
+                             .build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        MapTrait.builder()
+                                                .keyLocationName("key")
+                                                .valueLocationName("value")
+                                                .valueFieldInfo(
+                                                    SdkField.<String> builder(MarshallingType.STRING)
+                                                        .traits(LocationTrait.builder()
+                                                                             .location(MarshallLocation.PAYLOAD)
+                                                                             .locationName("value").build()).build())
+                                                .build()).build()).build()).build();
 
     private static final SdkField<Instant> TIMESTAMP_MEMBER_FIELD = SdkField.<Instant> builder(MarshallingType.INSTANT)
-            .getter(getter(AllTypesResponse::timestampMember)).setter(setter(Builder::timestampMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
+        .getter(getter(AllTypesResponse::timestampMember)).setter(setter(Builder::timestampMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
 
     private static final SdkField<StructWithTimestamp> STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD = SdkField
-            .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesResponse::structWithNestedTimestampMember))
-            .setter(setter(Builder::structWithNestedTimestampMember))
-            .constructor(StructWithTimestamp::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
-                    .build()).build();
+        .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesResponse::structWithNestedTimestampMember))
+        .setter(setter(Builder::structWithNestedTimestampMember))
+        .constructor(StructWithTimestamp::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
+                             .build()).build();
 
     private static final SdkField<SdkBytes> BLOB_ARG_FIELD = SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-            .getter(getter(AllTypesResponse::blobArg)).setter(setter(Builder::blobArg))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
+        .getter(getter(AllTypesResponse::blobArg)).setter(setter(Builder::blobArg))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
 
     private static final SdkField<StructWithNestedBlobType> STRUCT_WITH_NESTED_BLOB_FIELD = SdkField
-            .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::structWithNestedBlob))
-            .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
-            .build();
+        .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::structWithNestedBlob))
+                                                                     .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
+                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
+                                                                     .build();
 
     private static final SdkField<Map<String, SdkBytes>> BLOB_MAP_FIELD = SdkField
-            .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::blobMap))
-            .setter(setter(Builder::blobMap))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::blobMap))
+        .setter(setter(Builder::blobMap))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<List<SdkBytes>> LIST_OF_BLOBS_FIELD = SdkField
-            .<List<SdkBytes>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfBlobs))
-            .setter(setter(Builder::listOfBlobs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SdkBytes>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfBlobs))
+        .setter(setter(Builder::listOfBlobs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<RecursiveStructType> RECURSIVE_STRUCT_FIELD = SdkField
-            .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::recursiveStruct))
-            .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
+        .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::recursiveStruct))
+                                                                .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
+                                                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
 
     private static final SdkField<BaseType> POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD = SdkField
-            .<BaseType> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesResponse::polymorphicTypeWithSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithSubTypes))
-            .constructor(BaseType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
-                    .build()).build();
+        .<BaseType> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesResponse::polymorphicTypeWithSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithSubTypes))
+        .constructor(BaseType::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
+                             .build()).build();
 
     private static final SdkField<SubTypeOne> POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD = SdkField
-            .<SubTypeOne> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesResponse::polymorphicTypeWithoutSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
-            .constructor(SubTypeOne::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
-                    .build()).build();
+        .<SubTypeOne> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesResponse::polymorphicTypeWithoutSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
+        .constructor(SubTypeOne::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
+                             .build()).build();
 
     private static final SdkField<String> ENUM_TYPE_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesResponse::enumTypeAsString)).setter(setter(Builder::enumType))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
+        .getter(getter(AllTypesResponse::enumTypeAsString)).setter(setter(Builder::enumType))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(STRING_MEMBER_FIELD,
-            INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
-            SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
-            LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
-            MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
-            BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
-            POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
+                                                                                                   INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
+                                                                                                   SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
+                                                                                                   LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
+                                                                                                   MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
+                                                                                                   BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
+                                                                                                   POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
 
     private final String stringMember;
 
@@ -470,7 +472,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the StringMember property for this object.
-     * 
+     *
      * @return The value of the StringMember property for this object.
      */
     public String stringMember() {
@@ -479,7 +481,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the IntegerMember property for this object.
-     * 
+     *
      * @return The value of the IntegerMember property for this object.
      */
     public Integer integerMember() {
@@ -488,7 +490,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the BooleanMember property for this object.
-     * 
+     *
      * @return The value of the BooleanMember property for this object.
      */
     public Boolean booleanMember() {
@@ -497,7 +499,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the FloatMember property for this object.
-     * 
+     *
      * @return The value of the FloatMember property for this object.
      */
     public Float floatMember() {
@@ -506,7 +508,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the DoubleMember property for this object.
-     * 
+     *
      * @return The value of the DoubleMember property for this object.
      */
     public Double doubleMember() {
@@ -515,7 +517,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the LongMember property for this object.
-     * 
+     *
      * @return The value of the LongMember property for this object.
      */
     public Long longMember() {
@@ -523,11 +525,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the SimpleList property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSimpleList() {
+        return simpleList != null && !(simpleList instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the SimpleList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasSimpleList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the SimpleList property for this object.
      */
     public List<String> simpleList() {
@@ -539,7 +552,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<EnumType> listOfEnums() {
@@ -547,11 +563,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfEnums property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfEnums() {
+        return listOfEnums != null && !(listOfEnums instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<String> listOfEnumsAsStrings() {
@@ -559,11 +586,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfMaps property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfMaps() {
+        return listOfMaps != null && !(listOfMaps instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMaps property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMaps()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMaps property for this object.
      */
     public List<Map<String, String>> listOfMaps() {
@@ -571,11 +609,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfStructs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfStructs() {
+        return listOfStructs != null && !(listOfStructs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfStructs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfStructs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfStructs property for this object.
      */
     public List<SimpleStruct> listOfStructs() {
@@ -587,7 +636,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<EnumType, String>> listOfMapOfEnumToString() {
@@ -595,11 +647,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfMapOfEnumToString property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfMapOfEnumToString() {
+        return listOfMapOfEnumToString != null && !(listOfMapOfEnumToString instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<String, String>> listOfMapOfEnumToStringAsStrings() {
@@ -607,11 +671,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToIntegerList property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToIntegerList() {
+        return mapOfStringToIntegerList != null && !(mapOfStringToIntegerList instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToIntegerList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToIntegerList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToIntegerList property for this object.
      */
     public Map<String, List<Integer>> mapOfStringToIntegerList() {
@@ -619,11 +695,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToString() {
+        return mapOfStringToString != null && !(mapOfStringToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToString property for this object.
      */
     public Map<String, String> mapOfStringToString() {
@@ -631,11 +719,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToSimpleStruct() {
+        return mapOfStringToSimpleStruct != null && !(mapOfStringToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfStringToSimpleStruct() {
@@ -647,7 +747,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<EnumType, EnumType> mapOfEnumToEnum() {
@@ -655,11 +758,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToEnum() {
+        return mapOfEnumToEnum != null && !(mapOfEnumToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<String, String> mapOfEnumToEnumAsStrings() {
@@ -671,7 +786,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<EnumType, String> mapOfEnumToString() {
@@ -679,11 +797,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToString() {
+        return mapOfEnumToString != null && !(mapOfEnumToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<String, String> mapOfEnumToStringAsStrings() {
@@ -695,7 +825,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, EnumType> mapOfStringToEnum() {
@@ -703,11 +836,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToEnum() {
+        return mapOfStringToEnum != null && !(mapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, String> mapOfStringToEnumAsStrings() {
@@ -719,7 +864,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct() {
@@ -727,11 +875,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToSimpleStruct() {
+        return mapOfEnumToSimpleStruct != null && !(mapOfEnumToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfEnumToSimpleStructAsStrings() {
@@ -743,7 +903,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<EnumType, List<EnumType>> mapOfEnumToListOfEnums() {
@@ -751,11 +914,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToListOfEnums property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToListOfEnums() {
+        return mapOfEnumToListOfEnums != null && !(mapOfEnumToListOfEnums instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<String, List<String>> mapOfEnumToListOfEnumsAsStrings() {
@@ -767,7 +942,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum() {
@@ -775,11 +953,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToMapOfStringToEnum property was specified by the sender (it may be empty), or false
+     * if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the
+     * AWS service.
+     */
+    public boolean hasMapOfEnumToMapOfStringToEnum() {
+        return mapOfEnumToMapOfStringToEnum != null && !(mapOfEnumToMapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToMapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumAsStrings() {
@@ -788,7 +978,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the TimestampMember property for this object.
-     * 
+     *
      * @return The value of the TimestampMember property for this object.
      */
     public Instant timestampMember() {
@@ -797,7 +987,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the StructWithNestedTimestampMember property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedTimestampMember property for this object.
      */
     public StructWithTimestamp structWithNestedTimestampMember() {
@@ -806,7 +996,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * 
+     *
      * @return The value of the BlobArg property for this object.
      */
     public SdkBytes blobArg() {
@@ -815,7 +1005,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the StructWithNestedBlob property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedBlob property for this object.
      */
     public StructWithNestedBlobType structWithNestedBlob() {
@@ -823,11 +1013,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the BlobMap property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBlobMap() {
+        return blobMap != null && !(blobMap instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the BlobMap property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasBlobMap()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the BlobMap property for this object.
      */
     public Map<String, SdkBytes> blobMap() {
@@ -835,11 +1036,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfBlobs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfBlobs() {
+        return listOfBlobs != null && !(listOfBlobs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfBlobs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfBlobs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfBlobs property for this object.
      */
     public List<SdkBytes> listOfBlobs() {
@@ -848,7 +1060,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the RecursiveStruct property for this object.
-     * 
+     *
      * @return The value of the RecursiveStruct property for this object.
      */
     public RecursiveStructType recursiveStruct() {
@@ -857,7 +1069,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the PolymorphicTypeWithSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithSubTypes property for this object.
      */
     public BaseType polymorphicTypeWithSubTypes() {
@@ -866,7 +1078,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the PolymorphicTypeWithoutSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithoutSubTypes property for this object.
      */
     public SubTypeOne polymorphicTypeWithoutSubTypes() {
@@ -880,7 +1092,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -895,7 +1107,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -971,30 +1183,30 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
         AllTypesResponse other = (AllTypesResponse) obj;
         return Objects.equals(stringMember(), other.stringMember()) && Objects.equals(integerMember(), other.integerMember())
-                && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
-                && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
-                && Objects.equals(simpleList(), other.simpleList())
-                && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
-                && Objects.equals(listOfMaps(), other.listOfMaps()) && Objects.equals(listOfStructs(), other.listOfStructs())
-                && Objects.equals(listOfMapOfEnumToStringAsStrings(), other.listOfMapOfEnumToStringAsStrings())
-                && Objects.equals(mapOfStringToIntegerList(), other.mapOfStringToIntegerList())
-                && Objects.equals(mapOfStringToString(), other.mapOfStringToString())
-                && Objects.equals(mapOfStringToSimpleStruct(), other.mapOfStringToSimpleStruct())
-                && Objects.equals(mapOfEnumToEnumAsStrings(), other.mapOfEnumToEnumAsStrings())
-                && Objects.equals(mapOfEnumToStringAsStrings(), other.mapOfEnumToStringAsStrings())
-                && Objects.equals(mapOfStringToEnumAsStrings(), other.mapOfStringToEnumAsStrings())
-                && Objects.equals(mapOfEnumToSimpleStructAsStrings(), other.mapOfEnumToSimpleStructAsStrings())
-                && Objects.equals(mapOfEnumToListOfEnumsAsStrings(), other.mapOfEnumToListOfEnumsAsStrings())
-                && Objects.equals(mapOfEnumToMapOfStringToEnumAsStrings(), other.mapOfEnumToMapOfStringToEnumAsStrings())
-                && Objects.equals(timestampMember(), other.timestampMember())
-                && Objects.equals(structWithNestedTimestampMember(), other.structWithNestedTimestampMember())
-                && Objects.equals(blobArg(), other.blobArg())
-                && Objects.equals(structWithNestedBlob(), other.structWithNestedBlob())
-                && Objects.equals(blobMap(), other.blobMap()) && Objects.equals(listOfBlobs(), other.listOfBlobs())
-                && Objects.equals(recursiveStruct(), other.recursiveStruct())
-                && Objects.equals(polymorphicTypeWithSubTypes(), other.polymorphicTypeWithSubTypes())
-                && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
-                && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
+               && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
+               && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
+               && Objects.equals(simpleList(), other.simpleList())
+               && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
+               && Objects.equals(listOfMaps(), other.listOfMaps()) && Objects.equals(listOfStructs(), other.listOfStructs())
+               && Objects.equals(listOfMapOfEnumToStringAsStrings(), other.listOfMapOfEnumToStringAsStrings())
+               && Objects.equals(mapOfStringToIntegerList(), other.mapOfStringToIntegerList())
+               && Objects.equals(mapOfStringToString(), other.mapOfStringToString())
+               && Objects.equals(mapOfStringToSimpleStruct(), other.mapOfStringToSimpleStruct())
+               && Objects.equals(mapOfEnumToEnumAsStrings(), other.mapOfEnumToEnumAsStrings())
+               && Objects.equals(mapOfEnumToStringAsStrings(), other.mapOfEnumToStringAsStrings())
+               && Objects.equals(mapOfStringToEnumAsStrings(), other.mapOfStringToEnumAsStrings())
+               && Objects.equals(mapOfEnumToSimpleStructAsStrings(), other.mapOfEnumToSimpleStructAsStrings())
+               && Objects.equals(mapOfEnumToListOfEnumsAsStrings(), other.mapOfEnumToListOfEnumsAsStrings())
+               && Objects.equals(mapOfEnumToMapOfStringToEnumAsStrings(), other.mapOfEnumToMapOfStringToEnumAsStrings())
+               && Objects.equals(timestampMember(), other.timestampMember())
+               && Objects.equals(structWithNestedTimestampMember(), other.structWithNestedTimestampMember())
+               && Objects.equals(blobArg(), other.blobArg())
+               && Objects.equals(structWithNestedBlob(), other.structWithNestedBlob())
+               && Objects.equals(blobMap(), other.blobMap()) && Objects.equals(listOfBlobs(), other.listOfBlobs())
+               && Objects.equals(recursiveStruct(), other.recursiveStruct())
+               && Objects.equals(polymorphicTypeWithSubTypes(), other.polymorphicTypeWithSubTypes())
+               && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
+               && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
     }
 
     /**
@@ -1004,88 +1216,88 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     @Override
     public String toString() {
         return ToString.builder("AllTypesResponse").add("StringMember", stringMember()).add("IntegerMember", integerMember())
-                .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
-                .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
-                .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
-                .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
-                .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
-                .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
-                .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
-                .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
-                .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
-                .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
-                .add("TimestampMember", timestampMember())
-                .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
-                .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
-                .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
-                .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
-                .build();
+                       .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
+                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
+                       .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
+                       .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
+                       .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
+                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
+                       .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
+                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
+                       .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
+                       .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
+                       .add("TimestampMember", timestampMember())
+                       .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
+                       .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
+                       .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
+                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
+                       .build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "StringMember":
-            return Optional.ofNullable(clazz.cast(stringMember()));
-        case "IntegerMember":
-            return Optional.ofNullable(clazz.cast(integerMember()));
-        case "BooleanMember":
-            return Optional.ofNullable(clazz.cast(booleanMember()));
-        case "FloatMember":
-            return Optional.ofNullable(clazz.cast(floatMember()));
-        case "DoubleMember":
-            return Optional.ofNullable(clazz.cast(doubleMember()));
-        case "LongMember":
-            return Optional.ofNullable(clazz.cast(longMember()));
-        case "SimpleList":
-            return Optional.ofNullable(clazz.cast(simpleList()));
-        case "ListOfEnums":
-            return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
-        case "ListOfMaps":
-            return Optional.ofNullable(clazz.cast(listOfMaps()));
-        case "ListOfStructs":
-            return Optional.ofNullable(clazz.cast(listOfStructs()));
-        case "ListOfMapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
-        case "MapOfStringToIntegerList":
-            return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
-        case "MapOfStringToString":
-            return Optional.ofNullable(clazz.cast(mapOfStringToString()));
-        case "MapOfStringToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
-        case "MapOfEnumToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
-        case "MapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
-        case "MapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
-        case "MapOfEnumToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
-        case "MapOfEnumToListOfEnums":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
-        case "MapOfEnumToMapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
-        case "TimestampMember":
-            return Optional.ofNullable(clazz.cast(timestampMember()));
-        case "StructWithNestedTimestampMember":
-            return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
-        case "BlobArg":
-            return Optional.ofNullable(clazz.cast(blobArg()));
-        case "StructWithNestedBlob":
-            return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
-        case "BlobMap":
-            return Optional.ofNullable(clazz.cast(blobMap()));
-        case "ListOfBlobs":
-            return Optional.ofNullable(clazz.cast(listOfBlobs()));
-        case "RecursiveStruct":
-            return Optional.ofNullable(clazz.cast(recursiveStruct()));
-        case "PolymorphicTypeWithSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
-        case "PolymorphicTypeWithoutSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
-        case "EnumType":
-            return Optional.ofNullable(clazz.cast(enumTypeAsString()));
-        default:
-            return Optional.empty();
+            case "StringMember":
+                return Optional.ofNullable(clazz.cast(stringMember()));
+            case "IntegerMember":
+                return Optional.ofNullable(clazz.cast(integerMember()));
+            case "BooleanMember":
+                return Optional.ofNullable(clazz.cast(booleanMember()));
+            case "FloatMember":
+                return Optional.ofNullable(clazz.cast(floatMember()));
+            case "DoubleMember":
+                return Optional.ofNullable(clazz.cast(doubleMember()));
+            case "LongMember":
+                return Optional.ofNullable(clazz.cast(longMember()));
+            case "SimpleList":
+                return Optional.ofNullable(clazz.cast(simpleList()));
+            case "ListOfEnums":
+                return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
+            case "ListOfMaps":
+                return Optional.ofNullable(clazz.cast(listOfMaps()));
+            case "ListOfStructs":
+                return Optional.ofNullable(clazz.cast(listOfStructs()));
+            case "ListOfMapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
+            case "MapOfStringToIntegerList":
+                return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
+            case "MapOfStringToString":
+                return Optional.ofNullable(clazz.cast(mapOfStringToString()));
+            case "MapOfStringToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
+            case "MapOfEnumToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
+            case "MapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
+            case "MapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
+            case "MapOfEnumToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
+            case "MapOfEnumToListOfEnums":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
+            case "MapOfEnumToMapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
+            case "TimestampMember":
+                return Optional.ofNullable(clazz.cast(timestampMember()));
+            case "StructWithNestedTimestampMember":
+                return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
+            case "BlobArg":
+                return Optional.ofNullable(clazz.cast(blobArg()));
+            case "StructWithNestedBlob":
+                return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
+            case "BlobMap":
+                return Optional.ofNullable(clazz.cast(blobMap()));
+            case "ListOfBlobs":
+                return Optional.ofNullable(clazz.cast(listOfBlobs()));
+            case "RecursiveStruct":
+                return Optional.ofNullable(clazz.cast(recursiveStruct()));
+            case "PolymorphicTypeWithSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
+            case "PolymorphicTypeWithoutSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
+            case "EnumType":
+                return Optional.ofNullable(clazz.cast(enumTypeAsString()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -1255,7 +1467,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link List<SimpleStruct>.Builder#build()} is called immediately and its
          * result is passed to {@link #listOfStructs(List<SimpleStruct>)}.
-         * 
+         *
          * @param listOfStructs
          *        a consumer that will call methods on {@link List<SimpleStruct>.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1442,7 +1654,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link StructWithTimestamp.Builder#build()} is called immediately and
          * its result is passed to {@link #structWithNestedTimestampMember(StructWithTimestamp)}.
-         * 
+         *
          * @param structWithNestedTimestampMember
          *        a consumer that will call methods on {@link StructWithTimestamp.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1450,7 +1662,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          */
         default Builder structWithNestedTimestampMember(Consumer<StructWithTimestamp.Builder> structWithNestedTimestampMember) {
             return structWithNestedTimestampMember(StructWithTimestamp.builder().applyMutation(structWithNestedTimestampMember)
-                    .build());
+                                                                      .build());
         }
 
         /**
@@ -1479,7 +1691,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link StructWithNestedBlobType.Builder#build()} is called immediately
          * and its result is passed to {@link #structWithNestedBlob(StructWithNestedBlobType)}.
-         * 
+         *
          * @param structWithNestedBlob
          *        a consumer that will call methods on {@link StructWithNestedBlobType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1533,7 +1745,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
          * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
-         * 
+         *
          * @param recursiveStruct
          *        a consumer that will call methods on {@link RecursiveStructType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1560,7 +1772,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link BaseType.Builder#build()} is called immediately and its result is
          * passed to {@link #polymorphicTypeWithSubTypes(BaseType)}.
-         * 
+         *
          * @param polymorphicTypeWithSubTypes
          *        a consumer that will call methods on {@link BaseType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1587,7 +1799,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link SubTypeOne.Builder#build()} is called immediately and its result
          * is passed to {@link #polymorphicTypeWithoutSubTypes(SubTypeOne)}.
-         * 
+         *
          * @param polymorphicTypeWithoutSubTypes
          *        a consumer that will call methods on {@link SubTypeOne.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1880,7 +2092,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Collection<SimpleStruct.Builder> getListOfStructs() {
             return listOfStructs != null ? listOfStructs.stream().map(SimpleStruct::toBuilder).collect(Collectors.toList())
-                    : null;
+                                         : null;
         }
 
         @Override
@@ -1900,7 +2112,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
-                    .collect(Collectors.toList()));
+                                .collect(Collectors.toList()));
             return this;
         }
 
@@ -1959,7 +2171,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
             return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
-                    SimpleStruct::toBuilder) : null;
+                                                                                 SimpleStruct::toBuilder) : null;
         }
 
         @Override
@@ -2034,7 +2246,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
-                    : null;
+                                                   : null;
         }
 
         @Override
@@ -2119,7 +2331,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                    .build() : null;
+                .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {
@@ -2152,7 +2364,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Map<String, ByteBuffer> getBlobMap() {
             return blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
@@ -2163,7 +2375,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
             blobMap(blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
         public final List<ByteBuffer> getListOfBlobs() {
@@ -2185,7 +2397,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
             listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
-                    .collect(Collectors.toList()));
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {
@@ -2228,7 +2440,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setPolymorphicTypeWithoutSubTypes(SubTypeOne.BuilderImpl polymorphicTypeWithoutSubTypes) {
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes != null ? polymorphicTypeWithoutSubTypes.build()
-                    : null;
+                                                                                         : null;
         }
 
         public final String getEnumTypeAsString() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingrequest.java
@@ -1,0 +1,456 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest implements
+                                                                                ToCopyableBuilder<ExistenceCheckNamingRequest.Builder, ExistenceCheckNamingRequest> {
+    private static final SdkField<List<String>> BUILD_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingRequest::build))
+        .setter(setter(Builder::build))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Build").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<List<String>> SUPER_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingRequest::superValue))
+        .setter(setter(Builder::superValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("super").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> TO_STRING_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingRequest::toStringValue))
+        .setter(setter(Builder::toStringValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("toString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> EQUALS_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingRequest::equalsValue))
+        .setter(setter(Builder::equalsValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("equals").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(BUILD_FIELD, SUPER_FIELD,
+                                                                                                   TO_STRING_FIELD, EQUALS_FIELD));
+
+    private final List<String> build;
+
+    private final List<String> superValue;
+
+    private final Map<String, String> toStringValue;
+
+    private final Map<String, String> equalsValue;
+
+    private ExistenceCheckNamingRequest(BuilderImpl builder) {
+        super(builder);
+        this.build = builder.build;
+        this.superValue = builder.superValue;
+        this.toStringValue = builder.toStringValue;
+        this.equalsValue = builder.equalsValue;
+    }
+
+    /**
+     * Returns true if the Build property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBuild() {
+        return build != null && !(build instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Build property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasBuild()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Build property for this object.
+     */
+    public List<String> build() {
+        return build;
+    }
+
+    /**
+     * Returns true if the Super property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSuperValue() {
+        return superValue != null && !(superValue instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Super property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasSuperValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Super property for this object.
+     */
+    public List<String> superValue() {
+        return superValue;
+    }
+
+    /**
+     * Returns true if the ToString property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasToStringValue() {
+        return toStringValue != null && !(toStringValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the ToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasToStringValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the ToString property for this object.
+     */
+    public Map<String, String> toStringValue() {
+        return toStringValue;
+    }
+
+    /**
+     * Returns true if the Equals property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasEqualsValue() {
+        return equalsValue != null && !(equalsValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the Equals property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasEqualsValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Equals property for this object.
+     */
+    public Map<String, String> equalsValue() {
+        return equalsValue;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        hashCode = 31 * hashCode + Objects.hashCode(build());
+        hashCode = 31 * hashCode + Objects.hashCode(superValue());
+        hashCode = 31 * hashCode + Objects.hashCode(toStringValue());
+        hashCode = 31 * hashCode + Objects.hashCode(equalsValue());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ExistenceCheckNamingRequest)) {
+            return false;
+        }
+        ExistenceCheckNamingRequest other = (ExistenceCheckNamingRequest) obj;
+        return Objects.equals(build(), other.build()) && Objects.equals(superValue(), other.superValue())
+               && Objects.equals(toStringValue(), other.toStringValue()) && Objects.equals(equalsValue(), other.equalsValue());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("ExistenceCheckNamingRequest").add("Build", build()).add("Super", superValue())
+                       .add("ToString", toStringValue()).add("Equals", equalsValue()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Build":
+                return Optional.ofNullable(clazz.cast(build()));
+            case "super":
+                return Optional.ofNullable(clazz.cast(superValue()));
+            case "toString":
+                return Optional.ofNullable(clazz.cast(toStringValue()));
+            case "equals":
+                return Optional.ofNullable(clazz.cast(equalsValue()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<ExistenceCheckNamingRequest, T> g) {
+        return obj -> g.apply((ExistenceCheckNamingRequest) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, ExistenceCheckNamingRequest> {
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(Collection<String> build);
+
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(String... build);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(Collection<String> superValue);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(String... superValue);
+
+        /**
+         * Sets the value of the ToString property for this object.
+         *
+         * @param toStringValue
+         *        The new value for the ToString property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder toStringValue(Map<String, String> toStringValue);
+
+        /**
+         * Sets the value of the Equals property for this object.
+         *
+         * @param equalsValue
+         *        The new value for the Equals property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder equalsValue(Map<String, String> equalsValue);
+
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends JsonProtocolTestsRequest.BuilderImpl implements Builder {
+        private List<String> build = DefaultSdkAutoConstructList.getInstance();
+
+        private List<String> superValue = DefaultSdkAutoConstructList.getInstance();
+
+        private Map<String, String> toStringValue = DefaultSdkAutoConstructMap.getInstance();
+
+        private Map<String, String> equalsValue = DefaultSdkAutoConstructMap.getInstance();
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(ExistenceCheckNamingRequest model) {
+            super(model);
+            build(model.build);
+            superValue(model.superValue);
+            toStringValue(model.toStringValue);
+            equalsValue(model.equalsValue);
+        }
+
+        public final Collection<String> getBuild() {
+            return build;
+        }
+
+        @Override
+        public final Builder build(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder build(String... build) {
+            build(Arrays.asList(build));
+            return this;
+        }
+
+        public final void setBuild(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+        }
+
+        public final Collection<String> getSuperValue() {
+            return superValue;
+        }
+
+        @Override
+        public final Builder superValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder superValue(String... superValue) {
+            superValue(Arrays.asList(superValue));
+            return this;
+        }
+
+        public final void setSuperValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+        }
+
+        public final Map<String, String> getToStringValue() {
+            return toStringValue;
+        }
+
+        @Override
+        public final Builder toStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+            return this;
+        }
+
+        public final void setToStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+        }
+
+        public final Map<String, String> getEqualsValue() {
+            return equalsValue;
+        }
+
+        @Override
+        public final Builder equalsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+            return this;
+        }
+
+        public final void setEqualsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public ExistenceCheckNamingRequest build() {
+            return new ExistenceCheckNamingRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingresponse.java
@@ -1,0 +1,436 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class ExistenceCheckNamingResponse extends JsonProtocolTestsResponse implements
+                                                                                  ToCopyableBuilder<ExistenceCheckNamingResponse.Builder, ExistenceCheckNamingResponse> {
+    private static final SdkField<List<String>> BUILD_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingResponse::build))
+        .setter(setter(Builder::build))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Build").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<List<String>> SUPER_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingResponse::superValue))
+        .setter(setter(Builder::superValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("super").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> TO_STRING_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingResponse::toStringValue))
+        .setter(setter(Builder::toStringValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("toString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> EQUALS_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingResponse::equalsValue))
+        .setter(setter(Builder::equalsValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("equals").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(BUILD_FIELD, SUPER_FIELD,
+                                                                                                   TO_STRING_FIELD, EQUALS_FIELD));
+
+    private final List<String> build;
+
+    private final List<String> superValue;
+
+    private final Map<String, String> toStringValue;
+
+    private final Map<String, String> equalsValue;
+
+    private ExistenceCheckNamingResponse(BuilderImpl builder) {
+        super(builder);
+        this.build = builder.build;
+        this.superValue = builder.superValue;
+        this.toStringValue = builder.toStringValue;
+        this.equalsValue = builder.equalsValue;
+    }
+
+    /**
+     * Returns true if the Build property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBuild() {
+        return build != null && !(build instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Build property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasBuild()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Build property for this object.
+     */
+    public List<String> build() {
+        return build;
+    }
+
+    /**
+     * Returns true if the Super property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSuperValue() {
+        return superValue != null && !(superValue instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Super property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasSuperValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Super property for this object.
+     */
+    public List<String> superValue() {
+        return superValue;
+    }
+
+    /**
+     * Returns true if the ToString property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasToStringValue() {
+        return toStringValue != null && !(toStringValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the ToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasToStringValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the ToString property for this object.
+     */
+    public Map<String, String> toStringValue() {
+        return toStringValue;
+    }
+
+    /**
+     * Returns true if the Equals property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasEqualsValue() {
+        return equalsValue != null && !(equalsValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the Equals property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasEqualsValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Equals property for this object.
+     */
+    public Map<String, String> equalsValue() {
+        return equalsValue;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        hashCode = 31 * hashCode + Objects.hashCode(build());
+        hashCode = 31 * hashCode + Objects.hashCode(superValue());
+        hashCode = 31 * hashCode + Objects.hashCode(toStringValue());
+        hashCode = 31 * hashCode + Objects.hashCode(equalsValue());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ExistenceCheckNamingResponse)) {
+            return false;
+        }
+        ExistenceCheckNamingResponse other = (ExistenceCheckNamingResponse) obj;
+        return Objects.equals(build(), other.build()) && Objects.equals(superValue(), other.superValue())
+               && Objects.equals(toStringValue(), other.toStringValue()) && Objects.equals(equalsValue(), other.equalsValue());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("ExistenceCheckNamingResponse").add("Build", build()).add("Super", superValue())
+                       .add("ToString", toStringValue()).add("Equals", equalsValue()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Build":
+                return Optional.ofNullable(clazz.cast(build()));
+            case "super":
+                return Optional.ofNullable(clazz.cast(superValue()));
+            case "toString":
+                return Optional.ofNullable(clazz.cast(toStringValue()));
+            case "equals":
+                return Optional.ofNullable(clazz.cast(equalsValue()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<ExistenceCheckNamingResponse, T> g) {
+        return obj -> g.apply((ExistenceCheckNamingResponse) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, ExistenceCheckNamingResponse> {
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(Collection<String> build);
+
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(String... build);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(Collection<String> superValue);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(String... superValue);
+
+        /**
+         * Sets the value of the ToString property for this object.
+         *
+         * @param toStringValue
+         *        The new value for the ToString property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder toStringValue(Map<String, String> toStringValue);
+
+        /**
+         * Sets the value of the Equals property for this object.
+         *
+         * @param equalsValue
+         *        The new value for the Equals property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder equalsValue(Map<String, String> equalsValue);
+    }
+
+    static final class BuilderImpl extends JsonProtocolTestsResponse.BuilderImpl implements Builder {
+        private List<String> build = DefaultSdkAutoConstructList.getInstance();
+
+        private List<String> superValue = DefaultSdkAutoConstructList.getInstance();
+
+        private Map<String, String> toStringValue = DefaultSdkAutoConstructMap.getInstance();
+
+        private Map<String, String> equalsValue = DefaultSdkAutoConstructMap.getInstance();
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(ExistenceCheckNamingResponse model) {
+            super(model);
+            build(model.build);
+            superValue(model.superValue);
+            toStringValue(model.toStringValue);
+            equalsValue(model.equalsValue);
+        }
+
+        public final Collection<String> getBuild() {
+            return build;
+        }
+
+        @Override
+        public final Builder build(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder build(String... build) {
+            build(Arrays.asList(build));
+            return this;
+        }
+
+        public final void setBuild(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+        }
+
+        public final Collection<String> getSuperValue() {
+            return superValue;
+        }
+
+        @Override
+        public final Builder superValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder superValue(String... superValue) {
+            superValue(Arrays.asList(superValue));
+            return this;
+        }
+
+        public final void setSuperValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+        }
+
+        public final Map<String, String> getToStringValue() {
+            return toStringValue;
+        }
+
+        @Override
+        public final Builder toStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+            return this;
+        }
+
+        public final void setToStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+        }
+
+        public final Map<String, String> getEqualsValue() {
+            return equalsValue;
+        }
+
+        @Override
+        public final Builder equalsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+            return this;
+        }
+
+        public final void setEqualsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+        }
+
+        @Override
+        public ExistenceCheckNamingResponse build() {
+            return new ExistenceCheckNamingResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersrequest.java
@@ -21,6 +21,8 @@ import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -29,104 +31,104 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class NestedContainersRequest extends JsonProtocolTestsRequest implements
-        ToCopyableBuilder<NestedContainersRequest.Builder, NestedContainersRequest> {
+                                                                            ToCopyableBuilder<NestedContainersRequest.Builder, NestedContainersRequest> {
     private static final SdkField<List<List<String>>> LIST_OF_LIST_OF_STRINGS_FIELD = SdkField
-            .<List<List<String>>> builder(MarshallingType.LIST)
-            .getter(getter(NestedContainersRequest::listOfListOfStrings))
-            .setter(setter(Builder::listOfListOfStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfStrings").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<List<String>>> builder(MarshallingType.LIST)
+        .getter(getter(NestedContainersRequest::listOfListOfStrings))
+        .setter(setter(Builder::listOfListOfStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfStrings").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<List<String>> builder(MarshallingType.LIST)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    ListTrait
+                                        .builder()
+                                        .memberLocationName(null)
+                                        .memberFieldInfo(
+                                            SdkField.<String> builder(MarshallingType.STRING)
+                                                .traits(LocationTrait.builder()
+                                                                     .location(MarshallLocation.PAYLOAD)
+                                                                     .locationName("member").build()).build())
+                                        .build()).build()).build()).build();
 
     private static final SdkField<List<List<List<String>>>> LIST_OF_LIST_OF_LIST_OF_STRINGS_FIELD = SdkField
-            .<List<List<List<String>>>> builder(MarshallingType.LIST)
-            .getter(getter(NestedContainersRequest::listOfListOfListOfStrings))
-            .setter(setter(Builder::listOfListOfListOfStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfListOfStrings").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<List<List<String>>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    ListTrait
+        .<List<List<List<String>>>> builder(MarshallingType.LIST)
+        .getter(getter(NestedContainersRequest::listOfListOfListOfStrings))
+        .setter(setter(Builder::listOfListOfListOfStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfListOfStrings").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<List<List<String>>> builder(MarshallingType.LIST)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    ListTrait
+                                        .builder()
+                                        .memberLocationName(null)
+                                        .memberFieldInfo(
+                                            SdkField.<List<String>> builder(MarshallingType.LIST)
+                                                .traits(LocationTrait.builder()
+                                                                     .location(MarshallLocation.PAYLOAD)
+                                                                     .locationName("member").build(),
+                                                        ListTrait
                                                             .builder()
                                                             .memberLocationName(null)
                                                             .memberFieldInfo(
-                                                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build(),
-                                                                                    ListTrait
-                                                                                            .builder()
-                                                                                            .memberLocationName(null)
-                                                                                            .memberFieldInfo(
-                                                                                                    SdkField.<String> builder(
-                                                                                                            MarshallingType.STRING)
-                                                                                                            .traits(LocationTrait
-                                                                                                                    .builder()
-                                                                                                                    .location(
-                                                                                                                            MarshallLocation.PAYLOAD)
-                                                                                                                    .locationName(
-                                                                                                                            "member")
-                                                                                                                    .build())
-                                                                                                            .build()).build())
-                                                                            .build()).build()).build()).build()).build();
+                                                                SdkField.<String> builder(
+                                                                    MarshallingType.STRING)
+                                                                    .traits(LocationTrait
+                                                                                .builder()
+                                                                                .location(
+                                                                                    MarshallLocation.PAYLOAD)
+                                                                                .locationName(
+                                                                                    "member")
+                                                                                .build())
+                                                                    .build()).build())
+                                                .build()).build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<List<String>>>> MAP_OF_STRING_TO_LIST_OF_LIST_OF_STRINGS_FIELD = SdkField
-            .<Map<String, List<List<String>>>> builder(MarshallingType.MAP)
-            .getter(getter(NestedContainersRequest::mapOfStringToListOfListOfStrings))
-            .setter(setter(Builder::mapOfStringToListOfListOfStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToListOfListOfStrings")
-                    .build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<List<String>>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build(),
-                                                                                    ListTrait
-                                                                                            .builder()
-                                                                                            .memberLocationName(null)
-                                                                                            .memberFieldInfo(
-                                                                                                    SdkField.<String> builder(
-                                                                                                            MarshallingType.STRING)
-                                                                                                            .traits(LocationTrait
-                                                                                                                    .builder()
-                                                                                                                    .location(
-                                                                                                                            MarshallLocation.PAYLOAD)
-                                                                                                                    .locationName(
-                                                                                                                            "member")
-                                                                                                                    .build())
-                                                                                                            .build()).build())
-                                                                            .build()).build()).build()).build()).build();
+        .<Map<String, List<List<String>>>> builder(MarshallingType.MAP)
+        .getter(getter(NestedContainersRequest::mapOfStringToListOfListOfStrings))
+        .setter(setter(Builder::mapOfStringToListOfListOfStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToListOfListOfStrings")
+                             .build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<List<String>>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<List<String>> builder(MarshallingType.LIST)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build(),
+                                                            ListTrait
+                                                                .builder()
+                                                                .memberLocationName(null)
+                                                                .memberFieldInfo(
+                                                                    SdkField.<String> builder(
+                                                                        MarshallingType.STRING)
+                                                                        .traits(LocationTrait
+                                                                                    .builder()
+                                                                                    .location(
+                                                                                        MarshallLocation.PAYLOAD)
+                                                                                    .locationName(
+                                                                                        "member")
+                                                                                    .build())
+                                                                        .build()).build())
+                                                    .build()).build()).build()).build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(LIST_OF_LIST_OF_STRINGS_FIELD,
-            LIST_OF_LIST_OF_LIST_OF_STRINGS_FIELD, MAP_OF_STRING_TO_LIST_OF_LIST_OF_STRINGS_FIELD));
+                                                                                                   LIST_OF_LIST_OF_LIST_OF_STRINGS_FIELD, MAP_OF_STRING_TO_LIST_OF_LIST_OF_STRINGS_FIELD));
 
     private final List<List<String>> listOfListOfStrings;
 
@@ -142,11 +144,23 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     }
 
     /**
+     * Returns true if the ListOfListOfStrings property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfStrings() {
+        return listOfListOfStrings != null && !(listOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfListOfStrings()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfListOfStrings property for this object.
      */
     public List<List<String>> listOfListOfStrings() {
@@ -154,11 +168,23 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     }
 
     /**
+     * Returns true if the ListOfListOfListOfStrings property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfListOfStrings() {
+        return listOfListOfListOfStrings != null && !(listOfListOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfListOfListOfStrings()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfListOfListOfStrings property for this object.
      */
     public List<List<List<String>>> listOfListOfListOfStrings() {
@@ -166,11 +192,23 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     }
 
     /**
+     * Returns true if the MapOfStringToListOfListOfStrings property was specified by the sender (it may be empty), or
+     * false if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender
+     * is the AWS service.
+     */
+    public boolean hasMapOfStringToListOfListOfStrings() {
+        return mapOfStringToListOfListOfStrings != null && !(mapOfStringToListOfListOfStrings instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToListOfListOfStrings()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToListOfListOfStrings property for this object.
      */
     public Map<String, List<List<String>>> mapOfStringToListOfListOfStrings() {
@@ -218,8 +256,8 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         }
         NestedContainersRequest other = (NestedContainersRequest) obj;
         return Objects.equals(listOfListOfStrings(), other.listOfListOfStrings())
-                && Objects.equals(listOfListOfListOfStrings(), other.listOfListOfListOfStrings())
-                && Objects.equals(mapOfStringToListOfListOfStrings(), other.mapOfStringToListOfListOfStrings());
+               && Objects.equals(listOfListOfListOfStrings(), other.listOfListOfListOfStrings())
+               && Objects.equals(mapOfStringToListOfListOfStrings(), other.mapOfStringToListOfListOfStrings());
     }
 
     /**
@@ -229,20 +267,20 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     @Override
     public String toString() {
         return ToString.builder("NestedContainersRequest").add("ListOfListOfStrings", listOfListOfStrings())
-                .add("ListOfListOfListOfStrings", listOfListOfListOfStrings())
-                .add("MapOfStringToListOfListOfStrings", mapOfStringToListOfListOfStrings()).build();
+                       .add("ListOfListOfListOfStrings", listOfListOfListOfStrings())
+                       .add("MapOfStringToListOfListOfStrings", mapOfStringToListOfListOfStrings()).build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "ListOfListOfStrings":
-            return Optional.ofNullable(clazz.cast(listOfListOfStrings()));
-        case "ListOfListOfListOfStrings":
-            return Optional.ofNullable(clazz.cast(listOfListOfListOfStrings()));
-        case "MapOfStringToListOfListOfStrings":
-            return Optional.ofNullable(clazz.cast(mapOfStringToListOfListOfStrings()));
-        default:
-            return Optional.empty();
+            case "ListOfListOfStrings":
+                return Optional.ofNullable(clazz.cast(listOfListOfStrings()));
+            case "ListOfListOfListOfStrings":
+                return Optional.ofNullable(clazz.cast(listOfListOfListOfStrings()));
+            case "MapOfStringToListOfListOfStrings":
+                return Optional.ofNullable(clazz.cast(mapOfStringToListOfListOfStrings()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -304,7 +342,7 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder mapOfStringToListOfListOfStrings(
-                Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings);
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings);
 
         @Override
         Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
@@ -357,7 +395,7 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
 
         @Override
         public final Builder listOfListOfListOfStrings(
-                Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
+            Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
             this.listOfListOfListOfStrings = ListOfListOfListOfStringsCopier.copy(listOfListOfListOfStrings);
             return this;
         }
@@ -370,7 +408,7 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         }
 
         public final void setListOfListOfListOfStrings(
-                Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
+            Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
             this.listOfListOfListOfStrings = ListOfListOfListOfStringsCopier.copy(listOfListOfListOfStrings);
         }
 
@@ -380,13 +418,13 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
 
         @Override
         public final Builder mapOfStringToListOfListOfStrings(
-                Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
             this.mapOfStringToListOfListOfStrings = MapOfStringToListOfListOfStringsCopier.copy(mapOfStringToListOfListOfStrings);
             return this;
         }
 
         public final void setMapOfStringToListOfListOfStrings(
-                Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
             this.mapOfStringToListOfListOfStrings = MapOfStringToListOfListOfStringsCopier.copy(mapOfStringToListOfListOfStrings);
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersresponse.java
@@ -19,6 +19,8 @@ import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -27,104 +29,104 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class NestedContainersResponse extends JsonProtocolTestsResponse implements
-        ToCopyableBuilder<NestedContainersResponse.Builder, NestedContainersResponse> {
+                                                                              ToCopyableBuilder<NestedContainersResponse.Builder, NestedContainersResponse> {
     private static final SdkField<List<List<String>>> LIST_OF_LIST_OF_STRINGS_FIELD = SdkField
-            .<List<List<String>>> builder(MarshallingType.LIST)
-            .getter(getter(NestedContainersResponse::listOfListOfStrings))
-            .setter(setter(Builder::listOfListOfStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfStrings").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<List<String>>> builder(MarshallingType.LIST)
+        .getter(getter(NestedContainersResponse::listOfListOfStrings))
+        .setter(setter(Builder::listOfListOfStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfStrings").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<List<String>> builder(MarshallingType.LIST)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    ListTrait
+                                        .builder()
+                                        .memberLocationName(null)
+                                        .memberFieldInfo(
+                                            SdkField.<String> builder(MarshallingType.STRING)
+                                                .traits(LocationTrait.builder()
+                                                                     .location(MarshallLocation.PAYLOAD)
+                                                                     .locationName("member").build()).build())
+                                        .build()).build()).build()).build();
 
     private static final SdkField<List<List<List<String>>>> LIST_OF_LIST_OF_LIST_OF_STRINGS_FIELD = SdkField
-            .<List<List<List<String>>>> builder(MarshallingType.LIST)
-            .getter(getter(NestedContainersResponse::listOfListOfListOfStrings))
-            .setter(setter(Builder::listOfListOfListOfStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfListOfStrings").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<List<List<String>>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    ListTrait
+        .<List<List<List<String>>>> builder(MarshallingType.LIST)
+        .getter(getter(NestedContainersResponse::listOfListOfListOfStrings))
+        .setter(setter(Builder::listOfListOfListOfStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfListOfListOfStrings").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<List<List<String>>> builder(MarshallingType.LIST)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    ListTrait
+                                        .builder()
+                                        .memberLocationName(null)
+                                        .memberFieldInfo(
+                                            SdkField.<List<String>> builder(MarshallingType.LIST)
+                                                .traits(LocationTrait.builder()
+                                                                     .location(MarshallLocation.PAYLOAD)
+                                                                     .locationName("member").build(),
+                                                        ListTrait
                                                             .builder()
                                                             .memberLocationName(null)
                                                             .memberFieldInfo(
-                                                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build(),
-                                                                                    ListTrait
-                                                                                            .builder()
-                                                                                            .memberLocationName(null)
-                                                                                            .memberFieldInfo(
-                                                                                                    SdkField.<String> builder(
-                                                                                                            MarshallingType.STRING)
-                                                                                                            .traits(LocationTrait
-                                                                                                                    .builder()
-                                                                                                                    .location(
-                                                                                                                            MarshallLocation.PAYLOAD)
-                                                                                                                    .locationName(
-                                                                                                                            "member")
-                                                                                                                    .build())
-                                                                                                            .build()).build())
-                                                                            .build()).build()).build()).build()).build();
+                                                                SdkField.<String> builder(
+                                                                    MarshallingType.STRING)
+                                                                    .traits(LocationTrait
+                                                                                .builder()
+                                                                                .location(
+                                                                                    MarshallLocation.PAYLOAD)
+                                                                                .locationName(
+                                                                                    "member")
+                                                                                .build())
+                                                                    .build()).build())
+                                                .build()).build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<List<String>>>> MAP_OF_STRING_TO_LIST_OF_LIST_OF_STRINGS_FIELD = SdkField
-            .<Map<String, List<List<String>>>> builder(MarshallingType.MAP)
-            .getter(getter(NestedContainersResponse::mapOfStringToListOfListOfStrings))
-            .setter(setter(Builder::mapOfStringToListOfListOfStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToListOfListOfStrings")
-                    .build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<List<String>>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build(),
-                                                                                    ListTrait
-                                                                                            .builder()
-                                                                                            .memberLocationName(null)
-                                                                                            .memberFieldInfo(
-                                                                                                    SdkField.<String> builder(
-                                                                                                            MarshallingType.STRING)
-                                                                                                            .traits(LocationTrait
-                                                                                                                    .builder()
-                                                                                                                    .location(
-                                                                                                                            MarshallLocation.PAYLOAD)
-                                                                                                                    .locationName(
-                                                                                                                            "member")
-                                                                                                                    .build())
-                                                                                                            .build()).build())
-                                                                            .build()).build()).build()).build()).build();
+        .<Map<String, List<List<String>>>> builder(MarshallingType.MAP)
+        .getter(getter(NestedContainersResponse::mapOfStringToListOfListOfStrings))
+        .setter(setter(Builder::mapOfStringToListOfListOfStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToListOfListOfStrings")
+                             .build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<List<String>>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<List<String>> builder(MarshallingType.LIST)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build(),
+                                                            ListTrait
+                                                                .builder()
+                                                                .memberLocationName(null)
+                                                                .memberFieldInfo(
+                                                                    SdkField.<String> builder(
+                                                                        MarshallingType.STRING)
+                                                                        .traits(LocationTrait
+                                                                                    .builder()
+                                                                                    .location(
+                                                                                        MarshallLocation.PAYLOAD)
+                                                                                    .locationName(
+                                                                                        "member")
+                                                                                    .build())
+                                                                        .build()).build())
+                                                    .build()).build()).build()).build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(LIST_OF_LIST_OF_STRINGS_FIELD,
-            LIST_OF_LIST_OF_LIST_OF_STRINGS_FIELD, MAP_OF_STRING_TO_LIST_OF_LIST_OF_STRINGS_FIELD));
+                                                                                                   LIST_OF_LIST_OF_LIST_OF_STRINGS_FIELD, MAP_OF_STRING_TO_LIST_OF_LIST_OF_STRINGS_FIELD));
 
     private final List<List<String>> listOfListOfStrings;
 
@@ -140,11 +142,23 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     /**
+     * Returns true if the ListOfListOfStrings property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfStrings() {
+        return listOfListOfStrings != null && !(listOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfListOfStrings()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfListOfStrings property for this object.
      */
     public List<List<String>> listOfListOfStrings() {
@@ -152,11 +166,23 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     /**
+     * Returns true if the ListOfListOfListOfStrings property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfListOfStrings() {
+        return listOfListOfListOfStrings != null && !(listOfListOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfListOfListOfStrings()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfListOfListOfStrings property for this object.
      */
     public List<List<List<String>>> listOfListOfListOfStrings() {
@@ -164,11 +190,23 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     /**
+     * Returns true if the MapOfStringToListOfListOfStrings property was specified by the sender (it may be empty), or
+     * false if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender
+     * is the AWS service.
+     */
+    public boolean hasMapOfStringToListOfListOfStrings() {
+        return mapOfStringToListOfListOfStrings != null && !(mapOfStringToListOfListOfStrings instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToListOfListOfStrings()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToListOfListOfStrings property for this object.
      */
     public Map<String, List<List<String>>> mapOfStringToListOfListOfStrings() {
@@ -216,8 +254,8 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         }
         NestedContainersResponse other = (NestedContainersResponse) obj;
         return Objects.equals(listOfListOfStrings(), other.listOfListOfStrings())
-                && Objects.equals(listOfListOfListOfStrings(), other.listOfListOfListOfStrings())
-                && Objects.equals(mapOfStringToListOfListOfStrings(), other.mapOfStringToListOfListOfStrings());
+               && Objects.equals(listOfListOfListOfStrings(), other.listOfListOfListOfStrings())
+               && Objects.equals(mapOfStringToListOfListOfStrings(), other.mapOfStringToListOfListOfStrings());
     }
 
     /**
@@ -227,20 +265,20 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     @Override
     public String toString() {
         return ToString.builder("NestedContainersResponse").add("ListOfListOfStrings", listOfListOfStrings())
-                .add("ListOfListOfListOfStrings", listOfListOfListOfStrings())
-                .add("MapOfStringToListOfListOfStrings", mapOfStringToListOfListOfStrings()).build();
+                       .add("ListOfListOfListOfStrings", listOfListOfListOfStrings())
+                       .add("MapOfStringToListOfListOfStrings", mapOfStringToListOfListOfStrings()).build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "ListOfListOfStrings":
-            return Optional.ofNullable(clazz.cast(listOfListOfStrings()));
-        case "ListOfListOfListOfStrings":
-            return Optional.ofNullable(clazz.cast(listOfListOfListOfStrings()));
-        case "MapOfStringToListOfListOfStrings":
-            return Optional.ofNullable(clazz.cast(mapOfStringToListOfListOfStrings()));
-        default:
-            return Optional.empty();
+            case "ListOfListOfStrings":
+                return Optional.ofNullable(clazz.cast(listOfListOfStrings()));
+            case "ListOfListOfListOfStrings":
+                return Optional.ofNullable(clazz.cast(listOfListOfListOfStrings()));
+            case "MapOfStringToListOfListOfStrings":
+                return Optional.ofNullable(clazz.cast(mapOfStringToListOfListOfStrings()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -258,7 +296,7 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
-            CopyableBuilder<Builder, NestedContainersResponse> {
+                                     CopyableBuilder<Builder, NestedContainersResponse> {
         /**
          * Sets the value of the ListOfListOfStrings property for this object.
          *
@@ -303,7 +341,7 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder mapOfStringToListOfListOfStrings(
-                Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings);
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings);
     }
 
     static final class BuilderImpl extends JsonProtocolTestsResponse.BuilderImpl implements Builder {
@@ -350,7 +388,7 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
 
         @Override
         public final Builder listOfListOfListOfStrings(
-                Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
+            Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
             this.listOfListOfListOfStrings = ListOfListOfListOfStringsCopier.copy(listOfListOfListOfStrings);
             return this;
         }
@@ -363,7 +401,7 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         }
 
         public final void setListOfListOfListOfStrings(
-                Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
+            Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
             this.listOfListOfListOfStrings = ListOfListOfListOfStringsCopier.copy(listOfListOfListOfStrings);
         }
 
@@ -373,13 +411,13 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
 
         @Override
         public final Builder mapOfStringToListOfListOfStrings(
-                Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
             this.mapOfStringToListOfListOfStrings = MapOfStringToListOfListOfStringsCopier.copy(mapOfStringToListOfListOfStrings);
             return this;
         }
 
         public final void setMapOfStringToListOfListOfStrings(
-                Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
+            Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
             this.mapOfStringToListOfListOfStrings = MapOfStringToListOfListOfStringsCopier.copy(mapOfStringToListOfListOfStrings);
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesrequest.java
@@ -25,6 +25,8 @@ import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -34,344 +36,344 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class AllTypesRequest extends JsonProtocolTestsRequest implements
-        ToCopyableBuilder<AllTypesRequest.Builder, AllTypesRequest> {
+                                                                    ToCopyableBuilder<AllTypesRequest.Builder, AllTypesRequest> {
     private static final SdkField<String> STRING_MEMBER_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesRequest::stringMember)).setter(setter(Builder::stringMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
+        .getter(getter(AllTypesRequest::stringMember)).setter(setter(Builder::stringMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
 
     private static final SdkField<Integer> INTEGER_MEMBER_FIELD = SdkField.<Integer> builder(MarshallingType.INTEGER)
-            .getter(getter(AllTypesRequest::integerMember)).setter(setter(Builder::integerMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
+        .getter(getter(AllTypesRequest::integerMember)).setter(setter(Builder::integerMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
 
     private static final SdkField<Boolean> BOOLEAN_MEMBER_FIELD = SdkField.<Boolean> builder(MarshallingType.BOOLEAN)
-            .getter(getter(AllTypesRequest::booleanMember)).setter(setter(Builder::booleanMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
+        .getter(getter(AllTypesRequest::booleanMember)).setter(setter(Builder::booleanMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
 
     private static final SdkField<Float> FLOAT_MEMBER_FIELD = SdkField.<Float> builder(MarshallingType.FLOAT)
-            .getter(getter(AllTypesRequest::floatMember)).setter(setter(Builder::floatMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
+        .getter(getter(AllTypesRequest::floatMember)).setter(setter(Builder::floatMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
 
     private static final SdkField<Double> DOUBLE_MEMBER_FIELD = SdkField.<Double> builder(MarshallingType.DOUBLE)
-            .getter(getter(AllTypesRequest::doubleMember)).setter(setter(Builder::doubleMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
+        .getter(getter(AllTypesRequest::doubleMember)).setter(setter(Builder::doubleMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
 
     private static final SdkField<Long> LONG_MEMBER_FIELD = SdkField.<Long> builder(MarshallingType.LONG)
-            .getter(getter(AllTypesRequest::longMember)).setter(setter(Builder::longMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
+        .getter(getter(AllTypesRequest::longMember)).setter(setter(Builder::longMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
 
     private static final SdkField<List<String>> SIMPLE_LIST_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::simpleList))
-            .setter(setter(Builder::simpleList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::simpleList))
+        .setter(setter(Builder::simpleList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<String>> LIST_OF_ENUMS_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfEnumsAsStrings))
-            .setter(setter(Builder::listOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfEnumsAsStrings))
+        .setter(setter(Builder::listOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAPS_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfMaps))
-            .setter(setter(Builder::listOfMaps))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfMaps))
+        .setter(setter(Builder::listOfMaps))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<List<SimpleStruct>> LIST_OF_STRUCTS_FIELD = SdkField
-            .<List<SimpleStruct>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfStructs))
-            .setter(setter(Builder::listOfStructs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SimpleStruct>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfStructs))
+        .setter(setter(Builder::listOfStructs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                            .constructor(SimpleStruct::builder)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfMapOfEnumToStringAsStrings))
-            .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfMapOfEnumToStringAsStrings))
+        .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<Integer>>> MAP_OF_STRING_TO_INTEGER_LIST_FIELD = SdkField
-            .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToIntegerList))
-            .setter(setter(Builder::mapOfStringToIntegerList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<Integer>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<Integer> builder(MarshallingType.INTEGER)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToIntegerList))
+        .setter(setter(Builder::mapOfStringToIntegerList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<Integer>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<Integer> builder(MarshallingType.INTEGER)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToString))
-            .setter(setter(Builder::mapOfStringToString))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToString))
+        .setter(setter(Builder::mapOfStringToString))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToSimpleStruct))
-            .setter(setter(Builder::mapOfStringToSimpleStruct))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToSimpleStruct))
+        .setter(setter(Builder::mapOfStringToSimpleStruct))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToStringAsStrings))
-            .setter(setter(Builder::mapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToStringAsStrings))
+        .setter(setter(Builder::mapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToSimpleStructAsStrings))
-            .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToSimpleStructAsStrings))
+        .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<String>>> MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD = SdkField
-            .<Map<String, List<String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToListOfEnumsAsStrings))
-            .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToListOfEnumsAsStrings))
+        .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<String>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, Map<String, String>>> MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::mapOfEnumToMapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
-                    .build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::mapOfEnumToMapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
+                             .build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        MapTrait.builder()
+                                                .keyLocationName("key")
+                                                .valueLocationName("value")
+                                                .valueFieldInfo(
+                                                    SdkField.<String> builder(MarshallingType.STRING)
+                                                        .traits(LocationTrait.builder()
+                                                                             .location(MarshallLocation.PAYLOAD)
+                                                                             .locationName("value").build()).build())
+                                                .build()).build()).build()).build();
 
     private static final SdkField<Instant> TIMESTAMP_MEMBER_FIELD = SdkField.<Instant> builder(MarshallingType.INSTANT)
-            .getter(getter(AllTypesRequest::timestampMember)).setter(setter(Builder::timestampMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
+        .getter(getter(AllTypesRequest::timestampMember)).setter(setter(Builder::timestampMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
 
     private static final SdkField<StructWithTimestamp> STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD = SdkField
-            .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesRequest::structWithNestedTimestampMember))
-            .setter(setter(Builder::structWithNestedTimestampMember))
-            .constructor(StructWithTimestamp::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
-                    .build()).build();
+        .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesRequest::structWithNestedTimestampMember))
+        .setter(setter(Builder::structWithNestedTimestampMember))
+        .constructor(StructWithTimestamp::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
+                             .build()).build();
 
     private static final SdkField<SdkBytes> BLOB_ARG_FIELD = SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-            .getter(getter(AllTypesRequest::blobArg)).setter(setter(Builder::blobArg))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
+        .getter(getter(AllTypesRequest::blobArg)).setter(setter(Builder::blobArg))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
 
     private static final SdkField<StructWithNestedBlobType> STRUCT_WITH_NESTED_BLOB_FIELD = SdkField
-            .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::structWithNestedBlob))
-            .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
-            .build();
+        .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::structWithNestedBlob))
+                                                                     .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
+                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
+                                                                     .build();
 
     private static final SdkField<Map<String, SdkBytes>> BLOB_MAP_FIELD = SdkField
-            .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesRequest::blobMap))
-            .setter(setter(Builder::blobMap))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesRequest::blobMap))
+        .setter(setter(Builder::blobMap))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<List<SdkBytes>> LIST_OF_BLOBS_FIELD = SdkField
-            .<List<SdkBytes>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesRequest::listOfBlobs))
-            .setter(setter(Builder::listOfBlobs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SdkBytes>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesRequest::listOfBlobs))
+        .setter(setter(Builder::listOfBlobs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<RecursiveStructType> RECURSIVE_STRUCT_FIELD = SdkField
-            .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::recursiveStruct))
-            .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
+        .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesRequest::recursiveStruct))
+                                                                .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
+                                                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
 
     private static final SdkField<BaseType> POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD = SdkField
-            .<BaseType> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesRequest::polymorphicTypeWithSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithSubTypes))
-            .constructor(BaseType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
-                    .build()).build();
+        .<BaseType> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesRequest::polymorphicTypeWithSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithSubTypes))
+        .constructor(BaseType::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
+                             .build()).build();
 
     private static final SdkField<SubTypeOne> POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD = SdkField
-            .<SubTypeOne> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesRequest::polymorphicTypeWithoutSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
-            .constructor(SubTypeOne::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
-                    .build()).build();
+        .<SubTypeOne> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesRequest::polymorphicTypeWithoutSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
+        .constructor(SubTypeOne::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
+                             .build()).build();
 
     private static final SdkField<String> ENUM_TYPE_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesRequest::enumTypeAsString)).setter(setter(Builder::enumType))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
+        .getter(getter(AllTypesRequest::enumTypeAsString)).setter(setter(Builder::enumType))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(STRING_MEMBER_FIELD,
-            INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
-            SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
-            LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
-            MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
-            BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
-            POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
+                                                                                                   INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
+                                                                                                   SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
+                                                                                                   LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
+                                                                                                   MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
+                                                                                                   BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
+                                                                                                   POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
 
     private final String stringMember;
 
@@ -469,7 +471,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the StringMember property for this object.
-     * 
+     *
      * @return The value of the StringMember property for this object.
      */
     public String stringMember() {
@@ -478,7 +480,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the IntegerMember property for this object.
-     * 
+     *
      * @return The value of the IntegerMember property for this object.
      */
     public Integer integerMember() {
@@ -487,7 +489,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the BooleanMember property for this object.
-     * 
+     *
      * @return The value of the BooleanMember property for this object.
      */
     public Boolean booleanMember() {
@@ -496,7 +498,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the FloatMember property for this object.
-     * 
+     *
      * @return The value of the FloatMember property for this object.
      */
     public Float floatMember() {
@@ -505,7 +507,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the DoubleMember property for this object.
-     * 
+     *
      * @return The value of the DoubleMember property for this object.
      */
     public Double doubleMember() {
@@ -514,7 +516,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the LongMember property for this object.
-     * 
+     *
      * @return The value of the LongMember property for this object.
      */
     public Long longMember() {
@@ -522,11 +524,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the SimpleList property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSimpleList() {
+        return simpleList != null && !(simpleList instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the SimpleList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasSimpleList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the SimpleList property for this object.
      */
     public List<String> simpleList() {
@@ -538,7 +551,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<EnumType> listOfEnums() {
@@ -546,11 +562,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfEnums property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfEnums() {
+        return listOfEnums != null && !(listOfEnums instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<String> listOfEnumsAsStrings() {
@@ -558,11 +585,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfMaps property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfMaps() {
+        return listOfMaps != null && !(listOfMaps instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMaps property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMaps()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMaps property for this object.
      */
     public List<Map<String, String>> listOfMaps() {
@@ -570,11 +608,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfStructs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfStructs() {
+        return listOfStructs != null && !(listOfStructs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfStructs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfStructs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfStructs property for this object.
      */
     public List<SimpleStruct> listOfStructs() {
@@ -586,7 +635,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<EnumType, String>> listOfMapOfEnumToString() {
@@ -594,11 +646,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfMapOfEnumToString property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfMapOfEnumToString() {
+        return listOfMapOfEnumToString != null && !(listOfMapOfEnumToString instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<String, String>> listOfMapOfEnumToStringAsStrings() {
@@ -606,11 +670,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToIntegerList property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToIntegerList() {
+        return mapOfStringToIntegerList != null && !(mapOfStringToIntegerList instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToIntegerList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToIntegerList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToIntegerList property for this object.
      */
     public Map<String, List<Integer>> mapOfStringToIntegerList() {
@@ -618,11 +694,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToString() {
+        return mapOfStringToString != null && !(mapOfStringToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToString property for this object.
      */
     public Map<String, String> mapOfStringToString() {
@@ -630,11 +718,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToSimpleStruct() {
+        return mapOfStringToSimpleStruct != null && !(mapOfStringToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfStringToSimpleStruct() {
@@ -646,7 +746,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<EnumType, EnumType> mapOfEnumToEnum() {
@@ -654,11 +757,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToEnum() {
+        return mapOfEnumToEnum != null && !(mapOfEnumToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<String, String> mapOfEnumToEnumAsStrings() {
@@ -670,7 +785,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<EnumType, String> mapOfEnumToString() {
@@ -678,11 +796,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToString() {
+        return mapOfEnumToString != null && !(mapOfEnumToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<String, String> mapOfEnumToStringAsStrings() {
@@ -694,7 +824,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, EnumType> mapOfStringToEnum() {
@@ -702,11 +835,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfStringToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToEnum() {
+        return mapOfStringToEnum != null && !(mapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, String> mapOfStringToEnumAsStrings() {
@@ -718,7 +863,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct() {
@@ -726,11 +874,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToSimpleStruct() {
+        return mapOfEnumToSimpleStruct != null && !(mapOfEnumToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfEnumToSimpleStructAsStrings() {
@@ -742,7 +902,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<EnumType, List<EnumType>> mapOfEnumToListOfEnums() {
@@ -750,11 +913,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToListOfEnums property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToListOfEnums() {
+        return mapOfEnumToListOfEnums != null && !(mapOfEnumToListOfEnums instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<String, List<String>> mapOfEnumToListOfEnumsAsStrings() {
@@ -766,7 +941,10 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum() {
@@ -774,11 +952,23 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the MapOfEnumToMapOfStringToEnum property was specified by the sender (it may be empty), or false
+     * if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the
+     * AWS service.
+     */
+    public boolean hasMapOfEnumToMapOfStringToEnum() {
+        return mapOfEnumToMapOfStringToEnum != null && !(mapOfEnumToMapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToMapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumAsStrings() {
@@ -787,7 +977,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the TimestampMember property for this object.
-     * 
+     *
      * @return The value of the TimestampMember property for this object.
      */
     public Instant timestampMember() {
@@ -796,7 +986,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the StructWithNestedTimestampMember property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedTimestampMember property for this object.
      */
     public StructWithTimestamp structWithNestedTimestampMember() {
@@ -805,7 +995,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * 
+     *
      * @return The value of the BlobArg property for this object.
      */
     public SdkBytes blobArg() {
@@ -814,7 +1004,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the StructWithNestedBlob property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedBlob property for this object.
      */
     public StructWithNestedBlobType structWithNestedBlob() {
@@ -822,11 +1012,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the BlobMap property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBlobMap() {
+        return blobMap != null && !(blobMap instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the BlobMap property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasBlobMap()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the BlobMap property for this object.
      */
     public Map<String, SdkBytes> blobMap() {
@@ -834,11 +1035,22 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     }
 
     /**
+     * Returns true if the ListOfBlobs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfBlobs() {
+        return listOfBlobs != null && !(listOfBlobs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfBlobs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfBlobs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfBlobs property for this object.
      */
     public List<SdkBytes> listOfBlobs() {
@@ -847,7 +1059,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the RecursiveStruct property for this object.
-     * 
+     *
      * @return The value of the RecursiveStruct property for this object.
      */
     public RecursiveStructType recursiveStruct() {
@@ -856,7 +1068,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the PolymorphicTypeWithSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithSubTypes property for this object.
      */
     public BaseType polymorphicTypeWithSubTypes() {
@@ -865,7 +1077,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the PolymorphicTypeWithoutSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithoutSubTypes property for this object.
      */
     public SubTypeOne polymorphicTypeWithoutSubTypes() {
@@ -879,7 +1091,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -894,7 +1106,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -995,6 +1207,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
                && Objects.equals(polymorphicTypeWithoutSubTypes(), other.polymorphicTypeWithoutSubTypes())
                && Objects.equals(enumTypeAsString(), other.enumTypeAsString());
     }
+
     /**
      * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
      * redacted from this string using a placeholder value.
@@ -1002,88 +1215,88 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
     @Override
     public String toString() {
         return ToString.builder("AllTypesRequest").add("StringMember", stringMember()).add("IntegerMember", integerMember())
-                .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
-                .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
-                .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
-                .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
-                .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
-                .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
-                .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
-                .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
-                .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
-                .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
-                .add("TimestampMember", timestampMember())
-                .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
-                .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
-                .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
-                .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
-                .build();
+                       .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
+                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
+                       .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
+                       .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
+                       .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
+                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
+                       .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
+                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
+                       .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
+                       .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
+                       .add("TimestampMember", timestampMember())
+                       .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
+                       .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
+                       .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
+                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
+                       .build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "StringMember":
-            return Optional.ofNullable(clazz.cast(stringMember()));
-        case "IntegerMember":
-            return Optional.ofNullable(clazz.cast(integerMember()));
-        case "BooleanMember":
-            return Optional.ofNullable(clazz.cast(booleanMember()));
-        case "FloatMember":
-            return Optional.ofNullable(clazz.cast(floatMember()));
-        case "DoubleMember":
-            return Optional.ofNullable(clazz.cast(doubleMember()));
-        case "LongMember":
-            return Optional.ofNullable(clazz.cast(longMember()));
-        case "SimpleList":
-            return Optional.ofNullable(clazz.cast(simpleList()));
-        case "ListOfEnums":
-            return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
-        case "ListOfMaps":
-            return Optional.ofNullable(clazz.cast(listOfMaps()));
-        case "ListOfStructs":
-            return Optional.ofNullable(clazz.cast(listOfStructs()));
-        case "ListOfMapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
-        case "MapOfStringToIntegerList":
-            return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
-        case "MapOfStringToString":
-            return Optional.ofNullable(clazz.cast(mapOfStringToString()));
-        case "MapOfStringToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
-        case "MapOfEnumToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
-        case "MapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
-        case "MapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
-        case "MapOfEnumToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
-        case "MapOfEnumToListOfEnums":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
-        case "MapOfEnumToMapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
-        case "TimestampMember":
-            return Optional.ofNullable(clazz.cast(timestampMember()));
-        case "StructWithNestedTimestampMember":
-            return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
-        case "BlobArg":
-            return Optional.ofNullable(clazz.cast(blobArg()));
-        case "StructWithNestedBlob":
-            return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
-        case "BlobMap":
-            return Optional.ofNullable(clazz.cast(blobMap()));
-        case "ListOfBlobs":
-            return Optional.ofNullable(clazz.cast(listOfBlobs()));
-        case "RecursiveStruct":
-            return Optional.ofNullable(clazz.cast(recursiveStruct()));
-        case "PolymorphicTypeWithSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
-        case "PolymorphicTypeWithoutSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
-        case "EnumType":
-            return Optional.ofNullable(clazz.cast(enumTypeAsString()));
-        default:
-            return Optional.empty();
+            case "StringMember":
+                return Optional.ofNullable(clazz.cast(stringMember()));
+            case "IntegerMember":
+                return Optional.ofNullable(clazz.cast(integerMember()));
+            case "BooleanMember":
+                return Optional.ofNullable(clazz.cast(booleanMember()));
+            case "FloatMember":
+                return Optional.ofNullable(clazz.cast(floatMember()));
+            case "DoubleMember":
+                return Optional.ofNullable(clazz.cast(doubleMember()));
+            case "LongMember":
+                return Optional.ofNullable(clazz.cast(longMember()));
+            case "SimpleList":
+                return Optional.ofNullable(clazz.cast(simpleList()));
+            case "ListOfEnums":
+                return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
+            case "ListOfMaps":
+                return Optional.ofNullable(clazz.cast(listOfMaps()));
+            case "ListOfStructs":
+                return Optional.ofNullable(clazz.cast(listOfStructs()));
+            case "ListOfMapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
+            case "MapOfStringToIntegerList":
+                return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
+            case "MapOfStringToString":
+                return Optional.ofNullable(clazz.cast(mapOfStringToString()));
+            case "MapOfStringToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
+            case "MapOfEnumToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
+            case "MapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
+            case "MapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
+            case "MapOfEnumToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
+            case "MapOfEnumToListOfEnums":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
+            case "MapOfEnumToMapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
+            case "TimestampMember":
+                return Optional.ofNullable(clazz.cast(timestampMember()));
+            case "StructWithNestedTimestampMember":
+                return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
+            case "BlobArg":
+                return Optional.ofNullable(clazz.cast(blobArg()));
+            case "StructWithNestedBlob":
+                return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
+            case "BlobMap":
+                return Optional.ofNullable(clazz.cast(blobMap()));
+            case "ListOfBlobs":
+                return Optional.ofNullable(clazz.cast(listOfBlobs()));
+            case "RecursiveStruct":
+                return Optional.ofNullable(clazz.cast(recursiveStruct()));
+            case "PolymorphicTypeWithSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
+            case "PolymorphicTypeWithoutSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
+            case "EnumType":
+                return Optional.ofNullable(clazz.cast(enumTypeAsString()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -1253,7 +1466,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link List<SimpleStruct>.Builder#build()} is called immediately and its
          * result is passed to {@link #listOfStructs(List<SimpleStruct>)}.
-         * 
+         *
          * @param listOfStructs
          *        a consumer that will call methods on {@link List<SimpleStruct>.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1440,7 +1653,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link StructWithTimestamp.Builder#build()} is called immediately and
          * its result is passed to {@link #structWithNestedTimestampMember(StructWithTimestamp)}.
-         * 
+         *
          * @param structWithNestedTimestampMember
          *        a consumer that will call methods on {@link StructWithTimestamp.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1448,7 +1661,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          */
         default Builder structWithNestedTimestampMember(Consumer<StructWithTimestamp.Builder> structWithNestedTimestampMember) {
             return structWithNestedTimestampMember(StructWithTimestamp.builder().applyMutation(structWithNestedTimestampMember)
-                    .build());
+                                                                      .build());
         }
 
         /**
@@ -1477,7 +1690,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link StructWithNestedBlobType.Builder#build()} is called immediately
          * and its result is passed to {@link #structWithNestedBlob(StructWithNestedBlobType)}.
-         * 
+         *
          * @param structWithNestedBlob
          *        a consumer that will call methods on {@link StructWithNestedBlobType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1531,7 +1744,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
          * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
-         * 
+         *
          * @param recursiveStruct
          *        a consumer that will call methods on {@link RecursiveStructType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1558,7 +1771,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link BaseType.Builder#build()} is called immediately and its result is
          * passed to {@link #polymorphicTypeWithSubTypes(BaseType)}.
-         * 
+         *
          * @param polymorphicTypeWithSubTypes
          *        a consumer that will call methods on {@link BaseType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1585,7 +1798,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *
          * When the {@link Consumer} completes, {@link SubTypeOne.Builder#build()} is called immediately and its result
          * is passed to {@link #polymorphicTypeWithoutSubTypes(SubTypeOne)}.
-         * 
+         *
          * @param polymorphicTypeWithoutSubTypes
          *        a consumer that will call methods on {@link SubTypeOne.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1884,7 +2097,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Collection<SimpleStruct.Builder> getListOfStructs() {
             return listOfStructs != null ? listOfStructs.stream().map(SimpleStruct::toBuilder).collect(Collectors.toList())
-                    : null;
+                                         : null;
         }
 
         @Override
@@ -1904,7 +2117,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
-                    .collect(Collectors.toList()));
+                                .collect(Collectors.toList()));
             return this;
         }
 
@@ -1963,7 +2176,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
             return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
-                    SimpleStruct::toBuilder) : null;
+                                                                                 SimpleStruct::toBuilder) : null;
         }
 
         @Override
@@ -2038,7 +2251,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
-                    : null;
+                                                   : null;
         }
 
         @Override
@@ -2123,7 +2336,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                    .build() : null;
+                .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {
@@ -2156,7 +2369,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final Map<String, ByteBuffer> getBlobMap() {
             return blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
@@ -2167,7 +2380,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
             blobMap(blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
         public final List<ByteBuffer> getListOfBlobs() {
@@ -2189,7 +2402,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
             listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
-                    .collect(Collectors.toList()));
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {
@@ -2232,7 +2445,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         public final void setPolymorphicTypeWithoutSubTypes(SubTypeOne.BuilderImpl polymorphicTypeWithoutSubTypes) {
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes != null ? polymorphicTypeWithoutSubTypes.build()
-                    : null;
+                                                                                         : null;
         }
 
         public final String getEnumTypeAsString() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesresponse.java
@@ -24,6 +24,8 @@ import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -33,344 +35,344 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class AllTypesResponse extends JsonProtocolTestsResponse implements
-        ToCopyableBuilder<AllTypesResponse.Builder, AllTypesResponse> {
+                                                                      ToCopyableBuilder<AllTypesResponse.Builder, AllTypesResponse> {
     private static final SdkField<String> STRING_MEMBER_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesResponse::stringMember)).setter(setter(Builder::stringMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
+        .getter(getter(AllTypesResponse::stringMember)).setter(setter(Builder::stringMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StringMember").build()).build();
 
     private static final SdkField<Integer> INTEGER_MEMBER_FIELD = SdkField.<Integer> builder(MarshallingType.INTEGER)
-            .getter(getter(AllTypesResponse::integerMember)).setter(setter(Builder::integerMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
+        .getter(getter(AllTypesResponse::integerMember)).setter(setter(Builder::integerMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("IntegerMember").build()).build();
 
     private static final SdkField<Boolean> BOOLEAN_MEMBER_FIELD = SdkField.<Boolean> builder(MarshallingType.BOOLEAN)
-            .getter(getter(AllTypesResponse::booleanMember)).setter(setter(Builder::booleanMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
+        .getter(getter(AllTypesResponse::booleanMember)).setter(setter(Builder::booleanMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BooleanMember").build()).build();
 
     private static final SdkField<Float> FLOAT_MEMBER_FIELD = SdkField.<Float> builder(MarshallingType.FLOAT)
-            .getter(getter(AllTypesResponse::floatMember)).setter(setter(Builder::floatMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
+        .getter(getter(AllTypesResponse::floatMember)).setter(setter(Builder::floatMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("FloatMember").build()).build();
 
     private static final SdkField<Double> DOUBLE_MEMBER_FIELD = SdkField.<Double> builder(MarshallingType.DOUBLE)
-            .getter(getter(AllTypesResponse::doubleMember)).setter(setter(Builder::doubleMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
+        .getter(getter(AllTypesResponse::doubleMember)).setter(setter(Builder::doubleMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("DoubleMember").build()).build();
 
     private static final SdkField<Long> LONG_MEMBER_FIELD = SdkField.<Long> builder(MarshallingType.LONG)
-            .getter(getter(AllTypesResponse::longMember)).setter(setter(Builder::longMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
+        .getter(getter(AllTypesResponse::longMember)).setter(setter(Builder::longMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
 
     private static final SdkField<List<String>> SIMPLE_LIST_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::simpleList))
-            .setter(setter(Builder::simpleList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::simpleList))
+        .setter(setter(Builder::simpleList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("SimpleList").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<String>> LIST_OF_ENUMS_FIELD = SdkField
-            .<List<String>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfEnumsAsStrings))
-            .setter(setter(Builder::listOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfEnumsAsStrings))
+        .setter(setter(Builder::listOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfEnums").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAPS_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfMaps))
-            .setter(setter(Builder::listOfMaps))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfMaps))
+        .setter(setter(Builder::listOfMaps))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMaps").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<List<SimpleStruct>> LIST_OF_STRUCTS_FIELD = SdkField
-            .<List<SimpleStruct>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfStructs))
-            .setter(setter(Builder::listOfStructs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SimpleStruct>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfStructs))
+        .setter(setter(Builder::listOfStructs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfStructs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                            .constructor(SimpleStruct::builder)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<List<Map<String, String>>> LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<List<Map<String, String>>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfMapOfEnumToStringAsStrings))
-            .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<List<Map<String, String>>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfMapOfEnumToStringAsStrings))
+        .setter(setter(Builder::listOfMapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfMapOfEnumToString").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build(),
+                                    MapTrait.builder()
+                                            .keyLocationName("key")
+                                            .valueLocationName("value")
+                                            .valueFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("value").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<Integer>>> MAP_OF_STRING_TO_INTEGER_LIST_FIELD = SdkField
-            .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToIntegerList))
-            .setter(setter(Builder::mapOfStringToIntegerList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<Integer>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<Integer> builder(MarshallingType.INTEGER)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<Integer>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToIntegerList))
+        .setter(setter(Builder::mapOfStringToIntegerList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToIntegerList").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<Integer>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<Integer> builder(MarshallingType.INTEGER)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToString))
-            .setter(setter(Builder::mapOfStringToString))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToString))
+        .setter(setter(Builder::mapOfStringToString))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToSimpleStruct))
-            .setter(setter(Builder::mapOfStringToSimpleStruct))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToSimpleStruct))
+        .setter(setter(Builder::mapOfStringToSimpleStruct))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_ENUM_TO_STRING_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToStringAsStrings))
-            .setter(setter(Builder::mapOfEnumToStringWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToStringAsStrings))
+        .setter(setter(Builder::mapOfEnumToStringWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, String>> MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, String>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<String> builder(MarshallingType.STRING)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfStringToEnum").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, SimpleStruct>> MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD = SdkField
-            .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToSimpleStructAsStrings))
-            .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
-                                            .constructor(SimpleStruct::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SimpleStruct>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToSimpleStructAsStrings))
+        .setter(setter(Builder::mapOfEnumToSimpleStructWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToSimpleStruct").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SimpleStruct> builder(MarshallingType.SDK_POJO)
+                                .constructor(SimpleStruct::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<Map<String, List<String>>> MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD = SdkField
-            .<Map<String, List<String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToListOfEnumsAsStrings))
-            .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<List<String>> builder(MarshallingType.LIST)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    ListTrait
-                                                            .builder()
-                                                            .memberLocationName(null)
-                                                            .memberFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("member").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, List<String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToListOfEnumsAsStrings))
+        .setter(setter(Builder::mapOfEnumToListOfEnumsWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToListOfEnums").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<List<String>> builder(MarshallingType.LIST)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        ListTrait
+                                            .builder()
+                                            .memberLocationName(null)
+                                            .memberFieldInfo(
+                                                SdkField.<String> builder(MarshallingType.STRING)
+                                                    .traits(LocationTrait.builder()
+                                                                         .location(MarshallLocation.PAYLOAD)
+                                                                         .locationName("member").build()).build())
+                                            .build()).build()).build()).build();
 
     private static final SdkField<Map<String, Map<String, String>>> MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD = SdkField
-            .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::mapOfEnumToMapOfStringToEnumAsStrings))
-            .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
-                    .build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<Map<String, String>> builder(MarshallingType.MAP)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build(),
-                                                    MapTrait.builder()
-                                                            .keyLocationName("key")
-                                                            .valueLocationName("value")
-                                                            .valueFieldInfo(
-                                                                    SdkField.<String> builder(MarshallingType.STRING)
-                                                                            .traits(LocationTrait.builder()
-                                                                                    .location(MarshallLocation.PAYLOAD)
-                                                                                    .locationName("value").build()).build())
-                                                            .build()).build()).build()).build();
+        .<Map<String, Map<String, String>>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::mapOfEnumToMapOfStringToEnumAsStrings))
+        .setter(setter(Builder::mapOfEnumToMapOfStringToEnumWithStrings))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("MapOfEnumToMapOfStringToEnum")
+                             .build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<Map<String, String>> builder(MarshallingType.MAP)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build(),
+                                        MapTrait.builder()
+                                                .keyLocationName("key")
+                                                .valueLocationName("value")
+                                                .valueFieldInfo(
+                                                    SdkField.<String> builder(MarshallingType.STRING)
+                                                        .traits(LocationTrait.builder()
+                                                                             .location(MarshallLocation.PAYLOAD)
+                                                                             .locationName("value").build()).build())
+                                                .build()).build()).build()).build();
 
     private static final SdkField<Instant> TIMESTAMP_MEMBER_FIELD = SdkField.<Instant> builder(MarshallingType.INSTANT)
-            .getter(getter(AllTypesResponse::timestampMember)).setter(setter(Builder::timestampMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
+        .getter(getter(AllTypesResponse::timestampMember)).setter(setter(Builder::timestampMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("TimestampMember").build()).build();
 
     private static final SdkField<StructWithTimestamp> STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD = SdkField
-            .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesResponse::structWithNestedTimestampMember))
-            .setter(setter(Builder::structWithNestedTimestampMember))
-            .constructor(StructWithTimestamp::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
-                    .build()).build();
+        .<StructWithTimestamp> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesResponse::structWithNestedTimestampMember))
+        .setter(setter(Builder::structWithNestedTimestampMember))
+        .constructor(StructWithTimestamp::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedTimestampMember")
+                             .build()).build();
 
     private static final SdkField<SdkBytes> BLOB_ARG_FIELD = SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-            .getter(getter(AllTypesResponse::blobArg)).setter(setter(Builder::blobArg))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
+        .getter(getter(AllTypesResponse::blobArg)).setter(setter(Builder::blobArg))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobArg").build()).build();
 
     private static final SdkField<StructWithNestedBlobType> STRUCT_WITH_NESTED_BLOB_FIELD = SdkField
-            .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::structWithNestedBlob))
-            .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
-            .build();
+        .<StructWithNestedBlobType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::structWithNestedBlob))
+                                                                     .setter(setter(Builder::structWithNestedBlob)).constructor(StructWithNestedBlobType::builder)
+                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("StructWithNestedBlob").build())
+                                                                     .build();
 
     private static final SdkField<Map<String, SdkBytes>> BLOB_MAP_FIELD = SdkField
-            .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
-            .getter(getter(AllTypesResponse::blobMap))
-            .setter(setter(Builder::blobMap))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, SdkBytes>> builder(MarshallingType.MAP)
+        .getter(getter(AllTypesResponse::blobMap))
+        .setter(setter(Builder::blobMap))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("BlobMap").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final SdkField<List<SdkBytes>> LIST_OF_BLOBS_FIELD = SdkField
-            .<List<SdkBytes>> builder(MarshallingType.LIST)
-            .getter(getter(AllTypesResponse::listOfBlobs))
-            .setter(setter(Builder::listOfBlobs))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<SdkBytes>> builder(MarshallingType.LIST)
+        .getter(getter(AllTypesResponse::listOfBlobs))
+        .setter(setter(Builder::listOfBlobs))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ListOfBlobs").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<RecursiveStructType> RECURSIVE_STRUCT_FIELD = SdkField
-            .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::recursiveStruct))
-            .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
+        .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(AllTypesResponse::recursiveStruct))
+                                                                .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
+                                                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
 
     private static final SdkField<BaseType> POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD = SdkField
-            .<BaseType> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesResponse::polymorphicTypeWithSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithSubTypes))
-            .constructor(BaseType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
-                    .build()).build();
+        .<BaseType> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesResponse::polymorphicTypeWithSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithSubTypes))
+        .constructor(BaseType::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithSubTypes")
+                             .build()).build();
 
     private static final SdkField<SubTypeOne> POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD = SdkField
-            .<SubTypeOne> builder(MarshallingType.SDK_POJO)
-            .getter(getter(AllTypesResponse::polymorphicTypeWithoutSubTypes))
-            .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
-            .constructor(SubTypeOne::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
-                    .build()).build();
+        .<SubTypeOne> builder(MarshallingType.SDK_POJO)
+        .getter(getter(AllTypesResponse::polymorphicTypeWithoutSubTypes))
+        .setter(setter(Builder::polymorphicTypeWithoutSubTypes))
+        .constructor(SubTypeOne::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("PolymorphicTypeWithoutSubTypes")
+                             .build()).build();
 
     private static final SdkField<String> ENUM_TYPE_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(AllTypesResponse::enumTypeAsString)).setter(setter(Builder::enumType))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
+        .getter(getter(AllTypesResponse::enumTypeAsString)).setter(setter(Builder::enumType))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("EnumType").build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(STRING_MEMBER_FIELD,
-            INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
-            SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
-            LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
-            MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
-            MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
-            BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
-            POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
+                                                                                                   INTEGER_MEMBER_FIELD, BOOLEAN_MEMBER_FIELD, FLOAT_MEMBER_FIELD, DOUBLE_MEMBER_FIELD, LONG_MEMBER_FIELD,
+                                                                                                   SIMPLE_LIST_FIELD, LIST_OF_ENUMS_FIELD, LIST_OF_MAPS_FIELD, LIST_OF_STRUCTS_FIELD,
+                                                                                                   LIST_OF_MAP_OF_ENUM_TO_STRING_FIELD, MAP_OF_STRING_TO_INTEGER_LIST_FIELD, MAP_OF_STRING_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_ENUM_FIELD, MAP_OF_ENUM_TO_STRING_FIELD,
+                                                                                                   MAP_OF_STRING_TO_ENUM_FIELD, MAP_OF_ENUM_TO_SIMPLE_STRUCT_FIELD, MAP_OF_ENUM_TO_LIST_OF_ENUMS_FIELD,
+                                                                                                   MAP_OF_ENUM_TO_MAP_OF_STRING_TO_ENUM_FIELD, TIMESTAMP_MEMBER_FIELD, STRUCT_WITH_NESTED_TIMESTAMP_MEMBER_FIELD,
+                                                                                                   BLOB_ARG_FIELD, STRUCT_WITH_NESTED_BLOB_FIELD, BLOB_MAP_FIELD, LIST_OF_BLOBS_FIELD, RECURSIVE_STRUCT_FIELD,
+                                                                                                   POLYMORPHIC_TYPE_WITH_SUB_TYPES_FIELD, POLYMORPHIC_TYPE_WITHOUT_SUB_TYPES_FIELD, ENUM_TYPE_FIELD));
 
     private final String stringMember;
 
@@ -468,7 +470,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the StringMember property for this object.
-     * 
+     *
      * @return The value of the StringMember property for this object.
      */
     public String stringMember() {
@@ -477,7 +479,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the IntegerMember property for this object.
-     * 
+     *
      * @return The value of the IntegerMember property for this object.
      */
     public Integer integerMember() {
@@ -486,7 +488,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the BooleanMember property for this object.
-     * 
+     *
      * @return The value of the BooleanMember property for this object.
      */
     public Boolean booleanMember() {
@@ -495,7 +497,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the FloatMember property for this object.
-     * 
+     *
      * @return The value of the FloatMember property for this object.
      */
     public Float floatMember() {
@@ -504,7 +506,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the DoubleMember property for this object.
-     * 
+     *
      * @return The value of the DoubleMember property for this object.
      */
     public Double doubleMember() {
@@ -513,7 +515,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the LongMember property for this object.
-     * 
+     *
      * @return The value of the LongMember property for this object.
      */
     public Long longMember() {
@@ -521,11 +523,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the SimpleList property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSimpleList() {
+        return simpleList != null && !(simpleList instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the SimpleList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasSimpleList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the SimpleList property for this object.
      */
     public List<String> simpleList() {
@@ -537,7 +550,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<EnumType> listOfEnums() {
@@ -545,11 +561,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfEnums property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfEnums() {
+        return listOfEnums != null && !(listOfEnums instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfEnums property for this object.
      */
     public List<String> listOfEnumsAsStrings() {
@@ -557,11 +584,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfMaps property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfMaps() {
+        return listOfMaps != null && !(listOfMaps instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMaps property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMaps()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMaps property for this object.
      */
     public List<Map<String, String>> listOfMaps() {
@@ -569,11 +607,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfStructs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfStructs() {
+        return listOfStructs != null && !(listOfStructs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfStructs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfStructs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfStructs property for this object.
      */
     public List<SimpleStruct> listOfStructs() {
@@ -585,7 +634,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<EnumType, String>> listOfMapOfEnumToString() {
@@ -593,11 +645,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfMapOfEnumToString property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfMapOfEnumToString() {
+        return listOfMapOfEnumToString != null && !(listOfMapOfEnumToString instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfMapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfMapOfEnumToString property for this object.
      */
     public List<Map<String, String>> listOfMapOfEnumToStringAsStrings() {
@@ -605,11 +669,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToIntegerList property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToIntegerList() {
+        return mapOfStringToIntegerList != null && !(mapOfStringToIntegerList instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToIntegerList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToIntegerList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToIntegerList property for this object.
      */
     public Map<String, List<Integer>> mapOfStringToIntegerList() {
@@ -617,11 +693,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToString() {
+        return mapOfStringToString != null && !(mapOfStringToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToString property for this object.
      */
     public Map<String, String> mapOfStringToString() {
@@ -629,11 +717,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToSimpleStruct() {
+        return mapOfStringToSimpleStruct != null && !(mapOfStringToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfStringToSimpleStruct() {
@@ -645,7 +745,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<EnumType, EnumType> mapOfEnumToEnum() {
@@ -653,11 +756,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToEnum() {
+        return mapOfEnumToEnum != null && !(mapOfEnumToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToEnum property for this object.
      */
     public Map<String, String> mapOfEnumToEnumAsStrings() {
@@ -669,7 +784,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<EnumType, String> mapOfEnumToString() {
@@ -677,11 +795,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToString property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToString() {
+        return mapOfEnumToString != null && !(mapOfEnumToString instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToString property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToString()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToString property for this object.
      */
     public Map<String, String> mapOfEnumToStringAsStrings() {
@@ -693,7 +823,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, EnumType> mapOfStringToEnum() {
@@ -701,11 +834,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfStringToEnum property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfStringToEnum() {
+        return mapOfStringToEnum != null && !(mapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfStringToEnum property for this object.
      */
     public Map<String, String> mapOfStringToEnumAsStrings() {
@@ -717,7 +862,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct() {
@@ -725,11 +873,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToSimpleStruct property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToSimpleStruct() {
+        return mapOfEnumToSimpleStruct != null && !(mapOfEnumToSimpleStruct instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToSimpleStruct property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToSimpleStruct()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToSimpleStruct property for this object.
      */
     public Map<String, SimpleStruct> mapOfEnumToSimpleStructAsStrings() {
@@ -741,7 +901,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<EnumType, List<EnumType>> mapOfEnumToListOfEnums() {
@@ -749,11 +912,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToListOfEnums property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasMapOfEnumToListOfEnums() {
+        return mapOfEnumToListOfEnums != null && !(mapOfEnumToListOfEnums instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToListOfEnums property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToListOfEnums()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToListOfEnums property for this object.
      */
     public Map<String, List<String>> mapOfEnumToListOfEnumsAsStrings() {
@@ -765,7 +940,10 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum() {
@@ -773,11 +951,23 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the MapOfEnumToMapOfStringToEnum property was specified by the sender (it may be empty), or false
+     * if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the
+     * AWS service.
+     */
+    public boolean hasMapOfEnumToMapOfStringToEnum() {
+        return mapOfEnumToMapOfStringToEnum != null && !(mapOfEnumToMapOfStringToEnum instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfEnumToMapOfStringToEnum property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasMapOfEnumToMapOfStringToEnum()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the MapOfEnumToMapOfStringToEnum property for this object.
      */
     public Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumAsStrings() {
@@ -786,7 +976,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the TimestampMember property for this object.
-     * 
+     *
      * @return The value of the TimestampMember property for this object.
      */
     public Instant timestampMember() {
@@ -795,7 +985,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the StructWithNestedTimestampMember property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedTimestampMember property for this object.
      */
     public StructWithTimestamp structWithNestedTimestampMember() {
@@ -804,7 +994,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the BlobArg property for this object.
-     * 
+     *
      * @return The value of the BlobArg property for this object.
      */
     public SdkBytes blobArg() {
@@ -813,7 +1003,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the StructWithNestedBlob property for this object.
-     * 
+     *
      * @return The value of the StructWithNestedBlob property for this object.
      */
     public StructWithNestedBlobType structWithNestedBlob() {
@@ -821,11 +1011,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the BlobMap property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBlobMap() {
+        return blobMap != null && !(blobMap instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the BlobMap property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasBlobMap()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the BlobMap property for this object.
      */
     public Map<String, SdkBytes> blobMap() {
@@ -833,11 +1034,22 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     }
 
     /**
+     * Returns true if the ListOfBlobs property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasListOfBlobs() {
+        return listOfBlobs != null && !(listOfBlobs instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfBlobs property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasListOfBlobs()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the ListOfBlobs property for this object.
      */
     public List<SdkBytes> listOfBlobs() {
@@ -846,7 +1058,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the RecursiveStruct property for this object.
-     * 
+     *
      * @return The value of the RecursiveStruct property for this object.
      */
     public RecursiveStructType recursiveStruct() {
@@ -855,7 +1067,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the PolymorphicTypeWithSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithSubTypes property for this object.
      */
     public BaseType polymorphicTypeWithSubTypes() {
@@ -864,7 +1076,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the PolymorphicTypeWithoutSubTypes property for this object.
-     * 
+     *
      * @return The value of the PolymorphicTypeWithoutSubTypes property for this object.
      */
     public SubTypeOne polymorphicTypeWithoutSubTypes() {
@@ -878,7 +1090,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -893,7 +1105,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
      * return {@link EnumType#UNKNOWN_TO_SDK_VERSION}. The raw value returned by the service is available from
      * {@link #enumTypeAsString}.
      * </p>
-     * 
+     *
      * @return The value of the EnumType property for this object.
      * @see EnumType
      */
@@ -1002,88 +1214,88 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
     @Override
     public String toString() {
         return ToString.builder("AllTypesResponse").add("StringMember", stringMember()).add("IntegerMember", integerMember())
-                .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
-                .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
-                .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
-                .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
-                .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
-                .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
-                .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
-                .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
-                .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
-                .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
-                .add("TimestampMember", timestampMember())
-                .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
-                .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
-                .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
-                .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
-                .build();
+                       .add("BooleanMember", booleanMember()).add("FloatMember", floatMember()).add("DoubleMember", doubleMember())
+                       .add("LongMember", longMember()).add("SimpleList", simpleList()).add("ListOfEnums", listOfEnumsAsStrings())
+                       .add("ListOfMaps", listOfMaps()).add("ListOfStructs", listOfStructs())
+                       .add("ListOfMapOfEnumToString", listOfMapOfEnumToStringAsStrings())
+                       .add("MapOfStringToIntegerList", mapOfStringToIntegerList()).add("MapOfStringToString", mapOfStringToString())
+                       .add("MapOfStringToSimpleStruct", mapOfStringToSimpleStruct()).add("MapOfEnumToEnum", mapOfEnumToEnumAsStrings())
+                       .add("MapOfEnumToString", mapOfEnumToStringAsStrings()).add("MapOfStringToEnum", mapOfStringToEnumAsStrings())
+                       .add("MapOfEnumToSimpleStruct", mapOfEnumToSimpleStructAsStrings())
+                       .add("MapOfEnumToListOfEnums", mapOfEnumToListOfEnumsAsStrings())
+                       .add("MapOfEnumToMapOfStringToEnum", mapOfEnumToMapOfStringToEnumAsStrings())
+                       .add("TimestampMember", timestampMember())
+                       .add("StructWithNestedTimestampMember", structWithNestedTimestampMember()).add("BlobArg", blobArg())
+                       .add("StructWithNestedBlob", structWithNestedBlob()).add("BlobMap", blobMap()).add("ListOfBlobs", listOfBlobs())
+                       .add("RecursiveStruct", recursiveStruct()).add("PolymorphicTypeWithSubTypes", polymorphicTypeWithSubTypes())
+                       .add("PolymorphicTypeWithoutSubTypes", polymorphicTypeWithoutSubTypes()).add("EnumType", enumTypeAsString())
+                       .build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "StringMember":
-            return Optional.ofNullable(clazz.cast(stringMember()));
-        case "IntegerMember":
-            return Optional.ofNullable(clazz.cast(integerMember()));
-        case "BooleanMember":
-            return Optional.ofNullable(clazz.cast(booleanMember()));
-        case "FloatMember":
-            return Optional.ofNullable(clazz.cast(floatMember()));
-        case "DoubleMember":
-            return Optional.ofNullable(clazz.cast(doubleMember()));
-        case "LongMember":
-            return Optional.ofNullable(clazz.cast(longMember()));
-        case "SimpleList":
-            return Optional.ofNullable(clazz.cast(simpleList()));
-        case "ListOfEnums":
-            return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
-        case "ListOfMaps":
-            return Optional.ofNullable(clazz.cast(listOfMaps()));
-        case "ListOfStructs":
-            return Optional.ofNullable(clazz.cast(listOfStructs()));
-        case "ListOfMapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
-        case "MapOfStringToIntegerList":
-            return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
-        case "MapOfStringToString":
-            return Optional.ofNullable(clazz.cast(mapOfStringToString()));
-        case "MapOfStringToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
-        case "MapOfEnumToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
-        case "MapOfEnumToString":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
-        case "MapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
-        case "MapOfEnumToSimpleStruct":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
-        case "MapOfEnumToListOfEnums":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
-        case "MapOfEnumToMapOfStringToEnum":
-            return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
-        case "TimestampMember":
-            return Optional.ofNullable(clazz.cast(timestampMember()));
-        case "StructWithNestedTimestampMember":
-            return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
-        case "BlobArg":
-            return Optional.ofNullable(clazz.cast(blobArg()));
-        case "StructWithNestedBlob":
-            return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
-        case "BlobMap":
-            return Optional.ofNullable(clazz.cast(blobMap()));
-        case "ListOfBlobs":
-            return Optional.ofNullable(clazz.cast(listOfBlobs()));
-        case "RecursiveStruct":
-            return Optional.ofNullable(clazz.cast(recursiveStruct()));
-        case "PolymorphicTypeWithSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
-        case "PolymorphicTypeWithoutSubTypes":
-            return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
-        case "EnumType":
-            return Optional.ofNullable(clazz.cast(enumTypeAsString()));
-        default:
-            return Optional.empty();
+            case "StringMember":
+                return Optional.ofNullable(clazz.cast(stringMember()));
+            case "IntegerMember":
+                return Optional.ofNullable(clazz.cast(integerMember()));
+            case "BooleanMember":
+                return Optional.ofNullable(clazz.cast(booleanMember()));
+            case "FloatMember":
+                return Optional.ofNullable(clazz.cast(floatMember()));
+            case "DoubleMember":
+                return Optional.ofNullable(clazz.cast(doubleMember()));
+            case "LongMember":
+                return Optional.ofNullable(clazz.cast(longMember()));
+            case "SimpleList":
+                return Optional.ofNullable(clazz.cast(simpleList()));
+            case "ListOfEnums":
+                return Optional.ofNullable(clazz.cast(listOfEnumsAsStrings()));
+            case "ListOfMaps":
+                return Optional.ofNullable(clazz.cast(listOfMaps()));
+            case "ListOfStructs":
+                return Optional.ofNullable(clazz.cast(listOfStructs()));
+            case "ListOfMapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(listOfMapOfEnumToStringAsStrings()));
+            case "MapOfStringToIntegerList":
+                return Optional.ofNullable(clazz.cast(mapOfStringToIntegerList()));
+            case "MapOfStringToString":
+                return Optional.ofNullable(clazz.cast(mapOfStringToString()));
+            case "MapOfStringToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfStringToSimpleStruct()));
+            case "MapOfEnumToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToEnumAsStrings()));
+            case "MapOfEnumToString":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToStringAsStrings()));
+            case "MapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfStringToEnumAsStrings()));
+            case "MapOfEnumToSimpleStruct":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToSimpleStructAsStrings()));
+            case "MapOfEnumToListOfEnums":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToListOfEnumsAsStrings()));
+            case "MapOfEnumToMapOfStringToEnum":
+                return Optional.ofNullable(clazz.cast(mapOfEnumToMapOfStringToEnumAsStrings()));
+            case "TimestampMember":
+                return Optional.ofNullable(clazz.cast(timestampMember()));
+            case "StructWithNestedTimestampMember":
+                return Optional.ofNullable(clazz.cast(structWithNestedTimestampMember()));
+            case "BlobArg":
+                return Optional.ofNullable(clazz.cast(blobArg()));
+            case "StructWithNestedBlob":
+                return Optional.ofNullable(clazz.cast(structWithNestedBlob()));
+            case "BlobMap":
+                return Optional.ofNullable(clazz.cast(blobMap()));
+            case "ListOfBlobs":
+                return Optional.ofNullable(clazz.cast(listOfBlobs()));
+            case "RecursiveStruct":
+                return Optional.ofNullable(clazz.cast(recursiveStruct()));
+            case "PolymorphicTypeWithSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithSubTypes()));
+            case "PolymorphicTypeWithoutSubTypes":
+                return Optional.ofNullable(clazz.cast(polymorphicTypeWithoutSubTypes()));
+            case "EnumType":
+                return Optional.ofNullable(clazz.cast(enumTypeAsString()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -1253,7 +1465,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link List<SimpleStruct>.Builder#build()} is called immediately and its
          * result is passed to {@link #listOfStructs(List<SimpleStruct>)}.
-         * 
+         *
          * @param listOfStructs
          *        a consumer that will call methods on {@link List<SimpleStruct>.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1440,7 +1652,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link StructWithTimestamp.Builder#build()} is called immediately and
          * its result is passed to {@link #structWithNestedTimestampMember(StructWithTimestamp)}.
-         * 
+         *
          * @param structWithNestedTimestampMember
          *        a consumer that will call methods on {@link StructWithTimestamp.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1448,7 +1660,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          */
         default Builder structWithNestedTimestampMember(Consumer<StructWithTimestamp.Builder> structWithNestedTimestampMember) {
             return structWithNestedTimestampMember(StructWithTimestamp.builder().applyMutation(structWithNestedTimestampMember)
-                    .build());
+                                                                      .build());
         }
 
         /**
@@ -1477,7 +1689,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link StructWithNestedBlobType.Builder#build()} is called immediately
          * and its result is passed to {@link #structWithNestedBlob(StructWithNestedBlobType)}.
-         * 
+         *
          * @param structWithNestedBlob
          *        a consumer that will call methods on {@link StructWithNestedBlobType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1531,7 +1743,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
          * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
-         * 
+         *
          * @param recursiveStruct
          *        a consumer that will call methods on {@link RecursiveStructType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1558,7 +1770,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link BaseType.Builder#build()} is called immediately and its result is
          * passed to {@link #polymorphicTypeWithSubTypes(BaseType)}.
-         * 
+         *
          * @param polymorphicTypeWithSubTypes
          *        a consumer that will call methods on {@link BaseType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1585,7 +1797,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *
          * When the {@link Consumer} completes, {@link SubTypeOne.Builder#build()} is called immediately and its result
          * is passed to {@link #polymorphicTypeWithoutSubTypes(SubTypeOne)}.
-         * 
+         *
          * @param polymorphicTypeWithoutSubTypes
          *        a consumer that will call methods on {@link SubTypeOne.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -1878,7 +2090,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Collection<SimpleStruct.Builder> getListOfStructs() {
             return listOfStructs != null ? listOfStructs.stream().map(SimpleStruct::toBuilder).collect(Collectors.toList())
-                    : null;
+                                         : null;
         }
 
         @Override
@@ -1898,7 +2110,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
-                    .collect(Collectors.toList()));
+                                .collect(Collectors.toList()));
             return this;
         }
 
@@ -1957,7 +2169,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
             return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
-                    SimpleStruct::toBuilder) : null;
+                                                                                 SimpleStruct::toBuilder) : null;
         }
 
         @Override
@@ -2032,7 +2244,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
-                    : null;
+                                                   : null;
         }
 
         @Override
@@ -2117,7 +2329,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setStructWithNestedTimestampMember(StructWithTimestamp.BuilderImpl structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember != null ? structWithNestedTimestampMember
-                    .build() : null;
+                .build() : null;
         }
 
         public final ByteBuffer getBlobArg() {
@@ -2150,7 +2362,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final Map<String, ByteBuffer> getBlobMap() {
             return blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
+                                                   .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().asByteBuffer()));
         }
 
         @Override
@@ -2161,7 +2373,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setBlobMap(Map<String, ByteBuffer> blobMap) {
             blobMap(blobMap == null ? null : blobMap.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
+                                                    .collect(Collectors.toMap(e -> e.getKey(), e -> SdkBytes.fromByteBuffer(e.getValue()))));
         }
 
         public final List<ByteBuffer> getListOfBlobs() {
@@ -2183,7 +2395,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setListOfBlobs(Collection<ByteBuffer> listOfBlobs) {
             listOfBlobs(listOfBlobs == null ? null : listOfBlobs.stream().map(SdkBytes::fromByteBuffer)
-                    .collect(Collectors.toList()));
+                                                                .collect(Collectors.toList()));
         }
 
         public final RecursiveStructType.Builder getRecursiveStruct() {
@@ -2226,7 +2438,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         public final void setPolymorphicTypeWithoutSubTypes(SubTypeOne.BuilderImpl polymorphicTypeWithoutSubTypes) {
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes != null ? polymorphicTypeWithoutSubTypes.build()
-                    : null;
+                                                                                         : null;
         }
 
         public final String getEnumTypeAsString() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/existencechecknamingrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/existencechecknamingrequest.java
@@ -1,0 +1,454 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest implements
+                                                                                ToCopyableBuilder<ExistenceCheckNamingRequest.Builder, ExistenceCheckNamingRequest> {
+    private static final SdkField<List<String>> BUILD_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingRequest::build))
+        .setter(setter(Builder::build))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Build").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<List<String>> SUPER_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingRequest::superValue))
+        .setter(setter(Builder::superValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("super").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> TO_STRING_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingRequest::toStringValue))
+        .setter(setter(Builder::toStringValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("toString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> EQUALS_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingRequest::equalsValue))
+        .setter(setter(Builder::equalsValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("equals").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(BUILD_FIELD, SUPER_FIELD,
+                                                                                                   TO_STRING_FIELD, EQUALS_FIELD));
+
+    private final List<String> build;
+
+    private final List<String> superValue;
+
+    private final Map<String, String> toStringValue;
+
+    private final Map<String, String> equalsValue;
+
+    private ExistenceCheckNamingRequest(BuilderImpl builder) {
+        super(builder);
+        this.build = builder.build;
+        this.superValue = builder.superValue;
+        this.toStringValue = builder.toStringValue;
+        this.equalsValue = builder.equalsValue;
+    }
+
+    /**
+     * Returns true if the Build property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBuild() {
+        return build != null && !(build instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Build property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasBuild()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Build property for this object.
+     */
+    public List<String> build() {
+        return build;
+    }
+
+    /**
+     * Returns true if the Super property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSuperValue() {
+        return superValue != null && !(superValue instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Super property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasSuperValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Super property for this object.
+     */
+    public List<String> superValue() {
+        return superValue;
+    }
+
+    /**
+     * Returns true if the ToString property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasToStringValue() {
+        return toStringValue != null && !(toStringValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the ToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasToStringValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the ToString property for this object.
+     */
+    public Map<String, String> toStringValue() {
+        return toStringValue;
+    }
+
+    /**
+     * Returns true if the Equals property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasEqualsValue() {
+        return equalsValue != null && !(equalsValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the Equals property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasEqualsValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Equals property for this object.
+     */
+    public Map<String, String> equalsValue() {
+        return equalsValue;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        hashCode = 31 * hashCode + Objects.hashCode(build());
+        hashCode = 31 * hashCode + Objects.hashCode(superValue());
+        hashCode = 31 * hashCode + Objects.hashCode(toStringValue());
+        hashCode = 31 * hashCode + Objects.hashCode(equalsValue());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ExistenceCheckNamingRequest)) {
+            return false;
+        }
+        ExistenceCheckNamingRequest other = (ExistenceCheckNamingRequest) obj;
+        return Objects.equals(build(), other.build()) && Objects.equals(superValue(), other.superValue())
+               && Objects.equals(toStringValue(), other.toStringValue()) && Objects.equals(equalsValue(), other.equalsValue());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("ExistenceCheckNamingRequest").add("Build", build()).add("Super", superValue())
+                       .add("ToString", toStringValue()).add("Equals", equalsValue()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Build":
+                return Optional.ofNullable(clazz.cast(build()));
+            case "super":
+                return Optional.ofNullable(clazz.cast(superValue()));
+            case "toString":
+                return Optional.ofNullable(clazz.cast(toStringValue()));
+            case "equals":
+                return Optional.ofNullable(clazz.cast(equalsValue()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<ExistenceCheckNamingRequest, T> g) {
+        return obj -> g.apply((ExistenceCheckNamingRequest) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    public interface Builder extends JsonProtocolTestsRequest.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, ExistenceCheckNamingRequest> {
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(Collection<String> build);
+
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(String... build);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(Collection<String> superValue);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(String... superValue);
+
+        /**
+         * Sets the value of the ToString property for this object.
+         *
+         * @param toStringValue
+         *        The new value for the ToString property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder toStringValue(Map<String, String> toStringValue);
+
+        /**
+         * Sets the value of the Equals property for this object.
+         *
+         * @param equalsValue
+         *        The new value for the Equals property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder equalsValue(Map<String, String> equalsValue);
+
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends JsonProtocolTestsRequest.BuilderImpl implements Builder {
+        private List<String> build;
+
+        private List<String> superValue;
+
+        private Map<String, String> toStringValue;
+
+        private Map<String, String> equalsValue;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(ExistenceCheckNamingRequest model) {
+            super(model);
+            build(model.build);
+            superValue(model.superValue);
+            toStringValue(model.toStringValue);
+            equalsValue(model.equalsValue);
+        }
+
+        public final Collection<String> getBuild() {
+            return build;
+        }
+
+        @Override
+        public final Builder build(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder build(String... build) {
+            build(Arrays.asList(build));
+            return this;
+        }
+
+        public final void setBuild(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+        }
+
+        public final Collection<String> getSuperValue() {
+            return superValue;
+        }
+
+        @Override
+        public final Builder superValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder superValue(String... superValue) {
+            superValue(Arrays.asList(superValue));
+            return this;
+        }
+
+        public final void setSuperValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+        }
+
+        public final Map<String, String> getToStringValue() {
+            return toStringValue;
+        }
+
+        @Override
+        public final Builder toStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+            return this;
+        }
+
+        public final void setToStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+        }
+
+        public final Map<String, String> getEqualsValue() {
+            return equalsValue;
+        }
+
+        @Override
+        public final Builder equalsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+            return this;
+        }
+
+        public final void setEqualsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public ExistenceCheckNamingRequest build() {
+            return new ExistenceCheckNamingRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/existencechecknamingresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/existencechecknamingresponse.java
@@ -1,0 +1,434 @@
+package software.amazon.awssdk.services.jsonprotocoltests.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.ListTrait;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class ExistenceCheckNamingResponse extends JsonProtocolTestsResponse implements
+                                                                                  ToCopyableBuilder<ExistenceCheckNamingResponse.Builder, ExistenceCheckNamingResponse> {
+    private static final SdkField<List<String>> BUILD_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingResponse::build))
+        .setter(setter(Builder::build))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Build").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<List<String>> SUPER_FIELD = SdkField
+        .<List<String>> builder(MarshallingType.LIST)
+        .getter(getter(ExistenceCheckNamingResponse::superValue))
+        .setter(setter(Builder::superValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("super").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<String> builder(MarshallingType.STRING)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> TO_STRING_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingResponse::toStringValue))
+        .setter(setter(Builder::toStringValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("toString").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final SdkField<Map<String, String>> EQUALS_FIELD = SdkField
+        .<Map<String, String>> builder(MarshallingType.MAP)
+        .getter(getter(ExistenceCheckNamingResponse::equalsValue))
+        .setter(setter(Builder::equalsValue))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("equals").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<String> builder(MarshallingType.STRING)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(BUILD_FIELD, SUPER_FIELD,
+                                                                                                   TO_STRING_FIELD, EQUALS_FIELD));
+
+    private final List<String> build;
+
+    private final List<String> superValue;
+
+    private final Map<String, String> toStringValue;
+
+    private final Map<String, String> equalsValue;
+
+    private ExistenceCheckNamingResponse(BuilderImpl builder) {
+        super(builder);
+        this.build = builder.build;
+        this.superValue = builder.superValue;
+        this.toStringValue = builder.toStringValue;
+        this.equalsValue = builder.equalsValue;
+    }
+
+    /**
+     * Returns true if the Build property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasBuild() {
+        return build != null && !(build instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Build property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasBuild()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Build property for this object.
+     */
+    public List<String> build() {
+        return build;
+    }
+
+    /**
+     * Returns true if the Super property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasSuperValue() {
+        return superValue != null && !(superValue instanceof SdkAutoConstructList);
+    }
+
+    /**
+     * Returns the value of the Super property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasSuperValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Super property for this object.
+     */
+    public List<String> superValue() {
+        return superValue;
+    }
+
+    /**
+     * Returns true if the ToString property was specified by the sender (it may be empty), or false if the sender did
+     * not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasToStringValue() {
+        return toStringValue != null && !(toStringValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the ToString property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasToStringValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the ToString property for this object.
+     */
+    public Map<String, String> toStringValue() {
+        return toStringValue;
+    }
+
+    /**
+     * Returns true if the Equals property was specified by the sender (it may be empty), or false if the sender did not
+     * specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasEqualsValue() {
+        return equalsValue != null && !(equalsValue instanceof SdkAutoConstructMap);
+    }
+
+    /**
+     * Returns the value of the Equals property for this object.
+     * <p>
+     * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasEqualsValue()} to see if a value was sent in this field.
+     * </p>
+     *
+     * @return The value of the Equals property for this object.
+     */
+    public Map<String, String> equalsValue() {
+        return equalsValue;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        hashCode = 31 * hashCode + Objects.hashCode(build());
+        hashCode = 31 * hashCode + Objects.hashCode(superValue());
+        hashCode = 31 * hashCode + Objects.hashCode(toStringValue());
+        hashCode = 31 * hashCode + Objects.hashCode(equalsValue());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ExistenceCheckNamingResponse)) {
+            return false;
+        }
+        ExistenceCheckNamingResponse other = (ExistenceCheckNamingResponse) obj;
+        return Objects.equals(build(), other.build()) && Objects.equals(superValue(), other.superValue())
+               && Objects.equals(toStringValue(), other.toStringValue()) && Objects.equals(equalsValue(), other.equalsValue());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("ExistenceCheckNamingResponse").add("Build", build()).add("Super", superValue())
+                       .add("ToString", toStringValue()).add("Equals", equalsValue()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Build":
+                return Optional.ofNullable(clazz.cast(build()));
+            case "super":
+                return Optional.ofNullable(clazz.cast(superValue()));
+            case "toString":
+                return Optional.ofNullable(clazz.cast(toStringValue()));
+            case "equals":
+                return Optional.ofNullable(clazz.cast(equalsValue()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<ExistenceCheckNamingResponse, T> g) {
+        return obj -> g.apply((ExistenceCheckNamingResponse) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    public interface Builder extends JsonProtocolTestsResponse.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, ExistenceCheckNamingResponse> {
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(Collection<String> build);
+
+        /**
+         * Sets the value of the Build property for this object.
+         *
+         * @param build
+         *        The new value for the Build property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder build(String... build);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(Collection<String> superValue);
+
+        /**
+         * Sets the value of the Super property for this object.
+         *
+         * @param superValue
+         *        The new value for the Super property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder superValue(String... superValue);
+
+        /**
+         * Sets the value of the ToString property for this object.
+         *
+         * @param toStringValue
+         *        The new value for the ToString property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder toStringValue(Map<String, String> toStringValue);
+
+        /**
+         * Sets the value of the Equals property for this object.
+         *
+         * @param equalsValue
+         *        The new value for the Equals property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder equalsValue(Map<String, String> equalsValue);
+    }
+
+    static final class BuilderImpl extends JsonProtocolTestsResponse.BuilderImpl implements Builder {
+        private List<String> build;
+
+        private List<String> superValue;
+
+        private Map<String, String> toStringValue;
+
+        private Map<String, String> equalsValue;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(ExistenceCheckNamingResponse model) {
+            super(model);
+            build(model.build);
+            superValue(model.superValue);
+            toStringValue(model.toStringValue);
+            equalsValue(model.equalsValue);
+        }
+
+        public final Collection<String> getBuild() {
+            return build;
+        }
+
+        @Override
+        public final Builder build(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder build(String... build) {
+            build(Arrays.asList(build));
+            return this;
+        }
+
+        public final void setBuild(Collection<String> build) {
+            this.build = ListOfStringsCopier.copy(build);
+        }
+
+        public final Collection<String> getSuperValue() {
+            return superValue;
+        }
+
+        @Override
+        public final Builder superValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+            return this;
+        }
+
+        @Override
+        @SafeVarargs
+        public final Builder superValue(String... superValue) {
+            superValue(Arrays.asList(superValue));
+            return this;
+        }
+
+        public final void setSuperValue(Collection<String> superValue) {
+            this.superValue = ListOfStringsCopier.copy(superValue);
+        }
+
+        public final Map<String, String> getToStringValue() {
+            return toStringValue;
+        }
+
+        @Override
+        public final Builder toStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+            return this;
+        }
+
+        public final void setToStringValue(Map<String, String> toStringValue) {
+            this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
+        }
+
+        public final Map<String, String> getEqualsValue() {
+            return equalsValue;
+        }
+
+        @Override
+        public final Builder equalsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+            return this;
+        }
+
+        public final void setEqualsValue(Map<String, String> equalsValue) {
+            this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
+        }
+
+        @Override
+        public ExistenceCheckNamingResponse build() {
+            return new ExistenceCheckNamingResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/nestedcontainersrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/nestedcontainersrequest.java
@@ -19,6 +19,8 @@ import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -140,9 +142,21 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     }
 
     /**
+     * Returns true if the ListOfListOfStrings property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfStrings() {
+        return listOfListOfStrings != null && !(listOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasListOfListOfStrings()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the ListOfListOfStrings property for this object.
@@ -152,9 +166,21 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     }
 
     /**
+     * Returns true if the ListOfListOfListOfStrings property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfListOfStrings() {
+        return listOfListOfListOfStrings != null && !(listOfListOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasListOfListOfListOfStrings()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the ListOfListOfListOfStrings property for this object.
@@ -164,9 +190,21 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
     }
 
     /**
+     * Returns true if the MapOfStringToListOfListOfStrings property was specified by the sender (it may be empty), or
+     * false if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender
+     * is the AWS service.
+     */
+    public boolean hasMapOfStringToListOfListOfStrings() {
+        return mapOfStringToListOfListOfStrings != null && !(mapOfStringToListOfListOfStrings instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasMapOfStringToListOfListOfStrings()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the MapOfStringToListOfListOfStrings property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/nestedcontainersresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/nestedcontainersresponse.java
@@ -17,6 +17,8 @@ import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -138,9 +140,21 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     /**
+     * Returns true if the ListOfListOfStrings property was specified by the sender (it may be empty), or false if the
+     * sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfStrings() {
+        return listOfListOfStrings != null && !(listOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasListOfListOfStrings()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the ListOfListOfStrings property for this object.
@@ -150,9 +164,21 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     /**
+     * Returns true if the ListOfListOfListOfStrings property was specified by the sender (it may be empty), or false if
+     * the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS
+     * service.
+     */
+    public boolean hasListOfListOfListOfStrings() {
+        return listOfListOfListOfStrings != null && !(listOfListOfListOfStrings instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the ListOfListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasListOfListOfListOfStrings()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the ListOfListOfListOfStrings property for this object.
@@ -162,9 +188,21 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
     }
 
     /**
+     * Returns true if the MapOfStringToListOfListOfStrings property was specified by the sender (it may be empty), or
+     * false if the sender did not specify the value (it will be empty). For responses returned by the SDK, the sender
+     * is the AWS service.
+     */
+    public boolean hasMapOfStringToListOfListOfStrings() {
+        return mapOfStringToListOfListOfStrings != null && !(mapOfStringToListOfListOfStrings instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the MapOfStringToListOfListOfStrings property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasMapOfStringToListOfListOfStrings()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the MapOfStringToListOfListOfStrings property for this object.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/recursivestructtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/recursivestructtype.java
@@ -21,6 +21,8 @@ import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -107,9 +109,20 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
     }
 
     /**
+     * Returns true if the RecursiveList property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasRecursiveList() {
+        return recursiveList != null && !(recursiveList instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the RecursiveList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasRecursiveList()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the RecursiveList property for this object.
@@ -119,9 +132,20 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
     }
 
     /**
+     * Returns true if the RecursiveMap property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasRecursiveMap() {
+        return recursiveMap != null && !(recursiveMap instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the RecursiveMap property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
+     * </p>
+     * <p>
+     * You can use {@link #hasRecursiveMap()} to see if a value was sent in this field.
      * </p>
      *
      * @return The value of the RecursiveMap property for this object.
@@ -395,4 +419,3 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
@@ -23,6 +23,8 @@ import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -32,46 +34,46 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class RecursiveStructType implements SdkPojo, Serializable,
-        ToCopyableBuilder<RecursiveStructType.Builder, RecursiveStructType> {
+                                                  ToCopyableBuilder<RecursiveStructType.Builder, RecursiveStructType> {
     private static final SdkField<String> NO_RECURSE_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .getter(getter(RecursiveStructType::noRecurse)).setter(setter(Builder::noRecurse))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NoRecurse").build()).build();
+        .getter(getter(RecursiveStructType::noRecurse)).setter(setter(Builder::noRecurse))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NoRecurse").build()).build();
 
     private static final SdkField<RecursiveStructType> RECURSIVE_STRUCT_FIELD = SdkField
-            .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(RecursiveStructType::recursiveStruct))
-            .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
+        .<RecursiveStructType> builder(MarshallingType.SDK_POJO).getter(getter(RecursiveStructType::recursiveStruct))
+                                                                .setter(setter(Builder::recursiveStruct)).constructor(RecursiveStructType::builder)
+                                                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
 
     private static final SdkField<List<RecursiveStructType>> RECURSIVE_LIST_FIELD = SdkField
-            .<List<RecursiveStructType>> builder(MarshallingType.LIST)
-            .getter(getter(RecursiveStructType::recursiveList))
-            .setter(setter(Builder::recursiveList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveList").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
-                                            .constructor(RecursiveStructType::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<RecursiveStructType>> builder(MarshallingType.LIST)
+        .getter(getter(RecursiveStructType::recursiveList))
+        .setter(setter(Builder::recursiveList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveList").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
+                            .constructor(RecursiveStructType::builder)
+                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                 .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<Map<String, RecursiveStructType>> RECURSIVE_MAP_FIELD = SdkField
-            .<Map<String, RecursiveStructType>> builder(MarshallingType.MAP)
-            .getter(getter(RecursiveStructType::recursiveMap))
-            .setter(setter(Builder::recursiveMap))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveMap").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
-                                            .constructor(RecursiveStructType::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, RecursiveStructType>> builder(MarshallingType.MAP)
+        .getter(getter(RecursiveStructType::recursiveMap))
+        .setter(setter(Builder::recursiveMap))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveMap").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
+                                .constructor(RecursiveStructType::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("value").build()).build()).build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(NO_RECURSE_FIELD,
-            RECURSIVE_STRUCT_FIELD, RECURSIVE_LIST_FIELD, RECURSIVE_MAP_FIELD));
+                                                                                                   RECURSIVE_STRUCT_FIELD, RECURSIVE_LIST_FIELD, RECURSIVE_MAP_FIELD));
 
     private static final long serialVersionUID = 1L;
 
@@ -92,7 +94,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
 
     /**
      * Returns the value of the NoRecurse property for this object.
-     * 
+     *
      * @return The value of the NoRecurse property for this object.
      */
     public String noRecurse() {
@@ -101,7 +103,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
 
     /**
      * Returns the value of the RecursiveStruct property for this object.
-     * 
+     *
      * @return The value of the RecursiveStruct property for this object.
      */
     public RecursiveStructType recursiveStruct() {
@@ -109,11 +111,22 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
     }
 
     /**
+     * Returns true if the RecursiveList property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasRecursiveList() {
+        return recursiveList != null && !(recursiveList instanceof SdkAutoConstructList);
+    }
+
+    /**
      * Returns the value of the RecursiveList property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasRecursiveList()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the RecursiveList property for this object.
      */
     public List<RecursiveStructType> recursiveList() {
@@ -121,11 +134,22 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
     }
 
     /**
+     * Returns true if the RecursiveMap property was specified by the sender (it may be empty), or false if the sender
+     * did not specify the value (it will be empty). For responses returned by the SDK, the sender is the AWS service.
+     */
+    public boolean hasRecursiveMap() {
+        return recursiveMap != null && !(recursiveMap instanceof SdkAutoConstructMap);
+    }
+
+    /**
      * Returns the value of the RecursiveMap property for this object.
      * <p>
      * Attempts to modify the collection returned by this method will result in an UnsupportedOperationException.
      * </p>
-     * 
+     * <p>
+     * You can use {@link #hasRecursiveMap()} to see if a value was sent in this field.
+     * </p>
+     *
      * @return The value of the RecursiveMap property for this object.
      */
     public Map<String, RecursiveStructType> recursiveMap() {
@@ -173,7 +197,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
         RecursiveStructType other = (RecursiveStructType) obj;
         return Objects.equals(noRecurse(), other.noRecurse()) && Objects.equals(recursiveStruct(), other.recursiveStruct())
-                && Objects.equals(recursiveList(), other.recursiveList()) && Objects.equals(recursiveMap(), other.recursiveMap());
+               && Objects.equals(recursiveList(), other.recursiveList()) && Objects.equals(recursiveMap(), other.recursiveMap());
     }
 
     /**
@@ -183,21 +207,21 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
     @Override
     public String toString() {
         return ToString.builder("RecursiveStructType").add("NoRecurse", noRecurse()).add("RecursiveStruct", recursiveStruct())
-                .add("RecursiveList", recursiveList()).add("RecursiveMap", recursiveMap()).build();
+                       .add("RecursiveList", recursiveList()).add("RecursiveMap", recursiveMap()).build();
     }
 
     public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "NoRecurse":
-            return Optional.ofNullable(clazz.cast(noRecurse()));
-        case "RecursiveStruct":
-            return Optional.ofNullable(clazz.cast(recursiveStruct()));
-        case "RecursiveList":
-            return Optional.ofNullable(clazz.cast(recursiveList()));
-        case "RecursiveMap":
-            return Optional.ofNullable(clazz.cast(recursiveMap()));
-        default:
-            return Optional.empty();
+            case "NoRecurse":
+                return Optional.ofNullable(clazz.cast(noRecurse()));
+            case "RecursiveStruct":
+                return Optional.ofNullable(clazz.cast(recursiveStruct()));
+            case "RecursiveList":
+                return Optional.ofNullable(clazz.cast(recursiveList()));
+            case "RecursiveMap":
+                return Optional.ofNullable(clazz.cast(recursiveMap()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -241,7 +265,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
          *
          * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
          * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
-         * 
+         *
          * @param recursiveStruct
          *        a consumer that will call methods on {@link RecursiveStructType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -277,7 +301,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
          *
          * When the {@link Consumer} completes, {@link List<RecursiveStructType>.Builder#build()} is called immediately
          * and its result is passed to {@link #recursiveList(List<RecursiveStructType>)}.
-         * 
+         *
          * @param recursiveList
          *        a consumer that will call methods on {@link List<RecursiveStructType>.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -344,7 +368,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
 
         public final Collection<Builder> getRecursiveList() {
             return recursiveList != null ? recursiveList.stream().map(RecursiveStructType::toBuilder)
-                    .collect(Collectors.toList()) : null;
+                                                        .collect(Collectors.toList()) : null;
         }
 
         @Override
@@ -364,7 +388,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         @SafeVarargs
         public final Builder recursiveList(Consumer<Builder>... recursiveList) {
             recursiveList(Stream.of(recursiveList).map(c -> RecursiveStructType.builder().applyMutation(c).build())
-                    .collect(Collectors.toList()));
+                                .collect(Collectors.toList()));
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/service-2.json
@@ -80,6 +80,19 @@
       "input": {
         "shape": "EventStreamOperationWithOnlyInputRequest"
       }
+    },
+    "ExistenceCheckNaming": {
+      "name": "ExistenceCheckNaming",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/ExistenceCheckNaming"
+      },
+      "input": {
+        "shape": "ExistenceCheckNamingRequest"
+      },
+      "output": {
+        "shape": "ExistenceCheckNamingResponse"
+      }
     }
   },
   "shapes":{
@@ -137,6 +150,24 @@
       "members":{
       },
       "exception":true
+    },
+    "ExistenceCheckNamingRequest": {
+      "type": "structure",
+      "members": {
+        "Build":{"shape": "ListOfStrings"},
+        "super":{"shape": "ListOfStrings"},
+        "toString":{"shape": "MapOfStringToString"},
+        "equals":{"shape": "MapOfStringToString"}
+      }
+    },
+    "ExistenceCheckNamingResponse": {
+      "type": "structure",
+      "members": {
+        "Build":{"shape": "ListOfStrings"},
+        "super":{"shape": "ListOfStrings"},
+        "toString":{"shape": "MapOfStringToString"},
+        "equals":{"shape": "MapOfStringToString"}
+      }
     },
     "Float":{"type":"float"},
     "IdempotentOperationStructure":{


### PR DESCRIPTION
Add an existence check method for Lists and Maps. 

## Description
Adds a getter method, `hasX` for every member that is a list or map type. Adds a NamingStrategy for this type of method.

## Motivation and Context
Fixes #867 

There is no single way for SDK consumers to identify if a collection might be an empty list or null without exposing the AutoConstruct types. This fix provides the existence check.

## Testing
protocol tests caught an issue in the naming.
other fixes were caught by the parameterized tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
