### PR TITLE
Update netty reactive streams version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <xmlunit.version>1.3</xmlunit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spotbugs.version>3.1.11</spotbugs.version>
-        <netty-reactive-streams-http.version>2.0.3</netty-reactive-streams-http.version>
+        <netty-reactive-streams-http.version>2.0.4</netty-reactive-streams-http.version>
         <freemarker.version>2.3.24-incubating</freemarker.version>
         <javapoet.verion>1.11.1</javapoet.verion>
         <org.eclipse.jdt.version>3.10.0</org.eclipse.jdt.version>


### PR DESCRIPTION
## Description
New version bumps the version 4.1.43.Final.

## Motivation and Context
Older version depends on older Netty version, tripping some security scans, such as #1524.

## Testing
`mvn clean install`. Running integ tests just to be sure as well, but there don't look to be any code changes (aside from tests) since 2.0.3.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
