### PR TITLE
Add support for tagging builder in createMultipartUploadRequest

### DIFF
--- a/.changes/next-release/feature-AmazonS3-7700da3.json
+++ b/.changes/next-release/feature-AmazonS3-7700da3.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "feature", 
+    "description": "Add support for Tagging builder in `CreateMultipartUploadRequest`. See [#1440](https://github.com/aws/aws-sdk-java-v2/issues/1440)"
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ObjectTaggingIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ObjectTaggingIntegrationTest.java
@@ -20,11 +20,13 @@ import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBu
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
@@ -33,6 +35,7 @@ import software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.model.VersioningConfiguration;
 
 /**
@@ -95,10 +98,7 @@ public class ObjectTaggingIntegrationTest extends S3IntegrationTestBase {
 
     @Test
     public void getObjectTagging_Succeeds() {
-        List<Tag> tagSet = new ArrayList<>();
-        tagSet.add(Tag.builder().key("foo").value("1").build());
-        tagSet.add(Tag.builder().key("bar").value("2").build());
-        tagSet.add(Tag.builder().key("baz").value("3").build());
+        List<Tag> tagSet = tags();
 
         Tagging tags = Tagging.builder().tagSet(tagSet).build();
 
@@ -147,10 +147,7 @@ public class ObjectTaggingIntegrationTest extends S3IntegrationTestBase {
 
     @Test
     public void copyObject_Succeeds_WithNewTags() {
-        List<Tag> tagSet = new ArrayList<>();
-        tagSet.add(Tag.builder().key("foo").value("1").build());
-        tagSet.add(Tag.builder().key("bar").value("2").build());
-        tagSet.add(Tag.builder().key("baz").value("3").build());
+        List<Tag> tagSet = tags();
 
         Tagging tags = Tagging.builder().tagSet(tagSet).build();
 
@@ -183,12 +180,43 @@ public class ObjectTaggingIntegrationTest extends S3IntegrationTestBase {
         assertThat(getTaggingResult).containsExactlyInAnyOrder(tagsCopy.tagSet().toArray(new Tag[tagsCopy.tagSet().size()]));
     }
 
-    @Test
-    public void testDeleteObjectTagging() {
+    private List<Tag> tags() {
         List<Tag> tagSet = new ArrayList<>();
         tagSet.add(Tag.builder().key("foo").value("1").build());
         tagSet.add(Tag.builder().key("bar").value("2").build());
         tagSet.add(Tag.builder().key("baz").value("3").build());
+        return tagSet;
+    }
+
+    @Test
+    public void multipartUploadWithNewTags_shouldSucceed() {
+        List<Tag> tagSet = tags();
+
+        Tagging tags = Tagging.builder().tagSet(tagSet).build();
+
+        String key = makeNewKey();
+        String uploadId =
+            s3.createMultipartUpload(b -> b.tagging(tags).bucket(BUCKET).key(key)).uploadId();
+
+        UploadPartResponse uploadPartResponse = s3.uploadPart(b -> b.bucket(BUCKET).key(key).partNumber(1).uploadId(uploadId),
+                                                              RequestBody.fromString(RandomStringUtils.random(1000)));
+        CompletedMultipartUpload parts =
+            CompletedMultipartUpload.builder().parts(p -> p.partNumber(1).eTag(uploadPartResponse.eTag()).build()).build();
+
+        s3.completeMultipartUpload(b -> b.bucket(BUCKET).key(key).multipartUpload(parts).uploadId(uploadId).build());
+
+        List<Tag> getTaggingResult = s3.getObjectTagging(GetObjectTaggingRequest.builder()
+                                                                                .bucket(BUCKET)
+                                                                                .key(key)
+                                                                                .build())
+                                       .tagSet();
+
+        assertThat(getTaggingResult).containsExactlyInAnyOrder(tags.tagSet().toArray(new Tag[0]));
+    }
+
+    @Test
+    public void testDeleteObjectTagging() {
+        List<Tag> tagSet = tags();
 
         Tagging tags = Tagging.builder().tagSet(tagSet).build();
 

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -75,6 +75,12 @@
       "memberName": "Tagging",
       "convenienceType": "software.amazon.awssdk.services.s3.model.Tagging",
       "typeAdapterFqcn": "software.amazon.awssdk.services.s3.internal.TaggingAdapter"
+    },
+    {
+      "shapeName": "CreateMultipartUploadRequest",
+      "memberName": "Tagging",
+      "convenienceType": "software.amazon.awssdk.services.s3.model.Tagging",
+      "typeAdapterFqcn": "software.amazon.awssdk.services.s3.internal.TaggingAdapter"
     }
   ],
   "customResponseMetadata": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for tagging builder in createMultipartUploadRequest.

I've verified there are no other existing models that have `Tagging` field

## Motivation and Context
See #1440 

## Testing
Added integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
