### PR TITLE
PR #728 attempt 2: Fixed buggy netty-reactive-streams test and re-added changes from PR

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,5 +10,7 @@ THIRD PARTY COMPONENTS
 This software includes third party software subject to the following copyrights:
 - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
 - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+- Apache Commons Lang - https://github.com/apache/commons-lang
+- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
 
 The licenses for these third party components are included in LICENSE.txt

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -301,6 +301,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${hamcrest.version}</version>

--- a/build-tools/src/main/resources/software/amazon/awssdk/spotbugs-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/spotbugs-suppressions.xml
@@ -150,4 +150,13 @@
         <Method name="createKeyStore"/>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
     </Match>
+
+    <!-- If we're not sure about the RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT, skip the warning. -->
+    <Match>
+        <Package name="~software.amazon.awssdk.http.nio.netty.*"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+        <Not>
+            <Confidence value="1"/>
+        </Not>
+    </Match>
 </FindBugsFilter>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -61,15 +61,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <configuration>
-                        <ignoredUnusedDeclaredDependencies>
-                            <ignoredUnusedDeclaredDependency>software.amazon.awssdk:aws-sdk-java</ignoredUnusedDeclaredDependency>
-                        </ignoredUnusedDeclaredDependencies>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.1.0</version>

--- a/http-clients/netty-nio-client/pom.xml
+++ b/http-clients/netty-nio-client/pom.xml
@@ -119,6 +119,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/Http2Configuration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/Http2Configuration.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.http.nio.netty;
 
 import java.time.Duration;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPool.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.http.nio.netty.internal;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.IN_USE;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ChannelUtils.removeIfExists;
 
