### PR TITLE
Flush parent before reading on H2 connection

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
@@ -27,6 +27,7 @@ import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.nio.netty.internal.http2.FlushOnReadHandler;
 
 /**
  * Removes any per request {@link ChannelHandler} from the pipeline prior to releasing
@@ -79,6 +80,7 @@ public class HandlerRemovingChannelPool implements ChannelPool {
             removeIfExists(channel.pipeline(),
                            HttpStreamsClientHandler.class,
                            LastHttpContentHandler.class,
+                           FlushOnReadHandler.class,
                            ResponseHandler.class,
                            ReadTimeoutHandler.class,
                            WriteTimeoutHandler.class);

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -62,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.nio.netty.internal.http2.FlushOnReadHandler;
 import software.amazon.awssdk.http.nio.netty.internal.http2.Http2ToHttpInboundAdapter;
 import software.amazon.awssdk.http.nio.netty.internal.http2.HttpToHttp2OutboundAdapter;
 import software.amazon.awssdk.http.nio.netty.internal.utils.ChannelUtils;
@@ -172,6 +173,9 @@ public final class NettyRequestExecutor {
         }
 
         pipeline.addLast(LastHttpContentHandler.create());
+        if (Protocol.HTTP2.equals(protocol)) {
+            pipeline.addLast(FlushOnReadHandler.getInstance());
+        }
         pipeline.addLast(new HttpStreamsClientHandler());
         pipeline.addLast(ResponseHandler.getInstance());
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/FlushOnReadHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/FlushOnReadHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.http2;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This is an HTTP/2 related workaround for an issue where a WINDOW_UPDATE is
+ * queued but not written to the socket, causing a read() on the channel to
+ * hang if the remote endpoint thinks our inbound window is 0.
+ */
+@SdkInternalApi
+@ChannelHandler.Sharable
+public final class FlushOnReadHandler extends ChannelOutboundHandlerAdapter {
+    private static final FlushOnReadHandler INSTANCE = new FlushOnReadHandler();
+
+    private FlushOnReadHandler() {
+    }
+
+    @Override
+    public void read(ChannelHandlerContext ctx) {
+        //Note: order is important, we need to fire the read() event first
+        // since it's what triggers the WINDOW_UPDATE frame write
+        ctx.read();
+        ctx.channel().parent().flush();
+    }
+
+    public static FlushOnReadHandler getInstance() {
+        return INSTANCE;
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/FlushOnReadTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/FlushOnReadTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.http2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FlushOnReadTest {
+
+    @Mock
+    private ChannelHandlerContext mockCtx;
+
+    @Mock
+    private Channel mockChannel;
+
+    @Mock
+    private Channel mockParentChannel;
+
+    @Test
+    public void read_forwardsReadBeforeParentFlush() {
+        when(mockCtx.channel()).thenReturn(mockChannel);
+        when(mockChannel.parent()).thenReturn(mockParentChannel);
+
+        FlushOnReadHandler handler = FlushOnReadHandler.getInstance();
+
+        handler.read(mockCtx);
+
+        InOrder inOrder = Mockito.inOrder(mockCtx, mockParentChannel);
+
+        inOrder.verify(mockCtx).read();
+        inOrder.verify(mockParentChannel).flush();
+    }
+
+    @Test
+    public void getInstance_returnsSingleton() {
+        assertThat(FlushOnReadHandler.getInstance() == FlushOnReadHandler.getInstance()).isTrue();
+    }
+}


### PR DESCRIPTION
## Description
It's possible that WINDOW_UPDATE in the outbound buffer is not be written in a
timely manner to the socket, causing subsequent read()'s to hang until the
remote endpoint sees the local window increase.


## Motivation and Context

## Testing
New unit and integ tests. Running full integ and benchmark suites.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
