### PR TITLE
Add sfn specific http configs

### DIFF
--- a/.changes/next-release/feature-AWSStepFunctions-26702fe.json
+++ b/.changes/next-release/feature-AWSStepFunctions-26702fe.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Step Functions", 
+    "type": "feature", 
+    "description": "Add sfn specific http configurations. See [#1325](https://github.com/aws/aws-sdk-java-v2/issues/1325)"
+}

--- a/services/sfn/src/it/java/software/amazon/awssdk/services/sfn/SfnIntegrationTest.java
+++ b/services/sfn/src/it/java/software/amazon/awssdk/services/sfn/SfnIntegrationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sfn;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
+
+public class SfnIntegrationTest extends AwsIntegrationTestBase {
+
+    private static SfnClient sfnClient;
+    private static String activityArn;
+
+    @BeforeClass
+    public static void setUpClient() {
+        sfnClient = SfnClient.builder().credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).build();
+        activityArn = sfnClient.createActivity(b -> b.name("test")).activityArn();
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        if (activityArn != null) {
+            sfnClient.deleteActivity(b -> b.activityArn(activityArn));
+        }
+    }
+
+    @Test
+    public void getActivityTask_shouldWorkByDefault(){
+        assertNotNull(sfnClient.getActivityTask(b -> b.activityArn(activityArn)));
+    }
+}

--- a/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/internal/SfnHttpConfigurationOptions.java
+++ b/services/sfn/src/main/java/software/amazon/awssdk/services/sfn/internal/SfnHttpConfigurationOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sfn.internal;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Sfn specific http configurations.
+ */
+@SdkInternalApi
+public final class SfnHttpConfigurationOptions {
+
+    private static final AttributeMap OPTIONS = AttributeMap
+        .builder()
+        // Sfn has long polling APIs such as getActivityTask that could take up to
+        // 60 seconds to respond
+        .put(SdkHttpConfigurationOption.READ_TIMEOUT, Duration.ofSeconds(65))
+        .build();
+
+    private SfnHttpConfigurationOptions() {
+    }
+
+    public static AttributeMap defaultHttpConfig() {
+        return OPTIONS;
+    }
+}

--- a/services/sfn/src/main/resources/codegen-resources/customization.config
+++ b/services/sfn/src/main/resources/codegen-resources/customization.config
@@ -2,5 +2,6 @@
     "verifiedSimpleMethods" : [
         "listActivities",
         "listStateMachines"
-    ]
+    ],
+    "serviceSpecificHttpConfig": "software.amazon.awssdk.services.sfn.internal.SfnHttpConfigurationOptions"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add sfn specific http configs because Sfn has long polling APIs such as getActivityTask that could take up to 60 seconds to respond and the default sdk socket timeout would not work. See #1325 

## Testing
Added integ test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
