### PR TITLE
Increase the priority of the AWS_WEB_IDENTITY_TOKEN_FILE/AWS_ROLE_ARN…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-3cee32c.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-3cee32c.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Increase the priority of the AWS_WEB_IDENTITY_TOKEN_FILE/AWS_ROLE_ARN/AWS_ROLE_SESSION_NAME environment variables when loading credentials so that they are considered before web_identity_token_file/role_arn/role_session_name profile properties. This is consistent with the other AWS SDKs, including the CLI."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -71,8 +71,8 @@ public final class DefaultCredentialsProvider implements AwsCredentialsProvider,
             AwsCredentialsProvider[] credentialsProviders = new AwsCredentialsProvider[] {
                     SystemPropertyCredentialsProvider.create(),
                     EnvironmentVariableCredentialsProvider.create(),
-                    ProfileCredentialsProvider.create(),
                     WebIdentityTokenFileCredentialsProvider.create(),
+                    ProfileCredentialsProvider.create(),
                     ContainerCredentialsProvider.builder()
                                                 .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
                                                 .build(),


### PR DESCRIPTION
…/AWS_ROLE_SESSION_NAME environment variables when loading credentials so that they are considered before web_identity_token_file/role_arn/role_session_name profile properties. This is consistent with the other AWS SDKs, including the CLI.