### PR TITLE
Do not validate checksums when the service reports it is using customer-managed keys with server-side encryption.

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-61d34b5.json
+++ b/.changes/next-release/bugfix-AmazonS3-61d34b5.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Fixed an issue where the SDK would attempt to validate the checksum on a PutObjectRequest when S3 was returning invalid checksums. This would cause all requests to buckets with customer-managed-key service-side encryption to fail."
+}

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -97,6 +97,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <artifactId>kms</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncServerSideEncryptionIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncServerSideEncryptionIntegrationTest.java
@@ -14,47 +14,21 @@
  */
 package software.amazon.awssdk.services.s3;
 
-import static org.assertj.core.api.Fail.fail;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
-import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.UUID;
-import javax.crypto.KeyGenerator;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
-import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.testutils.SdkAsserts;
 import software.amazon.awssdk.utils.Md5Utils;
 
-public class AsyncServerSideEncryptionIntegrationTest extends S3IntegrationTestBase {
-    
-    private static final String BUCKET = temporaryBucketName(GetObjectIntegrationTest.class);
-
-    private static File file;
-
-    @BeforeClass
-    public static void setupFixture() throws IOException {
-        createBucket(BUCKET);
-        file = new RandomTempFile(10_000);
-    }
-
-    @AfterClass
-    public static void tearDownFixture() {
-        deleteBucketAndAllContents(BUCKET);
-        file.delete();
-    }
-
+public class AsyncServerSideEncryptionIntegrationTest extends ServerSideEncryptionIntegrationTestBase {
     @Test
     public void sse_AES256_succeeds() throws FileNotFoundException {
         String key = UUID.randomUUID().toString();
@@ -121,20 +95,27 @@ public class AsyncServerSideEncryptionIntegrationTest extends S3IntegrationTestB
         verifyGetResponse(getObjectRequest);
     }
 
+    @Test
+    public void sse_onBucket_succeeds() throws FileNotFoundException {
+        String key = UUID.randomUUID().toString();
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                                                   .key(key)
+                                                   .bucket(BUCKET_WITH_SSE)
+                                                   .build();
+
+        s3Async.putObject(request, file.toPath()).join();
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                                                            .key(key)
+                                                            .bucket(BUCKET_WITH_SSE)
+                                                            .build();
+
+        verifyGetResponse(getObjectRequest);
+    }
+
     private void verifyGetResponse(GetObjectRequest getObjectRequest) throws FileNotFoundException {
         String response = s3Async.getObject(getObjectRequest, AsyncResponseTransformer.toBytes()).join().asUtf8String();
         SdkAsserts.assertStringEqualsStream(response, new FileInputStream(file));
     }
-
-    private static byte[] generateSecretKey() {
-        KeyGenerator generator;
-        try {
-            generator = KeyGenerator.getInstance("AES");
-            generator.init(256, new SecureRandom());
-            return generator.generateKey().getEncoded();
-        } catch (Exception e) {
-            fail("Unable to generate symmetric key: " + e.getMessage());
-            return null;
-        }
-    }    
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ServerSideEncryptionIntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ServerSideEncryptionIntegrationTestBase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Fail.fail;
+import static software.amazon.awssdk.services.s3.S3IntegrationTestBase.createBucket;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.SecureRandom;
+import javax.crypto.KeyGenerator;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.testutils.RandomTempFile;
+
+public class ServerSideEncryptionIntegrationTestBase extends S3IntegrationTestBase {
+
+    protected static final String BUCKET = temporaryBucketName(ServerSideEncryptionIntegrationTestBase.class);
+    protected static final String BUCKET_WITH_SSE = temporaryBucketName(ServerSideEncryptionIntegrationTestBase.class);
+
+    private static final KmsClient KMS = KmsClient.builder()
+                                                  .region(DEFAULT_REGION)
+                                                  .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                                  .build();
+
+    protected static File file;
+
+    private static String keyId;
+
+    @BeforeClass
+    public static void setupFixture() throws IOException {
+        createBucket(BUCKET);
+        createBucket(BUCKET_WITH_SSE);
+        keyId = KMS.createKey().keyMetadata().keyId();
+
+        s3.putBucketEncryption(r -> r
+            .bucket(BUCKET_WITH_SSE)
+            .serverSideEncryptionConfiguration(ssec -> ssec
+                .rules(rule -> rule
+                    .applyServerSideEncryptionByDefault(d -> d.kmsMasterKeyID(keyId)
+                                                              .sseAlgorithm(ServerSideEncryption.AWS_KMS)))));
+        file = new RandomTempFile(10_000);
+    }
+
+    @AfterClass
+    public static void tearDownFixture() {
+        deleteBucketAndAllContents(BUCKET);
+        deleteBucketAndAllContents(BUCKET_WITH_SSE);
+        file.delete();
+        KMS.scheduleKeyDeletion(r -> r.keyId(keyId));
+    }
+
+    protected static byte[] generateSecretKey() {
+        KeyGenerator generator;
+        try {
+            generator = KeyGenerator.getInstance("AES");
+            generator.init(256, new SecureRandom());
+            return generator.generateKey().getEncoded();
+        } catch (Exception e) {
+            fail("Unable to generate symmetric key: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/SyncServerSideEncryptionIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/SyncServerSideEncryptionIntegrationTest.java
@@ -14,47 +14,22 @@
  */
 package software.amazon.awssdk.services.s3;
 
-import static org.assertj.core.api.Fail.fail;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AES256;
-import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
-import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.UUID;
-import javax.crypto.KeyGenerator;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
-import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.testutils.SdkAsserts;
 import software.amazon.awssdk.utils.Md5Utils;
 
-public class SyncServerSideEncryptionIntegrationTest extends S3IntegrationTestBase {
-
-    private static final String BUCKET = temporaryBucketName(GetObjectIntegrationTest.class);
-
-    private static File file;
-
-    @BeforeClass
-    public static void setupFixture() throws IOException {
-        createBucket(BUCKET);
-        file = new RandomTempFile(10_000);
-    }
-
-    @AfterClass
-    public static void tearDownFixture() {
-        deleteBucketAndAllContents(BUCKET);
-        file.delete();
-    }
-
+public class SyncServerSideEncryptionIntegrationTest extends ServerSideEncryptionIntegrationTestBase {
     @Test
     public void sse_AES256_succeeds() throws Exception {
         String key = UUID.randomUUID().toString();
@@ -124,15 +99,23 @@ public class SyncServerSideEncryptionIntegrationTest extends S3IntegrationTestBa
         SdkAsserts.assertFileEqualsStream(file, response);
     }
 
-    private static byte[] generateSecretKey() {
-        KeyGenerator generator;
-        try {
-            generator = KeyGenerator.getInstance("AES");
-            generator.init(256, new SecureRandom());
-            return generator.generateKey().getEncoded();
-        } catch (Exception e) {
-            fail("Unable to generate symmetric key: " + e.getMessage());
-            return null;
-        }
+    @Test
+    public void sse_onBucket_succeeds() throws FileNotFoundException {
+        String key = UUID.randomUUID().toString();
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                                                   .key(key)
+                                                   .bucket(BUCKET_WITH_SSE)
+                                                   .build();
+
+        s3.putObject(request, file.toPath());
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                                                            .key(key)
+                                                            .bucket(BUCKET_WITH_SSE)
+                                                            .build();
+
+        String response = s3.getObject(getObjectRequest, ResponseTransformer.toBytes()).asUtf8String();
+        SdkAsserts.assertStringEqualsStream(response, new FileInputStream(file));
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/AsyncChecksumValidationInterceptor.java
@@ -19,7 +19,8 @@ import static software.amazon.awssdk.core.ClientType.ASYNC;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.CONTENT_LENGTH_HEADER;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.CHECKSUM;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.getObjectChecksumEnabledPerResponse;
-import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.putObjectChecksumEnabled;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.responseChecksumIsValid;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.shouldRecordChecksum;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.validatePutObjectChecksum;
 
 import java.nio.ByteBuffer;
@@ -30,6 +31,7 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.checksums.Md5Checksum;
 import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.services.s3.checksums.ChecksumCalculatingAsyncRequestBody;
@@ -38,15 +40,16 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 @SdkInternalApi
 public final class AsyncChecksumValidationInterceptor implements ExecutionInterceptor {
+    private static ExecutionAttribute<Boolean> ASYNC_RECORDING_CHECKSUM = new ExecutionAttribute<>("asyncRecordingChecksum");
 
     @Override
     public Optional<AsyncRequestBody> modifyAsyncHttpContent(Context.ModifyHttpRequest context,
                                                              ExecutionAttributes executionAttributes) {
-        boolean putObjectTrailingChecksumsEnabled =
-            putObjectChecksumEnabled(context.request(), ASYNC, executionAttributes, context.httpRequest());
+        boolean shouldRecordChecksum = shouldRecordChecksum(context.request(), ASYNC, executionAttributes, context.httpRequest());
 
-        if (putObjectTrailingChecksumsEnabled && context.asyncRequestBody().isPresent()) {
+        if (shouldRecordChecksum && context.asyncRequestBody().isPresent()) {
             SdkChecksum checksum = new Md5Checksum();
+            executionAttributes.putAttribute(ASYNC_RECORDING_CHECKSUM, true);
             executionAttributes.putAttribute(CHECKSUM, checksum);
             return Optional.of(new ChecksumCalculatingAsyncRequestBody(context.asyncRequestBody().get(), checksum));
         }
@@ -76,10 +79,10 @@ public final class AsyncChecksumValidationInterceptor implements ExecutionInterc
 
     @Override
     public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
-        boolean putObjectChecksumsEnabled =
-            putObjectChecksumEnabled(context.request(), ASYNC, executionAttributes, context.httpRequest());
+        boolean recordingChecksum = Boolean.TRUE.equals(executionAttributes.getAttribute(ASYNC_RECORDING_CHECKSUM));
+        boolean responseChecksumIsValid = responseChecksumIsValid(context.httpResponse());
 
-        if (putObjectChecksumsEnabled) {
+        if (recordingChecksum && responseChecksumIsValid) {
             validatePutObjectChecksum((PutObjectResponse) context.response(), executionAttributes);
         }
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/SyncChecksumValidationInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/SyncChecksumValidationInterceptor.java
@@ -19,7 +19,8 @@ import static software.amazon.awssdk.core.ClientType.SYNC;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.CONTENT_LENGTH_HEADER;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.CHECKSUM;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.getObjectChecksumEnabledPerResponse;
-import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.putObjectChecksumEnabled;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.responseChecksumIsValid;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.shouldRecordChecksum;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.validatePutObjectChecksum;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
@@ -29,6 +30,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.checksums.Md5Checksum;
 import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -39,14 +41,16 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 @SdkInternalApi
 public final class SyncChecksumValidationInterceptor implements ExecutionInterceptor {
+    private static ExecutionAttribute<Boolean> SYNC_RECORDING_CHECKSUM = new ExecutionAttribute<>("syncRecordingChecksum");
 
     @Override
     public Optional<RequestBody> modifyHttpContent(Context.ModifyHttpRequest context,
                                                    ExecutionAttributes executionAttributes) {
-        if (putObjectChecksumEnabled(context.request(), SYNC, executionAttributes, context.httpRequest())
+        if (shouldRecordChecksum(context.request(), SYNC, executionAttributes, context.httpRequest())
             && context.requestBody().isPresent()) {
             SdkChecksum checksum = new Md5Checksum();
             executionAttributes.putAttribute(CHECKSUM, checksum);
+            executionAttributes.putAttribute(SYNC_RECORDING_CHECKSUM, true);
 
             RequestBody requestBody = context.requestBody().get();
 
@@ -84,7 +88,10 @@ public final class SyncChecksumValidationInterceptor implements ExecutionInterce
 
     @Override
     public void afterUnmarshalling(Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
-        if (putObjectChecksumEnabled(context.request(), SYNC, executionAttributes, context.httpRequest())) {
+        boolean recordingChecksum = Boolean.TRUE.equals(executionAttributes.getAttribute(SYNC_RECORDING_CHECKSUM));
+        boolean responseChecksumIsValid = responseChecksumIsValid(context.httpResponse());
+
+        if (recordingChecksum && responseChecksumIsValid) {
             validatePutObjectChecksum((PutObjectResponse) context.response(), executionAttributes);
         }
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumsEnabledValidatorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumsEnabledValidatorTest.java
@@ -25,13 +25,17 @@ import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.SERV
 import static software.amazon.awssdk.services.s3.checksums.ChecksumConstant.SERVER_SIDE_ENCRYPTION_HEADER;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.getObjectChecksumEnabledPerRequest;
 import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.getObjectChecksumEnabledPerResponse;
-import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.putObjectChecksumEnabled;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.responseChecksumIsValid;
+import static software.amazon.awssdk.services.s3.checksums.ChecksumsEnabledValidator.shouldRecordChecksum;
 import static software.amazon.awssdk.services.s3.model.ServerSideEncryption.AWS_KMS;
 
 import org.junit.Test;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectAclRequest;
@@ -77,65 +81,86 @@ public class ChecksumsEnabledValidatorTest {
     }
 
     @Test
-    public void putObjectChecksumEnabled_defaultTrue() {
-        assertThat(putObjectChecksumEnabled(PutObjectRequest.builder().build(),
-                                            ClientType.SYNC,
-                                            getSyncExecutionAttributes(),
-                                            SdkHttpFullResponse.builder().build())).isTrue();
+    public void putObjectChecksumEnabled_defaultShouldRecord() {
+        assertThat(shouldRecordChecksum(PutObjectRequest.builder().build(),
+                                        ClientType.SYNC,
+                                        getSyncExecutionAttributes(),
+                                        emptyHttpRequest().build())).isTrue();
     }
 
     @Test
     public void putObjectChecksumEnabled_nonPutObjectRequest_false() {
-        assertThat(putObjectChecksumEnabled(PutBucketAclRequest.builder().build(),
-                                            ClientType.SYNC,
-                                            getSyncExecutionAttributes(),
-                                            SdkHttpFullResponse.builder().build())).isFalse();
+        assertThat(shouldRecordChecksum(PutBucketAclRequest.builder().build(),
+                                        ClientType.SYNC,
+                                        getSyncExecutionAttributes(),
+                                        emptyHttpRequest().build())).isFalse();
     }
 
     @Test
     public void putObjectChecksumEnabled_disabledFromConfig_false() {
         ExecutionAttributes executionAttributes = getExecutionAttributesWithChecksumDisabled();
 
-        assertThat(putObjectChecksumEnabled(PutObjectRequest.builder().build(),
-                                            ClientType.SYNC,
-                                            executionAttributes,
-                                            SdkHttpFullResponse.builder().build())).isFalse();
+        assertThat(shouldRecordChecksum(PutObjectRequest.builder().build(),
+                                        ClientType.SYNC,
+                                        executionAttributes,
+                                        emptyHttpRequest().build())).isFalse();
     }
 
     @Test
     public void putObjectChecksumEnabled_wrongClientType_false() {
         ExecutionAttributes executionAttributes = getSyncExecutionAttributes();
 
-        assertThat(putObjectChecksumEnabled(PutObjectRequest.builder().build(),
-                                            ClientType.ASYNC,
-                                            executionAttributes,
-                                            SdkHttpFullResponse.builder().build())).isFalse();
+        assertThat(shouldRecordChecksum(PutObjectRequest.builder().build(),
+                                        ClientType.ASYNC,
+                                        executionAttributes,
+                                        emptyHttpRequest().build())).isFalse();
     }
 
     @Test
     public void putObjectChecksumEnabled_serverSideCustomerEncryption_false() {
         ExecutionAttributes executionAttributes = getSyncExecutionAttributes();
-        SdkHttpFullResponse response = SdkHttpFullResponse.builder()
-                                                          .putHeader(SERVER_SIDE_CUSTOMER_ENCRYPTION_HEADER, "test")
-                                                          .build();
+        SdkHttpRequest response = emptyHttpRequest().putHeader(SERVER_SIDE_CUSTOMER_ENCRYPTION_HEADER, "test")
+                                                    .build();
 
-        assertThat(putObjectChecksumEnabled(PutObjectRequest.builder().build(),
-                                            ClientType.SYNC,
-                                            executionAttributes,
-                                            response)).isFalse();
+        assertThat(shouldRecordChecksum(PutObjectRequest.builder().build(),
+                                        ClientType.SYNC,
+                                        executionAttributes,
+                                        response)).isFalse();
     }
 
     @Test
     public void putObjectChecksumEnabled_serverSideEncryption_false() {
         ExecutionAttributes executionAttributes = getSyncExecutionAttributes();
-        SdkHttpFullResponse response = SdkHttpFullResponse.builder()
-                                                          .putHeader(SERVER_SIDE_ENCRYPTION_HEADER, AWS_KMS.toString())
-                                                          .build();
+        SdkHttpRequest response = emptyHttpRequest().putHeader(SERVER_SIDE_ENCRYPTION_HEADER, AWS_KMS.toString())
+                                                    .build();
 
-        assertThat(putObjectChecksumEnabled(PutObjectRequest.builder().build(),
-                                            ClientType.SYNC,
-                                            executionAttributes,
-                                            response)).isFalse();
+        assertThat(shouldRecordChecksum(PutObjectRequest.builder().build(),
+                                        ClientType.SYNC,
+                                        executionAttributes,
+                                        response)).isFalse();
+    }
+
+    @Test
+    public void responseChecksumIsValid_defaultTrue() {
+        assertThat(responseChecksumIsValid(SdkHttpResponse.builder().build())).isTrue();
+    }
+
+    @Test
+    public void responseChecksumIsValid_serverSideCustomerEncryption_false() {
+        SdkHttpResponse response = SdkHttpResponse.builder()
+                                                  .putHeader(SERVER_SIDE_CUSTOMER_ENCRYPTION_HEADER, "test")
+                                                  .build();
+
+        assertThat(responseChecksumIsValid(response)).isFalse();
+    }
+
+    @Test
+    public void responseChecksumIsValid_serverSideEncryption_false() {
+        SdkHttpResponse response = SdkHttpResponse.builder()
+                                                  .putHeader(SERVER_SIDE_ENCRYPTION_HEADER, AWS_KMS.toString())
+                                                  .build();
+
+        assertThat(responseChecksumIsValid(response)).isFalse();
     }
 
     private ExecutionAttributes getSyncExecutionAttributes() {
@@ -155,6 +180,14 @@ public class ChecksumsEnabledValidatorTest {
                               .putHeader(CONTENT_LENGTH_HEADER, "100")
                               .putHeader(CHECKSUM_ENABLED_RESPONSE_HEADER, ENABLE_MD5_CHECKSUM_HEADER_VALUE)
                               .build();
+    }
+
+    private SdkHttpRequest.Builder emptyHttpRequest() {
+        return SdkHttpFullRequest.builder()
+                                 .method(SdkHttpMethod.GET)
+                                 .protocol("https")
+                                 .host("localhost")
+                                 .port(80);
     }
 
 }


### PR DESCRIPTION
Previously this was only done when the customer reported this in their request.