### PR TITLE
Using the same versions of netty-codec-http and reactive-streams

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-90b7f71.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-90b7f71.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "using the same versions of netty and reactive-streams across the whole project"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,9 @@
         <equalsverifier.version>2.3.3</equalsverifier.version>
         <!-- Update netty-open-ssl-version accordingly whenever we update netty version-->
         <!-- https://github.com/netty/netty/blob/4.1/pom.xml#L286 -->
-        <netty.version>4.1.42.Final</netty.version>
+        <!-- We also depend on netty directly and transitive via com.typesafe.netty:netty-reactive-streams-http,
+             so please make sure we are depending on the same version when you are updating this dependency. -->
+        <netty.version>4.1.43.Final</netty.version>
         <unitils.version>3.3</unitils.version>
         <xmlunit.version>1.3</xmlunit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -156,7 +158,9 @@
         <unitils.version>3.3</unitils.version>
 
         <!-- Reactive Streams version -->
-        <reactive-streams.version>1.0.2</reactive-streams.version>
+        <!-- NOTE: We are depending directly and transitive on reactive-streams via com.typesafe.netty:netty-reactive-streams-http,
+             so please be careful when you update this version.-->
+        <reactive-streams.version>1.0.3</reactive-streams.version>
 
         <skip.unit.tests>${skipTests}</skip.unit.tests>
     </properties>


### PR DESCRIPTION
The SDK depends on io.netty:netty-codec-http directly and transitive via com.typesafe.netty:netty-reactive-streams-http. This makes both dependencies depending on the same version.

Same with org.reactivestreams:reactive-streams. Again we got a direct dependency and a transitive one via com.typesafe.netty:netty-reactive-streams-http.

## Description
Bumping up the versions used to match their transitive dependencies.

## Motivation and Context
We depend effectively on different versions. But in the classpath can be only one.

## Testing
mvn clean install

## Screenshots (if appropriate)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