-import com.typesafe.netty.http.HttpStreamsClientHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.pool.ChannelPool;
@@ -28,6 +27,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.nio.netty.internal.http2.FlushOnReadHandler;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler;
 
 /**
  * Removes any per request {@link ChannelHandler} from the pipeline prior to releasing

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -23,8 +23,6 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
 
-import com.typesafe.netty.http.HttpStreamsClientHandler;
-import com.typesafe.netty.http.StreamedHttpRequest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -65,6 +63,8 @@ import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.nio.netty.internal.http2.FlushOnReadHandler;
 import software.amazon.awssdk.http.nio.netty.internal.http2.Http2ToHttpInboundAdapter;
 import software.amazon.awssdk.http.nio.netty.internal.http2.HttpToHttp2OutboundAdapter;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.StreamedHttpRequest;
 import software.amazon.awssdk.http.nio.netty.internal.utils.ChannelUtils;
 
 @SdkInternalApi

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -25,8 +25,6 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatchFinally;
 
-import com.typesafe.netty.http.HttpStreamsClientHandler;
-import com.typesafe.netty.http.StreamedHttpResponse;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -60,6 +58,8 @@ import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 import software.amazon.awssdk.http.nio.netty.internal.http2.Http2ResetSendingSubscription;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.StreamedHttpResponse;
 import software.amazon.awssdk.utils.FunctionalUtils.UnsafeRunnable;
 import software.amazon.awssdk.utils.async.DelegatingSubscription;
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/CancelledSubscriber.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/CancelledSubscriber.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * A cancelled subscriber.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public final class CancelledSubscriber<T> implements Subscriber<T> {
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (subscription == null) {
+            throw new NullPointerException("Null subscription");
+        } else {
+            subscription.cancel();
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        if (error == null) {
+            throw new NullPointerException("Null error published");
+        }
+    }
+
+    @Override
+    public void onComplete() {
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DefaultStreamedHttpRequest.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DefaultStreamedHttpRequest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import java.util.Objects;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * A default streamed HTTP request.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public class DefaultStreamedHttpRequest extends DefaultHttpRequest implements StreamedHttpRequest {
+
+    private final Publisher<HttpContent> stream;
+
+    public DefaultStreamedHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, Publisher<HttpContent> stream) {
+        super(httpVersion, method, uri);
+        this.stream = stream;
+    }
+
+    public DefaultStreamedHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders,
+                                      Publisher<HttpContent> stream) {
+        super(httpVersion, method, uri, validateHeaders);
+        this.stream = stream;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpContent> subscriber) {
+        stream.subscribe(subscriber);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DefaultStreamedHttpRequest that = (DefaultStreamedHttpRequest) o;
+
+        return Objects.equals(stream, that.stream);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (stream != null ? stream.hashCode() : 0);
+        return result;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DefaultStreamedHttpResponse.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DefaultStreamedHttpResponse.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import java.util.Objects;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * A default streamed HTTP response.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public class DefaultStreamedHttpResponse extends DefaultHttpResponse implements StreamedHttpResponse {
+
+    private final Publisher<HttpContent> stream;
+
+    public DefaultStreamedHttpResponse(HttpVersion version, HttpResponseStatus status, Publisher<HttpContent> stream) {
+        super(version, status);
+        this.stream = stream;
+    }
+
+    public DefaultStreamedHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
+                                       Publisher<HttpContent> stream) {
+        super(version, status, validateHeaders);
+        this.stream = stream;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpContent> subscriber) {
+        stream.subscribe(subscriber);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DefaultStreamedHttpResponse that = (DefaultStreamedHttpResponse) o;
+
+        return Objects.equals(stream, that.stream);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (stream != null ? stream.hashCode() : 0);
+        return result;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateHttpMessage.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateHttpMessage.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpVersion;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+class DelegateHttpMessage implements HttpMessage {
+    protected final HttpMessage message;
+
+    DelegateHttpMessage(HttpMessage message) {
+        this.message = message;
+    }
+
+    @Override
+    @Deprecated
+    public HttpVersion getProtocolVersion() {
+        return message.protocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return message.protocolVersion();
+    }
+
+    @Override
+    public HttpMessage setProtocolVersion(HttpVersion version) {
+        message.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return message.headers();
+    }
+
+    @Override
+    @Deprecated
+    public DecoderResult getDecoderResult() {
+        return message.decoderResult();
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return message.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        message.setDecoderResult(result);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName() + "(" + message.toString() + ")";
+    }
+
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateHttpRequest.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateHttpRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+class DelegateHttpRequest extends DelegateHttpMessage implements HttpRequest {
+
+    protected final HttpRequest request;
+
+    DelegateHttpRequest(HttpRequest request) {
+        super(request);
+        this.request = request;
+    }
+
+    @Override
+    public HttpRequest setMethod(HttpMethod method) {
+        request.setMethod(method);
+        return this;
+    }
+
+    @Override
+    public HttpRequest setUri(String uri) {
+        request.setUri(uri);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public HttpMethod getMethod() {
+        return request.method();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return request.method();
+    }
+
+    @Override
+    @Deprecated
+    public String getUri() {
+        return request.uri();
+    }
+
+    @Override
+    public String uri() {
+        return request.uri();
+    }
+
+    @Override
+    public HttpRequest setProtocolVersion(HttpVersion version) {
+        super.setProtocolVersion(version);
+        return this;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateHttpResponse.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateHttpResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+class DelegateHttpResponse extends DelegateHttpMessage implements HttpResponse {
+
+    protected final HttpResponse response;
+
+    DelegateHttpResponse(HttpResponse response) {
+        super(response);
+        this.response = response;
+    }
+
+    @Override
+    public HttpResponse setStatus(HttpResponseStatus status) {
+        response.setStatus(status);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public HttpResponseStatus getStatus() {
+        return response.status();
+    }
+
+    @Override
+    public HttpResponseStatus status() {
+        return response.status();
+    }
+
+    @Override
+    public HttpResponse setProtocolVersion(HttpVersion version) {
+        super.setProtocolVersion(version);
+        return this;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateStreamedHttpRequest.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateStreamedHttpRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpRequest;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+final class DelegateStreamedHttpRequest extends DelegateHttpRequest implements StreamedHttpRequest {
+
+    private final Publisher<HttpContent> stream;
+
+    DelegateStreamedHttpRequest(HttpRequest request, Publisher<HttpContent> stream) {
+        super(request);
+        this.stream = stream;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpContent> subscriber) {
+        stream.subscribe(subscriber);
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateStreamedHttpResponse.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/DelegateStreamedHttpResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpResponse;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+final class DelegateStreamedHttpResponse extends DelegateHttpResponse implements StreamedHttpResponse {
+
+    private final Publisher<HttpContent> stream;
+
+    DelegateStreamedHttpResponse(HttpResponse response, Publisher<HttpContent> stream) {
+        super(response);
+        this.stream = stream;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpContent> subscriber) {
+        stream.subscribe(subscriber);
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/EmptyHttpRequest.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/EmptyHttpRequest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+class EmptyHttpRequest extends DelegateHttpRequest implements FullHttpRequest {
+
+    EmptyHttpRequest(HttpRequest request) {
+        super(request);
+    }
+
+    @Override
+    public FullHttpRequest setUri(String uri) {
+        super.setUri(uri);
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest setMethod(HttpMethod method) {
+        super.setMethod(method);
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest setProtocolVersion(HttpVersion version) {
+        super.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest copy() {
+        if (request instanceof FullHttpRequest) {
+            return new EmptyHttpRequest(((FullHttpRequest) request).copy());
+        } else {
+            DefaultHttpRequest copy = new DefaultHttpRequest(protocolVersion(), method(), uri());
+            copy.headers().set(headers());
+            return new EmptyHttpRequest(copy);
+        }
+    }
+
+    @Override
+    public FullHttpRequest retain(int increment) {
+        ReferenceCountUtil.retain(message, increment);
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest retain() {
+        ReferenceCountUtil.retain(message);
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch() {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).touch();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpRequest touch(Object o) {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).touch(o);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return new DefaultHttpHeaders();
+    }
+
+    @Override
+    public FullHttpRequest duplicate() {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).duplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpRequest retainedDuplicate() {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).retainedDuplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpRequest replace(ByteBuf byteBuf) {
+        if (message instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).replace(byteBuf);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public ByteBuf content() {
+        return Unpooled.EMPTY_BUFFER;
+    }
+
+    @Override
+    public int refCnt() {
+        if (message instanceof ReferenceCounted) {
+            return ((ReferenceCounted) message).refCnt();
+        } else {
+            return 1;
+        }
+    }
+
+    @Override
+    public boolean release() {
+        return ReferenceCountUtil.release(message);
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return ReferenceCountUtil.release(message, decrement);
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/EmptyHttpResponse.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/EmptyHttpResponse.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+class EmptyHttpResponse extends DelegateHttpResponse implements FullHttpResponse {
+
+    EmptyHttpResponse(HttpResponse response) {
+        super(response);
+    }
+
+    @Override
+    public FullHttpResponse setStatus(HttpResponseStatus status) {
+        super.setStatus(status);
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse setProtocolVersion(HttpVersion version) {
+        super.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse copy() {
+        if (response instanceof FullHttpResponse) {
+            return new EmptyHttpResponse(((FullHttpResponse) response).copy());
+        } else {
+            DefaultHttpResponse copy = new DefaultHttpResponse(protocolVersion(), status());
+            copy.headers().set(headers());
+            return new EmptyHttpResponse(copy);
+        }
+    }
+
+    @Override
+    public FullHttpResponse retain(int increment) {
+        ReferenceCountUtil.retain(message, increment);
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse retain() {
+        ReferenceCountUtil.retain(message);
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse touch() {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).touch();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpResponse touch(Object o) {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).touch(o);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return new DefaultHttpHeaders();
+    }
+
+    @Override
+    public FullHttpResponse duplicate() {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).duplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpResponse retainedDuplicate() {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).retainedDuplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpResponse replace(ByteBuf byteBuf) {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).replace(byteBuf);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public ByteBuf content() {
+        return Unpooled.EMPTY_BUFFER;
+    }
+
+    @Override
+    public int refCnt() {
+        if (message instanceof ReferenceCounted) {
+            return ((ReferenceCounted) message).refCnt();
+        } else {
+            return 1;
+        }
+    }
+
+    @Override
+    public boolean release() {
+        return ReferenceCountUtil.release(message);
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return ReferenceCountUtil.release(message, decrement);
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisher.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisher.java
@@ -1,0 +1,510 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.TypeParameterMatcher;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Publisher for a Netty Handler.
+ *
+ * This publisher supports only one subscriber.
+ *
+ * All interactions with the subscriber are done from the handlers executor, hence, they provide the same happens before
+ * semantics that Netty provides.
+ *
+ * The handler publishes all messages that match the type as specified by the passed in class. Any non matching messages
+ * are forwarded to the next handler.
+ *
+ * The publisher will signal complete if it receives a channel inactive event.
+ *
+ * The publisher will release any messages that it drops (for example, messages that are buffered when the subscriber
+ * cancels), but other than that, it does not release any messages.  It is up to the subscriber to release messages.
+ *
+ * If the subscriber cancels, the publisher will send a close event up the channel pipeline.
+ *
+ * All errors will short circuit the buffer, and cause publisher to immediately call the subscribers onError method,
+ * dropping the buffer.
+ *
+ * The publisher can be subscribed to or placed in a handler chain in any order.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ */
+@SdkInternalApi
+public class HandlerPublisher<T> extends ChannelDuplexHandler implements Publisher<T> {
+    /**
+     * Used for buffering a completion signal.
+     */
+    private static final Object COMPLETE = new Object() {
+        @Override
+        public String toString() {
+            return "COMPLETE";
+        }
+    };
+
+    private final EventExecutor executor;
+    private final TypeParameterMatcher matcher;
+
+    private final Queue<Object> buffer = new LinkedList<>();
+
+    /**
+     * Whether a subscriber has been provided. This is used to detect whether two subscribers are subscribing
+     * simultaneously.
+     */
+    private final AtomicBoolean hasSubscriber = new AtomicBoolean();
+
+    private State state = HandlerPublisher.State.NO_SUBSCRIBER_OR_CONTEXT;
+
+    private volatile Subscriber<? super T> subscriber;
+    private ChannelHandlerContext ctx;
+    private long outstandingDemand = 0;
+    private Throwable noSubscriberError;
+
+    /**
+     * Create a handler publisher.
+     *
+     * The supplied executor must be the same event loop as the event loop that this handler is eventually registered
+     * with, if not, an exception will be thrown when the handler is registered.
+     *
+     * @param executor The executor to execute asynchronous events from the subscriber on.
+     * @param subscriberMessageType The type of message this publisher accepts.
+     */
+    public HandlerPublisher(EventExecutor executor, Class<? extends T> subscriberMessageType) {
+        this.executor = executor;
+        this.matcher = TypeParameterMatcher.get(subscriberMessageType);
+    }
+
+    /**
+     * Returns {@code true} if the given message should be handled. If {@code false} it will be passed to the next
+     * {@link ChannelInboundHandler} in the {@link ChannelPipeline}.
+     *
+     * @param msg The message to check.
+     * @return True if the message should be accepted.
+     */
+    protected boolean acceptInboundMessage(Object msg) throws Exception {
+        return matcher.match(msg);
+    }
+
+    /**
+     * Override to handle when a subscriber cancels the subscription.
+     *
+     * By default, this method will simply close the channel.
+     */
+    protected void cancelled() {
+        ctx.close();
+    }
+
+    /**
+     * Override to intercept when demand is requested.
+     *
+     * By default, a channel read is invoked.
+     */
+    protected void requestDemand() {
+        ctx.read();
+    }
+
+    enum State {
+        /**
+         * Initial state. There's no subscriber, and no context.
+         */
+        NO_SUBSCRIBER_OR_CONTEXT,
+
+        /**
+         * A subscriber has been provided, but no context has been provided.
+         */
+        NO_CONTEXT,
+
+        /**
+         * A context has been provided, but no subscriber has been provided.
+         */
+        NO_SUBSCRIBER,
+
+        /**
+         * An error has been received, but there's no subscriber to receive it.
+         */
+        NO_SUBSCRIBER_ERROR,
+
+        /**
+         * There is no demand, and we have nothing buffered.
+         */
+        IDLE,
+
+        /**
+         * There is no demand, and we're buffering elements.
+         */
+        BUFFERING,
+
+        /**
+         * We have nothing buffered, but there is demand.
+         */
+        DEMANDING,
+
+        /**
+         * The stream is complete, however there are still elements buffered for which no demand has come from the subscriber.
+         */
+        DRAINING,
+
+        /**
+         * We're done, in the terminal state.
+         */
+        DONE
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super T> subscriber) {
+        if (subscriber == null) {
+            throw new NullPointerException("Null subscriber");
+        }
+
+        if (!hasSubscriber.compareAndSet(false, true)) {
+            // Must call onSubscribe first.
+            subscriber.onSubscribe(new Subscription() {
+                @Override
+                public void request(long n) {
+                }
+
+                @Override
+                public void cancel() {
+                }
+            });
+            subscriber.onError(new IllegalStateException("This publisher only supports one subscriber"));
+        } else {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    provideSubscriber(subscriber);
+                }
+            });
+        }
+    }
+
+    private void provideSubscriber(Subscriber<? super T> subscriber) {
+        this.subscriber = subscriber;
+        switch (state) {
+            case NO_SUBSCRIBER_OR_CONTEXT:
+                state = HandlerPublisher.State.NO_CONTEXT;
+                break;
+            case NO_SUBSCRIBER:
+                if (buffer.isEmpty()) {
+                    state = HandlerPublisher.State.IDLE;
+                } else {
+                    state = HandlerPublisher.State.BUFFERING;
+                }
+                subscriber.onSubscribe(new ChannelSubscription());
+                break;
+            case DRAINING:
+                subscriber.onSubscribe(new ChannelSubscription());
+                break;
+            case NO_SUBSCRIBER_ERROR:
+                cleanup();
+                state = HandlerPublisher.State.DONE;
+                subscriber.onSubscribe(new ChannelSubscription());
+                subscriber.onError(noSubscriberError);
+                break;
+            default:
+                // Do nothing
+        }
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        // If the channel is not yet registered, then it's not safe to invoke any methods on it, eg read() or close()
+        // So don't provide the context until it is registered.
+        if (ctx.channel().isRegistered()) {
+            provideChannelContext(ctx);
+        }
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        provideChannelContext(ctx);
+        ctx.fireChannelRegistered();
+    }
+
+    private void provideChannelContext(ChannelHandlerContext ctx) {
+        switch (state) {
+            case NO_SUBSCRIBER_OR_CONTEXT:
+                verifyRegisteredWithRightExecutor(ctx);
+                this.ctx = ctx;
+                // It's set, we don't have a subscriber
+                state = HandlerPublisher.State.NO_SUBSCRIBER;
+                break;
+            case NO_CONTEXT:
+                verifyRegisteredWithRightExecutor(ctx);
+                this.ctx = ctx;
+                state = HandlerPublisher.State.IDLE;
+                subscriber.onSubscribe(new ChannelSubscription());
+                break;
+            default:
+                // Ignore, this could be invoked twice by both handlerAdded and channelRegistered.
+        }
+    }
+
+    private void verifyRegisteredWithRightExecutor(ChannelHandlerContext ctx) {
+        if (!executor.inEventLoop()) {
+            throw new IllegalArgumentException("Channel handler MUST be registered with the same EventExecutor that it is "
+                                               + "created with.");
+        }
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        // If we subscribed before the channel was active, then our read would have been ignored.
+        if (state == HandlerPublisher.State.DEMANDING) {
+            requestDemand();
+        }
+        ctx.fireChannelActive();
+    }
+
+    private void receivedDemand(long demand) {
+        switch (state) {
+            case BUFFERING:
+            case DRAINING:
+                if (addDemand(demand)) {
+                    flushBuffer();
+                }
+                break;
+
+            case DEMANDING:
+                addDemand(demand);
+                break;
+
+            case IDLE:
+                if (addDemand(demand)) {
+                    // Important to change state to demanding before doing a read, in case we get a synchronous
+                    // read back.
+                    state = HandlerPublisher.State.DEMANDING;
+                    requestDemand();
+                }
+                break;
+            default:
+
+        }
+    }
+
+    private boolean addDemand(long demand) {
+
+        if (demand <= 0) {
+            illegalDemand();
+            return false;
+        } else {
+            if (outstandingDemand < Long.MAX_VALUE) {
+                outstandingDemand += demand;
+                if (outstandingDemand < 0) {
+                    outstandingDemand = Long.MAX_VALUE;
+                }
+            }
+            return true;
+        }
+    }
+
+    private void illegalDemand() {
+        cleanup();
+        subscriber.onError(new IllegalArgumentException("Request for 0 or negative elements in violation of Section 3.9 "
+                                                        + "of the Reactive Streams specification"));
+        ctx.close();
+        state = HandlerPublisher.State.DONE;
+    }
+
+    private void flushBuffer() {
+        while (!buffer.isEmpty() && (outstandingDemand > 0 || outstandingDemand == Long.MAX_VALUE)) {
+            publishMessage(buffer.remove());
+        }
+        if (buffer.isEmpty()) {
+            if (outstandingDemand > 0) {
+                if (state == HandlerPublisher.State.BUFFERING) {
+                    state = HandlerPublisher.State.DEMANDING;
+                } // otherwise we're draining
+                requestDemand();
+            } else if (state == HandlerPublisher.State.BUFFERING) {
+                state = HandlerPublisher.State.IDLE;
+            }
+        }
+    }
+
+    private void receivedCancel() {
+        switch (state) {
+            case BUFFERING:
+            case DEMANDING:
+            case IDLE:
+                cancelled();
+                state = HandlerPublisher.State.DONE;
+                break;
+            case DRAINING:
+                state = HandlerPublisher.State.DONE;
+                break;
+            default:
+                // ignore
+        }
+        cleanup();
+        subscriber = null;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
+        if (acceptInboundMessage(message)) {
+            switch (state) {
+                case IDLE:
+                    buffer.add(message);
+                    state = HandlerPublisher.State.BUFFERING;
+                    break;
+                case NO_SUBSCRIBER:
+                case BUFFERING:
+                    buffer.add(message);
+                    break;
+                case DEMANDING:
+                    publishMessage(message);
+                    break;
+                case DRAINING:
+                case DONE:
+                    ReferenceCountUtil.release(message);
+                    break;
+                case NO_CONTEXT:
+                case NO_SUBSCRIBER_OR_CONTEXT:
+                    throw new IllegalStateException("Message received before added to the channel context");
+                default:
+                    // Ignore
+            }
+        } else {
+            ctx.fireChannelRead(message);
+        }
+    }
+
+    private void publishMessage(Object message) {
+        if (COMPLETE.equals(message)) {
+            subscriber.onComplete();
+            state = HandlerPublisher.State.DONE;
+        } else {
+            @SuppressWarnings("unchecked")
+            T next = (T) message;
+            subscriber.onNext(next);
+            if (outstandingDemand < Long.MAX_VALUE) {
+                outstandingDemand--;
+                if (outstandingDemand == 0 && state != HandlerPublisher.State.DRAINING) {
+                    if (buffer.isEmpty()) {
+                        state = HandlerPublisher.State.IDLE;
+                    } else {
+                        state = HandlerPublisher.State.BUFFERING;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        if (state == HandlerPublisher.State.DEMANDING) {
+            requestDemand();
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        complete();
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        complete();
+    }
+
+    private void complete() {
+        switch (state) {
+            case NO_SUBSCRIBER:
+            case BUFFERING:
+                buffer.add(COMPLETE);
+                state = HandlerPublisher.State.DRAINING;
+                break;
+            case DEMANDING:
+            case IDLE:
+                subscriber.onComplete();
+                state = HandlerPublisher.State.DONE;
+                break;
+            case NO_SUBSCRIBER_ERROR:
+                // Ignore, we're already going to complete the stream with an error
+                // when the subscriber subscribes.
+                break;
+            default:
+                // Ignore
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        switch (state) {
+            case NO_SUBSCRIBER:
+                noSubscriberError = cause;
+                state = HandlerPublisher.State.NO_SUBSCRIBER_ERROR;
+                cleanup();
+                break;
+            case BUFFERING:
+            case DEMANDING:
+            case IDLE:
+            case DRAINING:
+                state = HandlerPublisher.State.DONE;
+                cleanup();
+                subscriber.onError(cause);
+                break;
+            default:
+                // Ignore
+        }
+    }
+
+    /**
+     * Release all elements from the buffer.
+     */
+    private void cleanup() {
+        while (!buffer.isEmpty()) {
+            ReferenceCountUtil.release(buffer.remove());
+        }
+    }
+
+    private class ChannelSubscription implements Subscription {
+        @Override
+        public void request(final long demand) {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    receivedDemand(demand);
+                }
+            });
+        }
+
+        @Override
+        public void cancel() {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    receivedCancel();
+                }
+            });
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriber.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriber.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.EventExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.nio.netty.internal.utils.OrderedWriteChannelHandlerContext;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Subscriber that publishes received messages to the handler pipeline.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public class HandlerSubscriber<T> extends ChannelDuplexHandler implements Subscriber<T> {
+    static final long DEFAULT_LOW_WATERMARK = 4;
+    static final long DEFAULT_HIGH_WATERMARK = 16;
+
+    private final EventExecutor executor;
+    private final long demandLowWatermark;
+    private final long demandHighWatermark;
+
+    private final AtomicBoolean hasSubscription = new AtomicBoolean();
+
+    private volatile Subscription subscription;
+    private volatile ChannelHandlerContext ctx;
+
+    private State state = HandlerSubscriber.State.NO_SUBSCRIPTION_OR_CONTEXT;
+    private long outstandingDemand = 0;
+    private ChannelFuture lastWriteFuture;
+
+    /**
+     * Create a new handler subscriber.
+     *
+     * The supplied executor must be the same event loop as the event loop that this handler is eventually registered
+     * with, if not, an exception will be thrown when the handler is registered.
+     *
+     * @param executor The executor to execute asynchronous events from the publisher on.
+     * @param demandLowWatermark  The low watermark for demand. When demand drops below this, more will be requested.
+     * @param demandHighWatermark The high watermark for demand. This is the maximum that will be requested.
+     */
+    public HandlerSubscriber(EventExecutor executor, long demandLowWatermark, long demandHighWatermark) {
+        this.executor = executor;
+        this.demandLowWatermark = demandLowWatermark;
+        this.demandHighWatermark = demandHighWatermark;
+    }
+
+    /**
+     * Create a new handler subscriber with the default low and high watermarks.
+     *
+     * The supplied executor must be the same event loop as the event loop that this handler is eventually registered
+     * with, if not, an exception will be thrown when the handler is registered.
+     *
+     * @param executor The executor to execute asynchronous events from the publisher on.
+     * @see #HandlerSubscriber(EventExecutor, long, long)
+     */
+    public HandlerSubscriber(EventExecutor executor) {
+        this(executor, DEFAULT_LOW_WATERMARK, DEFAULT_HIGH_WATERMARK);
+    }
+
+    /**
+     * Override for custom error handling. By default, it closes the channel.
+     *
+     * @param error The error to handle.
+     */
+    protected void error(Throwable error) {
+        doClose();
+    }
+
+    /**
+     * Override for custom completion handling. By default, it closes the channel.
+     */
+    protected void complete() {
+        doClose();
+    }
+
+    enum State {
+        NO_SUBSCRIPTION_OR_CONTEXT,
+        NO_SUBSCRIPTION,
+        NO_CONTEXT,
+        INACTIVE,
+        RUNNING,
+        CANCELLED,
+        COMPLETE
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        verifyRegisteredWithRightExecutor(ctx);
+
+        // Ensure that writes to the context happen consecutively, even if they're performed from within the event loop.
+        // See https://github.com/netty/netty/issues/7783
+        ctx = OrderedWriteChannelHandlerContext.wrap(ctx);
+
+        switch (state) {
+            case NO_SUBSCRIPTION_OR_CONTEXT:
+                this.ctx = ctx;
+                // We were in no subscription or context, now we just don't have a subscription.
+                state = HandlerSubscriber.State.NO_SUBSCRIPTION;
+                break;
+            case NO_CONTEXT:
+                this.ctx = ctx;
+                // We were in no context, we're now fully initialised
+                maybeStart();
+                break;
+            case COMPLETE:
+                // We are complete, close
+                state = HandlerSubscriber.State.COMPLETE;
+                ctx.close();
+                break;
+            default:
+                throw new IllegalStateException("This handler must only be added to a pipeline once " + state);
+        }
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        verifyRegisteredWithRightExecutor(ctx);
+        ctx.fireChannelRegistered();
+    }
+
+    private void verifyRegisteredWithRightExecutor(ChannelHandlerContext ctx) {
+        if (ctx.channel().isRegistered() && !executor.inEventLoop()) {
+            throw new IllegalArgumentException("Channel handler MUST be registered with the same EventExecutor that "
+                                               + "it is created with.");
+        }
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+        maybeRequestMore();
+        ctx.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        if (state == HandlerSubscriber.State.INACTIVE) {
+            state = HandlerSubscriber.State.RUNNING;
+            maybeRequestMore();
+        }
+        ctx.fireChannelActive();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        cancel();
+        ctx.fireChannelInactive();
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        cancel();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        cancel();
+        ctx.fireExceptionCaught(cause);
+    }
+
+    private void cancel() {
+        switch (state) {
+            case NO_SUBSCRIPTION:
+                state = HandlerSubscriber.State.CANCELLED;
+                break;
+            case RUNNING:
+            case INACTIVE:
+                subscription.cancel();
+                state = HandlerSubscriber.State.CANCELLED;
+                break;
+            default:
+                // ignore
+        }
+    }
+
+    @Override
+    public void onSubscribe(final Subscription subscription) {
+        if (subscription == null) {
+            throw new NullPointerException("Null subscription");
+        } else if (!hasSubscription.compareAndSet(false, true)) {
+            subscription.cancel();
+        } else {
+            this.subscription = subscription;
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    provideSubscription();
+                }
+            });
+        }
+    }
+
+    private void provideSubscription() {
+        switch (state) {
+            case NO_SUBSCRIPTION_OR_CONTEXT:
+                state = HandlerSubscriber.State.NO_CONTEXT;
+                break;
+            case NO_SUBSCRIPTION:
+                maybeStart();
+                break;
+            case CANCELLED:
+                subscription.cancel();
+                break;
+            default:
+                // ignore
+        }
+    }
+
+    private void maybeStart() {
+        if (ctx.channel().isActive()) {
+            state = HandlerSubscriber.State.RUNNING;
+            maybeRequestMore();
+        } else {
+            state = HandlerSubscriber.State.INACTIVE;
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        // Publish straight to the context.
+        Validate.notNull(t, "Event must not be null.");
+        lastWriteFuture = ctx.writeAndFlush(t);
+        lastWriteFuture.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                outstandingDemand--;
+                maybeRequestMore();
+            }
+        });
+    }
+
+    @Override
+    public void onError(final Throwable error) {
+        if (error == null) {
+            throw new NullPointerException("Null error published");
+        }
+        error(error);
+    }
+
+    @Override
+    public void onComplete() {
+        if (lastWriteFuture == null) {
+            complete();
+        } else {
+            lastWriteFuture.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture channelFuture) throws Exception {
+                    complete();
+                }
+            });
+        }
+    }
+
+    private void doClose() {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                switch (state) {
+                    case NO_SUBSCRIPTION:
+                    case INACTIVE:
+                    case RUNNING:
+                        ctx.close();
+                        state = HandlerSubscriber.State.COMPLETE;
+                        break;
+                    default:
+                        // ignore
+                }
+            }
+        });
+    }
+
+    private void maybeRequestMore() {
+        if (outstandingDemand <= demandLowWatermark && ctx.channel().isWritable()) {
+            long toRequest = demandHighWatermark - outstandingDemand;
+
+            outstandingDemand = demandHighWatermark;
+            subscription.request(toRequest);
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HttpStreamsClientHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HttpStreamsClientHandler.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Handler that converts written {@link StreamedHttpRequest} messages into {@link HttpRequest} messages
+ * followed by {@link HttpContent} messages and reads {@link HttpResponse} messages followed by
+ * {@link HttpContent} messages and produces {@link StreamedHttpResponse} messages.
+ *
+ * This allows request and response bodies to be handled using reactive streams.
+ *
+ * There are two types of messages that this handler accepts for writing, {@link StreamedHttpRequest} and
+ * {@link FullHttpRequest}. Writing any other messages may potentially lead to HTTP message mangling.
+ *
+ * There are two types of messages that this handler will send down the chain, {@link StreamedHttpResponse},
+ * and {@link FullHttpResponse}. If {@link io.netty.channel.ChannelOption#AUTO_READ} is false for the channel,
+ * then any {@link StreamedHttpResponse} messages <em>must</em> be subscribed to consume the body, otherwise
+ * it's possible that no read will be done of the messages.
+ *
+ * As long as messages are returned in the order that they arrive, this handler implicitly supports HTTP
+ * pipelining.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public class HttpStreamsClientHandler extends HttpStreamsHandler<HttpResponse, HttpRequest> {
+
+    private int inFlight = 0;
+    private int withServer = 0;
+    private ChannelPromise closeOnZeroInFlight = null;
+    private Subscriber<HttpContent> awaiting100Continue;
+    private StreamedHttpMessage awaiting100ContinueMessage;
+    private boolean ignoreResponseBody = false;
+
+    public HttpStreamsClientHandler() {
+        super(HttpResponse.class, HttpRequest.class);
+    }
+
+    @Override
+    protected boolean hasBody(HttpResponse response) {
+        if (response.status().code() >= 100 && response.status().code() < 200) {
+            return false;
+        }
+
+        if (response.status().equals(HttpResponseStatus.NO_CONTENT) ||
+            response.status().equals(HttpResponseStatus.NOT_MODIFIED)) {
+            return false;
+        }
+
+        if (HttpUtil.isTransferEncodingChunked(response)) {
+            return true;
+        }
+
+
+        if (HttpUtil.isContentLengthSet(response)) {
+            return HttpUtil.getContentLength(response) > 0;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise future) throws Exception {
+        if (inFlight == 0) {
+            ctx.close(future);
+        } else {
+            closeOnZeroInFlight = future;
+        }
+    }
+
+    @Override
+    protected void consumedInMessage(ChannelHandlerContext ctx) {
+        inFlight--;
+        withServer--;
+        if (inFlight == 0 && closeOnZeroInFlight != null) {
+            ctx.close(closeOnZeroInFlight);
+        }
+    }
+
+    @Override
+    protected void receivedOutMessage(ChannelHandlerContext ctx) {
+        inFlight++;
+    }
+
+    @Override
+    protected void sentOutMessage(ChannelHandlerContext ctx) {
+        withServer++;
+    }
+
+    @Override
+    protected HttpResponse createEmptyMessage(HttpResponse response) {
+        return new EmptyHttpResponse(response);
+    }
+
+    @Override
+    protected HttpResponse createStreamedMessage(HttpResponse response, Publisher<HttpContent> stream) {
+        return new DelegateStreamedHttpResponse(response, stream);
+    }
+
+    @Override
+    protected void subscribeSubscriberToStream(StreamedHttpMessage msg, Subscriber<HttpContent> subscriber) {
+        if (HttpUtil.is100ContinueExpected(msg)) {
+            awaiting100Continue = subscriber;
+            awaiting100ContinueMessage = msg;
+        } else {
+            super.subscribeSubscriberToStream(msg, subscriber);
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+
+        if (msg instanceof HttpResponse && awaiting100Continue != null && withServer == 0) {
+            HttpResponse response = (HttpResponse) msg;
+            if (response.status().equals(HttpResponseStatus.CONTINUE)) {
+                super.subscribeSubscriberToStream(awaiting100ContinueMessage, awaiting100Continue);
+                awaiting100Continue = null;
+                awaiting100ContinueMessage = null;
+                if (msg instanceof FullHttpResponse) {
+                    ReferenceCountUtil.release(msg);
+                } else {
+                    ignoreResponseBody = true;
+                }
+            } else {
+                awaiting100ContinueMessage.subscribe(new CancelledSubscriber<HttpContent>());
+                awaiting100ContinueMessage = null;
+                awaiting100Continue.onSubscribe(new NoOpSubscription());
+                awaiting100Continue.onComplete();
+                awaiting100Continue = null;
+                super.channelRead(ctx, msg);
+            }
+        } else if (ignoreResponseBody && msg instanceof HttpContent) {
+
+            ReferenceCountUtil.release(msg);
+            if (msg instanceof LastHttpContent) {
+                ignoreResponseBody = false;
+            }
+        } else {
+            super.channelRead(ctx, msg);
+        }
+    }
+
+    private static class NoOpSubscription implements Subscription {
+        @Override
+        public void request(long n) {}
+
+        @Override
+        public void cancel() {}
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HttpStreamsHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HttpStreamsHandler.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import java.util.LinkedList;
+import java.util.Queue;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+abstract class HttpStreamsHandler<InT extends HttpMessage, OutT extends HttpMessage> extends ChannelDuplexHandler {
+
+    private final Queue<Outgoing> outgoing = new LinkedList<>();
+    private final Class<InT> inClass;
+    private final Class<OutT> outClass;
+
+    /**
+     * The incoming message that is currently being streamed out to a subscriber.
+     *
+     * This is tracked so that if its subscriber cancels, we can go into a mode where we ignore the rest of the body.
+     * Since subscribers may cancel as many times as they like, including well after they've received all their content,
+     * we need to track what the current message that's being streamed out is so that we can ignore it if it's not
+     * currently being streamed out.
+     */
+    private InT currentlyStreamedMessage;
+
+    /**
+     * Ignore the remaining reads for the incoming message.
+     *
+     * This is used in conjunction with currentlyStreamedMessage, as well as in situations where we have received the
+     * full body, but still might be expecting a last http content message.
+     */
+    private boolean ignoreBodyRead;
+
+    /**
+     * Whether a LastHttpContent message needs to be written once the incoming publisher completes.
+     *
+     * Since the publisher may itself publish a LastHttpContent message, we need to track this fact, because if it
+     * doesn't, then we need to write one ourselves.
+     */
+    private boolean sendLastHttpContent;
+
+    HttpStreamsHandler(Class<InT> inClass, Class<OutT> outClass) {
+        this.inClass = inClass;
+        this.outClass = outClass;
+    }
+
+    /**
+     * Whether the given incoming message has a body.
+     */
+    protected abstract boolean hasBody(InT in);
+
+    /**
+     * Create an empty incoming message. This must be of type FullHttpMessage, and is invoked when we've determined
+     * that an incoming message can't have a body, so we send it on as a FullHttpMessage.
+     */
+    protected abstract InT createEmptyMessage(InT in);
+
+    /**
+     * Create a streamed incoming message with the given stream.
+     */
+    protected abstract InT createStreamedMessage(InT in, Publisher<HttpContent> stream);
+
+    /**
+     * Invoked when an incoming message is first received.
+     *
+     * Overridden by sub classes for state tracking.
+     */
+    protected void receivedInMessage(ChannelHandlerContext ctx) {}
+
+    /**
+     * Invoked when an incoming message is fully consumed.
+     *
+     * Overridden by sub classes for state tracking.
+     */
+    protected void consumedInMessage(ChannelHandlerContext ctx) {}
+
+    /**
+     * Invoked when an outgoing message is first received.
+     *
+     * Overridden by sub classes for state tracking.
+     */
+    protected void receivedOutMessage(ChannelHandlerContext ctx) {}
+
+    /**
+     * Invoked when an outgoing message is fully sent.
+     *
+     * Overridden by sub classes for state tracking.
+     */
+    protected void sentOutMessage(ChannelHandlerContext ctx) {}
+
+    /**
+     * Subscribe the given subscriber to the given streamed message.
+     *
+     * Provided so that the client subclass can intercept this to hold off sending the body of an expect 100 continue
+     * request.
+     */
+    protected void subscribeSubscriberToStream(StreamedHttpMessage msg, Subscriber<HttpContent> subscriber) {
+        msg.subscribe(subscriber);
+    }
+
+    /**
+     * Invoked every time a read of the incoming body is requested by the subscriber.
+     *
+     * Provided so that the server subclass can intercept this to send a 100 continue response.
+     */
+    protected void bodyRequested(ChannelHandlerContext ctx) {}
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, Object msg) throws Exception {
+
+        if (inClass.isInstance(msg)) {
+
+            receivedInMessage(ctx);
+            InT inMsg = inClass.cast(msg);
+
+            if (inMsg instanceof FullHttpMessage) {
+
+                // Forward as is
+                ctx.fireChannelRead(inMsg);
+                consumedInMessage(ctx);
+
+            } else if (!hasBody(inMsg)) {
+
+                // Wrap in empty message
+                ctx.fireChannelRead(createEmptyMessage(inMsg));
+                consumedInMessage(ctx);
+
+                // There will be a LastHttpContent message coming after this, ignore it
+                ignoreBodyRead = true;
+
+            } else {
+
+                currentlyStreamedMessage = inMsg;
+                // It has a body, stream it
+                HandlerPublisher<HttpContent> publisher = new HandlerPublisher<HttpContent>(ctx.executor(), HttpContent.class) {
+                    @Override
+                    protected void cancelled() {
+                        if (ctx.executor().inEventLoop()) {
+                            handleCancelled(ctx, inMsg);
+                        } else {
+                            ctx.executor().execute(new Runnable() {
+                                @Override
+                                public void run() {
+                                    handleCancelled(ctx, inMsg);
+                                }
+                            });
+                        }
+                    }
+
+                    @Override
+                    protected void requestDemand() {
+                        bodyRequested(ctx);
+                        super.requestDemand();
+                    }
+                };
+
+                ctx.channel().pipeline().addAfter(ctx.name(), ctx.name() + "-body-publisher", publisher);
+                ctx.fireChannelRead(createStreamedMessage(inMsg, publisher));
+            }
+        } else if (msg instanceof HttpContent) {
+            handleReadHttpContent(ctx, (HttpContent) msg);
+        }
+    }
+
+    private void handleCancelled(ChannelHandlerContext ctx, InT msg) {
+        if (currentlyStreamedMessage == msg) {
+            ignoreBodyRead = true;
+            // Need to do a read in case the subscriber ignored a read completed.
+            ctx.read();
+        }
+    }
+
+    private void handleReadHttpContent(ChannelHandlerContext ctx, HttpContent content) {
+        if (!ignoreBodyRead) {
+            if (content instanceof LastHttpContent) {
+
+                if (content.content().readableBytes() > 0 ||
+                        !((LastHttpContent) content).trailingHeaders().isEmpty()) {
+                    // It has data or trailing headers, send them
+                    ctx.fireChannelRead(content);
+                } else {
+                    ReferenceCountUtil.release(content);
+                }
+
+                removeHandlerIfActive(ctx, ctx.name() + "-body-publisher");
+                currentlyStreamedMessage = null;
+                consumedInMessage(ctx);
+
+            } else {
+                ctx.fireChannelRead(content);
+            }
+
+        } else {
+            ReferenceCountUtil.release(content);
+            if (content instanceof LastHttpContent) {
+                ignoreBodyRead = false;
+                if (currentlyStreamedMessage != null) {
+                    removeHandlerIfActive(ctx, ctx.name() + "-body-publisher");
+                }
+                currentlyStreamedMessage = null;
+            }
+        }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        if (ignoreBodyRead) {
+            ctx.read();
+        } else {
+            ctx.fireChannelReadComplete();
+        }
+    }
+
+    @Override
+    public void write(final ChannelHandlerContext ctx, Object msg, final ChannelPromise promise) throws Exception {
+        if (outClass.isInstance(msg)) {
+
+            Outgoing out = new Outgoing(outClass.cast(msg), promise);
+            receivedOutMessage(ctx);
+
+            if (outgoing.isEmpty()) {
+                outgoing.add(out);
+                flushNext(ctx);
+            } else {
+                outgoing.add(out);
+            }
+
+        } else if (msg instanceof LastHttpContent) {
+
+            sendLastHttpContent = false;
+            ctx.write(msg, promise);
+        } else {
+
+            ctx.write(msg, promise);
+        }
+    }
+
+    protected void unbufferedWrite(final ChannelHandlerContext ctx, final Outgoing out) {
+
+        if (out.message instanceof FullHttpMessage) {
+            // Forward as is
+            ctx.writeAndFlush(out.message, out.promise);
+            out.promise.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture channelFuture) throws Exception {
+                    executeInEventLoop(ctx, new Runnable() {
+                        @Override
+                        public void run() {
+                            sentOutMessage(ctx);
+                            outgoing.remove();
+                            flushNext(ctx);
+                        }
+                    });
+                }
+            });
+
+        } else if (out.message instanceof StreamedHttpMessage) {
+
+            StreamedHttpMessage streamed = (StreamedHttpMessage) out.message;
+            HandlerSubscriber<HttpContent> subscriber = new HandlerSubscriber<HttpContent>(ctx.executor()) {
+                @Override
+                protected void error(Throwable error) {
+                    out.promise.tryFailure(error);
+                    ctx.close();
+                }
+
+                @Override
+                protected void complete() {
+                    executeInEventLoop(ctx, new Runnable() {
+                        @Override
+                        public void run() {
+                            completeBody(ctx);
+                        }
+                    });
+                }
+            };
+
+            sendLastHttpContent = true;
+
+            // DON'T pass the promise through, create a new promise instead.
+            ctx.writeAndFlush(out.message);
+
+            ctx.pipeline().addAfter(ctx.name(), ctx.name() + "-body-subscriber", subscriber);
+            subscribeSubscriberToStream(streamed, subscriber);
+        }
+
+    }
+
+    private void completeBody(final ChannelHandlerContext ctx) {
+        removeHandlerIfActive(ctx, ctx.name() + "-body-subscriber");
+
+        if (sendLastHttpContent) {
+            ChannelPromise promise = outgoing.peek().promise;
+            ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT, promise).addListener(
+                    new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture channelFuture) throws Exception {
+                            executeInEventLoop(ctx, new Runnable() {
+                                @Override
+                                public void run() {
+                                    outgoing.remove();
+                                    sentOutMessage(ctx);
+                                    flushNext(ctx);
+                                }
+                            });
+                        }
+                    }
+            );
+        } else {
+            outgoing.remove().promise.setSuccess();
+            sentOutMessage(ctx);
+            flushNext(ctx);
+        }
+    }
+
+    /**
+     * Most operations we want to do even if the channel is not active, because if it's not, then we want to encounter
+     * the error that occurs when that operation happens and so that it can be passed up to the user. However, removing
+     * handlers should only be done if the channel is active, because the error that is encountered when they aren't
+     * makes no sense to the user (NoSuchElementException).
+     */
+    private void removeHandlerIfActive(ChannelHandlerContext ctx, String name) {
+        if (ctx.channel().isActive()) {
+            ctx.pipeline().remove(name);
+        }
+    }
+
+    private void flushNext(ChannelHandlerContext ctx) {
+        if (!outgoing.isEmpty()) {
+            unbufferedWrite(ctx, outgoing.element());
+        } else {
+            ctx.fireChannelWritabilityChanged();
+        }
+    }
+
+    private void executeInEventLoop(ChannelHandlerContext ctx, Runnable runnable) {
+        if (ctx.executor().inEventLoop()) {
+            runnable.run();
+        } else {
+            ctx.executor().execute(runnable);
+        }
+    }
+
+    class Outgoing {
+        final OutT message;
+        final ChannelPromise promise;
+
+        Outgoing(OutT message, ChannelPromise promise) {
+            this.message = message;
+            this.promise = promise;
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/StreamedHttpMessage.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/StreamedHttpMessage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMessage;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Combines {@link HttpMessage} and {@link Publisher} into one
+ * message. So it represents an http message with a stream of {@link HttpContent}
+ * messages that can be subscribed to.
+ *
+ * Note that receivers of this message <em>must</em> consume the publisher,
+ * since the publisher will exert back pressure up the stream if not consumed.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public interface StreamedHttpMessage extends HttpMessage, Publisher<HttpContent> {
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/StreamedHttpRequest.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/StreamedHttpRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpRequest;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Combines {@link HttpRequest} and {@link StreamedHttpMessage} into one
+ * message. So it represents an http request with a stream of
+ * {@link io.netty.handler.codec.http.HttpContent} messages that can be subscribed to.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public interface StreamedHttpRequest extends HttpRequest, StreamedHttpMessage {
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/StreamedHttpResponse.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/StreamedHttpResponse.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.handler.codec.http.HttpResponse;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Combines {@link HttpResponse} and {@link StreamedHttpMessage} into one
+ * message. So it represents an http response with a stream of
+ * {@link io.netty.handler.codec.http.HttpContent} messages that can be subscribed to.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+@SdkInternalApi
+public interface StreamedHttpResponse extends HttpResponse, StreamedHttpMessage {
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/package-info.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * This package contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+package software.amazon.awssdk.http.nio.netty.internal.nrs;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/DelegatingChannelHandlerContext.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/DelegatingChannelHandlerContext.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.utils;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
+import java.net.SocketAddress;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * An abstract implementation of {@link ChannelHandlerContext} that delegates to another
+ * context for non-overridden methods.
+ */
+@SdkInternalApi
+public abstract class DelegatingChannelHandlerContext implements ChannelHandlerContext {
+    private final ChannelHandlerContext delegate;
+
+    public DelegatingChannelHandlerContext(ChannelHandlerContext delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Channel channel() {
+        return delegate.channel();
+    }
+
+    @Override
+    public EventExecutor executor() {
+        return delegate.executor();
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public ChannelHandler handler() {
+        return delegate.handler();
+    }
+
+    @Override
+    public boolean isRemoved() {
+        return delegate.isRemoved();
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelRegistered() {
+        return delegate.fireChannelRegistered();
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelUnregistered() {
+        return delegate.fireChannelUnregistered();
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelActive() {
+        return delegate.fireChannelActive();
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelInactive() {
+        return delegate.fireChannelInactive();
+    }
+
+    @Override
+    public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+        return delegate.fireExceptionCaught(cause);
+    }
+
+    @Override
+    public ChannelHandlerContext fireUserEventTriggered(Object evt) {
+        return delegate.fireUserEventTriggered(evt);
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelRead(Object msg) {
+        return delegate.fireChannelRead(msg);
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelReadComplete() {
+        return delegate.fireChannelReadComplete();
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelWritabilityChanged() {
+        return delegate.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress) {
+        return delegate.bind(localAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress) {
+        return delegate.connect(remoteAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return delegate.connect(remoteAddress, localAddress);
+    }
+
+    @Override
+    public ChannelFuture disconnect() {
+        return delegate.disconnect();
+    }
+
+    @Override
+    public ChannelFuture close() {
+        return delegate.close();
+    }
+
+    @Override
+    public ChannelFuture deregister() {
+        return delegate.deregister();
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.bind(localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        return delegate.connect(remoteAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture disconnect(ChannelPromise promise) {
+        return delegate.disconnect(promise);
+    }
+
+    @Override
+    public ChannelFuture close(ChannelPromise promise) {
+        return delegate.close(promise);
+    }
+
+    @Override
+    public ChannelFuture deregister(ChannelPromise promise) {
+        return delegate.deregister(promise);
+    }
+
+    @Override
+    public ChannelHandlerContext read() {
+        return delegate.read();
+    }
+
+    @Override
+    public ChannelFuture write(Object msg) {
+        return delegate.write(msg);
+    }
+
+    @Override
+    public ChannelFuture write(Object msg, ChannelPromise promise) {
+        return delegate.write(msg, promise);
+    }
+
+    @Override
+    public ChannelHandlerContext flush() {
+        return delegate.flush();
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        return delegate.writeAndFlush(msg, promise);
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg) {
+        return delegate.writeAndFlush(msg);
+    }
+
+    @Override
+    public ChannelPromise newPromise() {
+        return delegate.newPromise();
+    }
+
+    @Override
+    public ChannelProgressivePromise newProgressivePromise() {
+        return delegate.newProgressivePromise();
+    }
+
+    @Override
+    public ChannelFuture newSucceededFuture() {
+        return delegate.newSucceededFuture();
+    }
+
+    @Override
+    public ChannelFuture newFailedFuture(Throwable cause) {
+        return delegate.newFailedFuture(cause);
+    }
+
+    @Override
+    public ChannelPromise voidPromise() {
+        return delegate.voidPromise();
+    }
+
+    @Override
+    public ChannelPipeline pipeline() {
+        return delegate.pipeline();
+    }
+
+    @Override
+    public ByteBufAllocator alloc() {
+        return delegate.alloc();
+    }
+
+    @Override
+    public <T> Attribute<T> attr(AttributeKey<T> key) {
+        return delegate.attr(key);
+    }
+
+    @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return delegate.hasAttr(key);
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/OrderedWriteChannelHandlerContext.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/OrderedWriteChannelHandlerContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.utils;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.AttributeKey;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * An implementation of {@link ChannelHandlerContext} that ensures all writes are performed in the order they are invoked.
+ *
+ * This works around https://github.com/netty/netty/issues/7783 where writes by an event loop 'skip ahead' of writes off of the
+ * event loop.
+ */
+@SdkInternalApi
+public class OrderedWriteChannelHandlerContext extends DelegatingChannelHandlerContext {
+    private static final AttributeKey<Void> ORDERED =
+        AttributeKey.newInstance("aws.http.nio.netty.async.OrderedWriteChannelHandlerContext.ORDERED");
+
+    private OrderedWriteChannelHandlerContext(ChannelHandlerContext delegate) {
+        super(delegate);
+        delegate.channel().attr(ORDERED).set(null);
+    }
+
+    public static ChannelHandlerContext wrap(ChannelHandlerContext ctx) {
+        if (ctx.channel().hasAttr(ORDERED)) {
+            return ctx;
+        }
+        return new OrderedWriteChannelHandlerContext(ctx);
+    }
+
+    @Override
+    public ChannelFuture write(Object msg) {
+        return doInOrder(promise -> super.write(msg, promise));
+    }
+
+    @Override
+    public ChannelFuture write(Object msg, ChannelPromise promise) {
+        doInOrder(() -> super.write(msg, promise));
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg) {
+        return doInOrder(promise -> super.writeAndFlush(msg, promise));
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        doInOrder(() -> super.writeAndFlush(msg, promise));
+        return promise;
+    }
+
+    private ChannelFuture doInOrder(Consumer<ChannelPromise> task) {
+        ChannelPromise promise = newPromise();
+        if (!channel().eventLoop().inEventLoop()) {
+            task.accept(promise);
+        } else {
+            // If we're in the event loop, queue a task to perform the write, so that it occurs after writes that were scheduled
+            // off of the event loop.
+            channel().eventLoop().execute(() -> task.accept(promise));
+        }
+        return promise;
+    }
+
+    private void doInOrder(Runnable task) {
+        if (!channel().eventLoop().inEventLoop()) {
+            task.run();
+        } else {
+            // If we're in the event loop, queue a task to perform the write, so that it occurs after writes that were scheduled
+            // off of the event loop.
+            channel().eventLoop().execute(task);
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/HandlerRemovingChannelPoolTest.java
@@ -21,7 +21,7 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
 
-import com.typesafe.netty.http.HttpStreamsClientHandler;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
@@ -25,8 +25,8 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.PROTOCOL_FUTURE;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 
-import com.typesafe.netty.http.DefaultStreamedHttpResponse;
-import com.typesafe.netty.http.StreamedHttpResponse;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.DefaultStreamedHttpResponse;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.StreamedHttpResponse;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.channel.ChannelHandlerContext;

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/ChannelPublisherTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/ChannelPublisherTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.Promise;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class ChannelPublisherTest {
+
+    private EventLoopGroup group;
+    private Channel channel;
+    private Publisher<Channel> publisher;
+    private SubscriberProbe<Channel> subscriber;
+
+    @Before
+    public void start() throws Exception {
+        group = new NioEventLoopGroup();
+        EventLoop eventLoop = group.next();
+
+        HandlerPublisher<Channel> handlerPublisher = new HandlerPublisher<>(eventLoop, Channel.class);
+        Bootstrap bootstrap = new Bootstrap();
+
+        bootstrap
+                .channel(NioServerSocketChannel.class)
+                .group(eventLoop)
+                .option(ChannelOption.AUTO_READ, false)
+                .handler(handlerPublisher)
+                .localAddress("127.0.0.1", 0);
+
+        channel = bootstrap.bind().await().channel();
+        this.publisher = handlerPublisher;
+
+        subscriber = new SubscriberProbe<>();
+    }
+
+    @After
+    public void stop() throws Exception {
+        channel.unsafe().closeForcibly();
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void test() throws Exception {
+        publisher.subscribe(subscriber);
+        Subscription sub = subscriber.takeSubscription();
+
+        // Try one cycle
+        sub.request(1);
+        Socket socket1 = connect();
+        receiveConnection();
+        readWriteData(socket1, 1);
+
+        // Check back pressure
+        Socket socket2 = connect();
+        subscriber.expectNoElements();
+
+        // Now request the next connection
+        sub.request(1);
+        receiveConnection();
+        readWriteData(socket2, 2);
+
+        // Close the channel
+        channel.close();
+        subscriber.expectNoElements();
+        subscriber.expectComplete();
+    }
+
+    private Socket connect() throws Exception {
+        InetSocketAddress address = (InetSocketAddress) channel.localAddress();
+        return new Socket(address.getAddress(), address.getPort());
+    }
+
+    private void readWriteData(Socket socket, int data) throws Exception {
+        OutputStream os = socket.getOutputStream();
+        os.write(data);
+        os.flush();
+        InputStream is = socket.getInputStream();
+        int received = is.read();
+        socket.close();
+        assertEquals(received, data);
+    }
+
+    private void receiveConnection() throws Exception {
+        Channel channel = subscriber.take();
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                ctx.writeAndFlush(msg);
+            }
+        });
+        group.register(channel);
+    }
+
+    private class SubscriberProbe<T> implements Subscriber<T> {
+        final BlockingQueue<Subscription> subscriptions = new LinkedBlockingQueue<>();
+        final BlockingQueue<T> elements = new LinkedBlockingQueue<>();
+        final Promise<Void> promise = new DefaultPromise<>(group.next());
+
+        public void onSubscribe(Subscription s) {
+            subscriptions.add(s);
+        }
+
+        public void onNext(T t) {
+            elements.add(t);
+        }
+
+        public void onError(Throwable t) {
+            promise.setFailure(t);
+        }
+
+        public void onComplete() {
+            promise.setSuccess(null);
+        }
+
+        Subscription takeSubscription() throws Exception {
+            Subscription sub = subscriptions.poll(100, TimeUnit.MILLISECONDS);
+            assertNotNull(sub);
+            return sub;
+        }
+
+        T take() throws Exception {
+            T t = elements.poll(1000, TimeUnit.MILLISECONDS);
+            assertNotNull(t);
+            return t;
+        }
+
+        void expectNoElements() throws Exception {
+            T t = elements.poll(100, TimeUnit.MILLISECONDS);
+            assertNull(t);
+        }
+
+        void expectComplete() throws Exception {
+            promise.get(100, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.local.LocalChannel;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.util.BatchedProducer;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.util.ClosedLoopChannel;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.util.ScheduledBatchedProducer;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class HandlerPublisherVerificationTest extends PublisherVerification<Long> {
+
+    private final int batchSize;
+    // The number of elements to publish initially, before the subscriber is received
+    private final int publishInitial;
+    // Whether we should use scheduled publishing (with a small delay)
+    private final boolean scheduled;
+
+    private ScheduledExecutorService executor;
+    private DefaultEventLoopGroup eventLoop;
+
+    @Factory(dataProvider = "data")
+    public HandlerPublisherVerificationTest(int batchSize, int publishInitial, boolean scheduled) {
+        super(new TestEnvironment(200));
+        this.batchSize = batchSize;
+        this.publishInitial = publishInitial;
+        this.scheduled = scheduled;
+    }
+
+    @DataProvider
+    public static Object[][] data() {
+        final int defaultBatchSize = 3;
+        final int defaultPublishInitial = 3;
+        final boolean defaultScheduled = false;
+
+        return new Object[][] {
+            { defaultBatchSize, defaultPublishInitial, defaultScheduled },
+            { 1, defaultPublishInitial, defaultScheduled },
+            { defaultBatchSize, 0, defaultScheduled },
+            { defaultBatchSize, defaultPublishInitial, true }
+        };
+    }
+
+    // I tried making this before/after class, but encountered a strange error where after 32 publishers were created,
+    // the following tests complained about the executor being shut down when I registered the channel. Though, it
+    // doesn't happen if you create 32 publishers in a single test.
+    @BeforeMethod
+    public void startEventLoop() {
+        eventLoop = new DefaultEventLoopGroup();
+    }
+
+    @AfterMethod
+    public void stopEventLoop() {
+        eventLoop.shutdownGracefully();
+        eventLoop = null;
+    }
+
+    @BeforeClass
+    public void startExecutor() {
+        if (scheduled) {
+            executor = Executors.newSingleThreadScheduledExecutor();
+        }
+    }
+
+    @AfterClass
+    public void stopExecutor() {
+        if (scheduled) {
+            executor.shutdown();
+        }
+    }
+
+    @Override
+    public Publisher<Long> createPublisher(final long elements) {
+        final BatchedProducer out;
+        if (scheduled) {
+            out = new ScheduledBatchedProducer(elements, batchSize, publishInitial, executor, 5);
+        } else {
+            out = new BatchedProducer(elements, batchSize, publishInitial);
+        }
+
+        final ClosedLoopChannel channel = new ClosedLoopChannel();
+        channel.config().setAutoRead(false);
+        ChannelFuture registered = eventLoop.register(channel);
+
+        final HandlerPublisher<Long> publisher = new HandlerPublisher<>(registered.channel().eventLoop(), Long.class);
+
+        registered.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                channel.pipeline().addLast("out", out);
+                channel.pipeline().addLast("publisher", publisher);
+
+                for (long i = 0; i < publishInitial && i < elements; i++) {
+                    channel.pipeline().fireChannelRead(i);
+                }
+                if (elements <= publishInitial) {
+                    channel.pipeline().fireChannelInactive();
+                }
+            }
+        });
+
+        return publisher;
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        LocalChannel channel = new LocalChannel();
+        eventLoop.register(channel);
+        HandlerPublisher<Long> publisher = new HandlerPublisher<>(channel.eventLoop(), Long.class);
+        channel.pipeline().addLast("publisher", publisher);
+        channel.pipeline().fireExceptionCaught(new RuntimeException("failed"));
+
+        return publisher;
+    }
+
+    @Override
+    public void stochastic_spec103_mustSignalOnMethodsSequentially() throws Throwable {
+        try {
+            super.stochastic_spec103_mustSignalOnMethodsSequentially();
+        } catch (Throwable t) {
+            // CI is failing here, but maven doesn't tell us which parameters failed
+            System.out.println("Stochastic test failed with parameters batchSize=" + batchSize +
+                               " publishInitial=" + publishInitial + " scheduled=" + scheduled);
+            throw t;
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
@@ -93,16 +93,12 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
 
     @BeforeClass
     public void startExecutor() {
-        if (scheduled) {
-            executor = Executors.newSingleThreadScheduledExecutor();
-        }
+        executor = Executors.newSingleThreadScheduledExecutor();
     }
 
     @AfterClass
     public void stopExecutor() {
-        if (scheduled) {
-            executor.shutdown();
-        }
+        executor.shutdown();
     }
 
     @Override
@@ -111,7 +107,7 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
         if (scheduled) {
             out = new ScheduledBatchedProducer(elements, batchSize, publishInitial, executor, 5);
         } else {
-            out = new BatchedProducer(elements, batchSize, publishInitial);
+            out = new BatchedProducer(elements, batchSize, publishInitial, executor);
         }
 
         final ClosedLoopChannel channel = new ClosedLoopChannel();

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberBlackboxVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberBlackboxVerificationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberBlackboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class HandlerSubscriberBlackboxVerificationTest extends SubscriberBlackboxVerification<Long> {
+
+    public HandlerSubscriberBlackboxVerificationTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Subscriber<Long> createSubscriber() {
+        // Embedded channel requires at least one handler when it's created, but HandlerSubscriber
+        // needs the channels event loop in order to be created, so start with a dummy, then replace.
+        ChannelHandler dummy = new ChannelDuplexHandler();
+        EmbeddedChannel channel = new EmbeddedChannel(dummy);
+        HandlerSubscriber<Long> subscriber = new HandlerSubscriber<>(channel.eventLoop(), 2, 4);
+        channel.pipeline().replace(dummy, "subscriber", subscriber);
+
+        return new SubscriberWithChannel<>(channel, subscriber);
+    }
+
+    @Override
+    public Long createElement(int element) {
+        return (long) element;
+    }
+
+    @Override
+    public void triggerRequest(Subscriber<? super Long> subscriber) {
+        EmbeddedChannel channel = ((SubscriberWithChannel) subscriber).channel;
+
+        channel.runPendingTasks();
+        while (channel.readOutbound() != null) {
+            channel.runPendingTasks();
+        }
+        channel.runPendingTasks();
+    }
+
+    /**
+     * Delegate subscriber that makes the embedded channel available so we can talk to it to trigger a request.
+     */
+    private static class SubscriberWithChannel<T> implements Subscriber<T> {
+        final EmbeddedChannel channel;
+        final HandlerSubscriber<T> subscriber;
+
+        public SubscriberWithChannel(EmbeddedChannel channel, HandlerSubscriber<T> subscriber) {
+            this.channel = channel;
+            this.subscriber = subscriber;
+        }
+
+        public void onSubscribe(Subscription s) {
+            subscriber.onSubscribe(s);
+        }
+
+        public void onNext(T t) {
+            subscriber.onNext(t);
+        }
+
+        public void onError(Throwable t) {
+            subscriber.onError(t);
+        }
+
+        public void onComplete() {
+            subscriber.onComplete();
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.ObjectUtil;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class HandlerSubscriberTest {
+    private EmbeddedChannel channel;
+    private CustomEmbeddedEventLoop eventLoop;
+    private HandlerSubscriber<HttpContent> handler;
+
+    @Before
+    public void setup() throws Exception {
+        channel = new CustomEmbeddedChannel();
+        eventLoop = new CustomEmbeddedEventLoop();
+        eventLoop.register(channel).syncUninterruptibly();
+
+        handler = new HandlerSubscriber<>(eventLoop);
+        channel.pipeline().addLast(handler);
+    }
+
+    @After
+    public void teardown() {
+        channel.close();
+    }
+
+    /**
+     * Ensures that onNext invocations against the {@link HandlerSubscriber} do not order things based on which thread is calling
+     * onNext.
+     */
+    @Test
+    public void onNextWritesInProperOrderFromAnyThread() {
+        HttpContent front = emptyHttpRequest();
+        HttpContent back = emptyHttpRequest();
+
+        handler.onSubscribe(doNothingSubscription());
+        eventLoop.inEventLoop(false);
+        handler.onNext(front);
+        eventLoop.inEventLoop(true);
+        handler.onNext(back);
+
+        eventLoop.runTasks();
+
+        Queue<Object> outboundMessages = channel.outboundMessages();
+
+        assertThat(outboundMessages).hasSize(2);
+        assertThat(outboundMessages.poll()).isSameAs(front);
+        assertThat(outboundMessages.poll()).isSameAs(back);
+    }
+
+    private DefaultFullHttpRequest emptyHttpRequest() {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://fake.com");
+    }
+
+    private Subscription doNothingSubscription() {
+        return new Subscription() {
+            @Override
+            public void request(long n) { }
+
+            @Override
+            public void cancel() { }
+        };
+    }
+
+    private  static class CustomEmbeddedChannel extends EmbeddedChannel {
+        private CustomEmbeddedChannel() {
+            super(false, false);
+        }
+
+        @Override
+        protected boolean isCompatible(EventLoop loop) {
+            return loop instanceof CustomEmbeddedEventLoop;
+        }
+    }
+
+    private static class CustomEmbeddedEventLoop extends AbstractEventExecutor implements EventLoop {
+        private final Queue<Runnable> tasks = new ArrayDeque<>(2);
+        private volatile boolean inEventLoop = true;
+
+        @Override
+        public EventLoopGroup parent() {
+            return (EventLoopGroup) super.parent();
+        }
+
+        @Override
+        public EventLoop next() {
+            return (EventLoop) super.next();
+        }
+
+        @Override
+        public void execute(Runnable runnable) {
+            tasks.add(runnable);
+        }
+
+        public void runTasks() {
+            for (;;) {
+                Runnable task = tasks.poll();
+                if (task == null) {
+                    break;
+                }
+
+                task.run();
+            }
+        }
+
+        @Override
+        public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<?> terminationFuture() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public void shutdown() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isShuttingDown() {
+            return false;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return false;
+        }
+
+        @Override
+        public ChannelFuture register(Channel channel) {
+            return register(new DefaultChannelPromise(channel, this));
+        }
+
+        @Override
+        public ChannelFuture register(ChannelPromise promise) {
+            ObjectUtil.checkNotNull(promise, "promise");
+            promise.channel().unsafe().register(this, promise);
+            return promise;
+        }
+
+        @Deprecated
+        @Override
+        public ChannelFuture register(Channel channel, ChannelPromise promise) {
+            channel.unsafe().register(this, promise);
+            return promise;
+        }
+
+        public void inEventLoop(boolean inEventLoop) {
+            this.inEventLoop = inEventLoop;
+        }
+
+        @Override
+        public boolean inEventLoop() {
+            return inEventLoop;
+        }
+
+        @Override
+        public boolean inEventLoop(Thread thread) {
+            return inEventLoop;
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberWhiteboxVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberWhiteboxVerificationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.Promise;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.util.ClosedLoopChannel;
+import software.amazon.awssdk.http.nio.netty.internal.nrs.util.ProbeHandler;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class HandlerSubscriberWhiteboxVerificationTest extends SubscriberWhiteboxVerification<Long> {
+
+    private boolean workAroundIssue277;
+
+    public HandlerSubscriberWhiteboxVerificationTest() {
+        super(new TestEnvironment());
+    }
+
+    private DefaultEventLoopGroup eventLoop;
+
+    // I tried making this before/after class, but encountered a strange error where after 32 publishers were created,
+    // the following tests complained about the executor being shut down when I registered the channel. Though, it
+    // doesn't happen if you create 32 publishers in a single test.
+    @BeforeMethod
+    public void startEventLoop() {
+        workAroundIssue277 = false;
+        eventLoop = new DefaultEventLoopGroup();
+    }
+
+    @AfterMethod
+    public void stopEventLoop() {
+        eventLoop.shutdownGracefully();
+        eventLoop = null;
+    }
+
+    @Override
+    public Subscriber<Long> createSubscriber(WhiteboxSubscriberProbe<Long> probe) {
+        final ClosedLoopChannel channel = new ClosedLoopChannel();
+        channel.config().setAutoRead(false);
+        ChannelFuture registered = eventLoop.register(channel);
+
+        final HandlerSubscriber<Long> subscriber = new HandlerSubscriber<>(registered.channel().eventLoop(), 2, 4);
+        final ProbeHandler<Long> probeHandler = new ProbeHandler<>(probe, Long.class);
+        final Promise<Void> handlersInPlace = new DefaultPromise<>(eventLoop.next());
+
+        registered.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                channel.pipeline().addLast("probe", probeHandler);
+                channel.pipeline().addLast("subscriber", subscriber);
+                handlersInPlace.setSuccess(null);
+                // Channel needs to be active before the subscriber starts responding to demand
+                channel.pipeline().fireChannelActive();
+            }
+        });
+
+        if (workAroundIssue277) {
+            try {
+                // Wait for the pipeline to be setup, so we're ready to receive elements even if they aren't requested,
+                // because https://github.com/reactive-streams/reactive-streams-jvm/issues/277
+                handlersInPlace.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return probeHandler.wrap(subscriber);
+    }
+
+    @Override
+    public void required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel() throws Throwable {
+        // See https://github.com/reactive-streams/reactive-streams-jvm/issues/277
+        workAroundIssue277 = true;
+        super.required_spec208_mustBePreparedToReceiveOnNextSignalsAfterHavingCalledSubscriptionCancel();
+    }
+
+    @Override
+    public void required_spec308_requestMustRegisterGivenNumberElementsToBeProduced() throws Throwable {
+        workAroundIssue277 = true;
+        super.required_spec308_requestMustRegisterGivenNumberElementsToBeProduced();
+    }
+
+    @Override
+    public Long createElement(int element) {
+        return (long) element;
+    }
+
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/BatchedProducer.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/BatchedProducer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A batched producer.
+ *
+ * Responds to read requests with batches of elements according to batch size. When eofOn is reached, it closes the
+ * channel.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class BatchedProducer extends ChannelOutboundHandlerAdapter {
+
+    protected final long eofOn;
+    protected final int batchSize;
+    protected final AtomicLong sequence;
+
+    public BatchedProducer(long eofOn, int batchSize, long sequence) {
+        this.eofOn = eofOn;
+        this.batchSize = batchSize;
+        this.sequence = new AtomicLong(sequence);
+    }
+
+    private boolean cancelled = false;
+
+
+    @Override
+    public void read(final ChannelHandlerContext ctx) throws Exception {
+        if (cancelled) {
+            throw new IllegalStateException("Received demand after being cancelled");
+        }
+        ctx.pipeline().channel().eventLoop().parent().execute(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < batchSize && sequence.get() != eofOn; i++) {
+                    ctx.fireChannelRead(sequence.getAndIncrement());
+                }
+                if (eofOn == sequence.get()) {
+                    ctx.fireChannelInactive();
+                } else {
+                    ctx.fireChannelReadComplete();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        if (cancelled) {
+            throw new IllegalStateException("Cancelled twice");
+        }
+        cancelled = true;
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/ClosedLoopChannel.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/ClosedLoopChannel.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import io.netty.channel.AbstractChannel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
+import java.net.SocketAddress;
+
+/**
+ * A closed loop channel that sends no events and receives no events, for testing purposes.
+ *
+ * Any outgoing events that reach the channel will throw an exception. All events should be caught
+ * be inserting a handler that catches them and responds accordingly.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class ClosedLoopChannel extends AbstractChannel {
+
+    private final ChannelConfig config = new DefaultChannelConfig(this);
+    private static final ChannelMetadata metadata = new ChannelMetadata(false);
+
+    private volatile boolean open = true;
+    private volatile boolean active = true;
+
+    public ClosedLoopChannel() {
+        super(null);
+    }
+
+    public void setOpen(boolean open) {
+        this.open = open;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    @Override
+    protected AbstractUnsafe newUnsafe() {
+        return new AbstractUnsafe() {
+            @Override
+            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    protected boolean isCompatible(EventLoop loop) {
+        return true;
+    }
+
+    @Override
+    protected SocketAddress localAddress0() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doDisconnect() throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doClose() throws Exception {
+        this.open = false;
+    }
+
+    @Override
+    protected void doBeginRead() throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return metadata;
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/Probe.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/Probe.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import java.util.Date;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class Probe {
+
+    protected final String name;
+    protected final Long start;
+
+    /**
+     * Create a new probe and log that it started.
+     */
+    protected Probe(String name) {
+        this.name = name;
+        start = System.nanoTime();
+        log("Probe created at " + new Date());
+    }
+
+    /**
+     * Create a new probe with the start time from another probe.
+     */
+    protected Probe(String name, long start) {
+        this.name = name;
+        this.start = start;
+    }
+
+    protected void log(String message) {
+        System.out.println(String.format("%10d %-5s %-15s %s", (System.nanoTime() - start) / 1000, name, Thread.currentThread().getName(), message));
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/ProbeHandler.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/ProbeHandler.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class ProbeHandler<T> extends ChannelDuplexHandler implements SubscriberWhiteboxVerification.SubscriberPuppet {
+
+    private static final int NO_CONTEXT = 0;
+    private static final int RUN = 1;
+    private static final int CANCEL = 2;
+
+    private final SubscriberWhiteboxVerification.WhiteboxSubscriberProbe<T> probe;
+    private final Class<T> clazz;
+    private final Queue<WriteEvent> queue = new LinkedList<>();
+    private final AtomicInteger state = new AtomicInteger(NO_CONTEXT);
+    private volatile ChannelHandlerContext ctx;
+    // Netty doesn't provide a way to send errors out, so we capture whether it was an error or complete here
+    private volatile Throwable receivedError = null;
+
+    public ProbeHandler(SubscriberWhiteboxVerification.WhiteboxSubscriberProbe<T> probe, Class<T> clazz) {
+        this.probe = probe;
+        this.clazz = clazz;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        this.ctx = ctx;
+        if (!state.compareAndSet(NO_CONTEXT, RUN)) {
+            ctx.fireChannelInactive();
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        queue.add(new WriteEvent(clazz.cast(msg), promise));
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise future) throws Exception {
+        if (receivedError == null) {
+            probe.registerOnComplete();
+        } else {
+            probe.registerOnError(receivedError);
+        }
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Exception {
+        while (!queue.isEmpty()) {
+            WriteEvent event = queue.remove();
+            probe.registerOnNext(event.msg);
+            event.future.setSuccess();
+        }
+    }
+
+    @Override
+    public void triggerRequest(long elements) {
+        // No need, the channel automatically requests
+    }
+
+    @Override
+    public void signalCancel() {
+        if (!state.compareAndSet(NO_CONTEXT, CANCEL)) {
+            ctx.fireChannelInactive();
+        }
+    }
+
+    private class WriteEvent {
+        final T msg;
+        final ChannelPromise future;
+
+        private WriteEvent(T msg, ChannelPromise future) {
+            this.msg = msg;
+            this.future = future;
+        }
+    }
+
+    public Subscriber<T> wrap(final Subscriber<T> subscriber) {
+        return new Subscriber<T>() {
+            public void onSubscribe(Subscription s) {
+                probe.registerOnSubscribe(ProbeHandler.this);
+                subscriber.onSubscribe(s);
+            }
+            public void onNext(T t) {
+                subscriber.onNext(t);
+            }
+            public void onError(Throwable t) {
+                receivedError = t;
+                subscriber.onError(t);
+            }
+            public void onComplete() {
+                subscriber.onComplete();
+            }
+        };
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/PublisherProbe.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/PublisherProbe.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class PublisherProbe<T> extends Probe implements Publisher<T> {
+
+    private final Publisher<T> publisher;
+
+    public PublisherProbe(Publisher<T> publisher, String name) {
+        super(name);
+        this.publisher = publisher;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        String sName = s == null ? "null" : s.getClass().getName();
+        log("invoke subscribe with subscriber " + sName);
+        publisher.subscribe(new SubscriberProbe<>(s, name, start));
+        log("finish subscribe");
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/ScheduledBatchedProducer.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/ScheduledBatchedProducer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import io.netty.channel.ChannelHandlerContext;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A batched producer.
+ *
+ * Responds to read requests with batches of elements according to batch size. When eofOn is reached, it closes the
+ * channel.
+ *
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class ScheduledBatchedProducer extends BatchedProducer {
+
+    private final ScheduledExecutorService executor;
+    private final long delay;
+
+    public ScheduledBatchedProducer(long eofOn, int batchSize, long sequence, ScheduledExecutorService executor, long delay) {
+        super(eofOn, batchSize, sequence);
+        this.executor = executor;
+        this.delay = delay;
+    }
+
+    protected boolean complete;
+
+    @Override
+    public void read(final ChannelHandlerContext ctx) throws Exception {
+        executor.schedule(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < batchSize && sequence.get() != eofOn; i++) {
+                    ctx.fireChannelRead(sequence.getAndIncrement());
+                }
+                complete = eofOn == sequence.get();
+                executor.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (complete) {
+                            ctx.fireChannelInactive();
+                        } else {
+                            ctx.fireChannelReadComplete();
+                        }
+                    }
+                }, delay, TimeUnit.MILLISECONDS);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/SubscriberProbe.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/util/SubscriberProbe.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * Original source licensed under the Apache License 2.0 by playframework.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs.util;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * This class contains source imported from https://github.com/playframework/netty-reactive-streams,
+ * licensed under the Apache License 2.0, available at the time of the fork (1/31/2020) here:
+ * https://github.com/playframework/netty-reactive-streams/blob/master/LICENSE.txt
+ *
+ * All original source licensed under the Apache License 2.0 by playframework. All modifications are
+ * licensed under the Apache License 2.0 by Amazon Web Services.
+ */
+public class SubscriberProbe<T> extends Probe implements Subscriber<T> {
+
+    private final Subscriber<T> subscriber;
+
+    public SubscriberProbe(Subscriber<T> subscriber, String name) {
+        super(name);
+        this.subscriber = subscriber;
+    }
+
+    SubscriberProbe(Subscriber<T> subscriber, String name, long start) {
+        super(name, start);
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public void onSubscribe(final Subscription s) {
+        String sName = s == null ? "null" : s.getClass().getName();
+        log("invoke onSubscribe with subscription " + sName);
+        subscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                log("invoke request " + n);
+                s.request(n);
+                log("finish request");
+            }
+
+            @Override
+            public void cancel() {
+                log("invoke cancel");
+                s.cancel();
+                log("finish cancel");
+            }
+        });
+        log("finish onSubscribe");
+    }
+
+    @Override
+    public void onNext(T t) {
+        log("invoke onNext with message " + t);
+        subscriber.onNext(t);
+        log("finish onNext");
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        String tName = t == null ? "null" : t.getClass().getName();
+        log("invoke onError with " + tName);
+        subscriber.onError(t);
+        log("finish onError");
+    }
+
+    @Override
+    public void onComplete() {
+        log("invoke onComplete");
+        subscriber.onComplete();
+        log("finish onComplete");
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/utils/OrderedWriteChannelHandlerContextTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/utils/OrderedWriteChannelHandlerContextTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+public class OrderedWriteChannelHandlerContextTest {
+    @Test
+    public void wrapOnlyHappensOnce() {
+        EmbeddedChannel channel = new EmbeddedChannel(new NoOpHandler());
+        ChannelHandlerContext ctx = channel.pipeline().context(NoOpHandler.class);
+        ChannelHandlerContext wrapped = OrderedWriteChannelHandlerContext.wrap(ctx);
+        ChannelHandlerContext wrapped2 = OrderedWriteChannelHandlerContext.wrap(wrapped);
+
+        assertThat(ctx).isNotSameAs(wrapped);
+        assertThat(wrapped).isSameAs(wrapped2);
+    }
+
+    private static class NoOpHandler implements ChannelHandler {
+        @Override
+        public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+
+        }
+
+        @Override
+        public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <assertj.version>3.8.0</assertj.version>
         <guava.version>28.2-jre</guava.version>
         <jimfs.version>1.1</jimfs.version>
+        <testng.version>7.1.0</testng.version> <!-- TCK Tests -->
         <commons-lang.verson>2.3</commons-lang.verson>
         <netty-open-ssl-version>2.0.25.Final</netty-open-ssl-version>
         <dynamodb-local.version>1.11.477</dynamodb-local.version>
@@ -405,6 +406,11 @@
                         <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:*</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.slf4j:slf4j-api</ignoredUsedUndeclaredDependency>
                     </ignoredUsedUndeclaredDependencies>
+                    <ignoredUnusedDeclaredDependencies>
+                        <!-- TODO: fix this when we've re-merged with netty-reactive-streams -->
+                        <ignoredUnusedDeclaredDependency>com.typesafe.netty:*</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>software.amazon.awssdk:aws-sdk-java</ignoredUnusedDeclaredDependency>
+                    </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
#728 was reverted because of an intermittent test failure, and we didn't want to risk releasing a bug. I've fixed that test failure after discovering it's a bug in the netty-reactive-streams test, not our implementation.

This change re-introduces the changes from #728 in one commit, and the fixes for the intermittent test failure in a second commit, for easier reviewing.

Before the fix, `HandlerPublisherVerificationTest#stochastic_spec103_mustSignalOnMethodsSequentially` would fail once every few hundred iterations. After the fix, `HandlerPublisherVerificationTest#stochastic_spec103_mustSignalOnMethodsSequentially` did not fail after a few thousand iterations.