### PR TITLE
CRT 0.4.13 API Update

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-9a322a2.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-9a322a2.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Common Runtime Client", 
+    "type": "bugfix", 
+    "description": "Upgrade to the latest version (0.3.35) of the AWS Common Runtime."
+}

--- a/.changes/next-release/feature-AWSCommonRuntimeClient-0306e36.json
+++ b/.changes/next-release/feature-AWSCommonRuntimeClient-0306e36.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Common Runtime Http Client", 
+    "type": "feature", 
+    "description": "Add initial support for the AWS Common Runtime (CRT) Http Client."
+}

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.7.10-SNAPSHOT</version>
+        <version>2.7.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.22</version>
+            <version>0.3.35</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.7.23-SNAPSHOT</version>
+        <version>2.10.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>http-clients</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.7.10-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>aws-crt-client</artifactId>
+    <name>AWS Java SDK :: HTTP Clients :: AWS Common Runtime Client</name>
+
+    <dependencies>
+        <!--AWS Common Runtime-->
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.3.12</version>
+        </dependency>
+
+        <!--SDK dependencies-->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+
+        <!--Test Dependencies-->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-tests</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>kms</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <artifactId>service-test-utils</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.verion}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The Reactive Streams TCK tests are based on TestNG. See http://maven.apache.org/surefire/maven-surefire-plugin/examples/testng.html#Running_TestNG_and_JUnit_Tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>junit</name>
+                            <value>false</value>
+                        </property>
+                    </properties>
+                    <threadCount>1</threadCount>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.http.crt</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.19</version>
+            <version>0.3.22</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.10.48-SNAPSHOT</version>
+        <version>2.10.55-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.4.13</version>
+            <version>0.4.19</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.35</version>
+            <version>0.4.1</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.12</version>
+            <version>0.3.14</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.14</version>
+            <version>0.3.17</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.10.9-SNAPSHOT</version>
+        <version>2.10.48-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.13</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.17</version>
+            <version>0.3.19</version>
         </dependency>
 
         <!--SDK dependencies-->

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.10.7-SNAPSHOT</version>
+        <version>2.10.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.7.11-SNAPSHOT</version>
+        <version>2.7.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
@@ -143,11 +143,8 @@ public class AwsCrtClientCallingPatternIntegrationTest {
                                      @FromDataPoints("SharedClient") boolean useSharedClient) throws Exception {
 
         try {
-            if (CrtResource.getAllocatedNativeResourceCount() > 0) {
-                System.err.println("Leaked Resources: " + String.join(", ", CrtResource.getAllocatedNativeResources()));
-            }
-            Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
 
+            CrtResource.waitForNoResources();
             String testName = String.format("Testing with eventLoopSize %d, connectionPoolSize %d, numberOfRequests %d, " +
                             "numberOfParallelJavaClients %d, useSharedClient %b", eventLoopSize, connectionPoolSize,
                     numberOfRequests, numberOfParallelClients, useSharedClient);
@@ -197,11 +194,7 @@ public class AwsCrtClientCallingPatternIntegrationTest {
             awsCrtHttpClient.close();
             Assert.assertFalse(failed.get());
 
-            if (CrtResource.getAllocatedNativeResourceCount() > 0) {
-                System.err.println("Leaked Resources: " + String.join(", ", CrtResource.getAllocatedNativeResources()));
-            }
-
-            Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+            CrtResource.waitForNoResources();
 
             float numSeconds = (float) ((System.currentTimeMillis() - start) / 1000.0);
             String timeElapsed = String.format("%.2f sec", numSeconds);

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
@@ -40,8 +40,12 @@ import software.amazon.awssdk.services.kms.model.GenerateRandomRequest;
 import software.amazon.awssdk.services.kms.model.GenerateRandomResponse;
 import software.amazon.awssdk.utils.AttributeMap;
 
+
+/**
+ * Test many possible different calling patterns that users might do, and make sure everything works.
+ */
 @RunWith(Theories.class)
-public class AwsCrtCombinatorialConfigStressIntegrationTest  {
+public class AwsCrtClientCallingPatternIntegrationTest {
     private final static String KEY_ALIAS = "alias/aws-sdk-java-v2-integ-test";
     private final static Region REGION = Region.US_EAST_1;
     private final static int DEFAULT_KEY_SIZE = 32;
@@ -86,8 +90,6 @@ public class AwsCrtCombinatorialConfigStressIntegrationTest  {
             }
             failures.get(0).printStackTrace();
         }
-
-
 
         return succeeded;
     }

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
@@ -1,0 +1,139 @@
+package software.amazon.awssdk.http.crt;
+
+import static software.amazon.awssdk.testutils.service.AwsTestBase.CREDENTIALS_PROVIDER_CHAIN;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsAsyncClient;
+import software.amazon.awssdk.services.kms.model.CreateAliasRequest;
+import software.amazon.awssdk.services.kms.model.CreateAliasResponse;
+import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
+import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
+import software.amazon.awssdk.services.kms.model.DecryptRequest;
+import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
+import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
+import software.amazon.awssdk.services.kms.model.EncryptRequest;
+import software.amazon.awssdk.services.kms.model.EncryptResponse;
+
+
+public class AwsCrtClientKmsIntegrationTest {
+    private static String KEY_ALIAS = "alias/aws-sdk-java-v2-integ-test";
+    private static Region REGION = Region.US_EAST_1;
+    private static SdkAsyncHttpClient client;
+    private static KmsAsyncClient kms;
+
+    List<CrtResource> crtResources = new ArrayList<>();
+
+    private void addResource(CrtResource resource) {
+        crtResources.add(resource);
+    }
+
+    @Before
+    public void setup() {
+        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+
+        ClientBootstrap bootstrap = new ClientBootstrap(1);
+        SocketOptions socketOptions = new SocketOptions();
+        TlsContext tlsContext = new TlsContext();
+
+        addResource(bootstrap);
+        addResource(socketOptions);
+        addResource(tlsContext);
+
+        client = AwsCrtAsyncHttpClient.builder()
+                .bootstrap(bootstrap)
+                .socketOptions(socketOptions)
+                .tlsContext(tlsContext)
+                .build();
+
+        kms = KmsAsyncClient.builder()
+                .region(REGION)
+                .httpClient(client)
+                .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                .build();
+    }
+
+    @After
+    public void tearDown() {
+        kms.close();
+        client.close();
+
+        for (CrtResource r: crtResources) {
+            r.close();
+        }
+
+        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+    }
+
+    private boolean doesKeyExist(String keyAlias) {
+        try {
+            DescribeKeyRequest req = DescribeKeyRequest.builder().keyId(keyAlias).build();
+            DescribeKeyResponse resp = kms.describeKey(req).get();
+            Assert.assertEquals(200, resp.sdkHttpResponse().statusCode());
+            return resp.sdkHttpResponse().isSuccessful();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void createKeyAlias(String keyId, String keyAlias) throws Exception {
+        CreateAliasRequest req = CreateAliasRequest.builder().aliasName(keyAlias).targetKeyId(keyId).build();
+        CreateAliasResponse resp = kms.createAlias(req).get();
+        Assert.assertEquals(200, resp.sdkHttpResponse().statusCode());
+    }
+
+    private String createKey() throws Exception {
+        CreateKeyRequest req = CreateKeyRequest.builder().build();
+        CreateKeyResponse resp = kms.createKey(req).get();
+        Assert.assertEquals(200, resp.sdkHttpResponse().statusCode());
+        return resp.keyMetadata().keyId();
+    }
+
+    private void createKeyIfNotExists(String keyAlias) throws Exception {
+        if (!doesKeyExist(keyAlias)) {
+            String keyId = createKey();
+            createKeyAlias(keyId, KEY_ALIAS);
+        }
+    }
+
+    private SdkBytes encrypt(String keyId, String plaintext) throws Exception {
+        SdkBytes bytes = SdkBytes.fromUtf8String(plaintext);
+        EncryptRequest req = EncryptRequest.builder().keyId(keyId).plaintext(bytes).build();
+        EncryptResponse resp = kms.encrypt(req).get();
+        Assert.assertEquals(200, resp.sdkHttpResponse().statusCode());
+        return resp.ciphertextBlob();
+    }
+
+    private String decrypt(SdkBytes ciphertext) throws Exception {
+        DecryptRequest req = DecryptRequest.builder().ciphertextBlob(ciphertext).build();
+        DecryptResponse resp = kms.decrypt(req).get();
+        Assert.assertEquals(200, resp.sdkHttpResponse().statusCode());
+        return resp.plaintext().asUtf8String();
+    }
+
+    @Test
+    public void testEncryptDecryptWithKms() throws Exception {
+        createKeyIfNotExists(KEY_ALIAS);
+        Assert.assertTrue(doesKeyExist(KEY_ALIAS));
+        Assert.assertFalse(doesKeyExist("alias/does-not-exist-" + UUID.randomUUID()));
+
+        String secret = UUID.randomUUID().toString();
+        SdkBytes cipherText = encrypt(KEY_ALIAS, secret);
+        String plainText = decrypt(cipherText);
+
+        Assert.assertEquals(plainText, secret);
+    }
+}

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
@@ -11,10 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.crt.CrtResource;
-import software.amazon.awssdk.crt.io.ClientBootstrap;
-import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
-import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -36,12 +33,6 @@ public class AwsCrtClientKmsIntegrationTest {
     private static Region REGION = Region.US_EAST_1;
     private static List<SdkAsyncHttpClient> awsCrtHttpClients = new ArrayList<>();
 
-    List<CrtResource> crtResources = new ArrayList<>();
-
-    private void addResource(CrtResource resource) {
-        crtResources.add(resource);
-    }
-
     @Before
     public void setup() {
         Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
@@ -52,33 +43,18 @@ public class AwsCrtClientKmsIntegrationTest {
                 continue;
             }
 
-            ClientBootstrap bootstrap = new ClientBootstrap(1);
-            SocketOptions socketOptions = new SocketOptions();
-            TlsContext tlsContext = new TlsContext();
-
-            addResource(bootstrap);
-            addResource(socketOptions);
-            addResource(tlsContext);
 
             SdkAsyncHttpClient awsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
-                    .bootstrap(bootstrap)
-                    .socketOptions(socketOptions)
-                    .tlsContext(tlsContext)
+                    .eventLoopSize(1)
                     .build();
 
             awsCrtHttpClients.add(awsCrtHttpClient);
         }
     }
 
-    private void closeResources() {
-        for (CrtResource r: crtResources) {
-            r.close();
-        }
-    }
 
     @After
     public void tearDown() {
-        closeResources();
         Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
     }
 

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
@@ -35,7 +35,7 @@ public class AwsCrtClientKmsIntegrationTest {
 
     @Before
     public void setup() {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
 
         // Create an Http Client for each TLS Cipher Preference supported on the current platform
         for (TlsCipherPreference pref: TlsCipherPreference.values()) {
@@ -55,7 +55,7 @@ public class AwsCrtClientKmsIntegrationTest {
 
     @After
     public void tearDown() {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
     }
 
     private boolean doesKeyExist(KmsAsyncClient kms, String keyAlias) {

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+
+public class AwsCrtClientS3IntegrationTest {
+    /**
+     * The name of the bucket created, used, and deleted by these tests.
+     */
+    private static String BUCKET_NAME = "aws-crt-test-stuff";
+
+    private static String KEY = "http_test_doc.txt";
+
+    private static String FILE_SHA256 = "C7FDB5314B9742467B16BD5EA2F8012190B5E2C44A005F7984F89AAB58219534";
+
+    private static Region REGION = Region.US_EAST_1;
+
+    private static SdkAsyncHttpClient crtClient;
+
+    private static S3AsyncClient s3;
+
+    List<CrtResource> crtResources = new ArrayList<>();
+
+    private void addResource(CrtResource resource) {
+        crtResources.add(resource);
+    }
+
+    @Before
+    public void setup() {
+        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+
+        ClientBootstrap bootstrap = new ClientBootstrap(1);
+        SocketOptions socketOptions = new SocketOptions();
+        TlsContext tlsContext = new TlsContext();
+
+        addResource(bootstrap);
+        addResource(socketOptions);
+        addResource(tlsContext);
+
+        crtClient = AwsCrtAsyncHttpClient.builder()
+                .bootstrap(bootstrap)
+                .socketOptions(socketOptions)
+                .tlsContext(tlsContext)
+                .build();
+
+        s3 = S3AsyncClient.builder()
+                .region(REGION)
+                .httpClient(crtClient)
+                .credentialsProvider(AnonymousCredentialsProvider.create()) // File is publicly readable
+                .build();
+    }
+
+    @After
+    public void tearDown() {
+        s3.close();
+        crtClient.close();
+
+        for (CrtResource r: crtResources) {
+            r.close();
+        }
+
+        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+    }
+
+    @Test
+    public void testDownloadFromS3() throws Exception {
+        GetObjectRequest s3Request = GetObjectRequest.builder()
+                .bucket(BUCKET_NAME)
+                .key(KEY)
+                .build();
+
+        byte[] responseBody = s3.getObject(s3Request, AsyncResponseTransformer.toBytes()).get(120, TimeUnit.SECONDS).asByteArray();
+
+        assertThat(sha256Hex(responseBody).toUpperCase()).isEqualTo(FILE_SHA256);
+    }
+}

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
@@ -56,7 +56,7 @@ public class AwsCrtClientS3IntegrationTest {
 
     @Before
     public void setup() {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
 
         crtClient = AwsCrtAsyncHttpClient.builder()
                 .eventLoopSize(4)
@@ -74,7 +74,7 @@ public class AwsCrtClientS3IntegrationTest {
         s3.close();
         crtClient.close();
 
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
     }
 
     @Test

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtCombinatorialConfigStressIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtCombinatorialConfigStressIntegrationTest.java
@@ -45,7 +45,7 @@ import software.amazon.awssdk.services.kms.model.GenerateRandomResponse;
 import software.amazon.awssdk.utils.AttributeMap;
 
 @RunWith(Theories.class)
-public class AwsCrtCombinatorialConfigStressTest {
+public class AwsCrtCombinatorialConfigStressIntegrationTest {
     private final static String KEY_ALIAS = "alias/aws-sdk-java-v2-integ-test";
     private final static Region REGION = Region.US_EAST_1;
     private final static List<SdkAsyncHttpClient> awsCrtHttpClients = new ArrayList<>();

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtCombinatorialConfigStressTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtCombinatorialConfigStressTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static software.amazon.awssdk.testutils.service.AwsTestBase.CREDENTIALS_PROVIDER_CHAIN;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsAsyncClient;
+import software.amazon.awssdk.services.kms.model.GenerateRandomRequest;
+import software.amazon.awssdk.services.kms.model.GenerateRandomResponse;
+import software.amazon.awssdk.utils.AttributeMap;
+
+@RunWith(Theories.class)
+public class AwsCrtCombinatorialConfigStressTest {
+    private final static String KEY_ALIAS = "alias/aws-sdk-java-v2-integ-test";
+    private final static Region REGION = Region.US_EAST_1;
+    private final static List<SdkAsyncHttpClient> awsCrtHttpClients = new ArrayList<>();
+    private final static int DEFAULT_KEY_SIZE = 32;
+
+    // Success rate will currently never go above ~99% due to aws-c-http not detecting connection close headers, and KMS
+    // closing the connection after the 100th Request on a Http Connection.
+    // Tracking Issue: https://github.com/awslabs/aws-c-http/issues/106
+    private static double MINIMUM_SUCCESS_RATE = 0.95;
+
+    private boolean testWithClient(KmsAsyncClient asyncKMSClient, int numberOfRequests) {
+        List<CompletableFuture<GenerateRandomResponse>> futures = new ArrayList<>();
+
+        for (int i = 0; i < numberOfRequests; i++) {
+            GenerateRandomRequest request = GenerateRandomRequest.builder().numberOfBytes(DEFAULT_KEY_SIZE).build();
+            CompletableFuture<GenerateRandomResponse> future = asyncKMSClient.generateRandom(request);
+            futures.add(future);
+        }
+
+        List<Exception> failures = new ArrayList<>();
+        int actualNumSucceeded = 0;
+        for (CompletableFuture<GenerateRandomResponse> f : futures) {
+            try {
+                GenerateRandomResponse resp = f.get(5, TimeUnit.MINUTES);
+                if (200 == resp.sdkHttpResponse().statusCode()) {
+                    actualNumSucceeded += 1;
+                }
+            } catch (Exception e) {
+                failures.add(e);
+            }
+        }
+
+        int minimumNumSucceeded = (int)(numberOfRequests * (MINIMUM_SUCCESS_RATE));
+        boolean succeeded = true;
+        if (actualNumSucceeded < minimumNumSucceeded) {
+            System.err.println("Failure Metrics: numRequests=" + numberOfRequests + ", numSucceeded=" + actualNumSucceeded);
+            succeeded = false;
+        }
+
+        if (!succeeded) {
+            for(Exception e: failures) {
+                System.err.println(e.getMessage());
+            }
+            failures.get(0).printStackTrace();
+        }
+
+
+
+        return succeeded;
+    }
+
+    private boolean testWithNewClient(int eventLoopSize, int numberOfRequests) {
+        try (ClientBootstrap newBootstrap = new ClientBootstrap(eventLoopSize)) {
+            try (SocketOptions newSocketOptions = new SocketOptions()) {
+                try (TlsContextOptions newContextOptions = new TlsContextOptions()) {
+                    try (TlsContext newTlsContext = new TlsContext(newContextOptions)) {
+                        try (SdkAsyncHttpClient newAwsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
+                                .bootstrap(newBootstrap)
+                                .socketOptions(newSocketOptions)
+                                .tlsContext(newTlsContext)
+                                .build()) {
+                            try (KmsAsyncClient newAsyncKMSClient = KmsAsyncClient.builder()
+                                    .region(REGION)
+                                    .httpClient(newAwsCrtHttpClient)
+                                    .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                    .build()) {
+                                boolean succeeded = testWithClient(newAsyncKMSClient, numberOfRequests);
+                                return succeeded;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @DataPoints("EventLoop")
+    public static int[] eventLoopValues(){
+        return new int[]{1, 4};
+    }
+
+    @DataPoints("ConnectionPool")
+    public static int[] connectionsValues(){
+        /* Don't use 1 connection Pool of size 1, otherwise test takes too long */
+        return new int[]{10, 100};
+    }
+
+    @DataPoints("NumRequests")
+    public static int[] requestValues(){
+        return new int[]{1, 25, 250};
+    }
+
+    @DataPoints("ParallelClients")
+    public static int[] parallelClientValues(){
+        return new int[]{1, 2, 8};
+    }
+
+    @DataPoints("SharedClient")
+    public static boolean[] sharedClientValue(){
+        return new boolean[]{true, false};
+    }
+
+    @Theory
+    public void checkAllCombinations(@FromDataPoints("EventLoop") int eventLoopSize,
+                                     @FromDataPoints("ConnectionPool") int connectionPoolSize,
+                                     @FromDataPoints("NumRequests") int numberOfRequests,
+                                     @FromDataPoints("ParallelClients") int numberOfParallelClients,
+                                     @FromDataPoints("SharedClient") boolean useSharedClient) throws Exception {
+
+        try {
+            if (CrtResource.getAllocatedNativeResourceCount() > 0) {
+                System.err.println("Leaked Resources: " + String.join(", ", CrtResource.getAllocatedNativeResources()));
+            }
+            Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+
+            String testName = String.format("Testing with eventLoopSize %d, connectionPoolSize %d, numberOfRequests %d, " +
+                            "numberOfParallelJavaClients %d, useSharedClient %b", eventLoopSize, connectionPoolSize,
+                    numberOfRequests, numberOfParallelClients, useSharedClient);
+            System.out.println("\n" + testName);
+
+            CountDownLatch latch = new CountDownLatch(numberOfParallelClients);
+
+            AttributeMap attributes = AttributeMap.builder()
+                    .put(SdkHttpConfigurationOption.MAX_CONNECTIONS, connectionPoolSize)
+                    .build();
+
+            ClientBootstrap bootstrap = new ClientBootstrap(eventLoopSize);
+            SocketOptions socketOptions = new SocketOptions();
+            TlsContext tlsContext = new TlsContext();
+            SdkAsyncHttpClient awsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
+                    .bootstrap(bootstrap)
+                    .socketOptions(socketOptions)
+                    .tlsContext(tlsContext)
+                    .buildWithDefaults(attributes);
+
+            KmsAsyncClient sharedAsyncKMSClient = KmsAsyncClient.builder()
+                    .region(REGION)
+                    .httpClient(awsCrtHttpClient)
+                    .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                    .build();
+
+            final AtomicBoolean failed = new AtomicBoolean(false);
+
+            long start = System.currentTimeMillis();
+            ExecutorService pool = Executors.newCachedThreadPool();
+            for (int threads = 0; threads < numberOfParallelClients; threads++) {
+                pool.submit(() -> {
+                    if (useSharedClient) {
+                        if (!testWithClient(sharedAsyncKMSClient, numberOfRequests)) {
+                            System.err.println("Failed: " + testName);
+                            failed.set(true);
+                        }
+                    } else {
+                        if (!testWithNewClient(eventLoopSize, numberOfRequests)) {
+                            System.err.println("Failed: " + testName);
+                            failed.set(true);
+                        }
+                    }
+                    latch.countDown();
+                });
+            }
+
+            latch.await(5, TimeUnit.MINUTES);
+
+            sharedAsyncKMSClient.close();
+            awsCrtHttpClient.close();
+            tlsContext.close();
+            socketOptions.close();
+            bootstrap.close();
+
+            Assert.assertFalse(failed.get());
+
+            if (CrtResource.getAllocatedNativeResourceCount() > 0) {
+                System.err.println("Leaked Resources: " + String.join(", ", CrtResource.getAllocatedNativeResources()));
+            }
+
+            Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+
+            float numSeconds = (float) ((System.currentTimeMillis() - start) / 1000.0);
+            String timeElapsed = String.format("%.2f sec", numSeconds);
+
+            System.out.println("Passed: " + testName + ", Time " + timeElapsed);
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.internal.AwsCrtAsyncHttpStreamAdapter;
 import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
@@ -250,12 +251,12 @@ public class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
     public void close() {
         isClosed.set(true);
         for (HttpConnectionPoolManager connPool : connectionPools.values()) {
-            connPool.close();
+            IoUtils.closeQuietly(connPool, log.logger());
         }
 
         while (ownedSubResources.size() > 0) {
             CrtResource r = ownedSubResources.pop();
-            r.close();
+            IoUtils.closeQuietly(r, log.logger());
         }
     }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -135,8 +135,7 @@ public class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
         Validate.notNull(uri, "URI must not be null");
         log.debug(() -> "Creating ConnectionPool for: URI:" + uri + ", MaxConns: " + maxConnectionsPerEndpoint);
 
-        return new HttpClientConnectionManager(bootstrap, socketOptions, tlsContext, uri,
-                                                HttpClientConnectionManager.DEFAULT_MAX_BUFFER_SIZE, windowSize,
+        return new HttpClientConnectionManager(bootstrap, socketOptions, tlsContext, uri, windowSize,
                                                 maxConnectionsPerEndpoint);
     }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -83,12 +83,12 @@ public class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
         Validate.isPositive(builder.windowSize, "windowSize");
 
         /**
-         * Must add to List in reverse order that they were created in, so that they are closed in the correct order.
+         * Must call own() in same order that CrtResources are created in, so that they will be closed in reverse order.
          *
-         * Do NOT use Dependency Injection for Native Resources. It's possible to crash the JVM Process if Native
-         * Dependencies are closed in the wrong order (Eg closing the Bootstrap/Threadpool when there are still open
-         * connections). By creating and owning our own Native Resources we can guarantee that things are shutdown in
-         * the correct order.
+         * Do NOT use Dependency Injection for Native CrtResources. It's possible to crash the JVM Process if Native
+         * Resources are closed in the wrong order (Eg closing the Bootstrap/Threadpool when there are still open
+         * connections). By creating and owning our own Native CrtResources we can guarantee that things are shutdown
+         * in the correct order.
          */
 
         bootstrap = own(new ClientBootstrap(builder.eventLoopSize));

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.crt.internal.AwsCrtAsyncHttpStreamAdapter;
+import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
+
+/**
+ * An implementation of {@link SdkHttpClient} that uses the AWS Common Runtime (CRT) Http Client to communicate with
+ * Http Web Services. This client is asynchronous and uses non-blocking IO.
+ *
+ * <p>This can be created via {@link #builder()}</p>
+ */
+@SdkPublicApi
+public class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
+    private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpClient.class);
+    private static final String HOST_HEADER = "Host";
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String AWS_COMMON_RUNTIME = "AwsCommonRuntime";
+    private static final int DEFAULT_STREAM_WINDOW_SIZE = 16 * 1024 * 1024; // 16 MB Total Buffer size
+    private static final int DEFAULT_HTTP_BODY_UPDATE_SIZE = 4 * 1024 * 1024; // 4 MB Update size from Native
+
+    private final Map<URI, HttpConnection> connections = new ConcurrentHashMap<>();
+    private final ClientBootstrap bootstrap;
+    private final SocketOptions socketOptions;
+    private final TlsContext tlsContext;
+    private final int windowSize;
+    private final int httpBodyUpdateSize;
+
+    public AwsCrtAsyncHttpClient(DefaultBuilder builder, AttributeMap serviceDefaultsMap) {
+        this(builder.bootstrap, builder.socketOptions, builder.tlsContext, builder.windowSize, builder.httpBodyUpdateSize);
+    }
+
+    public AwsCrtAsyncHttpClient(ClientBootstrap bootstrap, SocketOptions sockOpts, TlsContext tlsContext) {
+        this(bootstrap, sockOpts, tlsContext, DEFAULT_STREAM_WINDOW_SIZE, DEFAULT_HTTP_BODY_UPDATE_SIZE);
+    }
+
+    public AwsCrtAsyncHttpClient(ClientBootstrap bootstrap, SocketOptions sockOpts, TlsContext tlsContext,
+                                 int windowSize, int httpBodyUpdateSize) {
+        Validate.notNull(bootstrap, "ClientBootstrap must not be null");
+        Validate.notNull(sockOpts, "SocketOptions must not be null");
+        Validate.notNull(tlsContext, "TlsContext must not be null");
+        Validate.isPositive(windowSize, "windowSize must be > 0");
+
+        this.bootstrap = bootstrap;
+        this.socketOptions = sockOpts;
+        this.tlsContext = tlsContext;
+        this.windowSize = windowSize;
+        this.httpBodyUpdateSize = httpBodyUpdateSize;
+    }
+
+    private static URI toUri(SdkHttpRequest sdkRequest) {
+        Validate.notNull(sdkRequest, "SdkHttpRequest must not be null");
+        return invokeSafely(() -> new URI(sdkRequest.protocol(), null, sdkRequest.host(), sdkRequest.port(),
+                null, null, null));
+    }
+
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    @Override
+    public String clientName() {
+        return AWS_COMMON_RUNTIME;
+    }
+
+    private HttpConnection createConnection(URI uri) {
+        Validate.notNull(uri, "URI must not be null");
+        log.debug(() -> "Creating Connection to: " + uri);
+        return invokeSafely(() -> HttpConnection.createConnection(uri, bootstrap, socketOptions, tlsContext,
+                                                                    windowSize, httpBodyUpdateSize).get());
+    }
+
+    private HttpConnection getOrCreateConnection(URI uri) {
+        Validate.notNull(uri, "URI must not be null");
+        HttpConnection connToReturn = connections.get(uri);
+
+        if (connToReturn == null) {
+            HttpConnection newConn = createConnection(uri);
+            HttpConnection alreadyExistingConn = connections.putIfAbsent(uri, newConn);
+
+            if (alreadyExistingConn == null) {
+                connToReturn = newConn;
+            } else {
+                // Multiple threads trying to open connections to the same URI at once, close the newer one
+                newConn.close();
+                connToReturn = alreadyExistingConn;
+            }
+        }
+
+        // If connection was shutdown by peer, open a new connection
+        if (connToReturn.getShutdownFuture().isDone()) {
+            connections.remove(uri, connToReturn);
+            connToReturn.close();
+            return getOrCreateConnection(uri);
+        }
+
+        return connToReturn;
+    }
+
+    private List<HttpHeader> createHttpHeaderList(URI uri, AsyncExecuteRequest asyncRequest) {
+        SdkHttpRequest sdkRequest = asyncRequest.request();
+        List<HttpHeader> crtHeaderList = new ArrayList<>(sdkRequest.headers().size() + 2);
+
+        // Set Host Header if needed
+        if (isNullOrEmpty(sdkRequest.headers().get(HOST_HEADER))) {
+            crtHeaderList.add(new HttpHeader(HOST_HEADER, uri.getHost()));
+        }
+
+        // Set Content-Length if needed
+        Optional<Long> contentLength = asyncRequest.requestContentPublisher().contentLength();
+        if (isNullOrEmpty(sdkRequest.headers().get(CONTENT_LENGTH)) && contentLength.isPresent()) {
+            crtHeaderList.add(new HttpHeader(CONTENT_LENGTH, Long.toString(contentLength.get())));
+        }
+
+        // Add the rest of the Headers
+        for (Map.Entry<String, List<String>> headerList: sdkRequest.headers().entrySet()) {
+            for (String val: headerList.getValue()) {
+                HttpHeader h = new HttpHeader(headerList.getKey(), val);
+                crtHeaderList.add(h);
+            }
+        }
+
+        return crtHeaderList;
+    }
+
+    private HttpHeader[] asArray(List<HttpHeader> crtHeaderList) {
+        return crtHeaderList.toArray(new HttpHeader[crtHeaderList.size()]);
+    }
+
+    private HttpRequest toCrtRequest(URI uri, AsyncExecuteRequest asyncRequest) {
+        SdkHttpRequest sdkRequest = asyncRequest.request();
+        Validate.notNull(uri, "URI must not be null");
+        Validate.notNull(sdkRequest, "SdkHttpRequest must not be null");
+
+        String method = sdkRequest.method().name();
+        String encodedPath = sdkRequest.encodedPath();
+        String encodedQueryString = SdkHttpUtils.encodeAndFlattenQueryParameters(sdkRequest.rawQueryParameters())
+                .map(value -> "?" + value)
+                .orElse("");
+
+        HttpHeader[] crtHeaderArray = asArray(createHttpHeaderList(uri, asyncRequest));
+
+        return new HttpRequest(method, encodedPath + encodedQueryString, crtHeaderArray);
+    }
+
+    @Override
+    public CompletableFuture<Void> execute(AsyncExecuteRequest asyncRequest) {
+        Validate.notNull(asyncRequest, "AsyncExecuteRequest must not be null");
+        Validate.notNull(asyncRequest.request(), "SdkHttpRequest must not be null");
+        Validate.notNull(asyncRequest.requestContentPublisher(), "RequestContentPublisher must not be null");
+        Validate.notNull(asyncRequest.responseHandler(), "ResponseHandler must not be null");
+
+        URI uri = toUri(asyncRequest.request());
+        HttpConnection crtConn = getOrCreateConnection(uri);
+        HttpRequest crtRequest = toCrtRequest(uri, asyncRequest);
+
+        CompletableFuture<Void> requestFuture = new CompletableFuture<>();
+        AwsCrtAsyncHttpStreamAdapter crtToSdkAdapter =
+                new AwsCrtAsyncHttpStreamAdapter(requestFuture, asyncRequest, windowSize);
+
+        invokeSafely(() -> crtConn.makeRequest(crtRequest, crtToSdkAdapter));
+
+        return requestFuture;
+    }
+
+    @Override
+    public void close() {
+        for (HttpConnection conn : connections.values()) {
+            conn.close();
+        }
+    }
+
+    /**
+     * Builder that allows configuration of the AWS CRT HTTP implementation.
+     */
+    public interface Builder extends SdkAsyncHttpClient.Builder<AwsCrtAsyncHttpClient.Builder> {
+
+        /**
+         * The AWS CRT Bootstrap Instance to use for this Client
+         * @param boostrap The AWS Common Runtime Bootstrap
+         * @return the builder of the method chaining.
+         */
+        Builder bootstrap(ClientBootstrap boostrap);
+
+        /**
+         * The AWS CRT SocketOptions to use for this Client.
+         * @param socketOptions The AWS Common Runtime SocketOptions
+         * @return the builder of the method chaining.
+         */
+        Builder socketOptions(SocketOptions socketOptions);
+
+        /**
+         * The AWS CRT TlsContext to use for this Client
+         * @param tlsContext The AWS Common Runtime TlsContext
+         * @return the builder of the method chaining.
+         */
+        Builder tlsContext(TlsContext tlsContext);
+
+        /**
+         * The AWS CRT WindowSize to use for this HttpClient
+         * @param windowSize The AWS Common Runtime WindowSize
+         * @return the builder of the method chaining.
+         */
+        Builder windowSize(int windowSize);
+
+        /**
+         * The AWS CRT httpBodyUpdateSize to use for this HttpClient
+         * @param httpBodyUpdateSize The AWS Common Runtime httpBodyUpdateSize
+         * @return the builder of the method chaining.
+         */
+        Builder httpBodyUpdateSize(int httpBodyUpdateSize);
+    }
+
+    /**
+     * Factory that allows more advanced configuration of the AWS CRT HTTP implementation. Use {@link #builder()} to
+     * configure and construct an immutable instance of the factory.
+     */
+    private static final class DefaultBuilder implements Builder {
+        private final AttributeMap.Builder standardOptions = AttributeMap.builder();
+
+        private ClientBootstrap bootstrap;
+        private SocketOptions socketOptions;
+        private TlsContext tlsContext;
+        private int windowSize = DEFAULT_STREAM_WINDOW_SIZE;
+        private int httpBodyUpdateSize = DEFAULT_HTTP_BODY_UPDATE_SIZE;
+
+        private DefaultBuilder() {
+        }
+
+        @Override
+        public SdkAsyncHttpClient build() {
+            return new AwsCrtAsyncHttpClient(this, standardOptions.build()
+                                                                  .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
+        }
+
+        @Override
+        public SdkAsyncHttpClient buildWithDefaults(AttributeMap serviceDefaults) {
+            return new AwsCrtAsyncHttpClient(this, standardOptions.build()
+                                                           .merge(serviceDefaults)
+                                                           .merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS));
+        }
+
+        public Builder bootstrap(ClientBootstrap bootstrap) {
+            Validate.notNull(bootstrap, "bootstrap");
+            this.bootstrap = bootstrap;
+            return this;
+        }
+
+        @Override
+        public Builder socketOptions(SocketOptions socketOptions) {
+            Validate.notNull(socketOptions, "socketOptions");
+            this.socketOptions = socketOptions;
+            return this;
+        }
+
+        @Override
+        public Builder tlsContext(TlsContext tlsContext) {
+            Validate.notNull(tlsContext, "tlsContext");
+            this.tlsContext = tlsContext;
+            return this;
+        }
+
+        @Override
+        public Builder windowSize(int windowSize) {
+            Validate.isPositive(windowSize, "windowSize");
+            this.windowSize = windowSize;
+            return this;
+        }
+
+        @Override
+        public Builder httpBodyUpdateSize(int httpBodyUpdateSize) {
+            Validate.isPositive(httpBodyUpdateSize, "httpBodyUpdateSize");
+            this.httpBodyUpdateSize = httpBodyUpdateSize;
+            return this;
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -200,8 +200,7 @@ public class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
         HttpRequest crtRequest = toCrtRequest(uri, asyncRequest);
 
         CompletableFuture<Void> requestFuture = new CompletableFuture<>();
-        AwsCrtAsyncHttpStreamAdapter crtToSdkAdapter =
-                new AwsCrtAsyncHttpStreamAdapter(requestFuture, asyncRequest, windowSize);
+
 
         HttpRequestOptions reqOptions = new HttpRequestOptions();
         reqOptions.setBodyBufferSize(httpBodyUpdateSize);
@@ -215,8 +214,8 @@ public class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
                     return;
                 }
 
-                // When the Request is complete, return our connection back to the Connection Pool
-                requestFuture.whenComplete((v, t) ->  crtConnPool.releaseConnection(crtConn));
+                AwsCrtAsyncHttpStreamAdapter crtToSdkAdapter =
+                        new AwsCrtAsyncHttpStreamAdapter(crtConn, requestFuture, asyncRequest, windowSize);
 
                 // Submit the Request on this Connection
                 invokeSafely(() -> crtConn.makeRequest(crtRequest, reqOptions, crtToSdkAdapter));

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.http.crt.internal;
 
-import static software.amazon.awssdk.crt.utils.ByteBufferUtils.deepCopy;
-
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -80,16 +80,11 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     }
 
     @Override
-    public void onResponseHeadersDone(HttpStream stream, boolean hasBody) {
+    public void onResponseHeadersDone(HttpStream stream, int headerType) {
         initRespBodyPublisherIfNeeded(stream);
 
         respBuilder.statusCode(stream.getResponseStatusCode());
         sdkRequest.responseHandler().onHeaders(respBuilder.build());
-
-        if (!hasBody) {
-            respBodyPublisher.setQueueComplete();
-        }
-
         sdkRequest.responseHandler().onStream(respBodyPublisher);
     }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.CRT;
-import software.amazon.awssdk.crt.http.CrtHttpStreamHandler;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpException;
 import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
 import software.amazon.awssdk.crt.http.HttpStream;
+import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.utils.Logger;
@@ -33,7 +34,7 @@ import software.amazon.awssdk.utils.Validate;
  * Implements the CrtHttpStreamHandler API and converts CRT callbacks into calls to SDK AsyncExecuteRequest methods
  */
 @SdkInternalApi
-public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
+public class AwsCrtAsyncHttpStreamAdapter implements HttpStreamResponseHandler, HttpRequestBodyStream {
     private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpStreamAdapter.class);
 
     private final HttpClientConnection connection;
@@ -123,7 +124,7 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     }
 
     @Override
-    public boolean sendRequestBody(HttpStream stream, ByteBuffer bodyBytesOut) {
+    public boolean sendRequestBody(ByteBuffer bodyBytesOut) {
         return requestBodySubscriber.transferRequestBody(bodyBytesOut);
     }
 }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static software.amazon.awssdk.crt.utils.ByteBufferUtils.deepCopy;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.http.CrtHttpStreamHandler;
+import software.amazon.awssdk.crt.http.HttpException;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpStream;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Implements the CrtHttpStreamHandler API and converts CRT callbacks into calls to SDK AsyncExecuteRequest methods
+ */
+@SdkInternalApi
+public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
+    private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpStreamAdapter.class);
+    private final AsyncExecuteRequest sdkRequest;
+    private final CompletableFuture<Void> reqComplete;
+    private final SdkHttpResponse.Builder respBuilder = SdkHttpResponse.builder();
+    private final int windowSize;
+    private final AwsCrtRequestBodySubscriber requestBodySubscriber;
+    private AwsCrtResponseBodyPublisher respBodyPublisher = null;
+
+    public AwsCrtAsyncHttpStreamAdapter(CompletableFuture<Void> reqComplete, AsyncExecuteRequest sdkRequest,
+                                        int windowSize) {
+        Validate.notNull(reqComplete, "reqComplete Future is null");
+        Validate.notNull(sdkRequest, "AsyncExecuteRequest Future is null");
+        Validate.isPositive(windowSize, "windowSize is <= 0");
+
+        this.sdkRequest = sdkRequest;
+        this.reqComplete = reqComplete;
+        this.windowSize = windowSize;
+        this.requestBodySubscriber = new AwsCrtRequestBodySubscriber(windowSize);
+
+        sdkRequest.requestContentPublisher().subscribe(requestBodySubscriber);
+    }
+
+    @Override
+    public void onResponseHeaders(HttpStream stream, int responseStatusCode, HttpHeader[] nextHeaders) {
+        respBuilder.statusCode(responseStatusCode);
+
+        for (HttpHeader h : nextHeaders) {
+            respBuilder.appendHeader(h.getName(), h.getValue());
+        }
+    }
+
+    @Override
+    public void onResponseHeadersDone(HttpStream stream, boolean hasBody) {
+        respBuilder.statusCode(stream.getResponseStatusCode());
+        sdkRequest.responseHandler().onHeaders(respBuilder.build());
+        respBodyPublisher = new AwsCrtResponseBodyPublisher(stream, windowSize);
+
+
+        if (!hasBody) {
+            respBodyPublisher.setQueueComplete();
+        }
+
+        sdkRequest.responseHandler().onStream(respBodyPublisher);
+    }
+
+    @Override
+    public int onResponseBody(HttpStream stream, ByteBuffer bodyBytesIn) {
+        if (respBodyPublisher == null) {
+            log.error(() -> "Publisher is null, onResponseHeadersDone() was never called");
+            throw new IllegalStateException("Publisher is null, onResponseHeadersDone() was never called");
+        }
+
+        // Queue a Deep Copy since bodyBytesIn is only guaranteed to contain valid memory for the lifetime of this
+        // function call, and it's memory can be reused once this function returns.
+        respBodyPublisher.queueBuffer(deepCopy(bodyBytesIn));
+        respBodyPublisher.publishToSubscribers();
+
+        return 0;
+    }
+
+    @Override
+    public void onResponseComplete(HttpStream stream, int errorCode) {
+        if (errorCode == CRT.AWS_CRT_SUCCESS) {
+            log.debug(() -> "Response Completed Successfully");
+            respBodyPublisher.setQueueComplete();
+            respBodyPublisher.publishToSubscribers();
+            reqComplete.complete(null);
+        } else {
+            HttpException error = new HttpException(errorCode);
+            log.error(() -> "Response Encountered an Error.", error);
+
+            // Invoke Error Callback on SdkAsyncHttpResponseHandler
+            sdkRequest.responseHandler().onError(error);
+
+            // Invoke Error Callback on any Subscriber's of the Response Body
+            if (respBodyPublisher != null) {
+                respBodyPublisher.setError(error);
+                respBodyPublisher.publishToSubscribers();
+            }
+
+            reqComplete.completeExceptionally(error);
+        }
+
+        stream.close();
+    }
+
+    @Override
+    public boolean sendRequestBody(HttpStream stream, ByteBuffer bodyBytesOut) {
+        return requestBodySubscriber.transferRequestBody(bodyBytesOut);
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -100,10 +100,6 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
         respBodyPublisher.queueBuffer(bodyBytesIn);
         respBodyPublisher.publishToSubscribers();
 
-        if (bodyBytesIn.length != 0) {
-            throw new IllegalStateException("Unprocessed bytes remain in bodyBytesIn Buffer!");
-        }
-
         return 0;
     }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -97,8 +97,6 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
             throw new IllegalStateException("Publisher is null, onResponseHeadersDone() was never called");
         }
 
-        // Queue a Deep Copy since bodyBytesIn is only guaranteed to contain valid memory for the lifetime of this
-        // function call, and it's memory can be reused once this function returns.
         respBodyPublisher.queueBuffer(bodyBytesIn);
         respBodyPublisher.publishToSubscribers();
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -89,7 +89,7 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     }
 
     @Override
-    public int onResponseBody(HttpStream stream, ByteBuffer bodyBytesIn) {
+    public int onResponseBody(HttpStream stream, byte[] bodyBytesIn) {
         initRespBodyPublisherIfNeeded(stream);
 
         if (respBodyPublisher == null) {
@@ -99,10 +99,10 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
 
         // Queue a Deep Copy since bodyBytesIn is only guaranteed to contain valid memory for the lifetime of this
         // function call, and it's memory can be reused once this function returns.
-        respBodyPublisher.queueBuffer(deepCopy(bodyBytesIn));
+        respBodyPublisher.queueBuffer(bodyBytesIn);
         respBodyPublisher.publishToSubscribers();
 
-        if (bodyBytesIn.remaining() != 0) {
+        if (bodyBytesIn.length != 0) {
             throw new IllegalStateException("Unprocessed bytes remain in bodyBytesIn Buffer!");
         }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtAsyncHttpStreamAdapter.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.http.CrtHttpStreamHandler;
-import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpException;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.HttpStream;
@@ -38,7 +38,7 @@ import software.amazon.awssdk.utils.Validate;
 public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpStreamAdapter.class);
 
-    private final HttpConnection connection;
+    private final HttpClientConnection connection;
     private final CompletableFuture<Void> responseComplete;
     private final AsyncExecuteRequest sdkRequest;
     private final SdkHttpResponse.Builder respBuilder = SdkHttpResponse.builder();
@@ -46,7 +46,7 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     private final AwsCrtRequestBodySubscriber requestBodySubscriber;
     private AwsCrtResponseBodyPublisher respBodyPublisher = null;
 
-    public AwsCrtAsyncHttpStreamAdapter(HttpConnection connection, CompletableFuture<Void> responseComplete,
+    public AwsCrtAsyncHttpStreamAdapter(HttpClientConnection connection, CompletableFuture<Void> responseComplete,
                                         AsyncExecuteRequest sdkRequest, int windowSize) {
         Validate.notNull(connection, "HttpConnection is null");
         Validate.notNull(responseComplete, "reqComplete Future is null");
@@ -69,7 +69,7 @@ public class AwsCrtAsyncHttpStreamAdapter implements CrtHttpStreamHandler {
     }
 
     @Override
-    public void onResponseHeaders(HttpStream stream, int responseStatusCode, HttpHeader[] nextHeaders) {
+    public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType, HttpHeader[] nextHeaders) {
         initRespBodyPublisherIfNeeded(stream);
 
         respBuilder.statusCode(responseStatusCode);

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
@@ -99,8 +99,6 @@ public class AwsCrtRequestBodySubscriber implements Subscriber<ByteBuffer> {
         isComplete.set(true);
     }
 
-
-
     /**
      * Transfers any queued data from the Request Body subscriptionRef to the output buffer
      * @param out The output ByteBuffer

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
@@ -126,7 +126,7 @@ public class AwsCrtRequestBodySubscriber implements Subscriber<ByteBuffer> {
         if (!endOfStream) {
             requestDataIfNecessary();
         } else {
-            log.debug(() -> "End Of Stream reached");
+            log.debug(() -> "End Of RequestBody reached");
         }
 
         return endOfStream;

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtRequestBodySubscriber.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static software.amazon.awssdk.crt.utils.ByteBufferUtils.transferData;
+
+import java.nio.ByteBuffer;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Implements the Subscriber<ByteBuffer> API to be be callable from AwsCrtAsyncHttpStreamAdapter.sendRequestBody()
+ */
+@SdkInternalApi
+public class AwsCrtRequestBodySubscriber implements Subscriber<ByteBuffer> {
+    private static final Logger log = Logger.loggerFor(AwsCrtRequestBodySubscriber.class);
+
+    private final int windowSize;
+    private final Queue<ByteBuffer> queuedBuffers = new ConcurrentLinkedQueue<>();
+    private final AtomicLong queuedByteCount = new AtomicLong(0);
+    private final AtomicBoolean isComplete = new AtomicBoolean(false);
+    private final AtomicReference<Throwable> error = new AtomicReference<>(null);
+
+    private AtomicReference<Subscription> subscriptionRef = new AtomicReference<>(null);
+
+    /**
+     *
+     * @param windowSize The number bytes to be queued before we stop proactively queuing data
+     */
+    public AwsCrtRequestBodySubscriber(int windowSize) {
+        Validate.isPositive(windowSize, "windowSize is <= 0");
+        this.windowSize = windowSize;
+    }
+
+    protected void requestDataIfNecessary() {
+        Subscription subscription = subscriptionRef.get();
+        if (subscription == null) {
+            log.error(() -> "Subscription is null");
+            return;
+        }
+        if (queuedByteCount.get() < windowSize) {
+            subscription.request(1);
+        }
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        Validate.notNull(s, "Subscription should not be null");
+
+        boolean wasFirstSubscription = subscriptionRef.compareAndSet(null, s);
+
+        if (!wasFirstSubscription) {
+            log.error(() -> "Only one Subscription supported!");
+            s.cancel();
+            return;
+        }
+
+        requestDataIfNecessary();
+    }
+
+    @Override
+    public void onNext(ByteBuffer byteBuffer) {
+        Validate.notNull(byteBuffer, "ByteBuffer should not be null");
+        queuedBuffers.add(byteBuffer);
+        queuedByteCount.addAndGet(byteBuffer.remaining());
+        requestDataIfNecessary();
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        log.error(() -> "onError() received an error: " + t.getMessage());
+        error.compareAndSet(null, t);
+    }
+
+    @Override
+    public void onComplete() {
+        log.debug(() -> "AwsCrtRequestBodySubscriber Completed");
+        isComplete.set(true);
+    }
+
+
+
+    /**
+     * Transfers any queued data from the Request Body subscriptionRef to the output buffer
+     * @param out The output ByteBuffer
+     * @return true if Request Body is completely transferred, false otherwise
+     */
+    public synchronized boolean transferRequestBody(ByteBuffer out) {
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+
+        while (out.remaining() > 0 && queuedBuffers.size() > 0) {
+            ByteBuffer nextBuffer = queuedBuffers.peek();
+            int amtTransferred = transferData(nextBuffer, out);
+            queuedByteCount.addAndGet(-amtTransferred);
+
+            if (nextBuffer.remaining() == 0) {
+                queuedBuffers.remove();
+            }
+        }
+
+        boolean endOfStream = isComplete.get() && (queuedBuffers.size() == 0);
+
+        if (!endOfStream) {
+            requestDataIfNecessary();
+        } else {
+            log.debug(() -> "End Of Stream reached");
+        }
+
+        return endOfStream;
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -248,8 +248,8 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
             }
         }
 
-        // Check if Complete
-        if (queueComplete.get() && queuedBuffers.size() == 0) {
+        // Check if Complete, consider no subscriber as a completion.
+        if (queueComplete.get() && (subscriberRef.get() == null || queuedBuffers.size() == 0)) {
             completeSubscriptionExactlyOnce();
         }
     }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -41,7 +41,6 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
     private static final Logger log = Logger.loggerFor(AwsCrtResponseBodyPublisher.class);
     private static final LongUnaryOperator DECREMENT_IF_GREATER_THAN_ZERO = x -> ((x > 0) ? (x - 1) : (x));
 
-
     private final HttpConnection connection;
     private final HttpStream stream;
     private final CompletableFuture<Void> responseComplete;

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -132,6 +132,12 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
             outstandingReqs = outstandingRequests.addAndGet(n);
         }
 
+        /*
+         * Since we buffer, in the case where the subscriber came in after the publication has already begun,
+         * go ahead and flush what we have.
+         */
+        publishToSubscribers();
+
         log.trace(() -> "Subscriber Requested more Buffers. Outstanding Requests: " + outstandingReqs);
     }
 
@@ -249,7 +255,7 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
         }
 
         // Check if Complete, consider no subscriber as a completion.
-        if (queueComplete.get() && (subscriberRef.get() == null || queuedBuffers.size() == 0)) {
+        if (queueComplete.get() && queuedBuffers.size() == 0) {
             completeSubscriptionExactlyOnce();
         }
     }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import java.nio.ByteBuffer;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongUnaryOperator;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.http.HttpStream;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Adapts an AWS Common Runtime Response Body stream from CrtHttpStreamHandler to a Publisher<ByteBuffer>
+ */
+@SdkInternalApi
+public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
+    private static final Logger log = Logger.loggerFor(AwsCrtResponseBodyPublisher.class);
+    private static final LongUnaryOperator DECREMENT_IF_GREATER_THAN_ZERO = x -> ((x > 0) ? (x - 1) : (x));
+
+    private final AtomicLong outstandingRequests = new AtomicLong(0);
+    private final HttpStream stream;
+    private final int windowSize;
+    private final AtomicBoolean isCancelled = new AtomicBoolean(false);
+    private final AtomicBoolean isSubscriptionComplete = new AtomicBoolean(false);
+    private final AtomicBoolean queueComplete = new AtomicBoolean(false);
+    private final AtomicInteger mutualRecursionDepth = new AtomicInteger(0);
+    private final AtomicInteger queuedBytes = new AtomicInteger(0);
+    private final AtomicReference<Subscriber<? super ByteBuffer>> subscriberRef = new AtomicReference<>(null);
+    private final Queue<ByteBuffer> queuedBuffers = new ConcurrentLinkedQueue<>();
+    private final AtomicReference<Throwable> error = new AtomicReference<>(null);
+
+    /**
+     * Adapts a streaming AWS CRT Http Response Body to a Publisher<ByteBuffer>
+     * @param stream The AWS CRT Http Stream for this Response
+     * @param windowSize The max allowed bytes to be queued. The sum of the sizes of all queued ByteBuffers should
+     *                   never exceed this value.
+     */
+    public AwsCrtResponseBodyPublisher(HttpStream stream, int windowSize) {
+        Validate.notNull(stream, "Stream must not be null");
+        Validate.isPositive(windowSize, "windowSize must be > 0");
+        this.stream = stream;
+        this.windowSize = windowSize;
+    }
+
+    /**
+     * Method for the users consuming the Http Response Body to register a subscriber.
+     * @param subscriber The Subscriber to register.
+     */
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        Validate.notNull(subscriber, "Subscriber must not be null");
+
+        boolean wasFirstSubscriber = subscriberRef.compareAndSet(null, subscriber);
+
+        if (!wasFirstSubscriber) {
+            log.error(() -> "Only one subscriber allowed");
+            subscriber.onError(new IllegalStateException("Only one subscriber allowed"));
+            return;
+        }
+
+        subscriber.onSubscribe(new AwsCrtResponseBodySubscription(this));
+    }
+
+    /**
+     * Adds a Buffer to the Queue to be published to any Subscribers
+     * @param buffer The Buffer to be queued.
+     */
+    public void queueBuffer(ByteBuffer buffer) {
+        Validate.notNull(buffer, "ByteBuffer must not be null");
+
+        if (isCancelled.get()) {
+            // Immediately open HttpStream's IO window so it doesn't see any IO Back-pressure.
+            // AFAIK there's no way to abort an in-progress HttpStream, only free it's memory by calling close()
+            stream.incrementWindow(buffer.remaining());
+            return;
+        }
+
+        queuedBuffers.add(buffer);
+        int totalBytesQueued = queuedBytes.addAndGet(buffer.remaining());
+
+        if (totalBytesQueued > windowSize) {
+            throw new IllegalStateException("Queued more than Window Size: queued=" + totalBytesQueued
+                                            + ", window=" + windowSize);
+        }
+    }
+
+    /**
+     * Function called by Response Body Subscribers to request more Response Body buffers.
+     * @param n The number of buffers requested.
+     */
+    protected void request(long n) {
+        Validate.inclusiveBetween(1, Long.MAX_VALUE, n, "request");
+
+        // Check for overflow of outstanding Requests, and clamp to LONG_MAX.
+        long outstandingReqs;
+        if (n > (Long.MAX_VALUE - outstandingRequests.get())) {
+            outstandingRequests.set(Long.MAX_VALUE);
+            outstandingReqs = Long.MAX_VALUE;
+        } else {
+            outstandingReqs = outstandingRequests.addAndGet(n);
+        }
+
+        log.trace(() -> "Subscriber Requested more Buffers. Outstanding Requests: " + outstandingReqs);
+    }
+
+    public void setError(Throwable t) {
+        log.error(() -> "Error processing Response Body", t);
+        error.compareAndSet(null, t);
+    }
+
+    protected void setCancelled() {
+        isCancelled.set(true);
+        /**
+         * subscriberRef must set to null due to ReactiveStream Spec stating references to Subscribers must be deleted
+         * when onCancel() is called.
+         */
+        subscriberRef.set(null);
+    }
+
+    public void setQueueComplete() {
+        queueComplete.set(true);
+        log.trace(() -> "Response Body Publisher queue marked as completed.");
+    }
+
+    /**
+     * Completes the Subscription by calling either the .onError() or .onComplete() callbacks exactly once.
+     */
+    protected void completeSubscriptionExactlyOnce() {
+        boolean alreadyComplete = isSubscriptionComplete.getAndSet(true);
+
+        if (alreadyComplete) {
+            return;
+        }
+
+        Subscriber s = subscriberRef.getAndSet(null);
+
+        if (s == null) {
+            return;
+        }
+
+        Throwable throwable = error.get();
+
+        if (throwable != null) {
+            s.onError(throwable);
+        } else {
+            s.onComplete();
+        }
+    }
+
+    /**
+     * This method MUST be synchronized since it can be called simultaneously from both the Native EventLoop Thread and
+     * the User Thread. If this method wasn't synchronized, it'd be possible for each thread to dequeue a buffer by
+     * calling queuedBuffers.poll(), but then have the 2nd thread call subscriber.onNext(buffer) first, resulting in the
+     * subscriber seeing out-of-order data. To avoid this race condition, this method must be synchronized.
+     */
+    protected synchronized void publishToSubscribers() {
+        Subscriber subscriber = subscriberRef.get();
+        if (subscriber == null) {
+            log.warn(() -> "No Subscribers to publish to");
+            return;
+        }
+
+        if (error.get() != null) {
+            completeSubscriptionExactlyOnce();
+            return;
+        }
+
+        if (mutualRecursionDepth.get() > 0) {
+            /**
+             * If our depth is > 0, then we already made a call to publishToSubscribers() further up the stack that
+             * will continue publishing to subscribers, and this call should return without completing work to avoid
+             * infinite recursive loop between: "subscription.request() -> subscriber.onNext() -> subscription.request()"
+             */
+            return;
+        }
+
+        int totalAmountTransferred = 0;
+
+        while (outstandingRequests.get() > 0 && queuedBuffers.size() > 0) {
+            ByteBuffer buffer = queuedBuffers.poll();
+            outstandingRequests.getAndUpdate(DECREMENT_IF_GREATER_THAN_ZERO);
+            int amount = buffer.remaining();
+            publishWithoutMutualRecursion(subscriber, buffer);
+            totalAmountTransferred += amount;
+        }
+
+        if (totalAmountTransferred > 0) {
+            queuedBytes.addAndGet(-totalAmountTransferred);
+            // Open HttpStream's IO window so HttpStream can keep track of IO back-pressure
+            stream.incrementWindow(totalAmountTransferred);
+        }
+
+        // Check if Complete
+        if (queueComplete.get() && queuedBuffers.size() == 0) {
+            completeSubscriptionExactlyOnce();
+        }
+    }
+
+    /**
+     * This method is used to avoid a StackOverflow due to the potential infinite loop between
+     * "subscription.request() -> subscriber.onNext() -> subscription.request()" calls. We only call subscriber.onNext()
+     * if the recursion depth is zero, otherwise we return up to the stack frame with depth zero and continue publishing
+     * from there.
+     * @param subscriber The Subscriber to publish to.
+     * @param buffer The buffer to publish to the subscriber.
+     */
+    private synchronized void publishWithoutMutualRecursion(Subscriber<ByteBuffer> subscriber, ByteBuffer buffer) {
+        try {
+            /**
+             * Need to keep track of recursion depth between .onNext() -> .request() calls
+             */
+            int depth = mutualRecursionDepth.getAndIncrement();
+            if (depth == 0) {
+                subscriber.onNext(buffer);
+            }
+        } finally {
+            mutualRecursionDepth.decrementAndGet();
+        }
+    }
+
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodyPublisher.java
@@ -28,7 +28,7 @@ import java.util.function.LongUnaryOperator;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -41,7 +41,7 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
     private static final Logger log = Logger.loggerFor(AwsCrtResponseBodyPublisher.class);
     private static final LongUnaryOperator DECREMENT_IF_GREATER_THAN_ZERO = x -> ((x > 0) ? (x - 1) : (x));
 
-    private final HttpConnection connection;
+    private final HttpClientConnection connection;
     private final HttpStream stream;
     private final CompletableFuture<Void> responseComplete;
     private final AtomicLong outstandingRequests = new AtomicLong(0);
@@ -62,7 +62,7 @@ public class AwsCrtResponseBodyPublisher implements Publisher<ByteBuffer> {
      * @param windowSize The max allowed bytes to be queued. The sum of the sizes of all queued ByteBuffers should
      *                   never exceed this value.
      */
-    public AwsCrtResponseBodyPublisher(HttpConnection connection, HttpStream stream,
+    public AwsCrtResponseBodyPublisher(HttpClientConnection connection, HttpStream stream,
                                        CompletableFuture<Void> responseComplete, int windowSize) {
         Validate.notNull(connection, "HttpConnection must not be null");
         Validate.notNull(stream, "Stream must not be null");

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodySubscription.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodySubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodySubscription.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtResponseBodySubscription.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Helper Class that passes through calls from a Subscription to a AwsCrtResponseBodyPublisher
+ */
+@SdkInternalApi
+public class AwsCrtResponseBodySubscription implements Subscription {
+    private static final Logger log = Logger.loggerFor(AwsCrtResponseBodySubscription.class);
+    private final AwsCrtResponseBodyPublisher publisher;
+
+    public AwsCrtResponseBodySubscription(AwsCrtResponseBodyPublisher publisher) {
+        this.publisher = publisher;
+    }
+
+    @Override
+    public void request(long n) {
+        if (n <= 0) {
+            // Reactive Stream Spec requires us to call onError() callback instead of throwing Exception here.
+            publisher.setError(new IllegalArgumentException("Request is for <= 0 elements: " + n));
+            publisher.publishToSubscribers();
+            return;
+        }
+
+        publisher.request(n);
+        publisher.publishToSubscribers();
+    }
+
+    @Override
+    public void cancel() {
+        publisher.setCancelled();
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -68,7 +68,7 @@ public class AwsCrtHttpClientSpiVerificationTest {
 
     @Before
     public void setup() throws Exception {
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
 
         client = AwsCrtAsyncHttpClient.builder()
                 .build();
@@ -77,7 +77,7 @@ public class AwsCrtHttpClientSpiVerificationTest {
     @After
     public void tearDown() {
         client.close();
-        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+        CrtResource.waitForNoResources();
     }
 
     private byte[] generateRandomBody(int size) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.binaryEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.utils.Logger;
+
+public class AwsCrtHttpClientSpiVerificationTest {
+    private static final Logger log = Logger.loggerFor(AwsCrtHttpClientSpiVerificationTest.class);
+    private static final int TEST_BODY_LEN = 1024;
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort());
+
+    private SdkAsyncHttpClient client;
+    List<CrtResource> crtResources = new ArrayList<>();
+
+    private void addResource(CrtResource resource) {
+        crtResources.add(resource);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+
+        ClientBootstrap bootstrap = new ClientBootstrap(1);
+        SocketOptions socketOptions = new SocketOptions();
+        TlsContext tlsContext = new TlsContext();
+
+        addResource(bootstrap);
+        addResource(socketOptions);
+        addResource(tlsContext);
+
+        client = AwsCrtAsyncHttpClient.builder()
+                .bootstrap(bootstrap)
+                .socketOptions(socketOptions)
+                .tlsContext(tlsContext)
+                .build();
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
+
+        for (CrtResource r: crtResources) {
+            r.close();
+        }
+
+        Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
+    }
+
+    private byte[] generateRandomBody(int size) {
+        byte[] randomData = new byte[size];
+        new Random().nextBytes(randomData);
+        return randomData;
+    }
+
+    @Test
+    public void signalsErrorViaOnErrorAndFuture() throws InterruptedException, ExecutionException, TimeoutException {
+        stubFor(any(urlEqualTo("/")).willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+
+        CompletableFuture<Boolean> errorSignaled = new CompletableFuture<>();
+
+        SdkAsyncHttpResponseHandler handler = new TestResponseHandler() {
+            @Override
+            public void onError(Throwable error) {
+                errorSignaled.complete(true);
+            }
+        };
+
+        SdkHttpRequest request = createRequest(URI.create("http://localhost:" + mockServer.port()));
+
+        CompletableFuture<Void> executeFuture = client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .responseHandler(handler)
+                .requestContentPublisher(new EmptyPublisher())
+                .build());
+
+        assertThat(errorSignaled.get(1, TimeUnit.SECONDS)).isTrue();
+        assertThatThrownBy(executeFuture::join).hasCauseInstanceOf(Exception.class);
+
+    }
+
+    @Test
+    public void callsOnStreamForEmptyResponseContent() throws Exception {
+        stubFor(any(urlEqualTo("/")).willReturn(aResponse().withStatus(204).withHeader("foo", "bar")));
+
+        CompletableFuture<Boolean> streamReceived = new CompletableFuture<>();
+        final AtomicReference<SdkHttpResponse> response = new AtomicReference<>(null);
+
+        SdkAsyncHttpResponseHandler handler = new TestResponseHandler() {
+            @Override
+            public void onHeaders(SdkHttpResponse headers) {
+                response.compareAndSet(null, headers);
+            }
+            @Override
+            public void onStream(Publisher<ByteBuffer> stream) {
+                super.onStream(stream);
+                streamReceived.complete(true);
+            }
+        };
+
+        SdkHttpRequest request = createRequest(URI.create("http://localhost:" + mockServer.port()));
+
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .responseHandler(handler)
+                .requestContentPublisher(new EmptyPublisher())
+                .build());
+
+        assertThat(streamReceived.get(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(response.get() != null).isTrue();
+        assertThat(response.get().statusCode() == 204).isTrue();
+        assertThat(response.get().headers().get("foo").isEmpty()).isFalse();
+    }
+
+    @Test
+    public void testGetRequest() throws Exception {
+        String path = "/testGetRequest";
+        byte[] body = generateRandomBody(TEST_BODY_LEN);
+        String expectedBodyHash = sha256Hex(body).toUpperCase();
+        stubFor(any(urlEqualTo(path)).willReturn(aResponse().withStatus(200)
+                                                           .withHeader("Content-Length", Integer.toString(TEST_BODY_LEN))
+                                                           .withHeader("foo", "bar")
+                                                           .withBody(body)));
+
+        CompletableFuture<Boolean> streamReceived = new CompletableFuture<>();
+        final AtomicReference<SdkHttpResponse> response = new AtomicReference<>(null);
+        Sha256BodySubscriber bodySha256Subscriber = new Sha256BodySubscriber();
+        final AtomicReference<Throwable> error = new AtomicReference<>(null);
+
+        SdkAsyncHttpResponseHandler handler = new SdkAsyncHttpResponseHandler() {
+            @Override
+            public void onHeaders(SdkHttpResponse headers) {
+                response.compareAndSet(null, headers);
+            }
+            @Override
+            public void onStream(Publisher<ByteBuffer> stream) {
+                stream.subscribe(bodySha256Subscriber);
+                streamReceived.complete(true);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.compareAndSet(null, t);
+            }
+        };
+
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        SdkHttpRequest request = createRequest(uri, path, null, SdkHttpMethod.GET, emptyMap());
+
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .responseHandler(handler)
+                .requestContentPublisher(new EmptyPublisher())
+                .build());
+
+        assertThat(error.get()).isNull();
+        assertThat(streamReceived.get(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(bodySha256Subscriber.getFuture().get(60, TimeUnit.SECONDS)).isEqualTo(expectedBodyHash);
+        assertThat(response.get().statusCode()).isEqualTo(200);
+        assertThat(response.get().headers().get("foo").isEmpty()).isFalse();
+    }
+
+
+    private void makePutRequest(String path, byte[] reqBody, int expectedStatus) throws Exception {
+        CompletableFuture<Boolean> streamReceived = new CompletableFuture<>();
+        final AtomicReference<SdkHttpResponse> response = new AtomicReference<>(null);
+        final AtomicReference<Throwable> error = new AtomicReference<>(null);
+
+        SdkAsyncHttpResponseHandler handler = new SdkAsyncHttpResponseHandler() {
+            @Override
+            public void onHeaders(SdkHttpResponse headers) {
+                response.compareAndSet(null, headers);
+            }
+            @Override
+            public void onStream(Publisher<ByteBuffer> stream) {
+                streamReceived.complete(true);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.compareAndSet(null, t);
+            }
+        };
+
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        SdkHttpRequest request = createRequest(uri, path, reqBody, SdkHttpMethod.PUT, emptyMap());
+
+        client.execute(AsyncExecuteRequest.builder()
+                .request(request)
+                .responseHandler(handler)
+                .requestContentPublisher(new SdkTestHttpContentPublisher(reqBody))
+                .build());
+
+        assertThat(error.get()).isNull();
+        assertThat(streamReceived.get(60, TimeUnit.SECONDS)).isTrue();
+        assertThat(response.get().statusCode()).isEqualTo(expectedStatus);
+    }
+
+
+    @Test
+    public void testPutRequest() throws Exception {
+        String pathExpect200 = "/testPutRequest/return_200_on_exact_match";
+        byte[] expectedBody = generateRandomBody(TEST_BODY_LEN);
+        stubFor(any(urlEqualTo(pathExpect200)).withRequestBody(binaryEqualTo(expectedBody)).willReturn(aResponse().withStatus(200)));
+        makePutRequest(pathExpect200, expectedBody, 200);
+
+
+        String pathExpect404 = "/testPutRequest/return_404_always";
+        byte[] randomBody = generateRandomBody(TEST_BODY_LEN);
+        stubFor(any(urlEqualTo(pathExpect404)).willReturn(aResponse().withStatus(404)));
+        makePutRequest(pathExpect404, randomBody, 404);
+    }
+
+    private SdkHttpFullRequest createRequest(URI endpoint) {
+        return createRequest(endpoint, "/", null, SdkHttpMethod.GET, emptyMap());
+    }
+
+    private SdkHttpFullRequest createRequest(URI endpoint,
+                                             String resourcePath,
+                                             byte[] body,
+                                             SdkHttpMethod method,
+                                             Map<String, String> params) {
+
+        String contentLength = (body == null) ? null : String.valueOf(body.length);
+        return SdkHttpFullRequest.builder()
+                .uri(endpoint)
+                .method(method)
+                .encodedPath(resourcePath)
+                .applyMutation(b -> params.forEach(b::putRawQueryParameter))
+                .applyMutation(b -> {
+                    b.putHeader("Host", endpoint.getHost());
+                    if (contentLength != null) {
+                        b.putHeader("Content-Length", contentLength);
+                    }
+                }).build();
+    }
+
+    private static class TestResponseHandler implements SdkAsyncHttpResponseHandler {
+        @Override
+        public void onHeaders(SdkHttpResponse headers) {
+        }
+
+        @Override
+        public void onStream(Publisher<ByteBuffer> stream) {
+            stream.subscribe(new DrainingSubscriber<>());
+        }
+
+        @Override
+        public void onError(Throwable error) {
+        }
+    }
+
+    private static class DrainingSubscriber<T> implements Subscriber<T> {
+        private Subscription subscription;
+
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            this.subscription = subscription;
+            this.subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T t) {
+            this.subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+        }
+
+        @Override
+        public void onComplete() {
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -201,6 +201,25 @@ public class AwsCrtHttpClientSpiVerificationTest {
         final AtomicReference<SdkHttpResponse> response = new AtomicReference<>(null);
         final AtomicReference<Throwable> error = new AtomicReference<>(null);
 
+        Subscriber<ByteBuffer> subscriber = new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        };
+
         SdkAsyncHttpResponseHandler handler = new SdkAsyncHttpResponseHandler() {
             @Override
             public void onHeaders(SdkHttpResponse headers) {
@@ -208,6 +227,7 @@ public class AwsCrtHttpClientSpiVerificationTest {
             }
             @Override
             public void onStream(Publisher<ByteBuffer> stream) {
+                stream.subscribe(subscriber);
                 streamReceived.complete(true);
             }
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -238,7 +238,6 @@ public class AwsCrtHttpClientSpiVerificationTest {
         byte[] expectedBody = generateRandomBody(TEST_BODY_LEN);
         stubFor(any(urlEqualTo(pathExpect200)).withRequestBody(binaryEqualTo(expectedBody)).willReturn(aResponse().withStatus(200)));
         makePutRequest(pathExpect200, expectedBody, 200);
-
 
         String pathExpect404 = "/testPutRequest/return_404_always";
         byte[] randomBody = generateRandomBody(TEST_BODY_LEN);

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -159,12 +159,13 @@ public class AwsCrtHttpClientSpiVerificationTest {
 
         SdkHttpRequest request = createRequest(URI.create("http://localhost:" + mockServer.port()));
 
-        client.execute(AsyncExecuteRequest.builder()
+        CompletableFuture future = client.execute(AsyncExecuteRequest.builder()
                 .request(request)
                 .responseHandler(handler)
                 .requestContentPublisher(new EmptyPublisher())
                 .build());
 
+        future.get(60, TimeUnit.SECONDS);
         assertThat(streamReceived.get(1, TimeUnit.SECONDS)).isTrue();
         assertThat(response.get() != null).isTrue();
         assertThat(response.get().statusCode() == 204).isTrue();
@@ -206,12 +207,13 @@ public class AwsCrtHttpClientSpiVerificationTest {
         URI uri = URI.create("http://localhost:" + mockServer.port());
         SdkHttpRequest request = createRequest(uri, path, null, SdkHttpMethod.GET, emptyMap());
 
-        client.execute(AsyncExecuteRequest.builder()
+        CompletableFuture future = client.execute(AsyncExecuteRequest.builder()
                 .request(request)
                 .responseHandler(handler)
                 .requestContentPublisher(new EmptyPublisher())
                 .build());
 
+        future.get(60, TimeUnit.SECONDS);
         assertThat(error.get()).isNull();
         assertThat(streamReceived.get(1, TimeUnit.SECONDS)).isTrue();
         assertThat(bodySha256Subscriber.getFuture().get(60, TimeUnit.SECONDS)).isEqualTo(expectedBodyHash);
@@ -244,12 +246,12 @@ public class AwsCrtHttpClientSpiVerificationTest {
         URI uri = URI.create("http://localhost:" + mockServer.port());
         SdkHttpRequest request = createRequest(uri, path, reqBody, SdkHttpMethod.PUT, emptyMap());
 
-        client.execute(AsyncExecuteRequest.builder()
-                .request(request)
-                .responseHandler(handler)
-                .requestContentPublisher(new SdkTestHttpContentPublisher(reqBody))
-                .build());
-
+        CompletableFuture future = client.execute(AsyncExecuteRequest.builder()
+                                            .request(request)
+                                            .responseHandler(handler)
+                                            .requestContentPublisher(new SdkTestHttpContentPublisher(reqBody))
+                                            .build());
+        future.get(60, TimeUnit.SECONDS);
         assertThat(error.get()).isNull();
         assertThat(streamReceived.get(60, TimeUnit.SECONDS)).isTrue();
         assertThat(response.get().statusCode()).isEqualTo(expectedStatus);

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -30,8 +30,6 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -48,9 +46,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.crt.CrtResource;
-import software.amazon.awssdk.crt.io.ClientBootstrap;
-import software.amazon.awssdk.crt.io.SocketOptions;
-import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -70,39 +65,18 @@ public class AwsCrtHttpClientSpiVerificationTest {
             .dynamicHttpsPort());
 
     private SdkAsyncHttpClient client;
-    List<CrtResource> crtResources = new ArrayList<>();
-
-    private void addResource(CrtResource resource) {
-        crtResources.add(resource);
-    }
 
     @Before
     public void setup() throws Exception {
         Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
 
-        ClientBootstrap bootstrap = new ClientBootstrap(1);
-        SocketOptions socketOptions = new SocketOptions();
-        TlsContext tlsContext = new TlsContext();
-
-        addResource(bootstrap);
-        addResource(socketOptions);
-        addResource(tlsContext);
-
         client = AwsCrtAsyncHttpClient.builder()
-                .bootstrap(bootstrap)
-                .socketOptions(socketOptions)
-                .tlsContext(tlsContext)
                 .build();
     }
 
     @After
     public void tearDown() {
         client.close();
-
-        for (CrtResource r: crtResources) {
-            r.close();
-        }
-
         Assert.assertEquals("Expected Zero allocated AwsCrtResources", 0, CrtResource.getAllocatedNativeResourceCount());
     }
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtRequestBodySubscriberReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtRequestBodySubscriberReactiveStreamCompatTest.java
@@ -1,0 +1,66 @@
+package software.amazon.awssdk.http.crt;
+
+import java.nio.ByteBuffer;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.http.crt.internal.AwsCrtRequestBodySubscriber;
+
+public class AwsCrtRequestBodySubscriberReactiveStreamCompatTest extends SubscriberWhiteboxVerification<ByteBuffer> {
+    private static final int DEFAULT_STREAM_WINDOW_SIZE = 16 * 1024 * 1024; // 16 MB Total Buffer size
+
+    public AwsCrtRequestBodySubscriberReactiveStreamCompatTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Subscriber<ByteBuffer> createSubscriber(WhiteboxSubscriberProbe<ByteBuffer> probe) {
+        AwsCrtRequestBodySubscriber actualSubscriber = new AwsCrtRequestBodySubscriber(DEFAULT_STREAM_WINDOW_SIZE);
+
+        // Pass Through calls to AwsCrtRequestBodySubscriber, but also register calls to the whitebox probe
+        Subscriber<ByteBuffer> passthroughSubscriber = new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                actualSubscriber.onSubscribe(s);
+                probe.registerOnSubscribe(new SubscriberPuppet() {
+
+                    @Override
+                    public void triggerRequest(long elements) {
+                        s.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        s.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+                actualSubscriber.onNext(byteBuffer);
+                probe.registerOnNext(byteBuffer);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                actualSubscriber.onError(t);
+                probe.registerOnError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                actualSubscriber.onComplete();
+                probe.registerOnComplete();
+            }
+        };
+
+        return passthroughSubscriber;
+    }
+
+    @Override
+    public ByteBuffer createElement(int element) {
+        return ByteBuffer.wrap(Integer.toString(element).getBytes());
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
@@ -36,7 +37,7 @@ public class AwsCrtResponseBodyPublisherReactiveStreamCompatTest extends Publish
     @Override
     public Publisher<ByteBuffer> createPublisher(long elements) {
         HttpStream stream = mock(HttpStream.class);
-        AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(stream, Integer.MAX_VALUE);
+        AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(stream, new CompletableFuture<>(), Integer.MAX_VALUE);
 
         for (long i = 0; i < elements; i++) {
             bodyPublisher.queueBuffer(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()));

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.http.crt.internal.AwsCrtResponseBodyPublisher;
 import software.amazon.awssdk.utils.Logger;
@@ -37,7 +37,7 @@ public class AwsCrtResponseBodyPublisherReactiveStreamCompatTest extends Publish
 
     @Override
     public Publisher<ByteBuffer> createPublisher(long elements) {
-        HttpConnection connection = mock(HttpConnection.class);
+        HttpClientConnection connection = mock(HttpClientConnection.class);
         HttpStream stream = mock(HttpStream.class);
         AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(connection, stream, new CompletableFuture<>(), Integer.MAX_VALUE);
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
@@ -42,7 +42,7 @@ public class AwsCrtResponseBodyPublisherReactiveStreamCompatTest extends Publish
         AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(connection, stream, new CompletableFuture<>(), Integer.MAX_VALUE);
 
         for (long i = 0; i < elements; i++) {
-            bodyPublisher.queueBuffer(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()));
+            bodyPublisher.queueBuffer(UUID.randomUUID().toString().getBytes());
         }
 
         bodyPublisher.setQueueComplete();

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.crt.http.HttpConnection;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.http.crt.internal.AwsCrtResponseBodyPublisher;
 import software.amazon.awssdk.utils.Logger;
@@ -36,8 +37,9 @@ public class AwsCrtResponseBodyPublisherReactiveStreamCompatTest extends Publish
 
     @Override
     public Publisher<ByteBuffer> createPublisher(long elements) {
+        HttpConnection connection = mock(HttpConnection.class);
         HttpStream stream = mock(HttpStream.class);
-        AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(stream, new CompletableFuture<>(), Integer.MAX_VALUE);
+        AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(connection, stream, new CompletableFuture<>(), Integer.MAX_VALUE);
 
         for (long i = 0; i < elements; i++) {
             bodyPublisher.queueBuffer(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()));

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtResponseBodyPublisherReactiveStreamCompatTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static org.mockito.Mockito.mock;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.crt.http.HttpStream;
+import software.amazon.awssdk.http.crt.internal.AwsCrtResponseBodyPublisher;
+import software.amazon.awssdk.utils.Logger;
+
+public class AwsCrtResponseBodyPublisherReactiveStreamCompatTest extends PublisherVerification<ByteBuffer> {
+    private static final Logger log = Logger.loggerFor(AwsCrtResponseBodyPublisherReactiveStreamCompatTest.class);
+
+    public AwsCrtResponseBodyPublisherReactiveStreamCompatTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long elements) {
+        HttpStream stream = mock(HttpStream.class);
+        AwsCrtResponseBodyPublisher bodyPublisher = new AwsCrtResponseBodyPublisher(stream, Integer.MAX_VALUE);
+
+        for (long i = 0; i < elements; i++) {
+            bodyPublisher.queueBuffer(ByteBuffer.wrap(UUID.randomUUID().toString().getBytes()));
+        }
+
+        bodyPublisher.setQueueComplete();
+        return bodyPublisher;
+    }
+
+    // Some tests try to create INT_MAX elements, which causes OutOfMemory Exceptions. Lower the max allowed number of
+    // queued buffers to 1024.
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1024;
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        return null;
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/EmptyPublisher.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/EmptyPublisher.java
@@ -1,0 +1,45 @@
+package software.amazon.awssdk.http.crt;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+
+public class EmptyPublisher implements SdkHttpContentPublisher {
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+        subscriber.onSubscribe(new EmptySubscription(subscriber));
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.of(0L);
+    }
+
+    private static class EmptySubscription implements Subscription {
+        private final Subscriber subscriber;
+        private volatile boolean done;
+
+        EmptySubscription(Subscriber subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void request(long l) {
+            if (!done) {
+                done = true;
+                if (l <= 0) {
+                    this.subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+                } else {
+                    this.subscriber.onComplete();
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            done = true;
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/SdkTestHttpContentPublisher.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/SdkTestHttpContentPublisher.java
@@ -1,0 +1,56 @@
+package software.amazon.awssdk.http.crt;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+
+public class SdkTestHttpContentPublisher implements SdkHttpContentPublisher {
+    private final byte[] body;
+    private final AtomicReference<Subscriber<? super ByteBuffer>> subscriber = new AtomicReference<>(null);
+    private final AtomicBoolean complete = new AtomicBoolean(false);
+
+    public SdkTestHttpContentPublisher(byte[] body) {
+        this.body = body;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        boolean wasFirstSubscriber = subscriber.compareAndSet(null, s);
+
+        SdkTestHttpContentPublisher publisher = this;
+
+        if (wasFirstSubscriber) {
+            s.onSubscribe(new Subscription() {
+                @Override
+                public void request(long n) {
+                    publisher.request(n);
+                }
+
+                @Override
+                public void cancel() {
+                    // Do nothing
+                }
+            });
+        } else {
+            s.onError(new RuntimeException("Only allow one subscriber"));
+        }
+    }
+
+    protected void request(long n) {
+        // Send the whole body if they request >0 ByteBuffers
+        if (n >  0 && !complete.get()) {
+            complete.set(true);
+            subscriber.get().onNext(ByteBuffer.wrap(body));
+            subscriber.get().onComplete();
+        }
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.of((long)body.length);
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/Sha256BodySubscriber.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/Sha256BodySubscriber.java
@@ -1,0 +1,44 @@
+package software.amazon.awssdk.http.crt;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+public class Sha256BodySubscriber  implements Subscriber<ByteBuffer> {
+    private MessageDigest digest;
+    private CompletableFuture<String> future;
+
+    public Sha256BodySubscriber() throws NoSuchAlgorithmException {
+        digest =  MessageDigest.getInstance("SHA-256");
+        future = new CompletableFuture<>();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(ByteBuffer byteBuffer) {
+        digest.update(byteBuffer);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        future.completeExceptionally(t);
+    }
+
+    @Override
+    public void onComplete() {
+        future.complete(encodeHexString(digest.digest()).toUpperCase());
+    }
+
+    public CompletableFuture<String> getFuture() {
+        return future;
+    }
+}

--- a/http-clients/pom.xml
+++ b/http-clients/pom.xml
@@ -31,6 +31,7 @@
 
     <modules>
         <module>apache-client</module>
+        <module>aws-crt-client</module>
         <module>netty-nio-client</module>
         <module>url-connection-client</module>
     </modules>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.35</version>
+            <version>0.4.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -190,6 +190,18 @@
              <groupId>org.eclipse.jetty.http2</groupId>
              <artifactId>http2-hpack</artifactId>
          </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.3.14</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.14</version>
+            <version>0.3.17</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.22</version>
+            <version>0.3.35</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.3.17</version>
+            <version>0.3.22</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
@@ -1,0 +1,124 @@
+package software.amazon.awssdk.benchmark.apicall.httpclient.async;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.awssdk.benchmark.apicall.httpclient.SdkHttpClientBenchmark;
+import software.amazon.awssdk.benchmark.utils.MockServer;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
+
+/**
+ * Using aws-crt-client to test against local mock https server.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 15, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(2) // To reduce difference between each run
+@BenchmarkMode(Mode.Throughput)
+public class AwsCrtClientBenchmark implements SdkHttpClientBenchmark {
+
+    private MockServer mockServer;
+    private SdkAsyncHttpClient sdkHttpClient;
+    private ProtocolRestJsonAsyncClient client;
+    private TlsContextOptions tlsOptions;
+    private TlsContext tlsContext;
+    private SocketOptions socketOptions;
+    private ClientBootstrap bootstrap;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        mockServer = new MockServer();
+        mockServer.start();
+
+        int numCores = Runtime.getRuntime().availableProcessors();
+        bootstrap = new ClientBootstrap(numCores);
+        socketOptions = new SocketOptions();
+
+        tlsOptions = new TlsContextOptions();
+        tlsOptions.setVerifyPeer(false);
+        tlsContext = new TlsContext(tlsOptions);
+
+        sdkHttpClient = AwsCrtAsyncHttpClient.builder()
+                .bootstrap(bootstrap)
+                .socketOptions(socketOptions)
+                .tlsContext(tlsContext)
+                .build();
+
+        client = ProtocolRestJsonAsyncClient.builder()
+                .endpointOverride(mockServer.getHttpsUri())
+                .httpClient(sdkHttpClient)
+                .build();
+
+        // Making sure the request actually succeeds
+        client.allTypes().join();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        mockServer.stop();
+        client.close();
+        sdkHttpClient.close();
+        tlsContext.close();
+        tlsOptions.close();
+        socketOptions.close();
+        bootstrap.close();
+    }
+
+    @Override
+    @Benchmark
+    @OperationsPerInvocation(CONCURRENT_CALLS)
+    public void concurrentApiCall(Blackhole blackhole) {
+        CountDownLatch countDownLatch = new CountDownLatch(CONCURRENT_CALLS);
+        for (int i = 0; i < CONCURRENT_CALLS; i++) {
+            countDownUponCompletion(blackhole, client.allTypes(), countDownLatch);
+        }
+
+        awaitCountdownLatchUninterruptibly(countDownLatch, 10, TimeUnit.SECONDS);
+
+    }
+
+    @Override
+    @Benchmark
+    public void sequentialApiCall(Blackhole blackhole) {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownUponCompletion(blackhole, client.allTypes(), countDownLatch);
+        awaitCountdownLatchUninterruptibly(countDownLatch, 1, TimeUnit.SECONDS);
+    }
+
+    public static void main(String... args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(AwsCrtClientBenchmark.class.getSimpleName())
+                .addProfiler(StackProfiler.class)
+                .build();
+        Collection<RunResult> run = new Runner(opt).run();
+    }
+}

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
@@ -42,10 +42,6 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import software.amazon.awssdk.benchmark.apicall.httpclient.SdkHttpClientBenchmark;
 import software.amazon.awssdk.benchmark.utils.MockServer;
-import software.amazon.awssdk.crt.io.ClientBootstrap;
-import software.amazon.awssdk.crt.io.SocketOptions;
-import software.amazon.awssdk.crt.io.TlsContext;
-import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
@@ -63,28 +59,14 @@ public class AwsCrtClientBenchmark implements SdkHttpClientBenchmark {
     private MockServer mockServer;
     private SdkAsyncHttpClient sdkHttpClient;
     private ProtocolRestJsonAsyncClient client;
-    private TlsContextOptions tlsOptions;
-    private TlsContext tlsContext;
-    private SocketOptions socketOptions;
-    private ClientBootstrap bootstrap;
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
         mockServer = new MockServer();
         mockServer.start();
 
-        int numCores = Runtime.getRuntime().availableProcessors();
-        bootstrap = new ClientBootstrap(numCores);
-        socketOptions = new SocketOptions();
-
-        tlsOptions = new TlsContextOptions();
-        tlsOptions.setVerifyPeer(false);
-        tlsContext = new TlsContext(tlsOptions);
-
         sdkHttpClient = AwsCrtAsyncHttpClient.builder()
-                .bootstrap(bootstrap)
-                .socketOptions(socketOptions)
-                .tlsContext(tlsContext)
+                .verifyPeer(false)
                 .build();
 
         client = ProtocolRestJsonAsyncClient.builder()
@@ -101,10 +83,6 @@ public class AwsCrtClientBenchmark implements SdkHttpClientBenchmark {
         mockServer.stop();
         client.close();
         sdkHttpClient.close();
-        tlsContext.close();
-        tlsOptions.close();
-        socketOptions.close();
-        bootstrap.close();
     }
 
     @Override

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import software.amazon.awssdk.benchmark.apicall.httpclient.SdkHttpClientBenchmark;
 import software.amazon.awssdk.benchmark.utils.MockServer;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
@@ -59,14 +61,22 @@ public class AwsCrtClientBenchmark implements SdkHttpClientBenchmark {
     private MockServer mockServer;
     private SdkAsyncHttpClient sdkHttpClient;
     private ProtocolRestJsonAsyncClient client;
+    private EventLoopGroup eventLoopGroup;
+    private HostResolver hostResolver;
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
         mockServer = new MockServer();
         mockServer.start();
 
+        int numThreads = Runtime.getRuntime().availableProcessors();
+        eventLoopGroup = new EventLoopGroup(numThreads);
+        hostResolver = new HostResolver(eventLoopGroup);
+
         sdkHttpClient = AwsCrtAsyncHttpClient.builder()
                 .verifyPeer(false)
+                .eventLoopGroup(this.eventLoopGroup)
+                .hostResolver(this.hostResolver)
                 .build();
 
         client = ProtocolRestJsonAsyncClient.builder()
@@ -83,6 +93,8 @@ public class AwsCrtClientBenchmark implements SdkHttpClientBenchmark {
         mockServer.stop();
         client.close();
         sdkHttpClient.close();
+        hostResolver.close();
+        eventLoopGroup.close();
     }
 
     @Override

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
@@ -1,5 +1,27 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.awssdk.benchmark.apicall.httpclient.async;
 
+import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -27,14 +49,6 @@ import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
-
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
-import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
-import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
 
 /**
  * Using aws-crt-client to test against local mock https server.

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientNonTLSBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientNonTLSBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import software.amazon.awssdk.benchmark.apicall.httpclient.SdkHttpClientBenchmark;
 import software.amazon.awssdk.benchmark.utils.MockServer;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
@@ -59,14 +61,22 @@ public class AwsCrtClientNonTLSBenchmark implements SdkHttpClientBenchmark {
     private MockServer mockServer;
     private SdkAsyncHttpClient sdkHttpClient;
     private ProtocolRestJsonAsyncClient client;
+    private EventLoopGroup eventLoopGroup;
+    private HostResolver hostResolver;
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
         mockServer = new MockServer();
         mockServer.start();
 
+        int numThreads = Runtime.getRuntime().availableProcessors();
+        eventLoopGroup = new EventLoopGroup(numThreads);
+        hostResolver = new HostResolver(eventLoopGroup);
+
         sdkHttpClient = AwsCrtAsyncHttpClient.builder()
                 .verifyPeer(false)
+                .eventLoopGroup(eventLoopGroup)
+                .hostResolver(hostResolver)
                 .build();
 
         client = ProtocolRestJsonAsyncClient.builder()
@@ -83,6 +93,8 @@ public class AwsCrtClientNonTLSBenchmark implements SdkHttpClientBenchmark {
         mockServer.stop();
         client.close();
         sdkHttpClient.close();
+        hostResolver.close();
+        eventLoopGroup.close();
     }
 
     @Override

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientNonTLSBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientNonTLSBenchmark.java
@@ -15,7 +15,25 @@
 
 package software.amazon.awssdk.benchmark.apicall.httpclient.async;
 
-import org.openjdk.jmh.annotations.*;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.StackProfiler;
 import org.openjdk.jmh.results.RunResult;
@@ -27,14 +45,6 @@ import software.amazon.awssdk.benchmark.utils.MockServer;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
-
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
-import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
-import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
 
 /**
  * Using aws-crt-client to test against local mock https server.

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientNonTLSBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientNonTLSBenchmark.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.benchmark.apicall.httpclient.async;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.awssdk.benchmark.apicall.httpclient.SdkHttpClientBenchmark;
+import software.amazon.awssdk.benchmark.utils.MockServer;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
+
+/**
+ * Using aws-crt-client to test against local mock https server.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 15, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(2) // To reduce difference between each run
+@BenchmarkMode(Mode.Throughput)
+public class AwsCrtClientNonTLSBenchmark implements SdkHttpClientBenchmark {
+
+    private MockServer mockServer;
+    private SdkAsyncHttpClient sdkHttpClient;
+    private ProtocolRestJsonAsyncClient client;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        mockServer = new MockServer();
+        mockServer.start();
+
+        sdkHttpClient = AwsCrtAsyncHttpClient.builder()
+                .verifyPeer(false)
+                .build();
+
+        client = ProtocolRestJsonAsyncClient.builder()
+                .endpointOverride(mockServer.getHttpUri())
+                .httpClient(sdkHttpClient)
+                .build();
+
+        // Making sure the request actually succeeds
+        client.allTypes().join();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        mockServer.stop();
+        client.close();
+        sdkHttpClient.close();
+    }
+
+    @Override
+    @Benchmark
+    @OperationsPerInvocation(CONCURRENT_CALLS)
+    public void concurrentApiCall(Blackhole blackhole) {
+        CountDownLatch countDownLatch = new CountDownLatch(CONCURRENT_CALLS);
+        for (int i = 0; i < CONCURRENT_CALLS; i++) {
+            countDownUponCompletion(blackhole, client.allTypes(), countDownLatch);
+        }
+
+        awaitCountdownLatchUninterruptibly(countDownLatch, 10, TimeUnit.SECONDS);
+
+    }
+
+    @Override
+    @Benchmark
+    public void sequentialApiCall(Blackhole blackhole) {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownUponCompletion(blackhole, client.allTypes(), countDownLatch);
+        awaitCountdownLatchUninterruptibly(countDownLatch, 1, TimeUnit.SECONDS);
+    }
+
+    public static void main(String... args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(AwsCrtClientNonTLSBenchmark.class.getSimpleName())
+                .addProfiler(StackProfiler.class)
+                .build();
+        Collection<RunResult> run = new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Description
* This branch contains changes from the following branches.
  * crt-api-update (https://github.com/aws/aws-sdk-java-v2/pull/1498)
  * aws-crt-dev-preview
  * master

This was done by rebasing master onto crt-api-update, then rebasing crt-api-update onto aws-crt-dev-preview, making some additional changes to account for API changes, and then creating this branch.  I'm open to merging this into aws-crt-dev-preview first if that's preferable to merging everything into master.

As such, there are a lot of changes here not done by myself.  Only the changes done in commit 2723640 are, in that sense, actually new.  More detail about those changes:
* This points the SDK to the latest build of the Java CRT available in Maven, ie, 0.4.19.
* This required updating a handful of places where the API has changed.
* I'm currently relying on the existing unit tests invoked by mvn clean install, and would be open to any other means of validating these changes if someone knows better.
* Possible point for API discussion: the AwsCrtAsyncHttpClient now takes an EventLoopGroup and HostResolver via its builder.  It would be possible to have the client create these objects itself, making a simpler experience for the user.  However, because this does add the cost of an EventLoopGroup and HostResolver to each created AwsCrtAsyncHttpClient, and handling it for them potentially hides that cost, it seemed better to have the user explicitly specify their own.  For example, a customer may use a pattern that creates a large number of clients, not realizing each client is spinning up an EventLoopGroup and HostResolver.

## Testing
mvn clean install

[x ] I confirm that this pull request can be released under the Apache 2 license