### PR TITLE
Update to use Xenial, OpenJDK 8 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 sudo: true
-dist: precise
+dist: xenial
 install: /bin/true
 notifications:
   email:


### PR DESCRIPTION
Fixes the strange compile error for JDK 11 on Precise.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
