### PR TITLE
Add support for Asctime date format

### DIFF
--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/StringToInstant.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/StringToInstant.java
@@ -56,6 +56,8 @@ public final class StringToInstant implements StringToValueConverter.StringToVal
                 return safeParseDate(DateUtils::parseUnixTimestampMillisInstant).apply(value);
             case RFC_822:
                 return DateUtils.parseRfc1123Date(value);
+            case ASC_TIME:
+                return DateUtils.parseAsctimeDate(value);
             default:
                 throw SdkClientException.create("Unrecognized timestamp format - " + format);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TimestampFormatTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/TimestampFormatTrait.java
@@ -59,6 +59,11 @@ public final class TimestampFormatTrait implements Trait {
         RFC_822,
 
         /**
+         * See {@link DateUtils#parseAsctimeDate(String)}
+         */
+        ASC_TIME,
+
+        /**
          * See {@link DateUtils#parseUnixTimestampInstant(String)}
          */
         UNIX_TIMESTAMP,
@@ -80,6 +85,8 @@ public final class TimestampFormatTrait implements Trait {
                     return ISO_8601;
                 case "rfc822":
                     return RFC_822;
+                case "asctime":
+                    return ASC_TIME;
                 case "unixTimestamp":
                     return UNIX_TIMESTAMP;
                 // UNIX_TIMESTAMP_MILLIS does not have a defined string format so intentionally omitted here.

--- a/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
@@ -46,6 +46,15 @@ public final class DateUtils {
             .toFormatter()
             .withZone(UTC);
 
+    /**
+     * Asctime format.
+     */
+    static final DateTimeFormatter ASCTIME_DATE_FORMAT =
+            new DateTimeFormatterBuilder()
+                    .appendPattern("EEE MMM dd HH:mm:ss 'UTC' yyyy")
+                    .toFormatter()
+                    .withZone(UTC);
+
     private static final int MILLI_SECOND_PRECISION = 3;
 
     private DateUtils() {
@@ -111,6 +120,35 @@ public final class DateUtils {
      */
     public static String formatRfc1123Date(Instant instant) {
         return RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(instant, UTC));
+    }
+
+    /**
+     * Parses the specified date string as an Asctime date and returns the Date
+     * object.
+     *
+     * @param dateString
+     *            The date string to parse.
+     *
+     * @return The parsed Date object.
+     */
+    public static Instant parseAsctimeDate(String dateString) {
+        if (dateString == null) {
+            return null;
+        }
+
+        return parseInstant(dateString, ASCTIME_DATE_FORMAT);
+    }
+
+    /**
+     * Formats the specified date as an Asctime string.
+     *
+     * @param instant
+     *            The instant to format.
+     *
+     * @return The Asctime string representing the specified date.
+     */
+    public static String formatAsctimeDate(Instant instant) {
+        return  ASCTIME_DATE_FORMAT.format(ZonedDateTime.ofInstant(instant, UTC));
     }
 
     /**

--- a/utils/src/test/java/software/amazon/awssdk/utils/DateUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/DateUtilsTest.java
@@ -20,6 +20,7 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static software.amazon.awssdk.utils.DateUtils.ALTERNATE_ISO_8601_DATE_FORMAT;
+import static software.amazon.awssdk.utils.DateUtils.ASCTIME_DATE_FORMAT;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -42,10 +43,13 @@ public class DateUtilsTest {
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
     private static final SimpleDateFormat LONG_DATE_FORMAT =
             new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
+    private static final SimpleDateFormat ASC_TIME_FORMAT =
+            new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US);
 
     static {
         COMMON_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone(UTC));
         LONG_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone(UTC));
+        ASC_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone(UTC));
     }
 
     private static final Instant INSTANT = Instant.ofEpochMilli(1400284606000L);
@@ -89,6 +93,14 @@ public class DateUtilsTest {
     }
 
     @Test
+    public void parseAsctimeDate() throws ParseException {
+        String formatted = LONG_DATE_FORMAT.format(Date.from(INSTANT));
+        Instant expected = LONG_DATE_FORMAT.parse(formatted).toInstant();
+        Instant actual = DateUtils.parseRfc1123Date(formatted);
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void parseIso8601Date() throws ParseException {
         checkParsing(DateTimeFormatter.ISO_INSTANT, COMMON_DATE_FORMAT);
     }
@@ -98,12 +110,26 @@ public class DateUtilsTest {
         checkParsing(ALTERNATE_ISO_8601_DATE_FORMAT, COMMON_DATE_FORMAT);
     }
 
+    @Test
+    public void parseAsctimeFormat() throws ParseException {
+        checkAsctimeParsing(ASCTIME_DATE_FORMAT, ASC_TIME_FORMAT);
+    }
+
     private void checkParsing(DateTimeFormatter dateTimeFormatter, SimpleDateFormat dateFormat) throws ParseException {
         String formatted = dateFormat.format(Date.from(INSTANT));
         String alternative = dateTimeFormatter.format(INSTANT);
         assertEquals(formatted, alternative);
         Instant expected = dateFormat.parse(formatted).toInstant();
         Instant actualDate = DateUtils.parseIso8601Date(formatted);
+        assertEquals(expected, actualDate);
+    }
+
+    private void checkAsctimeParsing(DateTimeFormatter dateTimeFormatter, SimpleDateFormat dateFormat) throws ParseException {
+        String formatted = dateFormat.format(Date.from(INSTANT));
+        String alternative = dateTimeFormatter.format(INSTANT);
+        assertEquals(formatted, alternative);
+        Instant expected = dateFormat.parse(formatted).toInstant();
+        Instant actualDate = DateUtils.parseAsctimeDate(formatted);
         assertEquals(expected, actualDate);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for ANSI C Asctime date format

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
I included tests for formatting & parsing

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
