### PR TITLE
h2 connection exception handling 

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-dba3e80.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-dba3e80.json
@@ -1,0 +1,5 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "type": "bugfix", 
+    "description": "Deliver exceptions to stream channels correctly if there's an exception thrown on connection. This also fixes a bug where publisher signals onComplete if the stream is closed as a result of outbound GOAWAY."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
@@ -109,7 +109,14 @@ public final class ChannelPipelineInitializer extends AbstractChannelPoolHandler
         }
 
         pipeline.addLast(FutureCancelHandler.getInstance());
-        pipeline.addLast(UnusedChannelExceptionHandler.getInstance());
+
+        // Only add it for h1 channel because it does not apply to
+        // h2 connection channel. It will be attached
+        // to stream channels when they are created.
+        if (protocol == Protocol.HTTP1_1) {
+            pipeline.addLast(UnusedChannelExceptionHandler.getInstance());
+        }
+
         pipeline.addLast(new LoggingHandler(LogLevel.DEBUG));
     }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/GoAwayException.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/GoAwayException.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
  * Exception thrown when a GOAWAY frame is sent by the service.
  */
 @SdkInternalApi
-class GoAwayException extends IOException {
+public class GoAwayException extends IOException {
     private final String message;
 
     GoAwayException(long errorCode, ByteBuf debugData) {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/PingFailedException.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/PingFailedException.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
 @SdkInternalApi
-final class PingFailedException extends IOException {
+public final class PingFailedException extends IOException {
     PingFailedException(String msg) {
         super(msg);
     }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/ServerCloseConnectionTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/ServerCloseConnectionTest.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.http.nio.netty.fault;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -108,7 +108,10 @@ public class ServerCloseConnectionTest {
         server.ackPingOnFirstChannel = true;
         // The first request picks up a bad channel and should fail. Channel 1
         CompletableFuture<Void> firstRequest = sendGetRequest();
-        assertThatThrownBy(() -> firstRequest.join()).hasCauseInstanceOf(ClosedChannelException.class);
+        assertThatThrownBy(() -> firstRequest.join())
+            .hasMessageContaining("An error occurred on the connection")
+            .hasCauseInstanceOf(IOException.class)
+            .hasRootCauseInstanceOf(ClosedChannelException.class);
 
         server.failOnFirstChannel = false;
 


### PR DESCRIPTION
## Description
- Fix the issue where publisher signals onComplete if the stream is closed as a result of outbound GOAWAY. The root cause is that when `PingFailedException` is fired, `UnusedChannelExceptionHandler` is handling it instead of `ReleaseOnExceptionHandler`. `UnusedChannelExceptionHandler` only closes h2 connections. As a result, the exception would not be delivered to child channels as expected.

- ~~Change `UnusedChannelExceptionHandler` to a per-request handler because it doesn't really make sense to attach it to connection channel pipeline since we never set `IN_USE` attribute key on it.~~ Only attach `UnusedChannelExceptionHandler` to h2 stream channels and h1 channels.
- When delivering a connection exception to a child channel, wrap it with a more descriptive exception.

Previously, if a channel gets closed because of `PingFailedException`:
It could complete successfully or throw the following exception depending on the operation.
```
java.util.concurrent.CompletionException: java.io.IOException: Server failed to send complete response
```
Now it would throw the following exception:
```
java.util.concurrent.CompletionException: java.lang.IOException: An exception occurred on the connection: Server did not respond to PING after 487ms (limit: 200ms)
Caused by: software.amazon.awssdk.http.nio.netty.internal.http2.PingFailedException: Server did not respond to PING after 487ms (limit: 200ms)
```

## Testing
Added functional tests and unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
