### PR TITLE
Fixed s3 decoding response for ListObjectsVersion and ListMultipartUploads

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-9bf1df7.json
+++ b/.changes/next-release/bugfix-AmazonS3-9bf1df7.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon S3", 
+    "type": "bugfix", 
+    "description": "Fixed an issue where fields in `ListObjectVersionsResponse` and `ListMultipartUploadsResponse` are not decoded correctly when encodingType is specified as url. See [#1601](https://github.com/aws/aws-sdk-java-v2/issues/1601)"
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/UrlEncodingIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/UrlEncodingIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.EncodingType;
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+/**
+ * Integration tests for the operations that support encoding type
+ */
+public class UrlEncodingIntegrationTest extends S3IntegrationTestBase {
+    /**
+     * The name of the bucket created, used, and deleted by these tests.
+     */
+    private static final String BUCKET_NAME = temporaryBucketName(UrlEncodingIntegrationTest.class);
+    private static final String KEY_NAME_WITH_SPECIAL_CHARS = "filename_@_=_&_?_+_)_.temp";
+
+    @BeforeClass
+    public static void createResources() {
+        createBucket(BUCKET_NAME);
+        s3.putObject(PutObjectRequest.builder()
+                                     .bucket(BUCKET_NAME)
+                                     .key(KEY_NAME_WITH_SPECIAL_CHARS)
+                                     .build(), RequestBody.fromString(RandomStringUtils.random(1000)));
+    }
+
+    /**
+     * Releases all resources created in this test.
+     */
+    @AfterClass
+    public static void tearDown() {
+        deleteBucketAndAllContents(BUCKET_NAME);
+    }
+
+    @Test
+    public void listObjectVersionsWithUrlEncodingType_shouldDecode() {
+        ListObjectVersionsResponse listObjectVersionsResponse =
+            s3.listObjectVersions(b -> b.bucket(BUCKET_NAME).encodingType(EncodingType.URL));
+        listObjectVersionsResponse.versions().forEach(v -> assertKeyIsDecoded(v.key()));
+
+        ListObjectVersionsResponse asyncResponse =
+            s3Async.listObjectVersions(b -> b.bucket(BUCKET_NAME).encodingType(EncodingType.URL)).join();
+
+        asyncResponse.versions().forEach(v -> assertKeyIsDecoded(v.key()));
+    }
+
+    @Test
+    public void listObjectV2WithUrlEncodingType_shouldDecode() {
+        ListObjectsV2Response listObjectsV2Response =
+            s3.listObjectsV2(b -> b.bucket(BUCKET_NAME).encodingType(EncodingType.URL));
+
+        listObjectsV2Response.contents().forEach(c -> assertKeyIsDecoded(c.key()));
+        ListObjectVersionsResponse asyncResponse =
+            s3Async.listObjectVersions(b -> b.bucket(BUCKET_NAME).encodingType(EncodingType.URL)).join();
+
+        asyncResponse.versions().forEach(v -> assertKeyIsDecoded(v.key()));
+    }
+
+    @Test
+    public void listObjectWithUrlEncodingType_shouldDecode() {
+        ListObjectsResponse listObjectsV2Response =
+            s3.listObjects(b -> b.bucket(BUCKET_NAME).encodingType(EncodingType.URL));
+
+        listObjectsV2Response.contents().forEach(c -> assertKeyIsDecoded(c.key()));
+        ListObjectVersionsResponse asyncResponse =
+            s3Async.listObjectVersions(b -> b.bucket(BUCKET_NAME).encodingType(EncodingType.URL)).join();
+
+        asyncResponse.versions().forEach(v -> assertKeyIsDecoded(v.key()));
+    }
+
+    @Test
+    public void listMultipartUploadsWithUrlEncodingType_shouldDecode() {
+        String uploaddId = null;
+        try {
+            CreateMultipartUploadResponse multipartUploadResponse =
+                s3.createMultipartUpload(b -> b.bucket(BUCKET_NAME).key(KEY_NAME_WITH_SPECIAL_CHARS));
+            uploaddId = multipartUploadResponse.uploadId();
+
+            String finalUploadId = uploaddId;
+            UploadPartResponse uploadPartResponse = s3.uploadPart(b -> b.bucket(BUCKET_NAME)
+                                                                        .key(KEY_NAME_WITH_SPECIAL_CHARS)
+                                                                        .partNumber(1)
+                                                                        .uploadId(finalUploadId),
+                                                                  RequestBody.fromString(RandomStringUtils.random(1000)));
+
+
+            ListMultipartUploadsResponse listMultipartUploadsResponse =
+                s3.listMultipartUploads(b -> b.encodingType(EncodingType.URL).bucket(BUCKET_NAME));
+
+            listMultipartUploadsResponse.uploads().forEach(upload -> assertThat(upload.key()).isEqualTo(KEY_NAME_WITH_SPECIAL_CHARS));
+
+            ListMultipartUploadsResponse asyncListMultipartUploadsResponse =
+                s3Async.listMultipartUploads(b -> b.encodingType(EncodingType.URL).bucket(BUCKET_NAME)).join();
+
+            asyncListMultipartUploadsResponse.uploads().forEach(upload -> assertKeyIsDecoded(upload.key()));
+        } finally {
+            if (uploaddId != null) {
+                String finalUploadId = uploaddId;
+                s3.abortMultipartUpload(b -> b.bucket(BUCKET_NAME).key(KEY_NAME_WITH_SPECIAL_CHARS).uploadId(finalUploadId));
+            }
+        }
+    }
+
+    private void assertKeyIsDecoded(String key) {
+        assertThat(key).isEqualTo(KEY_NAME_WITH_SPECIAL_CHARS);
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/DecodeUrlEncodedResponseInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/DecodeUrlEncodedResponseInterceptor.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.s3.internal.handlers;
 
 import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlDecode;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -24,9 +25,14 @@ import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.EncodingType;
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.MultipartUpload;
+import software.amazon.awssdk.services.s3.model.ObjectVersion;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 /**
@@ -50,9 +56,19 @@ public final class DecodeUrlEncodedResponseInterceptor implements ExecutionInter
         SdkResponse response = context.response();
         if (shouldHandle(response)) {
             if (response instanceof ListObjectsResponse) {
-                response = modifyListObjectsResponse((ListObjectsResponse) response);
-            } else if (response instanceof ListObjectsV2Response) {
-                response = modifyListObjectsV2Response((ListObjectsV2Response) response);
+                return modifyListObjectsResponse((ListObjectsResponse) response);
+            }
+
+            if (response instanceof ListObjectsV2Response) {
+                return modifyListObjectsV2Response((ListObjectsV2Response) response);
+            }
+
+            if (response instanceof ListObjectVersionsResponse) {
+                return modifyListObjectVersionsResponse((ListObjectVersionsResponse) response);
+            }
+
+            if (response instanceof ListMultipartUploadsResponse) {
+                return modifyListMultipartUploadsResponse((ListMultipartUploadsResponse) response);
             }
         }
         return response;
@@ -67,30 +83,90 @@ public final class DecodeUrlEncodedResponseInterceptor implements ExecutionInter
     // Elements to decode: Delimiter, Marker, Prefix, NextMarker, Key
     private static SdkResponse modifyListObjectsResponse(ListObjectsResponse response) {
         return response.toBuilder()
-                .delimiter(urlDecode(response.delimiter()))
-                .marker(urlDecode(response.marker()))
-                .prefix(urlDecode(response.prefix()))
-                .nextMarker(urlDecode(response.nextMarker()))
-                .contents(decodeContents(response.contents()))
-                .build();
+                       .delimiter(urlDecode(response.delimiter()))
+                       .marker(urlDecode(response.marker()))
+                       .prefix(urlDecode(response.prefix()))
+                       .nextMarker(urlDecode(response.nextMarker()))
+                       .contents(decodeContents(response.contents()))
+                       .commonPrefixes(decodeCommonPrefixes(response.commonPrefixes()))
+                       .build();
     }
 
     // Elements to decode: Delimiter, Prefix, Key, and StartAfter
     private static SdkResponse modifyListObjectsV2Response(ListObjectsV2Response response) {
         return response.toBuilder()
-                .delimiter(urlDecode(response.delimiter()))
-                .prefix(urlDecode(response.prefix()))
-                .startAfter(urlDecode(response.startAfter()))
-                .contents(decodeContents(response.contents()))
-                .build();
+                       .delimiter(urlDecode(response.delimiter()))
+                       .prefix(urlDecode(response.prefix()))
+                       .startAfter(urlDecode(response.startAfter()))
+                       .contents(decodeContents(response.contents()))
+                       .commonPrefixes(decodeCommonPrefixes(response.commonPrefixes()))
+                       .build();
+    }
+
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
+    // Elements to decode: Delimiter, KeyMarker, NextKeyMarker, Prefix
+    private SdkResponse modifyListObjectVersionsResponse(ListObjectVersionsResponse response) {
+
+        return response.toBuilder()
+                       .prefix(urlDecode(response.prefix()))
+                       .keyMarker(urlDecode(response.keyMarker()))
+                       .delimiter(urlDecode(response.delimiter()))
+                       .nextKeyMarker(urlDecode(response.nextKeyMarker()))
+                       .commonPrefixes(decodeCommonPrefixes(response.commonPrefixes()))
+                       .versions(decodeObjectVersions(response.versions()))
+                       .build();
+    }
+
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+    // Elements to decode: Delimiter, KeyMarker, NextKeyMarker, Prefix, Key
+    private SdkResponse modifyListMultipartUploadsResponse(ListMultipartUploadsResponse response) {
+        return response.toBuilder()
+                       .delimiter(urlDecode(response.delimiter()))
+                       .keyMarker(urlDecode(response.keyMarker()))
+                       .nextKeyMarker(urlDecode(response.nextKeyMarker()))
+                       .prefix(urlDecode(response.prefix()))
+                       .commonPrefixes(decodeCommonPrefixes(response.commonPrefixes()))
+                       .uploads(decodeMultipartUpload(response.uploads()))
+                       .build();
+
     }
 
     private static List<S3Object> decodeContents(List<S3Object> contents) {
         if (contents == null) {
             return null;
         }
-        return contents.stream()
-                       .map(o -> o.toBuilder().key(urlDecode(o.key())).build())
-                       .collect(Collectors.toList());
+        return Collections.unmodifiableList(contents.stream()
+                                                     .map(o -> o.toBuilder().key(urlDecode(o.key())).build())
+                                                     .collect(Collectors.toList()));
+    }
+
+    private static List<ObjectVersion> decodeObjectVersions(List<ObjectVersion> objectVersions) {
+        if (objectVersions == null) {
+            return null;
+        }
+
+        return Collections.unmodifiableList(objectVersions.stream()
+                                                          .map(o -> o.toBuilder().key(urlDecode(o.key())).build())
+                                                          .collect(Collectors.toList()));
+    }
+
+    private static List<CommonPrefix> decodeCommonPrefixes(List<CommonPrefix> commonPrefixes) {
+        if (commonPrefixes == null) {
+            return null;
+        }
+
+        return Collections.unmodifiableList(commonPrefixes.stream()
+                                                          .map(p -> p.toBuilder().prefix(urlDecode(p.prefix())).build())
+                                                          .collect(Collectors.toList()));
+    }
+
+    private static List<MultipartUpload> decodeMultipartUpload(List<MultipartUpload> multipartUploads) {
+        if (multipartUploads == null) {
+            return null;
+        }
+
+        return Collections.unmodifiableList(multipartUploads.stream()
+                                                            .map(u -> u.toBuilder().key(urlDecode(u.key())).build())
+                                                            .collect(Collectors.toList()));
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/DecodeUrlEncodedResponseInterceptorTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/handlers/DecodeUrlEncodedResponseInterceptorTest.java
@@ -33,9 +33,15 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.EncodingType;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.MultipartUpload;
+import software.amazon.awssdk.services.s3.model.ObjectVersion;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 /**
@@ -54,6 +60,7 @@ public class DecodeUrlEncodedResponseInterceptorTest {
 
     private static final String TEST_URL_ENCODED_MARKER = "foo+%3D+bar+baz+%CE%B1+%CE%B2+%F0%9F%98%8A+marker";
     private static final String TEST_URL_ENCODED_PREFIX = "foo+%3D+bar+baz+%CE%B1+%CE%B2+%F0%9F%98%8A+prefix";
+    private static final String TEST_URL_ENCODED_KEY = "foo+%3D+bar+baz+%CE%B1+%CE%B2+%F0%9F%98%8A+key";
     private static final String TEST_URL_ENCODED_START_AFTER = "foo+%3D+bar+baz+%CE%B1+%CE%B2+%F0%9F%98%8A+startafter";
 
     // foo = bar baz α β 😊
@@ -67,22 +74,53 @@ public class DecodeUrlEncodedResponseInterceptorTest {
             S3Object.builder().key(TEST_URL_ENCODED).build()
     );
 
+    private static final List<CommonPrefix> COMMON_PREFIXES = Arrays.asList(CommonPrefix.builder()
+                                                                                       .prefix(TEST_URL_ENCODED_PREFIX)
+                                                                                       .build());
     private static final ListObjectsResponse V1_TEST_ENCODED_RESPONSE = ListObjectsResponse.builder()
-            .encodingType(EncodingType.URL)
-            .delimiter(TEST_URL_ENCODED_DELIMITER)
-            .nextMarker(TEST_URL_ENCODED_NEXT_MARKER)
-            .prefix(TEST_URL_ENCODED_PREFIX)
-            .marker(TEST_URL_ENCODED_MARKER)
-            .contents(TEST_CONTENTS)
-            .build();
+                                                                                           .encodingType(EncodingType.URL)
+                                                                                           .delimiter(TEST_URL_ENCODED_DELIMITER)
+                                                                                           .nextMarker(TEST_URL_ENCODED_NEXT_MARKER)
+                                                                                           .prefix(TEST_URL_ENCODED_PREFIX)
+                                                                                           .marker(TEST_URL_ENCODED_MARKER)
+                                                                                           .contents(TEST_CONTENTS)
+                                                                                           .commonPrefixes(COMMON_PREFIXES)
+                                                                                           .build();
 
     private static final ListObjectsV2Response V2_TEST_ENCODED_RESPONSE = ListObjectsV2Response.builder()
-            .encodingType(EncodingType.URL)
-            .delimiter(TEST_URL_ENCODED_DELIMITER)
-            .prefix(TEST_URL_ENCODED_PREFIX)
-            .startAfter(TEST_URL_ENCODED_START_AFTER)
-            .contents(TEST_CONTENTS)
-            .build();
+                                                                                               .encodingType(EncodingType.URL)
+                                                                                               .delimiter(TEST_URL_ENCODED_DELIMITER)
+                                                                                               .prefix(TEST_URL_ENCODED_PREFIX)
+                                                                                               .startAfter(TEST_URL_ENCODED_START_AFTER)
+                                                                                               .contents(TEST_CONTENTS)
+                                                                                               .commonPrefixes(COMMON_PREFIXES)
+                                                                                               .build();
+
+    private static final String TEST_URL_ENCODED_NEXT_KEY_MARKER = TEST_URL_ENCODED + "+nextKeyMarker";
+    private static final String TEST_URL_ENCODED_KEY_MARKER = TEST_URL_ENCODED + "+keyMarker";
+    private static final ListObjectVersionsResponse TEST_LIST_OBJECT_VERSION_RESPONSE = ListObjectVersionsResponse.builder()
+                                                                                                                  .encodingType(EncodingType.URL)
+                                                                                                                  .delimiter(TEST_URL_ENCODED_DELIMITER)
+                                                                                                                  .prefix(TEST_URL_ENCODED_PREFIX)
+                                                                                                                  .keyMarker(TEST_URL_ENCODED_KEY_MARKER)
+                                                                                                                  .nextKeyMarker(TEST_URL_ENCODED_NEXT_KEY_MARKER)
+                                                                                                                  .commonPrefixes(COMMON_PREFIXES)
+                                                                                                                  .versions(ObjectVersion.builder()
+                                                                                                                                         .key(TEST_URL_ENCODED_KEY)
+                                                                                                                                         .build())
+                                                                                                                  .build();
+
+
+    private static final ListMultipartUploadsResponse TEST_LIST_MULTIPART_UPLOADS_RESPONSE =
+        ListMultipartUploadsResponse.builder()
+                                    .encodingType(EncodingType.URL)
+                                    .delimiter(TEST_URL_ENCODED_DELIMITER)
+                                    .prefix(TEST_URL_ENCODED_PREFIX)
+                                    .keyMarker(TEST_URL_ENCODED_KEY_MARKER)
+                                    .nextKeyMarker(TEST_URL_ENCODED_NEXT_KEY_MARKER)
+                                    .uploads(MultipartUpload.builder().key(TEST_URL_ENCODED_KEY).build())
+                                    .commonPrefixes(COMMON_PREFIXES)
+                                    .build();
 
     @Test
     public void encodingTypeSet_decodesListObjectsResponseParts() {
@@ -95,6 +133,7 @@ public class DecodeUrlEncodedResponseInterceptorTest {
         assertDecoded(decoded::prefix, " prefix");
         assertDecoded(decoded::marker, " marker");
         assertKeysAreDecoded(decoded.contents());
+        assertCommonPrefixesAreDecoded(decoded.commonPrefixes());
     }
 
     @Test
@@ -107,6 +146,36 @@ public class DecodeUrlEncodedResponseInterceptorTest {
         assertDecoded(decoded::prefix, " prefix");
         assertDecoded(decoded::startAfter, " startafter");
         assertKeysAreDecoded(decoded.contents());
+        assertCommonPrefixesAreDecoded(decoded.commonPrefixes());
+    }
+
+    @Test
+    public void encodingTypeSet_decodesListObjectVersionsResponse() {
+        Context.ModifyResponse ctx = newContext(TEST_LIST_OBJECT_VERSION_RESPONSE);
+
+        ListObjectVersionsResponse decoded = (ListObjectVersionsResponse) INTERCEPTOR.modifyResponse(ctx, new ExecutionAttributes());
+
+        assertDecoded(decoded::delimiter, " delimiter");
+        assertDecoded(decoded::prefix, " prefix");
+        assertDecoded(decoded::keyMarker, " keyMarker");
+        assertDecoded(decoded::nextKeyMarker, " nextKeyMarker");
+        assertCommonPrefixesAreDecoded(decoded.commonPrefixes());
+        assertVersionsAreDecoded(decoded.versions());
+    }
+
+    @Test
+    public void encodingTypeSet_decodesListMultipartUploadsResponse() {
+        Context.ModifyResponse ctx = newContext(TEST_LIST_MULTIPART_UPLOADS_RESPONSE);
+
+        ListMultipartUploadsResponse decoded = (ListMultipartUploadsResponse) INTERCEPTOR.modifyResponse(ctx, new ExecutionAttributes());
+
+        assertDecoded(decoded::delimiter, " delimiter");
+        assertDecoded(decoded::prefix, " prefix");
+        assertDecoded(decoded::keyMarker, " keyMarker");
+        assertDecoded(decoded::nextKeyMarker, " nextKeyMarker");
+        assertCommonPrefixesAreDecoded(decoded.commonPrefixes());
+        assertUploadsAreDecoded(decoded.uploads());
+        assertCommonPrefixesAreDecoded(decoded.commonPrefixes());
     }
 
     @Test
@@ -135,8 +204,20 @@ public class DecodeUrlEncodedResponseInterceptorTest {
         assertThat(fromInterceptor).isEqualTo(original);
     }
 
+    @Test
+    public void otherResponses_shouldNotModifyResponse() {
+        HeadObjectResponse original = HeadObjectResponse.builder().build();
+        Context.ModifyResponse ctx = newContext(original);
+        SdkResponse sdkResponse = INTERCEPTOR.modifyResponse(ctx, new ExecutionAttributes());
+        assertThat(original.hashCode()).isEqualTo(sdkResponse.hashCode());
+    }
+
     private void assertKeysAreDecoded(List<S3Object> objects) {
         objects.forEach(o -> assertDecoded(o::key));
+    }
+
+    private void assertCommonPrefixesAreDecoded(List<CommonPrefix> commonPrefixes) {
+        commonPrefixes.forEach(c -> assertDecoded(c::prefix, " prefix"));
     }
 
     private void assertDecoded(Supplier<String> supplier) {
@@ -146,6 +227,15 @@ public class DecodeUrlEncodedResponseInterceptorTest {
     private void assertDecoded(Supplier<String> supplier, String suffix) {
         assertThat(supplier.get()).isEqualTo(TEST_URL_DECODED + suffix);
     }
+
+    private void assertVersionsAreDecoded(List<ObjectVersion> versions) {
+        versions.forEach(v -> assertDecoded(v::key, " key"));
+    }
+
+    private void assertUploadsAreDecoded(List<MultipartUpload> uploads) {
+        uploads.forEach(u -> assertDecoded(u::key, " key"));
+    }
+
 
     private static Context.ModifyResponse newContext(SdkResponse response) {
         return new Context.ModifyResponse() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue where fields in `ListObjectVersionsResponse` and `ListMultipartUploadsResponse` are not decoded correctly when encodingType is specified as url. See #1601 


## Testing
Added unit tests and integ tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
