### PR TITLE
Dynamodb-enhanced [preview]: changing usage of typed builders to expl…

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClientPreview-0418237.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClientPreview-0418237.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client [Preview]",
+    "description": "Changing usage of typed builders for PutItem, UpdateItem and StaticTableSchema to explicitly provide class type."
+}

--- a/services-custom/dynamodb-enhanced/README.md
+++ b/services-custom/dynamodb-enhanced/README.md
@@ -41,7 +41,7 @@ values used are also completely arbitrary.
    class itself, or somewhere else :-
    ```java
    static final TableSchema<Customer> CUSTOMER_TABLE_SCHEMA =
-     StaticTableSchema.builder()
+     StaticTableSchema.builder(Customer.class)
        .newItemSupplier(Customer::new)       // Tells the mapper how to make new objects when reading items
        .attributes(
          stringAttribute("account_id", 
@@ -243,7 +243,7 @@ public abstract class GenericRecord {
 }
 
 private static final StaticTableSchema<GenericRecord> GENERIC_RECORD_SCHEMA =
-  StaticTableSchema.builder()
+  StaticTableSchema.builder(GenericRecord.class)
     .attributes(
           // The partition key will be inherited by the top level mapper
       stringAttribute("id", GenericRecord::getId, GenericRecord::setId).as(primaryPartitionKey()),
@@ -251,7 +251,7 @@ private static final StaticTableSchema<GenericRecord> GENERIC_RECORD_SCHEMA =
     .build();
     
 private static final StaticTableSchema<Customer> CUSTOMER_TABLE_SCHEMA =
-  StaticTableSchema.builder()
+  StaticTableSchema.builder(Customer.class)
     .newItemSupplier(Customer::new)
     .attributes(
       stringAttribute("name", Customer::getName, Customer::setName))
@@ -274,7 +274,7 @@ public class GenericRecord {
 }
 
 private static final StaticTableSchema<GenericRecord> GENERIC_RECORD_SCHEMA =
-  StaticTableSchema.builder()
+  StaticTableSchema.builder(GenericRecord.class)
     .newItemSupplier(GenericRecord::new)
     .attributes(
       stringAttribute("id", GenericRecord::getId, GenericRecord::setId).as(primaryPartitionKey()),
@@ -282,7 +282,7 @@ private static final StaticTableSchema<GenericRecord> GENERIC_RECORD_SCHEMA =
     .build();
     
 private static final StaticTableSchema<Customer> CUSTOMER_TABLE_SCHEMA =
-  StaticTableSchema.builder()
+  StaticTableSchema.builder(Customer.class)
     .newItemSupplier(Customer::new)
     .attributes(stringAttribute("name", Customer::getName, Customer::setName))
     // Because we are flattening a component object, we supply a getter and setter so the

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/PutItem.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/PutItem.java
@@ -54,11 +54,11 @@ public class PutItem<T>
     }
 
     public static <T> PutItem<T> create(T item) {
-        return PutItem.builder().item(item).build();
+        return new Builder<T>().item(item).build();
     }
 
-    public static GenericBuilder builder() {
-        return new GenericBuilder();
+    public static <T> Builder<T> builder(Class<? extends T> itemClass) {
+        return new Builder<T>();
     }
 
     public Builder<T> toBuilder() {
@@ -204,26 +204,6 @@ public class PutItem<T>
     @Override
     public int hashCode() {
         return item != null ? item.hashCode() : 0;
-    }
-
-    public static class GenericBuilder {
-        private Expression conditionExpression;
-
-        private GenericBuilder() {
-        }
-
-        public <T> Builder<T> item(T item) {
-            return new Builder<T>().item(item).conditionExpression(conditionExpression);
-        }
-
-        public GenericBuilder conditionExpression(Expression conditionExpression) {
-            this.conditionExpression = conditionExpression;
-            return this;
-        }
-
-        public PutItem<?> build() {
-            throw new UnsupportedOperationException("Cannot construct a PutItem operation without an item to put.");
-        }
     }
 
     public static final class Builder<T> {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/PutItem.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/PutItem.java
@@ -58,7 +58,7 @@ public class PutItem<T>
     }
 
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
-        return new Builder<T>();
+        return new Builder<>();
     }
 
     public Builder<T> toBuilder() {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/UpdateItem.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/UpdateItem.java
@@ -72,7 +72,7 @@ public class UpdateItem<T>
     }
 
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
-        return new Builder<T>();
+        return new Builder<>();
     }
 
     public Builder<T> toBuilder() {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/UpdateItem.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/UpdateItem.java
@@ -68,11 +68,11 @@ public class UpdateItem<T>
     }
 
     public static <T> UpdateItem<T> create(T item) {
-        return UpdateItem.builder().item(item).build();
+        return new Builder<T>().item(item).build();
     }
 
-    public static GenericBuilder builder() {
-        return new GenericBuilder();
+    public static <T> Builder<T> builder(Class<? extends T> itemClass) {
+        return new Builder<T>();
     }
 
     public Builder<T> toBuilder() {
@@ -280,32 +280,6 @@ public class UpdateItem<T>
                          .expressionValues(Collections.unmodifiableMap(expressionAttributeValues))
                          .expressionNames(expressionAttributeNames)
                          .build();
-    }
-
-    public static class GenericBuilder {
-        private Boolean ignoreNulls;
-        private Expression conditionExpression;
-
-        private GenericBuilder() {
-        }
-
-        public GenericBuilder ignoreNulls(Boolean ignoreNulls) {
-            this.ignoreNulls = ignoreNulls;
-            return this;
-        }
-
-        public GenericBuilder conditionExpression(Expression conditionExpression) {
-            this.conditionExpression = conditionExpression;
-            return this;
-        }
-
-        public <T> Builder<T> item(T item) {
-            return new Builder<T>().item(item).ignoreNulls(ignoreNulls).conditionExpression(conditionExpression);
-        }
-
-        public UpdateItem<?> build() {
-            throw new UnsupportedOperationException("Cannot construct a UpdateItem operation without an item to put.");
-        }
     }
 
     public static final class Builder<T> {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/staticmapper/StaticTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/staticmapper/StaticTableSchema.java
@@ -61,7 +61,7 @@ public class StaticTableSchema<T> implements TableSchema<T> {
     }
 
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
-        return new Builder<T>();
+        return new Builder<>();
     }
 
     public static final class Builder<T> {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/staticmapper/StaticTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/staticmapper/StaticTableSchema.java
@@ -60,73 +60,17 @@ public class StaticTableSchema<T> implements TableSchema<T> {
                                 .collect(Collectors.toMap(Attribute::attributeName, Function.identity())));
     }
 
-    public static GenericBuilder builder() {
-        return new GenericBuilder();
-    }
-
-    public static class GenericBuilder {
-        private final StaticTableMetadata.Builder tableMetadataBuilder = StaticTableMetadata.builder();
-
-        public <T> StaticTableSchema<T> build() {
-            Builder<T> newBuilder = new Builder<>(tableMetadataBuilder);
-            return newBuilder.build();
-        }
-
-        public <T> Builder<T> newItemSupplier(Supplier<T> newItemSupplier) {
-            Builder<T> newBuilder = new Builder<>(tableMetadataBuilder);
-            return newBuilder.newItemSupplier(newItemSupplier);
-        }
-
-        public <T, R> Builder<T> flatten(StaticTableSchema<R> otherTableSchema,
-                                         Function<T, R> otherItemGetter,
-                                         BiConsumer<T, R> otherItemSetter) {
-            Builder<T> newBuilder = new Builder<>(tableMetadataBuilder);
-            return newBuilder.flatten(otherTableSchema, otherItemGetter, otherItemSetter);
-        }
-
-        /**
-         * Extends the {@link StaticTableSchema} of a super-class, effectively rolling all the attributes modelled by
-         * the super-class into the {@link StaticTableSchema} of the sub-class. If you are extending an abstract
-         * table schema that has no inferred type (due to having no attributes or a newItemSupplier) the compiler
-         * will not be able to correctly infer the type of the sub-class. To overcome this, specify the type
-         * explicitly as this example illustrates:
-         *
-         * {@code StaticTableSchema.builder().<Subclass>extend(superclassTableSchema).build(); }
-         *
-         * @param superTableSchema The {@link StaticTableSchema} of the super-class object.
-         * @param <T> The sub-class type of the {@link StaticTableSchema} being built.
-         * @return A strongly typed builder for the {@link StaticTableSchema} under construction.
-         */
-        public <T> Builder<T> extend(StaticTableSchema<? super T> superTableSchema) {
-            Builder<T> newBuilder = new Builder<>(tableMetadataBuilder);
-            return newBuilder.extend(superTableSchema);
-        }
-
-        @SafeVarargs
-        public final <T> Builder<T> attributes(AttributeSupplier<T>... mappedAttributes) {
-            Builder<T> newBuilder = new Builder<>(tableMetadataBuilder);
-            return newBuilder.attributes(mappedAttributes);
-        }
-
-        public final <T> Builder<T> attributes(Collection<AttributeSupplier<T>> mappedAttributes) {
-            Builder<T> newBuilder = new Builder<>(tableMetadataBuilder);
-            return newBuilder.attributes(mappedAttributes);
-        }
-
-        public GenericBuilder tagWith(TableTag... tableTags) {
-            Arrays.stream(tableTags).forEach(tableTag -> tableTag.setTableMetadata(tableMetadataBuilder));
-            return this;
-        }
+    public static <T> Builder<T> builder(Class<? extends T> itemClass) {
+        return new Builder<T>();
     }
 
     public static final class Builder<T> {
         private Supplier<T> newItemSupplier;
-        private final StaticTableMetadata.Builder tableMetadataBuilder;
+        private StaticTableMetadata.Builder tableMetadataBuilder = StaticTableMetadata.builder();
         private final List<Attribute<T>> mappedAttributes = new ArrayList<>();
         private final Map<String, Attribute<T>> indexedMappers = new HashMap<>();
 
-        private Builder(StaticTableMetadata.Builder tableMetadataBuilder) {
-            this.tableMetadataBuilder = tableMetadataBuilder;
+        private Builder() {
         }
 
         public Builder<T> newItemSupplier(Supplier<T> newItemSupplier) {
@@ -170,6 +114,18 @@ public class StaticTableSchema<T> implements TableSchema<T> {
             return this;
         }
 
+        /**
+         * Extends the {@link StaticTableSchema} of a super-class, effectively rolling all the attributes modelled by
+         * the super-class into the {@link StaticTableSchema} of the sub-class. If you are extending an abstract
+         * table schema that has no inferred type (due to having no attributes or a newItemSupplier) the compiler
+         * will not be able to correctly infer the type of the sub-class. To overcome this, specify the type
+         * explicitly as this example illustrates:
+         *
+         * {@code StaticTableSchema.builder().<Subclass>extend(superclassTableSchema).build(); }
+         *
+         * @param superTableSchema The {@link StaticTableSchema} of the super-class object.
+         * @return A strongly typed builder for the {@link StaticTableSchema} under construction.
+         */
         public Builder<T> extend(StaticTableSchema<? super T> superTableSchema) {
             // Upcast transform and merge attributes
             Stream<Attribute<T>> transformedAttributes =

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncBasicCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncBasicCrudTest.java
@@ -173,7 +173,7 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                    .newItemSupplier(Record::new)
                    .attributes(
                        stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),
@@ -188,7 +188,7 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
                    .build();
 
     private static final TableSchema<ShortRecord> SHORT_TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(ShortRecord.class)
                    .newItemSupplier(ShortRecord::new)
                    .attributes(
                        stringAttribute("id", ShortRecord::getId, ShortRecord::setId).as(primaryPartitionKey()),
@@ -332,7 +332,10 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
                                                    .putExpressionValue(":value1", stringValue("three"))
                                                    .build();
 
-        mappedTable.execute(PutItem.builder().item(record).conditionExpression(conditionExpression).build()).join();
+        mappedTable.execute(PutItem.builder(Record.class)
+                                   .item(record)
+                                   .conditionExpression(conditionExpression)
+                                   .build()).join();
 
         Record result =
             mappedTable.execute(GetItem.create(Key.create(stringValue("id-value"), stringValue("sort-value")))).join();
@@ -361,7 +364,7 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
 
         exception.expect(CompletionException.class);
         exception.expectCause(instanceOf(ConditionalCheckFailedException.class));
-        mappedTable.execute(PutItem.builder().item(record).conditionExpression(conditionExpression).build()).join();
+        mappedTable.execute(PutItem.builder(Record.class).item(record).conditionExpression(conditionExpression).build()).join();
     }
 
     @Test
@@ -499,7 +502,7 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
                                .setId("id-value")
                                .setSort("sort-value")
                                .setAttribute("four");
-        Record result = mappedTable.execute(UpdateItem.builder().item(record2).ignoreNulls(true).build()).join();
+        Record result = mappedTable.execute(UpdateItem.builder(Record.class).item(record2).ignoreNulls(true).build()).join();
 
         Record expectedResult = new Record()
                                .setId("id-value")
@@ -550,7 +553,11 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
         mappedTable.execute(PutItem.create(record)).join();
         Record updateRecord = new Record().setId("id-value").setSort("sort-value");
 
-        Record result = mappedTable.execute(UpdateItem.builder().item(updateRecord).ignoreNulls(true).build()).join();
+        Record result = mappedTable.execute(UpdateItem.builder(Record.class)
+                                                      .item(updateRecord)
+                                                      .ignoreNulls(true)
+                                                      .build())
+                                   .join();
 
         assertThat(result, is(record));
     }
@@ -575,7 +582,11 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
                                                    .putExpressionValue(":value1", stringValue("three"))
                                                    .build();
 
-        mappedTable.execute(UpdateItem.builder().item(record).conditionExpression(conditionExpression).build()).join();
+        mappedTable.execute(UpdateItem.builder(Record.class)
+                                      .item(record)
+                                      .conditionExpression(conditionExpression)
+                                      .build())
+                   .join();
 
         Record result =
             mappedTable.execute(GetItem.create(Key.create(stringValue("id-value"), stringValue("sort-value")))).join();
@@ -604,7 +615,11 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
 
         exception.expect(CompletionException.class);
         exception.expectCause(instanceOf(ConditionalCheckFailedException.class));
-        mappedTable.execute(UpdateItem.builder().item(record).conditionExpression(conditionExpression).build()).join();
+        mappedTable.execute(UpdateItem.builder(Record.class)
+                                      .item(record)
+                                      .conditionExpression(conditionExpression)
+                                      .build())
+                   .join();
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncBasicQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncBasicQueryTest.java
@@ -105,7 +105,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                    .newItemSupplier(Record::new)
                    .attributes(
                        stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncBasicScanTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncBasicScanTest.java
@@ -91,7 +91,7 @@ public class AsyncBasicScanTest extends LocalDynamoDbAsyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                    .newItemSupplier(Record::new)
                    .attributes(
                        stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncTransactGetItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncTransactGetItemsTest.java
@@ -99,14 +99,14 @@ public class AsyncTransactGetItemsTest extends LocalDynamoDbAsyncTestBase {
     }
 
     private static final TableSchema<Record1> TABLE_SCHEMA_1 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record1.class)
                    .newItemSupplier(Record1::new)
                    .attributes(
                        integerNumberAttribute("id_1", Record1::getId, Record1::setId).as(primaryPartitionKey()))
                    .build();
 
     private static final TableSchema<Record2> TABLE_SCHEMA_2 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record2.class)
                    .newItemSupplier(Record2::new)
                    .attributes(
                        integerNumberAttribute("id_2", Record2::getId, Record2::setId).as(primaryPartitionKey()))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncTransactWriteItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/AsyncTransactWriteItemsTest.java
@@ -133,7 +133,7 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
     }
 
     private static final TableSchema<Record1> TABLE_SCHEMA_1 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record1.class)
                    .newItemSupplier(Record1::new)
                    .attributes(
                        integerNumberAttribute("id_1", Record1::getId, Record1::setId).as(primaryPartitionKey()),
@@ -141,7 +141,7 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
                    .build();
 
     private static final TableSchema<Record2> TABLE_SCHEMA_2 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record2.class)
                    .newItemSupplier(Record2::new)
                    .attributes(
                        integerNumberAttribute("id_2", Record2::getId, Record2::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/BasicCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/BasicCrudTest.java
@@ -171,7 +171,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                          .newItemSupplier(Record::new)
                          .attributes(
                              stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),
@@ -186,7 +186,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                          .build();
 
     private static final TableSchema<ShortRecord> SHORT_TABLE_SCHEMA =
-            StaticTableSchema.builder()
+            StaticTableSchema.builder(ShortRecord.class)
                              .newItemSupplier(ShortRecord::new)
                              .attributes(
                                  stringAttribute("id", ShortRecord::getId, ShortRecord::setId).as(primaryPartitionKey()),
@@ -325,7 +325,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                                                    .putExpressionValue(":value1", stringValue("three"))
                                                    .build();
 
-        mappedTable.execute(PutItem.builder().item(record).conditionExpression(conditionExpression).build());
+        mappedTable.execute(PutItem.builder(Record.class).item(record).conditionExpression(conditionExpression).build());
 
         Record result = mappedTable.execute(GetItem.create(Key.create(stringValue("id-value"), stringValue("sort-value"))));
         assertThat(result, is(record));
@@ -352,7 +352,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                                                    .build();
 
         exception.expect(ConditionalCheckFailedException.class);
-        mappedTable.execute(PutItem.builder().item(record).conditionExpression(conditionExpression).build());
+        mappedTable.execute(PutItem.builder(Record.class).item(record).conditionExpression(conditionExpression).build());
     }
 
     @Test
@@ -488,7 +488,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                                .setId("id-value")
                                .setSort("sort-value")
                                .setAttribute("four");
-        Record result = mappedTable.execute(UpdateItem.builder().item(record2).ignoreNulls(true).build());
+        Record result = mappedTable.execute(UpdateItem.builder(Record.class).item(record2).ignoreNulls(true).build());
 
         Record expectedResult = new Record()
                                .setId("id-value")
@@ -539,7 +539,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
         mappedTable.execute(PutItem.create(record));
         Record updateRecord = new Record().setId("id-value").setSort("sort-value");
 
-        Record result = mappedTable.execute(UpdateItem.builder().item(updateRecord).ignoreNulls(true).build());
+        Record result = mappedTable.execute(UpdateItem.builder(Record.class).item(updateRecord).ignoreNulls(true).build());
 
         assertThat(result, is(record));
     }
@@ -564,7 +564,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                                                    .putExpressionValue(":value1", stringValue("three"))
                                                    .build();
 
-        mappedTable.execute(UpdateItem.builder().item(record).conditionExpression(conditionExpression).build());
+        mappedTable.execute(UpdateItem.builder(Record.class).item(record).conditionExpression(conditionExpression).build());
 
         Record result = mappedTable.execute(GetItem.create(Key.create(stringValue("id-value"), stringValue("sort-value"))));
         assertThat(result, is(record));
@@ -591,7 +591,7 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                                                    .build();
 
         exception.expect(ConditionalCheckFailedException.class);
-        mappedTable.execute(UpdateItem.builder().item(record).conditionExpression(conditionExpression).build());
+        mappedTable.execute(UpdateItem.builder(Record.class).item(record).conditionExpression(conditionExpression).build());
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/BasicQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/BasicQueryTest.java
@@ -105,7 +105,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                          .newItemSupplier(Record::new)
                          .attributes(
                              stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/BasicScanTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/BasicScanTest.java
@@ -91,7 +91,7 @@ public class BasicScanTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                          .newItemSupplier(Record::new)
                          .attributes(
                              stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/FlattenTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/FlattenTest.java
@@ -125,7 +125,7 @@ public class FlattenTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final StaticTableSchema<Document> DOCUMENT_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Document.class)
                          .newItemSupplier(Document::new)
                          .attributes(
                              stringAttribute("documentAttribute1",
@@ -140,7 +140,7 @@ public class FlattenTest extends LocalDynamoDbSyncTestBase {
                          .build();
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                          .newItemSupplier(Record::new)
                          .attributes(stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()))
                          .flatten(DOCUMENT_SCHEMA, Record::getDocument, Record::setDocument)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/IndexQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/IndexQueryTest.java
@@ -131,7 +131,7 @@ public class IndexQueryTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                          .newItemSupplier(Record::new)
                          .attributes(
                              stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/TransactGetItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/TransactGetItemsTest.java
@@ -99,14 +99,14 @@ public class TransactGetItemsTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record1> TABLE_SCHEMA_1 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record1.class)
                          .newItemSupplier(Record1::new)
                          .attributes(
                              integerNumberAttribute("id_1", Record1::getId, Record1::setId).as(primaryPartitionKey()))
                          .build();
 
     private static final TableSchema<Record2> TABLE_SCHEMA_2 =
-            StaticTableSchema.builder()
+            StaticTableSchema.builder(Record2.class)
                              .newItemSupplier(Record2::new)
                              .attributes(
                                  integerNumberAttribute("id_2", Record2::getId, Record2::setId).as(primaryPartitionKey()))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/TransactWriteItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/TransactWriteItemsTest.java
@@ -131,7 +131,7 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record1> TABLE_SCHEMA_1 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record1.class)
                          .newItemSupplier(Record1::new)
                          .attributes(
                              integerNumberAttribute("id_1", Record1::getId, Record1::setId).as(primaryPartitionKey()),
@@ -139,7 +139,7 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
                          .build();
 
     private static final TableSchema<Record2> TABLE_SCHEMA_2 =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record2.class)
                          .newItemSupplier(Record2::new)
                          .attributes(
                              integerNumberAttribute("id_2", Record2::getId, Record2::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/VersionedRecordTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/VersionedRecordTest.java
@@ -96,7 +96,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
     }
 
     private static final TableSchema<Record> TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(Record.class)
                          .newItemSupplier(Record::new)
                          .attributes(
                              stringAttribute("id", Record::getId, Record::setId).as(primaryPartitionKey()),
@@ -166,7 +166,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
                                                    .putExpressionValue(":v1", stringValue("one"))
                                                    .build();
 
-        mappedTable.execute(PutItem.builder()
+        mappedTable.execute(PutItem.builder(Record.class)
                                    .item(new Record().setId("id").setAttribute("one").setVersion(1))
                                    .conditionExpression(conditionExpression)
                                    .build());
@@ -187,7 +187,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
                                                    .build();
 
         exception.expect(ConditionalCheckFailedException.class);
-        mappedTable.execute(PutItem.builder()
+        mappedTable.execute(PutItem.builder(Record.class)
                                    .item(new Record().setId("id").setAttribute("one").setVersion(2))
                                    .conditionExpression(conditionExpression)
                                    .build());
@@ -204,7 +204,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
                                                    .build();
 
         exception.expect(ConditionalCheckFailedException.class);
-        mappedTable.execute(PutItem.builder()
+        mappedTable.execute(PutItem.builder(Record.class)
                                    .item(new Record().setId("id").setAttribute("one").setVersion(1))
                                    .conditionExpression(conditionExpression)
                                    .build());
@@ -220,7 +220,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
                                                    .putExpressionValue(":v1", stringValue("one"))
                                                    .build();
 
-        mappedTable.execute(UpdateItem.builder()
+        mappedTable.execute(UpdateItem.builder(Record.class)
                                       .item(new Record().setId("id").setAttribute("one").setVersion(1))
                                       .conditionExpression(conditionExpression)
                                       .build());
@@ -241,7 +241,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
                                                    .build();
 
         exception.expect(ConditionalCheckFailedException.class);
-        mappedTable.execute(UpdateItem.builder()
+        mappedTable.execute(UpdateItem.builder(Record.class)
                                       .item(new Record().setId("id").setAttribute("one").setVersion(2))
                                       .conditionExpression(conditionExpression)
                                       .build());
@@ -258,7 +258,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
                                                    .build();
 
         exception.expect(ConditionalCheckFailedException.class);
-        mappedTable.execute(UpdateItem.builder()
+        mappedTable.execute(UpdateItem.builder(Record.class)
                                       .item(new Record().setId("id").setAttribute("one").setVersion(1))
                                       .conditionExpression(conditionExpression)
                                       .build());

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItem.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItem.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItem extends FakeItemAbstractSubclass {
     private static final StaticTableSchema<FakeItem> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItem.class)
                          .newItemSupplier(FakeItem::new)
                          .flatten(FakeItemComposedClass.getTableSchema(),
                                   FakeItem::getComposedObject,

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemAbstractSubclass.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemAbstractSubclass.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 abstract class FakeItemAbstractSubclass extends FakeItemAbstractSubclass2 {
     private static final StaticTableSchema<FakeItemAbstractSubclass> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemAbstractSubclass.class)
                          .attributes(stringAttribute("subclass_attribute",
                                             FakeItemAbstractSubclass::getSubclassAttribute,
                                             FakeItemAbstractSubclass::setSubclassAttribute))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemAbstractSubclass2.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemAbstractSubclass2.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 abstract class FakeItemAbstractSubclass2 {
     private static final StaticTableSchema<FakeItemAbstractSubclass2> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemAbstractSubclass2.class)
                          .attributes(stringAttribute("abstract_subclass_2",
                                             FakeItemAbstractSubclass2::getSubclassAttribute2,
                                             FakeItemAbstractSubclass2::setSubclassAttribute2))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedAbstractSubclass.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedAbstractSubclass.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 abstract class FakeItemComposedAbstractSubclass {
     private static final StaticTableSchema<FakeItemComposedAbstractSubclass> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemComposedAbstractSubclass.class)
                          .attributes(stringAttribute("composed_abstract_subclass",
                                             FakeItemComposedAbstractSubclass::getComposedSubclassAttribute,
                                             FakeItemComposedAbstractSubclass::setComposedSubclassAttribute))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedAbstractSubclass2.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedAbstractSubclass2.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 abstract class FakeItemComposedAbstractSubclass2 {
     private static final StaticTableSchema<FakeItemComposedAbstractSubclass2> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemComposedAbstractSubclass2.class)
                          .attributes(stringAttribute("composed_abstract_subclass_2",
                                             FakeItemComposedAbstractSubclass2::getComposedSubclassAttribute2,
                                             FakeItemComposedAbstractSubclass2::setComposedSubclassAttribute2))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedClass.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedClass.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItemComposedClass {
     private static final StaticTableSchema<FakeItemComposedClass> ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemComposedClass.class)
                          .attributes(stringAttribute("composed_attribute",
                                            FakeItemComposedClass::getComposedAttribute,
                                            FakeItemComposedClass::setComposedAttribute))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedSubclass.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedSubclass.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItemComposedSubclass extends FakeItemComposedAbstractSubclass {
     private static final StaticTableSchema<FakeItemComposedSubclass> ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemComposedSubclass.class)
                          .newItemSupplier(FakeItemComposedSubclass::new)
                          .attributes(stringAttribute("composed_subclass",
                                             FakeItemComposedSubclass::getComposedAttribute,

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedSubclass2.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemComposedSubclass2.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItemComposedSubclass2 extends FakeItemComposedAbstractSubclass2 {
     private static final StaticTableSchema<FakeItemComposedSubclass2> ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemComposedSubclass2.class)
                          .newItemSupplier(FakeItemComposedSubclass2::new)
                          .extend(FakeItemComposedAbstractSubclass2.getSubclassTableSchema())
                          .attributes(stringAttribute("composed_subclass_2",

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithBinaryKey.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithBinaryKey.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItemWithBinaryKey {
     private static final StaticTableSchema<FakeItemWithBinaryKey> FAKE_ITEM_WITH_BINARY_KEY_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemWithBinaryKey.class)
                          .newItemSupplier(FakeItemWithBinaryKey::new)
                          .attributes(
                             binaryAttribute("id", FakeItemWithBinaryKey::getId, FakeItemWithBinaryKey::setId)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithIndices.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithIndices.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItemWithIndices {
     private static final StaticTableSchema<FakeItemWithIndices> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemWithIndices.class)
                          .newItemSupplier(FakeItemWithIndices::new)
                          .attributes(
                 stringAttribute("id", FakeItemWithIndices::getId, FakeItemWithIndices::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithNumericSort.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithNumericSort.java
@@ -29,7 +29,7 @@ public class FakeItemWithNumericSort {
     private static final Random RANDOM = new Random();
 
     private static final StaticTableSchema<FakeItemWithNumericSort> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemWithNumericSort.class)
                          .newItemSupplier(FakeItemWithNumericSort::new)
                          .attributes(
                             stringAttribute("id", FakeItemWithNumericSort::getId, FakeItemWithNumericSort::setId)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithSort.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/functionaltests/models/FakeItemWithSort.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.extensions.dynamodb.mappingclient.staticmapper.Sta
 
 public class FakeItemWithSort {
     private static final StaticTableSchema<FakeItemWithSort> FAKE_ITEM_MAPPER =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeItemWithSort.class)
                          .newItemSupplier(FakeItemWithSort::new)
                          .attributes(
                 stringAttribute("id", FakeItemWithSort::getId, FakeItemWithSort::setId).as(primaryPartitionKey()),

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/PutItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/PutItemTest.java
@@ -142,7 +142,7 @@ public class PutItemTest {
         FakeItem fakeItem = createUniqueFakeItem();
         fakeItem.setSubclassAttribute("subclass-value");
 
-        PutItem<FakeItem> putItemOperation = PutItem.builder()
+        PutItem<FakeItem> putItemOperation = PutItem.builder(FakeItem.class)
                                                     .conditionExpression(CONDITION_EXPRESSION)
                                                     .item(fakeItem)
                                                     .build();
@@ -171,7 +171,7 @@ public class PutItemTest {
         when(mockMapperExtension.beforeWrite(anyMap(), any(), any()))
             .thenReturn(WriteModification.builder().additionalConditionalExpression(CONDITION_EXPRESSION_2).build());
         PutItem<FakeItem> putItemOperation =
-            PutItem.builder().item(baseFakeItem).conditionExpression(CONDITION_EXPRESSION).build();
+            PutItem.builder(FakeItem.class).item(baseFakeItem).conditionExpression(CONDITION_EXPRESSION).build();
 
         PutItemRequest request = putItemOperation.generateRequest(FakeItem.getTableSchema(),
                                                                   PRIMARY_CONTEXT,

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/UpdateItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/operations/UpdateItemTest.java
@@ -170,7 +170,7 @@ public class UpdateItemTest {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
         item.setOtherAttribute1("value-1");
         UpdateItem<FakeItemWithSort> updateItemOperation =
-            UpdateItem.builder().item(item).conditionExpression(CONDITION_EXPRESSION).build();
+            UpdateItem.builder(FakeItemWithSort.class).item(item).conditionExpression(CONDITION_EXPRESSION).build();
         Map<String, AttributeValue> expectedKey = new HashMap<>();
         expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
         expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
@@ -203,7 +203,7 @@ public class UpdateItemTest {
     public void generateRequest_explicitlyUnsetIgnoreNulls() {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
         item.setOtherAttribute1("value-1");
-        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder().item(item).ignoreNulls(false).build();
+        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder(FakeItemWithSort.class).item(item).ignoreNulls(false).build();
         Map<String, AttributeValue> expectedKey = new HashMap<>();
         expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
         expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
@@ -235,7 +235,7 @@ public class UpdateItemTest {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
         item.setOtherAttribute1("value-1");
         item.setOtherAttribute2("value-2");
-        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder().item(item).ignoreNulls(false).build();
+        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder(FakeItemWithSort.class).item(item).ignoreNulls(false).build();
         Map<String, AttributeValue> expectedKey = new HashMap<>();
         expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
         expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
@@ -270,7 +270,10 @@ public class UpdateItemTest {
     @Test
     public void generateRequest_multipleDeletes() {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
-        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder().item(item).ignoreNulls(false).build();
+        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder(FakeItemWithSort.class)
+                                                                   .item(item)
+                                                                   .ignoreNulls(false)
+                                                                   .build();
         Map<String, AttributeValue> expectedKey = new HashMap<>();
         expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
         expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
@@ -300,7 +303,7 @@ public class UpdateItemTest {
     public void generateRequest_canIgnoreNullValues() {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
         item.setOtherAttribute1("value-1");
-        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder().item(item).ignoreNulls(true).build();
+        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder(FakeItemWithSort.class).item(item).ignoreNulls(true).build();
         Map<String, AttributeValue> expectedKey = new HashMap<>();
         expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
         expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
@@ -327,7 +330,10 @@ public class UpdateItemTest {
     @Test
     public void generateRequest_keyOnlyItem() {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
-        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder().item(item).ignoreNulls(true).build();
+        UpdateItem<FakeItemWithSort> updateItemOperation = UpdateItem.builder(FakeItemWithSort.class)
+                .item(item)
+                .ignoreNulls(true)
+                .build();
         Map<String, AttributeValue> expectedKey = new HashMap<>();
         expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
         expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
@@ -379,7 +385,7 @@ public class UpdateItemTest {
             .thenReturn(WriteModification.builder().transformedItem(fakeMap).build());
 
 
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -419,7 +425,7 @@ public class UpdateItemTest {
         Expression condition = Expression.builder().expression("condition").expressionValues(fakeMap).build();
         when(mockMapperExtension.beforeWrite(anyMap(), any(), any()))
             .thenReturn(WriteModification.builder().additionalConditionalExpression(condition).build());
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -443,7 +449,7 @@ public class UpdateItemTest {
             .thenReturn(WriteModification.builder().additionalConditionalExpression(condition1).build());
 
 
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -467,7 +473,7 @@ public class UpdateItemTest {
             .thenReturn(WriteModification.builder().additionalConditionalExpression(condition1).build());
 
 
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -492,7 +498,7 @@ public class UpdateItemTest {
             .thenReturn(WriteModification.builder().additionalConditionalExpression(condition).build());
 
 
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -514,7 +520,7 @@ public class UpdateItemTest {
             .thenReturn(WriteModification.builder().additionalConditionalExpression(condition).build());
 
 
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -531,7 +537,7 @@ public class UpdateItemTest {
         FakeItem baseFakeItem = createUniqueFakeItem();
         when(mockMapperExtension.beforeWrite(anyMap(), any(), any()))
             .thenReturn(WriteModification.builder().build());
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -563,7 +569,7 @@ public class UpdateItemTest {
                                                                                     .build())
                                          .build());
 
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -586,7 +592,7 @@ public class UpdateItemTest {
         FakeItem fakeItem = createUniqueFakeItem();
         Map<String, AttributeValue> baseFakeMap = FakeItem.getTableSchema().itemToMap(baseFakeItem, true);
         Map<String, AttributeValue> fakeMap = FakeItem.getTableSchema().itemToMap(fakeItem, true);
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();
@@ -608,7 +614,7 @@ public class UpdateItemTest {
     public void transformResponse_withNoOpExtension_returnsCorrectItem() {
         FakeItem baseFakeItem = createUniqueFakeItem();
         Map<String, AttributeValue> baseFakeMap = FakeItem.getTableSchema().itemToMap(baseFakeItem, true);
-        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder()
+        UpdateItem<FakeItem> updateItemOperation = UpdateItem.builder(FakeItem.class)
                                                              .item(baseFakeItem)
                                                              .ignoreNulls(true)
                                                              .build();

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/staticmapper/StaticTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/extensions/dynamodb/mappingclient/staticmapper/StaticTableSchemaTest.java
@@ -61,7 +61,7 @@ public class StaticTableSchemaTest {
     private static final AttributeValue ATTRIBUTE_VALUE_S = AttributeValue.builder().s("test-string").build();
 
     private static final StaticTableSchema<FakeDocument> FAKE_DOCUMENT_TABLE_SCHEMA =
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeDocument.class)
                          .newItemSupplier(FakeDocument::new)
                          .attributes(
                              stringAttribute("documentString", FakeDocument::getDocumentString, FakeDocument::setDocumentString),
@@ -680,7 +680,7 @@ public class StaticTableSchemaTest {
         stringAttribute("a_string", FakeMappedItem::getAString, FakeMappedItem::setAString));
 
     private StaticTableSchema<FakeMappedItem> createSimpleTableSchema() {
-        return StaticTableSchema.builder()
+        return StaticTableSchema.builder(FakeMappedItem.class)
                                 .newItemSupplier(FakeMappedItem::new)
                                 .attributes(ATTRIBUTES)
                                 .build();
@@ -1111,7 +1111,7 @@ public class StaticTableSchemaTest {
 
     @Test
     public void buildAbstractTableSchema() {
-        StaticTableSchema<FakeMappedItem> tableSchema = StaticTableSchema.builder()
+        StaticTableSchema<FakeMappedItem> tableSchema = StaticTableSchema.builder(FakeMappedItem.class)
                                                                          .attributes(stringAttribute("aString",
                                                                                      FakeMappedItem::getAString,
                                                                                      FakeMappedItem::setAString))
@@ -1127,7 +1127,7 @@ public class StaticTableSchemaTest {
     @Test
     public void buildAbstractWithFlatten() {
         StaticTableSchema<FakeMappedItem> tableSchema =
-            StaticTableSchema.builder()
+            StaticTableSchema.builder(FakeMappedItem.class)
                              .flatten(FAKE_DOCUMENT_TABLE_SCHEMA,
                                       FakeMappedItem::getAFakeDocument,
                                       FakeMappedItem::setAFakeDocument)
@@ -1143,14 +1143,14 @@ public class StaticTableSchemaTest {
     @Test
     public void buildAbstractExtends() {
         StaticTableSchema<FakeAbstractSuperclass> superclassTableSchema =
-            StaticTableSchema.builder()
+            StaticTableSchema.builder(FakeAbstractSuperclass.class)
                              .attributes(Attributes.stringAttribute("aString",
                                                            FakeAbstractSuperclass::getAString,
                                                            FakeAbstractSuperclass::setAString))
                              .build();
 
         StaticTableSchema<FakeAbstractSubclass> subclassTableSchema =
-            StaticTableSchema.builder()
+            StaticTableSchema.builder(FakeAbstractSubclass.class)
                              .<FakeAbstractSubclass>extend(superclassTableSchema)
                              .build();
 
@@ -1166,7 +1166,7 @@ public class StaticTableSchemaTest {
 
         StaticTableSchema<FakeDocument> abstractTableSchema =
             StaticTableSchema
-                .builder()
+                .builder(FakeDocument.class)
                 .tagWith(new TestTableTag())
                 .build();
 
@@ -1179,7 +1179,7 @@ public class StaticTableSchemaTest {
 
         StaticTableSchema<FakeDocument> concreteTableSchema =
             StaticTableSchema
-                .builder()
+                .builder(FakeDocument.class)
                 .newItemSupplier(FakeDocument::new)
                 .tagWith(new TestTableTag())
                 .build();
@@ -1191,7 +1191,7 @@ public class StaticTableSchemaTest {
     @Test
     public void instantiateFlattenedAbstractClassShouldThrowException() {
         StaticTableSchema<FakeAbstractSuperclass> superclassTableSchema =
-            StaticTableSchema.builder()
+            StaticTableSchema.builder(FakeAbstractSuperclass.class)
                              .attributes(Attributes.stringAttribute("aString",
                                                            FakeAbstractSuperclass::getAString,
                                                            FakeAbstractSuperclass::setAString))
@@ -1199,7 +1199,7 @@ public class StaticTableSchemaTest {
 
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("abstract");
-        StaticTableSchema.builder()
+        StaticTableSchema.builder(FakeBrokenClass.class)
                          .newItemSupplier(FakeBrokenClass::new)
                          .flatten(superclassTableSchema,
                                   FakeBrokenClass::getAbstractObject,
@@ -1210,7 +1210,7 @@ public class StaticTableSchemaTest {
                                  FakeMappedItem fakeMappedItem,
                                  AttributeValue attributeValue) {
 
-        StaticTableSchema<FakeMappedItem> tableSchema = StaticTableSchema.builder()
+        StaticTableSchema<FakeMappedItem> tableSchema = StaticTableSchema.builder(FakeMappedItem.class)
                                                                          .newItemSupplier(FakeMappedItem::new)
                                                                          .attributes(mappedAttribute)
                                                                          .build();
@@ -1226,7 +1226,7 @@ public class StaticTableSchemaTest {
     private void verifyNullAttribute(AttributeSupplier<FakeMappedItem> mappedAttribute,
                                      FakeMappedItem fakeMappedItem) {
 
-        StaticTableSchema<FakeMappedItem> tableSchema = StaticTableSchema.builder()
+        StaticTableSchema<FakeMappedItem> tableSchema = StaticTableSchema.builder(FakeMappedItem.class)
                                                                          .newItemSupplier(FakeMappedItem::new)
                                                                          .attributes(mappedAttribute)
                                                                          .build();


### PR DESCRIPTION
…icitly provide class type

## Description
PutItem, UpdateItem and StaticTableSchema, which all operate on items, previously had double builders, one generic and one typed, to support implicitly discovering the item class type. Now, the code has been simplified to a single typed Builder per class, which require users of these classes to explicitly provide the item class type when calling `builder()`.   

## Motivation and Context
Previous code was complex and risked being difficult to maintain and understand.

## Testing
All unit and integration tests working.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
