### PR TITLE
Add RequestBody.fromRemainingByteBuffer()

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e8d7ec5.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e8d7ec5.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "description": "Add `RequestBody.fromRemainingByteBuffer(ByteBuffer)` that copies only the remaining readable bytes of the buffer. See [#1534](https://github.com/aws/aws-sdk-java-v2/issues/1534)"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/RequestBody.java
@@ -161,12 +161,27 @@ public final class RequestBody {
     /**
      * Creates a {@link RequestBody} from a {@link ByteBuffer}. Buffer contents are copied so any modifications
      * made to the original {@link ByteBuffer} are not reflected in the {@link RequestBody}.
+     * <p>
+     * <b>NOTE:</b> This method always copies the entire contents of the buffer, ignoring the current read position. Use
+     * {@link #fromRemainingByteBuffer(ByteBuffer)} if you need it to copy only the remaining readable bytes.
      *
      * @param byteBuffer ByteBuffer to send to the service.
      * @return RequestBody instance.
      */
     public static RequestBody fromByteBuffer(ByteBuffer byteBuffer) {
         return fromBytesDirect(BinaryUtils.copyAllBytesFrom(byteBuffer));
+    }
+
+    /**
+     * Creates a {@link RequestBody} from the remaining readable bytes from a {@link ByteBuffer}. Unlike
+     * {@link #fromByteBuffer(ByteBuffer)}, this method respects the current read position of the buffer and reads only
+     * the remaining bytes. The buffer is copied before reading so no changes are made to original buffer.
+     *
+     * @param byteBuffer ByteBuffer to send to the service.
+     * @return RequestBody instance.
+     */
+    public static RequestBody fromRemainingByteBuffer(ByteBuffer byteBuffer) {
+        return fromBytesDirect(BinaryUtils.copyRemainingBytesFrom(byteBuffer));
     }
 
     /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/RequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/sync/RequestBodyTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -103,5 +102,24 @@ public class RequestBodyTest {
     public void emptyBytesConstructorHasCorrectContentType() {
         RequestBody requestBody = RequestBody.empty();
         assertThat(requestBody.contentType()).isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
+    }
+
+    @Test
+    public void remainingByteBufferConstructorOnlyRemainingBytesCopied() throws IOException {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[]{1, 2, 3, 4});
+        bb.flip();
+
+        bb.get();
+        bb.get();
+
+        int originalRemaining = bb.remaining();
+
+        RequestBody requestBody = RequestBody.fromRemainingByteBuffer(bb);
+
+        assertThat(requestBody.contentLength()).isEqualTo(originalRemaining);
+
+        byte[] requestBodyBytes = IoUtils.toByteArray(requestBody.contentStreamProvider().newStream());
+        assertThat(ByteBuffer.wrap(requestBodyBytes)).isEqualTo(bb);
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/BinaryUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/BinaryUtils.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.utils.internal.Base16Lower;
  */
 @SdkProtectedApi
 public final class BinaryUtils {
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
     private BinaryUtils() {
     }
@@ -147,6 +148,29 @@ public final class BinaryUtils {
 
         byte[] dst = new byte[copy.remaining()];
         copy.get(dst);
+        return dst;
+    }
+
+    public static byte[] copyRemainingBytesFrom(ByteBuffer bb) {
+        if (bb == null) {
+            return null;
+        }
+
+        if (!bb.hasRemaining()) {
+            return EMPTY_BYTE_ARRAY;
+        }
+
+        if (bb.hasArray()) {
+            int endIdx = bb.arrayOffset() + bb.limit();
+            int startIdx = endIdx - bb.remaining();
+            return Arrays.copyOfRange(bb.array(), startIdx, endIdx);
+        }
+
+        ByteBuffer copy = bb.asReadOnlyBuffer();
+
+        byte[] dst = new byte[copy.remaining()];
+        copy.get(dst);
+
         return dst;
     }
 

--- a/utils/src/test/java/software/amazon/awssdk/utils/BinaryUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/BinaryUtilsTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -158,5 +159,46 @@ public class BinaryUtilsTest {
         assertFalse(partial1 == partial2);
         assertTrue(partial1.length == 3);
         assertTrue(Arrays.equals(new byte[] {2, 3, 4}, partial1));
+    }
+
+    @Test
+    public void testCopyRemainingBytesFrom_nullBuffer() {
+        assertThat(BinaryUtils.copyRemainingBytesFrom(null)).isNull();
+    }
+
+    @Test
+    public void testCopyRemainingBytesFrom_noRemainingBytes() {
+        ByteBuffer bb = ByteBuffer.allocate(1);
+        bb.put(new byte[]{1});
+        bb.flip();
+
+        bb.get();
+
+        assertThat(BinaryUtils.copyRemainingBytesFrom(bb)).hasSize(0);
+    }
+
+    @Test
+    public void testCopyRemainingBytesFrom_fullBuffer() {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[]{1, 2, 3, 4});
+        bb.flip();
+
+        byte[] copy = BinaryUtils.copyRemainingBytesFrom(bb);
+        assertThat(bb).isEqualTo(ByteBuffer.wrap(copy));
+        assertThat(copy).hasSize(4);
+    }
+
+    @Test
+    public void testCopyRemainingBytesFrom_partiallyReadBuffer() {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[]{1, 2, 3, 4});
+        bb.flip();
+
+        bb.get();
+        bb.get();
+
+        byte[] copy = BinaryUtils.copyRemainingBytesFrom(bb);
+        assertThat(bb).isEqualTo(ByteBuffer.wrap(copy));
+        assertThat(copy).hasSize(2);
     }
 }


### PR DESCRIPTION
Fixes #1534

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
New unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
