### PR TITLE
String converters for Java types - 1 of 4 for Attribute Converters

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/Converter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/Converter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+
+/**
+ * A base class for converters that convert based on a specific type.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface Converter<T> {
+    /**
+     * The type supported by this converter.
+     */
+    TypeToken<T> type();
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/PrimitiveConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/PrimitiveConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * Interface for {@link StringConverter} and {@link AttributeConverter} implementations
+ * that support boxed and primitive types.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface PrimitiveConverter<T> {
+    /**
+     * The type supported by this converter.
+     */
+    TypeToken<T> primitiveType();
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/TypeConvertingVisitor.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/TypeConvertingVisitor.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter;
+
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.converter.attribute.ItemAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeValueType;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A visitor across all possible types of a {@link ItemAttributeValue}.
+ *
+ * <p>
+ * This is useful in {@link AttributeConverter} implementations, without having to write a switch statement on the
+ * {@link ItemAttributeValue#type()}.
+ *
+ * @see ItemAttributeValue#convert(TypeConvertingVisitor)
+ */
+@SdkPublicApi
+public abstract class TypeConvertingVisitor<T> {
+    protected final Class<?> targetType;
+    private final Class<?> converterClass;
+
+    /**
+     * Called by subclasses to provide enhanced logging when a specific type isn't handled.
+     *
+     * <p>
+     * Reasons this call may fail with a {@link RuntimeException}:
+     * <ol>
+     *     <li>If the provided type is null.</li>
+     * </ol>
+     *
+     * @param targetType The type to which this visitor is converting.
+     */
+    protected TypeConvertingVisitor(Class<?> targetType) {
+        this(targetType, null);
+    }
+
+    /**
+     * Called by subclasses to provide enhanced logging when a specific type isn't handled.
+     *
+     * <p>
+     * Reasons this call may fail with a {@link RuntimeException}:
+     * <ol>
+     *     <li>If the provided type is null.</li>
+     * </ol>
+     *
+     * @param targetType The type to which this visitor is converting.
+     * @param converterClass The converter implementation that is creating this visitor. This may be null.
+     */
+    protected TypeConvertingVisitor(Class<?> targetType,
+                                    Class<?> converterClass) {
+        Validate.paramNotNull(targetType, "targetType");
+        this.targetType = targetType;
+        this.converterClass = converterClass;
+    }
+
+    /**
+     * Convert the provided value into the target type.
+     *
+     * <p>
+     * Reasons this call may fail with a {@link RuntimeException}:
+     * <ol>
+     *     <li>If the value cannot be converted by this visitor.</li>
+     * </ol>
+     */
+    public final T convert(ItemAttributeValue value) {
+        switch (value.type()) {
+            case NULL: return convertNull();
+            case M: return convertMap(value.asMap());
+            case S: return convertString(value.asString());
+            case N: return convertNumber(value.asNumber());
+            case B: return convertBytes(value.asBytes());
+            case BOOL: return convertBoolean(value.asBoolean());
+            case SS: return convertSetOfStrings(value.asSetOfStrings());
+            case NS: return convertSetOfNumbers(value.asSetOfNumbers());
+            case BS: return convertSetOfBytes(value.asSetOfBytes());
+            case L: return convertListOfAttributeValues(value.asListOfAttributeValues());
+            default: throw new IllegalStateException("Unsupported type: " + value.type());
+        }
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isNull()} is true.
+     */
+    public T convertNull() {
+        return null;
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isMap()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertMap(Map<String, ItemAttributeValue> value) {
+        return defaultConvert(AttributeValueType.M, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isString()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertString(String value) {
+        return defaultConvert(AttributeValueType.S, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isNumber()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertNumber(String value) {
+        return defaultConvert(AttributeValueType.N, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isBytes()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertBytes(SdkBytes value) {
+        return defaultConvert(AttributeValueType.B, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isBoolean()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertBoolean(Boolean value) {
+        return defaultConvert(AttributeValueType.BOOL, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isSetOfStrings()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertSetOfStrings(List<String> value) {
+        return defaultConvert(AttributeValueType.SS, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isSetOfNumbers()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertSetOfNumbers(List<String> value) {
+        return defaultConvert(AttributeValueType.NS, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isSetOfBytes()} is true. The provided value is the
+     * underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertSetOfBytes(List<SdkBytes> value) {
+        return defaultConvert(AttributeValueType.BS, value);
+    }
+
+    /**
+     * Invoked when visiting an attribute in which {@link ItemAttributeValue#isListOfAttributeValues()} is true. The provided
+     * value is the underlying value of the {@link ItemAttributeValue} being converted.
+     */
+    public T convertListOfAttributeValues(List<ItemAttributeValue> value) {
+        return defaultConvert(AttributeValueType.L, value);
+    }
+
+    /**
+     * This is invoked by default if a different "convert" method is not overridden. By default, this throws an exception.
+     *
+     * @param type The type that wasn't handled by another "convert" method.
+     * @param value The value that wasn't handled by another "convert" method.
+     */
+    public T defaultConvert(AttributeValueType type, Object value) {
+        if (converterClass != null) {
+            throw new IllegalStateException(converterClass.getTypeName() + " cannot convert an attribute of type " + type +
+                                            " into the requested type " + targetType);
+        }
+
+        throw new IllegalStateException("Cannot convert attribute of type " + type + " into a " + targetType);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/attribute/ItemAttributeValue.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/attribute/ItemAttributeValue.java
@@ -1,0 +1,898 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.attribute;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
+import software.amazon.awssdk.enhanced.dynamodb.converter.TypeConvertingVisitor;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeValueType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A simpler, and more user-friendly version of the generated {@link AttributeValue}.
+ *
+ * <p>
+ * This is a union type of the types exposed by DynamoDB, exactly as they're exposed by DynamoDB.
+ *
+ * <p>
+ * An instance of {@link ItemAttributeValue} represents exactly one DynamoDB type, like String (s), Number (n) or Bytes (b). This
+ * type can be determined with the {@link #type()} method or the {@code is*} methods like {@link #isString()} or
+ * {@link #isNumber()}. Once the type is known, the value can be extracted with {@code as*} methods like {@link #asString()}
+ * or {@link #asNumber()}.
+ *
+ * <p>
+ * When converting an {@link ItemAttributeValue} into a concrete Java type, it can be tedious to use the {@link #type()} or
+ * {@code is*} methods. For this reason, a {@link #convert(TypeConvertingVisitor)} method is provided that exposes a polymorphic
+ * way of converting a value into another type.
+ *
+ * <p>
+ * An instance of {@link ItemAttributeValue} is created with the {@code from*} methods, like {@link #fromString(String)} or
+ * {@link #fromNumber(String)}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public final class ItemAttributeValue {
+    private final AttributeValueType type;
+    private final boolean isNull;
+    private final Map<String, ItemAttributeValue> mapValue;
+    private final String stringValue;
+    private final String numberValue;
+    private final SdkBytes bytesValue;
+    private final Boolean booleanValue;
+    private final List<String> setOfStringsValue;
+    private final List<String> setOfNumbersValue;
+    private final List<SdkBytes> setOfBytesValue;
+    private final List<ItemAttributeValue> listOfAttributeValuesValue;
+
+    private ItemAttributeValue(InternalBuilder builder) {
+        this.type = builder.type;
+        this.isNull = builder.isNull;
+        this.stringValue = builder.stringValue;
+        this.numberValue = builder.numberValue;
+        this.bytesValue = builder.bytesValue;
+        this.booleanValue = builder.booleanValue;
+
+        this.mapValue = builder.mapValue == null
+                        ? null
+                        : Collections.unmodifiableMap(new LinkedHashMap<>(builder.mapValue));
+        this.setOfStringsValue = builder.setOfStringsValue == null
+                                 ? null
+                                 : Collections.unmodifiableList(new ArrayList<>(builder.setOfStringsValue));
+        this.setOfNumbersValue = builder.setOfNumbersValue == null
+                                 ? null
+                                 : Collections.unmodifiableList(new ArrayList<>(builder.setOfNumbersValue));
+        this.setOfBytesValue = builder.setOfBytesValue == null
+                               ? null
+                               : Collections.unmodifiableList(new ArrayList<>(builder.setOfBytesValue));
+        this.listOfAttributeValuesValue = builder.listOfAttributeValuesValue == null
+                                          ? null
+                                          : Collections.unmodifiableList(new ArrayList<>(builder.listOfAttributeValuesValue));
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for the null DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().nul(true).build())}
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public static ItemAttributeValue nullValue() {
+        return new InternalBuilder().isNull().build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a map (m) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().m(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided map is null or has null keys.
+     */
+    public static ItemAttributeValue fromMap(Map<String, ItemAttributeValue> mapValue) {
+        Validate.paramNotNull(mapValue, "mapValue");
+        Validate.noNullElements(mapValue.keySet(), "Map must not have null keys.");
+        return new InternalBuilder().mapValue(mapValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a string (s) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().s(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
+     * null values.
+     */
+    public static ItemAttributeValue fromString(String stringValue) {
+        Validate.paramNotNull(stringValue, "stringValue");
+        return new InternalBuilder().stringValue(stringValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a number (n) DynamoDB type.
+     *
+     * <p>
+     * This is a String, because it matches the underlying DynamoDB representation.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().n(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
+     * null values.
+     */
+    public static ItemAttributeValue fromNumber(String numberValue) {
+        Validate.paramNotNull(numberValue, "numberValue");
+        return new InternalBuilder().numberValue(numberValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a bytes (b) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().b(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
+     * null values.
+     */
+    public static ItemAttributeValue fromBytes(SdkBytes bytesValue) {
+        Validate.paramNotNull(bytesValue, "bytesValue");
+        return new InternalBuilder().bytesValue(bytesValue).build();
+    }
+
+
+    /**
+     * Create an {@link ItemAttributeValue} for a boolean (bool) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bool(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null. Use {@link #nullValue()} for
+     * null values.
+     */
+    public static ItemAttributeValue fromBoolean(Boolean booleanValue) {
+        Validate.paramNotNull(booleanValue, "booleanValue");
+        return new InternalBuilder().booleanValue(booleanValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a set-of-strings (ss) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ss(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #fromListOfAttributeValues(List)} for null values. This <i>will not</i> validate that there are no
+     * duplicate values.
+     */
+    public static ItemAttributeValue fromSetOfStrings(String... setOfStringsValue) {
+        Validate.paramNotNull(setOfStringsValue, "setOfStringsValue");
+        return fromSetOfStrings(Arrays.asList(setOfStringsValue));
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a set-of-strings (ss) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ss(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #fromListOfAttributeValues(List)} for null values. This <i>will not</i> validate that there are no
+     * duplicate values.
+     */
+    public static ItemAttributeValue fromSetOfStrings(Collection<String> setOfStringsValue) {
+        Validate.paramNotNull(setOfStringsValue, "setOfStringsValue");
+        Validate.noNullElements(setOfStringsValue, "Set must not have null values.");
+        return new InternalBuilder().setOfStringsValue(setOfStringsValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a set-of-numbers (ns) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ns(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #fromListOfAttributeValues(List)} for null values. This <i>will not</i> validate that there are no
+     * duplicate values.
+     */
+    public static ItemAttributeValue fromSetOfNumbers(String... setOfNumbersValue) {
+        Validate.paramNotNull(setOfNumbersValue, "setOfNumbersValue");
+        return fromSetOfNumbers(Arrays.asList(setOfNumbersValue));
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a set-of-numbers (ns) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().ns(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #fromListOfAttributeValues(List)} for null values. This <i>will not</i> validate that there are no
+     * duplicate values.
+     */
+    public static ItemAttributeValue fromSetOfNumbers(Collection<String> setOfNumbersValue) {
+        Validate.paramNotNull(setOfNumbersValue, "setOfNumbersValue");
+        Validate.noNullElements(setOfNumbersValue, "Set must not have null values.");
+        return new InternalBuilder().setOfNumbersValue(setOfNumbersValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a set-of-bytes (bs) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bs(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #fromListOfAttributeValues(List)} for null values. This <i>will not</i> validate that there are no
+     * duplicate values.
+     */
+    public static ItemAttributeValue fromSetOfBytes(SdkBytes... setOfBytesValue) {
+        Validate.paramNotNull(setOfBytesValue, "setOfBytesValue");
+        return fromSetOfBytes(Arrays.asList(setOfBytesValue));
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a set-of-bytes (bs) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().bs(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #fromListOfAttributeValues(List)} for null values. This <i>will not</i> validate that there are no
+     * duplicate values.
+     */
+    public static ItemAttributeValue fromSetOfBytes(Collection<SdkBytes> setOfBytesValue) {
+        Validate.paramNotNull(setOfBytesValue, "setOfBytesValue");
+        Validate.noNullElements(setOfBytesValue, "Set must not have null values.");
+        return new InternalBuilder().setOfBytesValue(setOfBytesValue).build();
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a list-of-attributes (l) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().l(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #nullValue()} for null values.
+     */
+    public static ItemAttributeValue fromListOfAttributeValues(ItemAttributeValue... listOfAttributeValuesValue) {
+        Validate.paramNotNull(listOfAttributeValuesValue, "listOfAttributeValuesValue");
+        return fromListOfAttributeValues(Arrays.asList(listOfAttributeValuesValue));
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} for a list-of-attributes (l) DynamoDB type.
+     *
+     * <p>
+     * Equivalent to: {@code ItemAttributeValue.fromGeneratedAttributeValue(AttributeValue.builder().l(...).build())}
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null or contains a null value. Use
+     * {@link #nullValue()} for null values.
+     */
+    public static ItemAttributeValue fromListOfAttributeValues(List<ItemAttributeValue> listOfAttributeValuesValue) {
+        Validate.paramNotNull(listOfAttributeValuesValue, "listOfAttributeValuesValue");
+        Validate.noNullElements(listOfAttributeValuesValue, "List must not have null values.");
+        return new InternalBuilder().listOfAttributeValuesValue(listOfAttributeValuesValue).build();
+    }
+
+    public static ItemAttributeValue flattenSet(List<ItemAttributeValue> listOfAttributeValuesValue) {
+        Validate.paramNotNull(listOfAttributeValuesValue, "listOfAttributeValuesValue");
+        Validate.noNullElements(listOfAttributeValuesValue, "List must not have null values.");
+
+        AttributeValueType type = listOfAttributeValuesValue.get(0).type;
+
+        switch (type) {
+            case N:
+                return ItemAttributeValue.fromSetOfNumbers(listOfAttributeValuesValue.stream()
+                                                                                     .map(i -> i.numberValue)
+                                                                                     .collect(Collectors.toList()));
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} from a generated {@code Map<String, AttributeValue>}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided map is null or contains a null key or value. Use
+     * {@link AttributeValue#nul()} for null values.
+     */
+    public static ItemAttributeValue fromGeneratedItem(Map<String, AttributeValue> attributeValues) {
+        Validate.paramNotNull(attributeValues, "attributeValues");
+        Map<String, ItemAttributeValue> result = new LinkedHashMap<>();
+        attributeValues.forEach((key, value) -> {
+            Validate.notNull(key, "Generated item must not contain null keys.");
+            result.put(key, fromGeneratedAttributeValue(value));
+        });
+        return ItemAttributeValue.fromMap(result);
+    }
+
+    /**
+     * Create an {@link ItemAttributeValue} from a generated {@link AttributeValue}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if the provided value is null ({@link AttributeValue#nul()} is okay).
+     */
+    public static ItemAttributeValue fromGeneratedAttributeValue(AttributeValue attributeValue) {
+        Validate.notNull(attributeValue, "Generated attribute value must not contain null values. " +
+                                         "Use AttributeValue#nul() instead.");
+        if (attributeValue.s() != null) {
+            return ItemAttributeValue.fromString(attributeValue.s());
+        }
+        if (attributeValue.n() != null) {
+            return ItemAttributeValue.fromNumber(attributeValue.n());
+        }
+        if (attributeValue.bool() != null) {
+            return ItemAttributeValue.fromBoolean(attributeValue.bool());
+        }
+        if (Boolean.TRUE.equals(attributeValue.nul())) {
+            return ItemAttributeValue.nullValue();
+        }
+        if (attributeValue.b() != null) {
+            return ItemAttributeValue.fromBytes(attributeValue.b());
+        }
+        if (attributeValue.m() != null && !(attributeValue.m() instanceof SdkAutoConstructMap)) {
+            Map<String, ItemAttributeValue> map = new LinkedHashMap<>();
+            attributeValue.m().forEach((k, v) -> map.put(k, ItemAttributeValue.fromGeneratedAttributeValue(v)));
+            return ItemAttributeValue.fromMap(map);
+        }
+        if (attributeValue.l() != null && !(attributeValue.l() instanceof SdkAutoConstructList)) {
+            List<ItemAttributeValue> list =
+                    attributeValue.l().stream().map(ItemAttributeValue::fromGeneratedAttributeValue).collect(toList());
+            return ItemAttributeValue.fromListOfAttributeValues(list);
+        }
+        if (attributeValue.bs() != null && !(attributeValue.bs() instanceof SdkAutoConstructList)) {
+            return ItemAttributeValue.fromSetOfBytes(attributeValue.bs());
+        }
+        if (attributeValue.ss() != null && !(attributeValue.ss() instanceof SdkAutoConstructList)) {
+            return ItemAttributeValue.fromSetOfStrings(attributeValue.ss());
+        }
+        if (attributeValue.ns() != null && !(attributeValue.ns() instanceof SdkAutoConstructList)) {
+            return ItemAttributeValue.fromSetOfNumbers(attributeValue.ns());
+        }
+
+        throw new IllegalStateException("Unable to convert attribute value: " + attributeValue);
+    }
+
+    /**
+     * Retrieve the underlying DynamoDB type of this value, such as String (s) or Number (n).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public AttributeValueType type() {
+        return type;
+    }
+
+    /**
+     * Apply the provided visitor to this item attribute value, converting it into a specific type. This is useful in
+     * {@link AttributeConverter} implementations, without having to write a switch statement on the {@link #type()}.
+     *
+     * <p>
+     * Reasons this call may fail with a {@link RuntimeException}:
+     * <ol>
+     *     <li>If the provided visitor is null.</li>
+     *     <li>If the value cannot be converted by this visitor.</li>
+     * </ol>
+     */
+    public <T> T convert(TypeConvertingVisitor<T> convertingVisitor) {
+        Validate.paramNotNull(convertingVisitor, "convertingVisitor");
+        return convertingVisitor.convert(this);
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a Map (m).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isMap() {
+        return mapValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a String (s).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isString() {
+        return stringValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a Number (n).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isNumber() {
+        return numberValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is Bytes (b).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isBytes() {
+        return bytesValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a Boolean (bool).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isBoolean() {
+        return booleanValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a Set of Strings (ss).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isSetOfStrings() {
+        return setOfStringsValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a Set of Numbers (ns).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isSetOfNumbers() {
+        return setOfNumbersValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a Set of Bytes (bs).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isSetOfBytes() {
+        return setOfBytesValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is a List of AttributeValues (l).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isListOfAttributeValues() {
+        return listOfAttributeValuesValue != null;
+    }
+
+    /**
+     * Returns true if the underlying DynamoDB type of this value is Null (null).
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public boolean isNull() {
+        return isNull;
+    }
+
+    /**
+     * Retrieve this value as a map.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isMap()} is false.
+     */
+    public Map<String, ItemAttributeValue> asMap() {
+        Validate.isTrue(isMap(), "Value is not a map.");
+        return mapValue;
+    }
+
+    /**
+     * Retrieve this value as a string.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isString()} is false.
+     */
+    public String asString() {
+        Validate.isTrue(isString(), "Value is not a string.");
+        return stringValue;
+    }
+
+    /**
+     * Retrieve this value as a number.
+     *
+     * Note: This returns a {@code String} (instead of a {@code Number}), because that's the generated type from
+     * DynamoDB: {@link AttributeValue#n()}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isNumber()} is false.
+     */
+    public String asNumber() {
+        Validate.isTrue(isNumber(), "Value is not a number.");
+        return numberValue;
+    }
+
+    /**
+     * Retrieve this value as bytes.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isBytes()} is false.
+     */
+    public SdkBytes asBytes() {
+        Validate.isTrue(isBytes(), "Value is not bytes.");
+        return bytesValue;
+    }
+
+    /**
+     * Retrieve this value as a boolean.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isBoolean()} is false.
+     */
+    public Boolean asBoolean() {
+        Validate.isTrue(isBoolean(), "Value is not a boolean.");
+        return booleanValue;
+    }
+
+    /**
+     * Retrieve this value as a set of strings.
+     *
+     * <p>
+     * Note: This returns a {@code List} (instead of a {@code Set}), because that's the generated type from
+     * DynamoDB: {@link AttributeValue#ss()}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isSetOfStrings()} is false.
+     */
+    public List<String> asSetOfStrings() {
+        Validate.isTrue(isSetOfStrings(), "Value is not a list of strings.");
+        return setOfStringsValue;
+    }
+
+    /**
+     * Retrieve this value as a set of numbers.
+     *
+     * <p>
+     * Note: This returns a {@code List<String>} (instead of a {@code Set<Number>}), because that's the generated type from
+     * DynamoDB: {@link AttributeValue#ns()}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isSetOfNumbers()} is false.
+     */
+    public List<String> asSetOfNumbers() {
+        Validate.isTrue(isSetOfNumbers(), "Value is not a list of numbers.");
+        return setOfNumbersValue;
+    }
+
+    /**
+     * Retrieve this value as a set of bytes.
+     *
+     * <p>
+     * Note: This returns a {@code List} (instead of a {@code Set}), because that's the generated type from
+     * DynamoDB: {@link AttributeValue#bs()}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isSetOfBytes()} is false.
+     */
+    public List<SdkBytes> asSetOfBytes() {
+        Validate.isTrue(isSetOfBytes(), "Value is not a list of bytes.");
+        return setOfBytesValue;
+    }
+
+    /**
+     * Retrieve this value as a list of attribute values.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isListOfAttributeValues()} is false.
+     */
+    public List<ItemAttributeValue> asListOfAttributeValues() {
+        Validate.isTrue(isListOfAttributeValues(), "Value is not a list of attribute values.");
+        return listOfAttributeValuesValue;
+    }
+
+    /**
+     * Convert this {@link ItemAttributeValue} into a generated {@code Map<String, AttributeValue>}.
+     *
+     * <p>
+     * This call will fail with a {@link RuntimeException} if {@link #isMap()} is false.
+     */
+    public Map<String, AttributeValue> toGeneratedItem() {
+        Validate.validState(isMap(), "Cannot convert an attribute value of type %s to a generated item. Must be %s.",
+                            type(), AttributeValueType.M);
+
+        AttributeValue generatedAttributeValue = toGeneratedAttributeValue();
+
+        Validate.validState(generatedAttributeValue.m() != null && !(generatedAttributeValue.m() instanceof SdkAutoConstructMap),
+                            "Map ItemAttributeValue was not converted into a Map AttributeValue.");
+        return generatedAttributeValue.m();
+    }
+
+    /**
+     * Convert this {@link ItemAttributeValue} into a generated {@link AttributeValue}.
+     *
+     * <p>
+     * This call should never fail with an {@link Exception}.
+     */
+    public AttributeValue toGeneratedAttributeValue() {
+        return convert(ToGeneratedAttributeValueVisitor.INSTANCE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ItemAttributeValue that = (ItemAttributeValue) o;
+
+        if (isNull != that.isNull) {
+            return false;
+        }
+        if (type != that.type) {
+            return false;
+        }
+        if (mapValue != null ? !mapValue.equals(that.mapValue) : that.mapValue != null) {
+            return false;
+        }
+        if (stringValue != null ? !stringValue.equals(that.stringValue) : that.stringValue != null) {
+            return false;
+        }
+        if (numberValue != null ? !numberValue.equals(that.numberValue) : that.numberValue != null) {
+            return false;
+        }
+        if (bytesValue != null ? !bytesValue.equals(that.bytesValue) : that.bytesValue != null) {
+            return false;
+        }
+        if (booleanValue != null ? !booleanValue.equals(that.booleanValue) : that.booleanValue != null) {
+            return false;
+        }
+        if (setOfStringsValue != null ? !setOfStringsValue.equals(that.setOfStringsValue) : that.setOfStringsValue != null) {
+            return false;
+        }
+        if (setOfNumbersValue != null ? !setOfNumbersValue.equals(that.setOfNumbersValue) : that.setOfNumbersValue != null) {
+            return false;
+        }
+        if (setOfBytesValue != null ? !setOfBytesValue.equals(that.setOfBytesValue) : that.setOfBytesValue != null) {
+            return false;
+        }
+        return listOfAttributeValuesValue != null ? listOfAttributeValuesValue.equals(that.listOfAttributeValuesValue)
+                                                  : that.listOfAttributeValuesValue == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + (isNull ? 1 : 0);
+        result = 31 * result + (mapValue != null ? mapValue.hashCode() : 0);
+        result = 31 * result + (stringValue != null ? stringValue.hashCode() : 0);
+        result = 31 * result + (numberValue != null ? numberValue.hashCode() : 0);
+        result = 31 * result + (bytesValue != null ? bytesValue.hashCode() : 0);
+        result = 31 * result + (booleanValue != null ? booleanValue.hashCode() : 0);
+        result = 31 * result + (setOfStringsValue != null ? setOfStringsValue.hashCode() : 0);
+        result = 31 * result + (setOfNumbersValue != null ? setOfNumbersValue.hashCode() : 0);
+        result = 31 * result + (setOfBytesValue != null ? setOfBytesValue.hashCode() : 0);
+        result = 31 * result + (listOfAttributeValuesValue != null ? listOfAttributeValuesValue.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        Object value = convert(ToStringVisitor.INSTANCE);
+        return ToString.builder("ItemAttributeValue")
+                       .add("type", type)
+                       .add("value", value)
+                       .build();
+    }
+
+    private static class ToGeneratedAttributeValueVisitor extends TypeConvertingVisitor<AttributeValue> {
+        private static final ToGeneratedAttributeValueVisitor INSTANCE = new ToGeneratedAttributeValueVisitor();
+
+        private ToGeneratedAttributeValueVisitor() {
+            super(AttributeValue.class);
+        }
+
+        @Override
+        public AttributeValue convertNull() {
+            return AttributeValue.builder().nul(true).build();
+        }
+
+        @Override
+        public AttributeValue convertMap(Map<String, ItemAttributeValue> value) {
+            Map<String, AttributeValue> map = new LinkedHashMap<>();
+            value.forEach((k, v) -> map.put(k, v.toGeneratedAttributeValue()));
+            return AttributeValue.builder().m(map).build();
+        }
+
+        @Override
+        public AttributeValue convertString(String value) {
+            return AttributeValue.builder().s(value).build();
+        }
+
+        @Override
+        public AttributeValue convertNumber(String value) {
+            return AttributeValue.builder().n(value).build();
+        }
+
+        @Override
+        public AttributeValue convertBytes(SdkBytes value) {
+            return AttributeValue.builder().b(value).build();
+        }
+
+        @Override
+        public AttributeValue convertBoolean(Boolean value) {
+            return AttributeValue.builder().bool(value).build();
+        }
+
+        @Override
+        public AttributeValue convertSetOfStrings(List<String> value) {
+            return AttributeValue.builder().ss(value).build();
+        }
+
+        @Override
+        public AttributeValue convertSetOfNumbers(List<String> value) {
+            return AttributeValue.builder().ns(value).build();
+        }
+
+        @Override
+        public AttributeValue convertSetOfBytes(List<SdkBytes> value) {
+            return AttributeValue.builder().bs(value).build();
+        }
+
+        @Override
+        public AttributeValue convertListOfAttributeValues(List<ItemAttributeValue> value) {
+            return AttributeValue.builder()
+                                 .l(value.stream().map(ItemAttributeValue::toGeneratedAttributeValue).collect(toList()))
+                                 .build();
+        }
+    }
+
+    private static class ToStringVisitor extends TypeConvertingVisitor<Object> {
+        private static final ToStringVisitor INSTANCE = new ToStringVisitor();
+
+        private ToStringVisitor() {
+            super(Object.class);
+        }
+
+        @Override
+        public Object convertNull() {
+            return "null";
+        }
+
+        @Override
+        public Object defaultConvert(AttributeValueType type, Object value) {
+            return value;
+        }
+    }
+
+    private static class InternalBuilder {
+        private AttributeValueType type;
+        private boolean isNull = false;
+        private Map<String, ItemAttributeValue> mapValue;
+        private String stringValue;
+        private String numberValue;
+        private SdkBytes bytesValue;
+        private Boolean booleanValue;
+        private Collection<String> setOfStringsValue;
+        private Collection<String> setOfNumbersValue;
+        private Collection<SdkBytes> setOfBytesValue;
+        private Collection<ItemAttributeValue> listOfAttributeValuesValue;
+
+        public InternalBuilder isNull() {
+            this.type = AttributeValueType.NULL;
+            this.isNull = true;
+            return this;
+        }
+
+        private InternalBuilder mapValue(Map<String, ItemAttributeValue> mapValue) {
+            this.type = AttributeValueType.M;
+            this.mapValue = mapValue;
+            return this;
+        }
+
+        private InternalBuilder stringValue(String stringValue) {
+            this.type = AttributeValueType.S;
+            this.stringValue = stringValue;
+            return this;
+        }
+
+        private InternalBuilder numberValue(String numberValue) {
+            this.type = AttributeValueType.N;
+            this.numberValue = numberValue;
+            return this;
+        }
+
+        private InternalBuilder bytesValue(SdkBytes bytesValue) {
+            this.type = AttributeValueType.B;
+            this.bytesValue = bytesValue;
+            return this;
+        }
+
+        private InternalBuilder booleanValue(Boolean booleanValue) {
+            this.type = AttributeValueType.BOOL;
+            this.booleanValue = booleanValue;
+            return this;
+        }
+
+        private InternalBuilder setOfStringsValue(Collection<String> setOfStringsValue) {
+            this.type = AttributeValueType.SS;
+            this.setOfStringsValue = setOfStringsValue;
+            return this;
+        }
+
+        private InternalBuilder setOfNumbersValue(Collection<String> setOfNumbersValue) {
+            this.type = AttributeValueType.NS;
+            this.setOfNumbersValue = setOfNumbersValue;
+            return this;
+        }
+
+        private InternalBuilder setOfBytesValue(Collection<SdkBytes> setOfBytesValue) {
+            this.type = AttributeValueType.BS;
+            this.setOfBytesValue = setOfBytesValue;
+            return this;
+        }
+
+        private InternalBuilder listOfAttributeValuesValue(Collection<ItemAttributeValue> listOfAttributeValuesValue) {
+            this.type = AttributeValueType.L;
+            this.listOfAttributeValuesValue = listOfAttributeValuesValue;
+            return this;
+        }
+
+        private ItemAttributeValue build() {
+            return new ItemAttributeValue(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/internal/ConverterUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/internal/ConverterUtils.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.internal;
+
+import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.utils.Pair;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public class ConverterUtils {
+    private ConverterUtils() {}
+
+    public static void validateDouble(Double input) {
+        Validate.isTrue(!Double.isNaN(input), "NaN is not supported by the default converters.");
+        Validate.isTrue(Double.isFinite(input), "Infinite numbers are not supported by the default converters.");
+    }
+
+    public static void validateFloat(Float input) {
+        Validate.isTrue(!Float.isNaN(input), "NaN is not supported by the default converters.");
+        Validate.isTrue(Float.isFinite(input), "Infinite numbers are not supported by the default converters.");
+    }
+
+    public static String padLeft2(int valueToPad) {
+        return valueToPad > 10 ? Integer.toString(valueToPad) : "0" + valueToPad;
+    }
+
+    public static String padLeft(int paddingAmount, int valueToPad) {
+        String value = Integer.toString(valueToPad);
+        int padding = paddingAmount - value.length();
+        StringBuilder result = new StringBuilder(paddingAmount);
+        for (int i = 0; i < padding; i++) {
+            result.append('0');
+        }
+        result.append(value);
+        return result.toString();
+    }
+
+    public static String padRight(int paddingAmount, String valueToPad) {
+        StringBuilder result = new StringBuilder(paddingAmount);
+        result.append(valueToPad);
+        for (int i = result.length(); i < paddingAmount; i++) {
+            result.append('0');
+        }
+        return result.toString();
+    }
+
+    public static String trimNumber(String number) {
+        int startInclusive = findTrimInclusiveStart(number, '0', 0);
+
+        if (startInclusive >= number.length()) {
+            return "0";
+        }
+
+        if (!number.contains(".")) {
+            return number.substring(startInclusive);
+        }
+
+        int endExclusive = findTrimExclusiveEnd(number, '0', number.length());
+        endExclusive = findTrimExclusiveEnd(number, '.', endExclusive);
+
+        if (startInclusive >= endExclusive) {
+            return "0";
+        }
+
+        String result = number.substring(startInclusive, endExclusive);
+        if (result.startsWith(".")) {
+            return "0" + result;
+        }
+        return result;
+    }
+
+    private static int findTrimInclusiveStart(String string, char characterToTrim, int startingIndex) {
+        int startInclusive = startingIndex;
+
+        while (startInclusive < string.length() && string.charAt(startInclusive) == characterToTrim) {
+            ++startInclusive;
+        }
+
+        return startInclusive;
+    }
+
+    private static int findTrimExclusiveEnd(String string, char characterToTrim, int startingIndex) {
+        int endExclusive = startingIndex;
+
+        while (endExclusive > 0 && string.charAt(endExclusive - 1) == characterToTrim) {
+            --endExclusive;
+        }
+
+        return endExclusive;
+    }
+
+    public static String[] splitNumberOnDecimal(String valueToSplit) {
+        int i = valueToSplit.indexOf('.');
+        if (i == -1) {
+            return new String[] { valueToSplit, "0" };
+        } else {
+            // Ends with '.' is not supported.
+            return new String[] { valueToSplit.substring(0, i), valueToSplit.substring(i + 1) };
+        }
+    }
+
+    public static Pair<TypeToken<?>, TypeToken<?>> getMapTypeParameters(TypeToken<?> desiredType) {
+        List<TypeToken<?>> mapTypeParameters = desiredType.rawClassParameters();
+
+        Validate.isTrue(mapTypeParameters.size() == 2,
+                        "Cannot determine key and value types for the requested map type: %s. If you're specifying a type " +
+                        "token, make sure you are specifying an element type (e.g. TypeToken.mapOf(String.class, " +
+                        "String.class) instead of TypeToken.of(Map.class). If you're using a custom map type " +
+                        "without the key and value types as parameters, it will need to implement " +
+                        "KeyValueTypeAwareMap to specify the element type. If you're using a custom map " +
+                        "type with the key and value types as parameters, but there is more than two parameters, it will " +
+                        "need to implement GenericConvertibleMap to specify which type " +
+                        "parameters are encoding the key and element types.", desiredType);
+
+        return Pair.of(mapTypeParameters.get(0), mapTypeParameters.get(1));
+    }
+
+    public static String[] chunk(String valueToChunk, int... splitSizes) {
+        String[] result = new String[splitSizes.length + 1];
+        int splitStartInclusive = chunkLeft(valueToChunk, result, splitSizes);
+
+        Validate.isTrue(splitStartInclusive == valueToChunk.length(), "Value size does not match expected chunking scheme.");
+
+        return result;
+    }
+
+    public static String[] chunkWithRightOverflow(String valueToChunk, int... splitSizesFromLeft) {
+        String[] result = new String[splitSizesFromLeft.length + 1];
+        int splitStartInclusive = chunkLeft(valueToChunk, result, splitSizesFromLeft);
+
+        result[splitSizesFromLeft.length] = valueToChunk.substring(splitStartInclusive);
+
+        return result;
+    }
+
+    public static String[] chunkWithLeftOverflow(String valueToChunk, int... splitSizesFromRight) {
+        try {
+            String[] result = new String[splitSizesFromRight.length + 1];
+            int splitEndExclusive = valueToChunk.length();
+
+            for (int i = splitSizesFromRight.length - 1; i >= 0; i--) {
+                int splitStartInclusive = splitEndExclusive - splitSizesFromRight[i];
+                result[i + 1] = valueToChunk.substring(splitStartInclusive, splitEndExclusive);
+                splitEndExclusive = splitStartInclusive;
+            }
+
+            result[0] = valueToChunk.substring(0, splitEndExclusive);
+
+            return result;
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new IllegalArgumentException("Invalid format for value.", e);
+        }
+    }
+
+    private static int chunkLeft(String valueToChunk, String[] result, int[] splitSizes) {
+        try {
+            int splitStartInclusive = 0;
+
+            for (int i = 0; i < splitSizes.length; i++) {
+                int splitEndExclusive = splitStartInclusive + splitSizes[i];
+                result[i] = valueToChunk.substring(splitStartInclusive, splitEndExclusive);
+                splitStartInclusive = splitEndExclusive;
+            }
+            return splitStartInclusive;
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new IllegalArgumentException("Invalid format for value.", e);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/internal/TimeConversion.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/internal/TimeConversion.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.internal;
+
+import static software.amazon.awssdk.enhanced.dynamodb.converter.internal.ConverterUtils.padLeft;
+import static software.amazon.awssdk.enhanced.dynamodb.converter.internal.ConverterUtils.padRight;
+import static software.amazon.awssdk.enhanced.dynamodb.converter.internal.ConverterUtils.splitNumberOnDecimal;
+import static software.amazon.awssdk.enhanced.dynamodb.converter.internal.ConverterUtils.trimNumber;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalQuery;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.converter.TypeConvertingVisitor;
+import software.amazon.awssdk.enhanced.dynamodb.converter.attribute.ItemAttributeValue;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public final class TimeConversion {
+    private static final InstantVisitor INSTANT_VISITOR = new InstantVisitor();
+    private static final OffsetDateTimeVisitor OFFSET_DATE_TIME_VISITOR = new OffsetDateTimeVisitor();
+    private static final ZonedDateTimeVisitor ZONED_DATE_TIME_VISITOR = new ZonedDateTimeVisitor();
+
+    private TimeConversion() {}
+
+    public static ItemAttributeValue toIntegerAttributeValue(Instant instant) {
+        long instantSeconds = instant.getEpochSecond();
+        int nanos = instant.getNano();
+
+        String value;
+        if (nanos == 0) {
+            value = Long.toString(instantSeconds);
+        } else if (instantSeconds >= 0) {
+            value = instantSeconds +
+                    "." + padLeft(9, nanos);
+        } else {
+            instantSeconds++;
+            nanos = 1_000_000_000 - nanos;
+
+            value = "-" +
+                    Math.abs(instantSeconds) +
+                    "." + padLeft(9, nanos);
+        }
+
+        return ItemAttributeValue.fromNumber(trimNumber(value));
+    }
+
+    public static ItemAttributeValue toStringAttributeValue(Instant instant) {
+        return ItemAttributeValue.fromString(DateTimeFormatter.ISO_INSTANT.format(instant));
+    }
+
+    public static ItemAttributeValue toStringAttributeValue(OffsetDateTime accessor) {
+        return ItemAttributeValue.fromString(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(accessor));
+    }
+
+    public static ItemAttributeValue toStringAttributeValue(ZonedDateTime accessor) {
+        return ItemAttributeValue.fromString(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(accessor));
+    }
+
+    public static Instant instantFromAttributeValue(ItemAttributeValue itemAttributeValue) {
+        return convert(itemAttributeValue, INSTANT_VISITOR);
+    }
+
+    public static OffsetDateTime offsetDateTimeFromAttributeValue(ItemAttributeValue itemAttributeValue) {
+        return convert(itemAttributeValue, OFFSET_DATE_TIME_VISITOR);
+    }
+
+    public static ZonedDateTime zonedDateTimeFromAttributeValue(ItemAttributeValue itemAttributeValue) {
+        return convert(itemAttributeValue, ZONED_DATE_TIME_VISITOR);
+    }
+
+    private static <T> T convert(ItemAttributeValue itemAttributeValue, TypeConvertingVisitor<T> visitor) {
+        try {
+            return itemAttributeValue.convert(visitor);
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static final class InstantVisitor extends BaseVisitor<Instant> {
+        protected InstantVisitor() {
+            super(Instant.class, Instant::from);
+        }
+
+        @Override
+        public Instant convertString(String value) {
+            try {
+                return super.convertString(value);
+            } catch (DateTimeParseException e) {
+                // Instant has a larger date range (-1,000,000,000 to 1,000,000,000) than zoned or offset date times
+                // (-999,999,999 to -999,999,999). An Instant was requested, so we try falling back to the ISO_INSTANT
+                // parser that supports Instant.MIN through Instant.MAX.
+                try {
+                    return DateTimeFormatter.ISO_INSTANT.parse(value, Instant::from);
+                } catch (DateTimeParseException e2) {
+                    // Nope, that didn't work either. Report the failures.
+                    throw new IllegalArgumentException("Record could not be parsed with either " +
+                                                       "DateTimeFormatter.ISO_ZONED_DATE_TIME (" + e.getMessage() +
+                                                       ") or DateTimeFormatter.ISO_INSTANT (" + e2.getMessage() +
+                                                       ").");
+                }
+            }
+        }
+
+        @Override
+        protected Instant fromUtcInstant(Instant instant) {
+            return instant;
+        }
+    }
+
+    private static final class OffsetDateTimeVisitor extends BaseVisitor<OffsetDateTime> {
+        protected OffsetDateTimeVisitor() {
+            super(OffsetDateTime.class, OffsetDateTime::from);
+        }
+
+        @Override
+        protected OffsetDateTime fromUtcInstant(Instant instant) {
+            return instant.atOffset(ZoneOffset.UTC);
+        }
+    }
+
+    private static final class ZonedDateTimeVisitor extends BaseVisitor<ZonedDateTime> {
+        protected ZonedDateTimeVisitor() {
+            super(ZonedDateTime.class, ZonedDateTime::from);
+        }
+
+        @Override
+        protected ZonedDateTime fromUtcInstant(Instant instant) {
+            return instant.atZone(ZoneOffset.UTC);
+        }
+    }
+
+    private abstract static class BaseVisitor<T> extends TypeConvertingVisitor<T> {
+        private final TemporalQuery<T> query;
+
+        protected BaseVisitor(Class<T> targetType, TemporalQuery<T> query) {
+            super(targetType);
+            this.query = query;
+        }
+
+        @Override
+        public T convertString(String value) {
+            return DateTimeFormatter.ISO_ZONED_DATE_TIME.parse(value, query);
+        }
+
+        @Override
+        public T convertNumber(String value) {
+            String[] splitOnDecimal = splitNumberOnDecimal(value);
+
+            Validate.isTrue(splitOnDecimal[1].length() <= 9, "Nanoseconds must be expressed in 9 or fewer digits.");
+
+            long epochSecond = splitOnDecimal[0].length() == 0 ? 0 : Long.parseLong(splitOnDecimal[0]);
+            int nanoAdjustment = Integer.parseInt(padRight(9, splitOnDecimal[1]));
+
+            if (value.startsWith("-")) {
+                nanoAdjustment = -nanoAdjustment;
+            }
+
+            return fromUtcInstant(Instant.ofEpochSecond(epochSecond, nanoAdjustment));
+        }
+
+        protected abstract T fromUtcInstant(Instant instant);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/DefaultStringConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/DefaultStringConverterProvider.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.AtomicBooleanStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.AtomicIntegerStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.AtomicLongStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.BigDecimalStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.BigIntegerStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.BooleanStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.ByteArrayStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.ByteStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.CharSequenceStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.CharacterArrayStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.CharacterStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.DoubleStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.DurationStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.FloatStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.InstantStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.IntegerStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.LocalDateStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.LocalDateTimeStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.LocalTimeStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.LongStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.MonthDayStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.OffsetDateTimeStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.OffsetTimeStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.OptionalDoubleStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.OptionalIntStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.OptionalLongStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.PeriodStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.SdkBytesStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.ShortStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.StringBufferStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.StringBuilderStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.StringStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.UriStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.UrlStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.UuidStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.YearMonthStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.YearStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.ZoneIdStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.ZoneOffsetStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled.ZonedDateTimeStringConverter;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * <p>
+ * Included converters:
+ * <ul>
+ *     <li>{@link AtomicIntegerStringConverter}</li>
+ *     <li>{@link AtomicLongStringConverter}</li>
+ *     <li>{@link BigDecimalStringConverter}</li>
+ *     <li>{@link BigIntegerStringConverter}</li>
+ *     <li>{@link DoubleStringConverter}</li>
+ *     <li>{@link DurationStringConverter}</li>
+ *     <li>{@link FloatStringConverter}</li>
+ *     <li>{@link InstantStringConverter}</li>
+ *     <li>{@link IntegerStringConverter}</li>
+ *     <li>{@link LocalDateStringConverter}</li>
+ *     <li>{@link LocalDateTimeStringConverter}</li>
+ *     <li>{@link LocalTimeStringConverter}</li>
+ *     <li>{@link LongStringConverter}</li>
+ *     <li>{@link MonthDayStringConverter}</li>
+ *     <li>{@link OptionalDoubleStringConverter}</li>
+ *     <li>{@link OptionalIntStringConverter}</li>
+ *     <li>{@link OptionalLongStringConverter}</li>
+ *     <li>{@link ShortStringConverter}</li>
+ *     <li>{@link CharacterArrayStringConverter}</li>
+ *     <li>{@link CharacterStringConverter}</li>
+ *     <li>{@link CharSequenceStringConverter}</li>
+ *     <li>{@link OffsetDateTimeStringConverter}</li>
+ *     <li>{@link PeriodStringConverter}</li>
+ *     <li>{@link StringStringConverter}</li>
+ *     <li>{@link StringBufferStringConverter}</li>
+ *     <li>{@link StringBuilderStringConverter}</li>
+ *     <li>{@link UriStringConverter}</li>
+ *     <li>{@link UrlStringConverter}</li>
+ *     <li>{@link UuidStringConverter}</li>
+ *     <li>{@link ZonedDateTimeStringConverter}</li>
+ *     <li>{@link ZoneIdStringConverter}</li>
+ *     <li>{@link ZoneOffsetStringConverter}</li>
+ *     <li>{@link ByteArrayStringConverter}</li>
+ *     <li>{@link ByteStringConverter}</li>
+ *     <li>{@link SdkBytesStringConverter}</li>
+ *     <li>{@link AtomicBooleanStringConverter}</li>
+ *     <li>{@link BooleanStringConverter}</li>
+ * </ul>
+ *
+ * <p>
+ * This can be created via {@link #create()}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class DefaultStringConverterProvider<T> implements StringConverterProvider {
+
+    private final ConcurrentHashMap<TypeToken<?>, StringConverter<? extends T>> converterCache =
+        new ConcurrentHashMap<>();
+
+    private DefaultStringConverterProvider(Builder<T> builder) {
+        // Converters are used in the REVERSE order of how they were added to the builder.
+        for (int i = builder.converters.size() - 1; i >= 0; i--) {
+            StringConverter<? extends T> converter = builder.converters.get(i);
+            converterCache.put(converter.type(), converter);
+
+            if (converter instanceof PrimitiveConverter) {
+                PrimitiveConverter primitiveConverter = (PrimitiveConverter) converter;
+                converterCache.put(primitiveConverter.primitiveType(), converter);
+            }
+        }
+    }
+
+    /**
+     * Create a builder for a {@link DefaultStringConverterProvider}.
+     */
+    public static Builder<Object> builder() {
+        return new Builder<>();
+    }
+
+    public static DefaultStringConverterProvider create() {
+        return DefaultStringConverterProvider.builder()
+                                             .addConverter(ByteArrayStringConverter.create())
+                                             .addConverter(CharacterArrayStringConverter.create())
+                                             .addConverter(BooleanStringConverter.create())
+                                             .addConverter(ShortStringConverter.create())
+                                             .addConverter(IntegerStringConverter.create())
+                                             .addConverter(LongStringConverter.create())
+                                             .addConverter(FloatStringConverter.create())
+                                             .addConverter(DoubleStringConverter.create())
+                                             .addConverter(CharacterStringConverter.create())
+                                             .addConverter(ByteStringConverter.create())
+                                             .addConverter(StringStringConverter.create())
+                                             .addConverter(CharSequenceStringConverter.create())
+                                             .addConverter(StringBufferStringConverter.create())
+                                             .addConverter(StringBuilderStringConverter.create())
+                                             .addConverter(BigIntegerStringConverter.create())
+                                             .addConverter(BigDecimalStringConverter.create())
+                                             .addConverter(AtomicLongStringConverter.create())
+                                             .addConverter(AtomicIntegerStringConverter.create())
+                                             .addConverter(AtomicBooleanStringConverter.create())
+                                             .addConverter(OptionalIntStringConverter.create())
+                                             .addConverter(OptionalLongStringConverter.create())
+                                             .addConverter(OptionalDoubleStringConverter.create())
+                                             .addConverter(InstantStringConverter.create())
+                                             .addConverter(DurationStringConverter.create())
+                                             .addConverter(LocalDateStringConverter.create())
+                                             .addConverter(LocalTimeStringConverter.create())
+                                             .addConverter(LocalDateTimeStringConverter.create())
+                                             .addConverter(OffsetTimeStringConverter.create())
+                                             .addConverter(OffsetDateTimeStringConverter.create())
+                                             .addConverter(ZonedDateTimeStringConverter.create())
+                                             .addConverter(YearStringConverter.create())
+                                             .addConverter(YearMonthStringConverter.create())
+                                             .addConverter(MonthDayStringConverter.create())
+                                             .addConverter(PeriodStringConverter.create())
+                                             .addConverter(ZoneOffsetStringConverter.create())
+                                             .addConverter(ZoneIdStringConverter.create())
+                                             .addConverter(UuidStringConverter.create())
+                                             .addConverter(UrlStringConverter.create())
+                                             .addConverter(UriStringConverter.create())
+                                             .build();
+    }
+
+    @Override
+    public <T> StringConverter<T> converterFor(TypeToken<T> typeToken) {
+        @SuppressWarnings("unchecked") // We initialized correctly, so this is safe.
+        StringConverter<T> converter = (StringConverter<T>) converterCache.get(typeToken);
+
+        if (converter == null) {
+            throw new IllegalArgumentException("No string converter exists for " + typeToken.rawClass());
+        }
+
+        return converter;
+    }
+
+    /**
+     * A builder for configuring and creating {@link DefaultStringConverterProvider}s.
+     */
+    public static class Builder<T> {
+        private List<StringConverter<? extends T>> converters = new ArrayList<>();
+
+        private Builder() {}
+
+        public Builder<T> addConverters(Collection<? extends StringConverter<? extends T>> converters) {
+            Validate.paramNotNull(converters, "converters");
+            Validate.noNullElements(converters, "Converters must not contain null members.");
+            this.converters.addAll(converters);
+            return this;
+        }
+
+        public Builder<T> addConverter(StringConverter<? extends T> converter) {
+            Validate.paramNotNull(converter, "converter");
+            this.converters.add(converter);
+            return this;
+        }
+
+        public Builder<T> clearConverters() {
+            this.converters.clear();
+            return this;
+        }
+
+        public DefaultStringConverterProvider<T> build() {
+            return new DefaultStringConverterProvider(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/StringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/StringConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.converter.Converter;
+
+/**
+ * Converts a specific Java type to/from a {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public interface StringConverter<T> extends Converter<T> {
+    /**
+     * Convert the provided object into a string.
+     */
+    default String toString(T object) {
+        return object.toString();
+    }
+
+    /**
+     * Convert the provided string into an object.
+     */
+    T fromString(String string);
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/StringConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/StringConverterProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+
+@SdkPublicApi
+public interface StringConverterProvider {
+    <T> StringConverter<T> converterFor(TypeToken<T> typeToken);
+
+    static StringConverterProvider defaultProvider() {
+        return DefaultStringConverterProvider.create();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/AtomicBooleanStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/AtomicBooleanStringConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link AtomicBoolean} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link BooleanStringConverter}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class AtomicBooleanStringConverter implements StringConverter<AtomicBoolean> {
+    private static BooleanStringConverter BOOLEAN_CONVERTER = BooleanStringConverter.create();
+
+    private AtomicBooleanStringConverter() { }
+
+    public static AtomicBooleanStringConverter create() {
+        return new AtomicBooleanStringConverter();
+    }
+
+    @Override
+    public TypeToken<AtomicBoolean> type() {
+        return TypeToken.of(AtomicBoolean.class);
+    }
+
+    @Override
+    public String toString(AtomicBoolean object) {
+        return BOOLEAN_CONVERTER.toString(object.get());
+    }
+
+    @Override
+    public AtomicBoolean fromString(String string) {
+        return new AtomicBoolean(BOOLEAN_CONVERTER.fromString(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/AtomicIntegerStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/AtomicIntegerStringConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link AtomicInteger} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link IntegerStringConverter}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class AtomicIntegerStringConverter implements StringConverter<AtomicInteger> {
+    private static IntegerStringConverter INTEGER_CONVERTER = IntegerStringConverter.create();
+
+    private AtomicIntegerStringConverter() { }
+
+    public static AtomicIntegerStringConverter create() {
+        return new AtomicIntegerStringConverter();
+    }
+
+    @Override
+    public TypeToken<AtomicInteger> type() {
+        return TypeToken.of(AtomicInteger.class);
+    }
+
+    @Override
+    public String toString(AtomicInteger object) {
+        return INTEGER_CONVERTER.toString(object.get());
+    }
+
+    @Override
+    public AtomicInteger fromString(String string) {
+        return new AtomicInteger(INTEGER_CONVERTER.fromString(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/AtomicLongStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/AtomicLongStringConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.concurrent.atomic.AtomicLong;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link AtomicLong} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link LongStringConverter}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class AtomicLongStringConverter implements StringConverter<AtomicLong> {
+    private static LongStringConverter LONG_CONVERTER = LongStringConverter.create();
+
+    private AtomicLongStringConverter() { }
+
+    public static AtomicLongStringConverter create() {
+        return new AtomicLongStringConverter();
+    }
+
+    @Override
+    public TypeToken<AtomicLong> type() {
+        return TypeToken.of(AtomicLong.class);
+    }
+
+    @Override
+    public String toString(AtomicLong object) {
+        return LONG_CONVERTER.toString(object.get());
+    }
+
+    @Override
+    public AtomicLong fromString(String string) {
+        return new AtomicLong(LONG_CONVERTER.fromString(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/BigDecimalStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/BigDecimalStringConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.math.BigDecimal;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link BigDecimal} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link BigDecimal#toString()} and {@link BigDecimal#BigDecimal(String)}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class BigDecimalStringConverter implements StringConverter<BigDecimal> {
+    private BigDecimalStringConverter() { }
+
+    public static BigDecimalStringConverter create() {
+        return new BigDecimalStringConverter();
+    }
+
+    @Override
+    public TypeToken<BigDecimal> type() {
+        return TypeToken.of(BigDecimal.class);
+    }
+
+    @Override
+    public BigDecimal fromString(String string) {
+        return new BigDecimal(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/BigIntegerStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/BigIntegerStringConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.math.BigInteger;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link BigInteger} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link BigInteger#toString()} and {@link BigInteger#BigInteger(String)}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class BigIntegerStringConverter implements StringConverter<BigInteger> {
+    private BigIntegerStringConverter() { }
+
+    public static BigIntegerStringConverter create() {
+        return new BigIntegerStringConverter();
+    }
+
+    @Override
+    public TypeToken<BigInteger> type() {
+        return TypeToken.of(BigInteger.class);
+    }
+
+    @Override
+    public BigInteger fromString(String string) {
+        return new BigInteger(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/BooleanStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/BooleanStringConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.math.BigInteger;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link BigInteger} and {@link String}.
+ *
+ * <p>
+ * This converts values to strings using {@link Boolean#toString()}. This converts the literal string values "true" and "false"
+ * to a boolean. Any other string values will result in an exception.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class BooleanStringConverter implements StringConverter<Boolean>, PrimitiveConverter<Boolean> {
+    private BooleanStringConverter() { }
+
+    public static BooleanStringConverter create() {
+        return new BooleanStringConverter();
+    }
+
+    @Override
+    public TypeToken<Boolean> type() {
+        return TypeToken.of(Boolean.class);
+    }
+
+    @Override
+    public TypeToken<Boolean> primitiveType() {
+        return TypeToken.of(boolean.class);
+    }
+
+    @Override
+    public Boolean fromString(String string) {
+        switch (string) {
+            case "true": return true;
+            case "false": return false;
+            default: throw new IllegalArgumentException("Boolean string was not 'true' or 'false': " + string);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ByteArrayStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ByteArrayStringConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.math.BigInteger;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+/**
+ * A converter between {@link BigInteger} and {@link String}.
+ *
+ * <p>
+ * This converts bytes to a base 64 string.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class ByteArrayStringConverter implements StringConverter<byte[]> {
+    private ByteArrayStringConverter() { }
+
+    public static ByteArrayStringConverter create() {
+        return new ByteArrayStringConverter();
+    }
+
+    @Override
+    public TypeToken<byte[]> type() {
+        return TypeToken.of(byte[].class);
+    }
+
+    @Override
+    public String toString(byte[] object) {
+        return BinaryUtils.toBase64(object);
+    }
+
+    @Override
+    public byte[] fromString(String string) {
+        return BinaryUtils.fromBase64(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ByteStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ByteStringConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.math.BigInteger;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link BigInteger} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link Byte#toString()} and {@link Byte#valueOf(String)}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class ByteStringConverter implements StringConverter<Byte>, PrimitiveConverter<Byte> {
+    private ByteStringConverter() { }
+
+    public static ByteStringConverter create() {
+        return new ByteStringConverter();
+    }
+
+    @Override
+    public TypeToken<Byte> type() {
+        return TypeToken.of(Byte.class);
+    }
+
+    @Override
+    public TypeToken<Byte> primitiveType() {
+        return TypeToken.of(byte.class);
+    }
+
+    @Override
+    public Byte fromString(String string) {
+        return Byte.valueOf(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/CharSequenceStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/CharSequenceStringConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link CharSequence} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class CharSequenceStringConverter implements StringConverter<CharSequence> {
+    private CharSequenceStringConverter() { }
+
+    public static CharSequenceStringConverter create() {
+        return new CharSequenceStringConverter();
+    }
+
+    @Override
+    public TypeToken<CharSequence> type() {
+        return TypeToken.of(CharSequence.class);
+    }
+
+    @Override
+    public CharSequence fromString(String string) {
+        return string;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/CharacterArrayStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/CharacterArrayStringConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@code char[]} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link String#String(char[])} and {@link String#toCharArray()}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class CharacterArrayStringConverter implements StringConverter<char[]> {
+    private CharacterArrayStringConverter() { }
+
+    public static CharacterArrayStringConverter create() {
+        return new CharacterArrayStringConverter();
+    }
+
+    @Override
+    public TypeToken<char[]> type() {
+        return TypeToken.of(char[].class);
+    }
+
+    @Override
+    public String toString(char[] object) {
+        return new String(object);
+    }
+
+    @Override
+    public char[] fromString(String string) {
+        return string.toCharArray();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/CharacterStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/CharacterStringConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A converter between {@link Character} and {@link String}.
+ *
+ * <p>
+ * This converts values using {@link Character#toString()} and {@link String#charAt(int)}. If the string value is longer
+ * than 1 character, an exception will be raised.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class CharacterStringConverter implements StringConverter<Character>, PrimitiveConverter<Character> {
+    private CharacterStringConverter() { }
+
+    public static CharacterStringConverter create() {
+        return new CharacterStringConverter();
+    }
+
+    @Override
+    public TypeToken<Character> type() {
+        return TypeToken.of(Character.class);
+    }
+
+    @Override
+    public TypeToken<Character> primitiveType() {
+        return TypeToken.of(char.class);
+    }
+
+    @Override
+    public Character fromString(String string) {
+        Validate.isTrue(string.length() == 1, "Character string was not of length 1: %s", string);
+        return string.charAt(0);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/DoubleStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/DoubleStringConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Double} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class DoubleStringConverter implements StringConverter<Double>, PrimitiveConverter<Double> {
+    private DoubleStringConverter() { }
+
+    public static DoubleStringConverter create() {
+        return new DoubleStringConverter();
+    }
+
+    @Override
+    public TypeToken<Double> type() {
+        return TypeToken.of(Double.class);
+    }
+
+    @Override
+    public TypeToken<Double> primitiveType() {
+        return TypeToken.of(double.class);
+    }
+
+    @Override
+    public Double fromString(String string) {
+        return Double.valueOf(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/DurationStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/DurationStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Duration} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class DurationStringConverter implements StringConverter<Duration> {
+    private DurationStringConverter() { }
+
+    public static DurationStringConverter create() {
+        return new DurationStringConverter();
+    }
+
+    @Override
+    public TypeToken<Duration> type() {
+        return TypeToken.of(Duration.class);
+    }
+
+    @Override
+    public Duration fromString(String string) {
+        return Duration.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/FloatStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/FloatStringConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Float} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class FloatStringConverter implements StringConverter<Float>, PrimitiveConverter<Float> {
+    private FloatStringConverter() { }
+
+    public static FloatStringConverter create() {
+        return new FloatStringConverter();
+    }
+
+    @Override
+    public TypeToken<Float> type() {
+        return TypeToken.of(Float.class);
+    }
+
+    @Override
+    public TypeToken<Float> primitiveType() {
+        return TypeToken.of(float.class);
+    }
+
+    @Override
+    public Float fromString(String string) {
+        return Float.valueOf(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/InstantStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/InstantStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.Instant;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Instant} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class InstantStringConverter implements StringConverter<Instant> {
+    private InstantStringConverter() { }
+
+    public static InstantStringConverter create() {
+        return new InstantStringConverter();
+    }
+
+    @Override
+    public TypeToken<Instant> type() {
+        return TypeToken.of(Instant.class);
+    }
+
+    @Override
+    public Instant fromString(String string) {
+        return Instant.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/IntegerStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/IntegerStringConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Integer} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class IntegerStringConverter implements StringConverter<Integer>, PrimitiveConverter<Integer> {
+    private IntegerStringConverter() { }
+
+    public static IntegerStringConverter create() {
+        return new IntegerStringConverter();
+    }
+
+    @Override
+    public TypeToken<Integer> type() {
+        return TypeToken.of(Integer.class);
+    }
+
+    @Override
+    public TypeToken<Integer> primitiveType() {
+        return TypeToken.of(int.class);
+    }
+
+    @Override
+    public Integer fromString(String string) {
+        return Integer.valueOf(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LocalDateStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LocalDateStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.LocalDate;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link LocalDate} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class LocalDateStringConverter implements StringConverter<LocalDate> {
+    private LocalDateStringConverter() { }
+
+    public static LocalDateStringConverter create() {
+        return new LocalDateStringConverter();
+    }
+
+    @Override
+    public TypeToken<LocalDate> type() {
+        return TypeToken.of(LocalDate.class);
+    }
+
+    @Override
+    public LocalDate fromString(String string) {
+        return LocalDate.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LocalDateTimeStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LocalDateTimeStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.LocalDateTime;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link LocalDateTime} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class LocalDateTimeStringConverter implements StringConverter<LocalDateTime> {
+    private LocalDateTimeStringConverter() { }
+
+    public static LocalDateTimeStringConverter create() {
+        return new LocalDateTimeStringConverter();
+    }
+
+    @Override
+    public TypeToken<LocalDateTime> type() {
+        return TypeToken.of(LocalDateTime.class);
+    }
+
+    @Override
+    public LocalDateTime fromString(String string) {
+        return LocalDateTime.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LocalTimeStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LocalTimeStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.LocalTime;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link LocalTime} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class LocalTimeStringConverter implements StringConverter<LocalTime> {
+    private LocalTimeStringConverter() { }
+
+    public static LocalTimeStringConverter create() {
+        return new LocalTimeStringConverter();
+    }
+
+    @Override
+    public TypeToken<LocalTime> type() {
+        return TypeToken.of(LocalTime.class);
+    }
+
+    @Override
+    public LocalTime fromString(String string) {
+        return LocalTime.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LongStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/LongStringConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Long} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class LongStringConverter implements StringConverter<Long>, PrimitiveConverter<Long> {
+    private LongStringConverter() { }
+
+    public static LongStringConverter create() {
+        return new LongStringConverter();
+    }
+
+    @Override
+    public TypeToken<Long> type() {
+        return TypeToken.of(Long.class);
+    }
+
+    @Override
+    public TypeToken<Long> primitiveType() {
+        return TypeToken.of(long.class);
+    }
+
+    @Override
+    public Long fromString(String string) {
+        return Long.valueOf(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/MonthDayStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/MonthDayStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.MonthDay;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link MonthDay} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class MonthDayStringConverter implements StringConverter<MonthDay> {
+    private MonthDayStringConverter() { }
+
+    public static MonthDayStringConverter create() {
+        return new MonthDayStringConverter();
+    }
+
+    @Override
+    public TypeToken<MonthDay> type() {
+        return TypeToken.of(MonthDay.class);
+    }
+
+    @Override
+    public MonthDay fromString(String string) {
+        return MonthDay.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OffsetDateTimeStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OffsetDateTimeStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.OffsetDateTime;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link OffsetDateTime} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class OffsetDateTimeStringConverter implements StringConverter<OffsetDateTime> {
+    private OffsetDateTimeStringConverter() { }
+
+    public static OffsetDateTimeStringConverter create() {
+        return new OffsetDateTimeStringConverter();
+    }
+
+    @Override
+    public TypeToken<OffsetDateTime> type() {
+        return TypeToken.of(OffsetDateTime.class);
+    }
+
+    @Override
+    public OffsetDateTime fromString(String string) {
+        return OffsetDateTime.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OffsetTimeStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OffsetTimeStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.OffsetTime;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link OffsetTime} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class OffsetTimeStringConverter implements StringConverter<OffsetTime> {
+    private OffsetTimeStringConverter() { }
+
+    public static OffsetTimeStringConverter create() {
+        return new OffsetTimeStringConverter();
+    }
+
+    @Override
+    public TypeToken<OffsetTime> type() {
+        return TypeToken.of(OffsetTime.class);
+    }
+
+    @Override
+    public OffsetTime fromString(String string) {
+        return OffsetTime.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OptionalDoubleStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OptionalDoubleStringConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.OptionalDouble;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link OptionalDouble} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class OptionalDoubleStringConverter implements StringConverter<OptionalDouble> {
+    private static DoubleStringConverter DOUBLE_CONVERTER = DoubleStringConverter.create();
+
+    private OptionalDoubleStringConverter() { }
+
+    public static OptionalDoubleStringConverter create() {
+        return new OptionalDoubleStringConverter();
+    }
+
+    @Override
+    public TypeToken<OptionalDouble> type() {
+        return TypeToken.of(OptionalDouble.class);
+    }
+
+    @Override
+    public String toString(OptionalDouble object) {
+        if (!object.isPresent()) {
+            return null;
+        }
+        return DOUBLE_CONVERTER.toString(object.getAsDouble());
+    }
+
+    @Override
+    public OptionalDouble fromString(String string) {
+        if (string == null) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of(DOUBLE_CONVERTER.fromString(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OptionalIntStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OptionalIntStringConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.OptionalInt;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link OptionalInt} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class OptionalIntStringConverter implements StringConverter<OptionalInt> {
+    private static IntegerStringConverter INTEGER_CONVERTER = IntegerStringConverter.create();
+
+    private OptionalIntStringConverter() { }
+
+    public static OptionalIntStringConverter create() {
+        return new OptionalIntStringConverter();
+    }
+
+    @Override
+    public TypeToken<OptionalInt> type() {
+        return TypeToken.of(OptionalInt.class);
+    }
+
+    @Override
+    public String toString(OptionalInt object) {
+        if (!object.isPresent()) {
+            return null;
+        }
+        return INTEGER_CONVERTER.toString(object.getAsInt());
+    }
+
+    @Override
+    public OptionalInt fromString(String string) {
+        if (string == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(INTEGER_CONVERTER.fromString(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OptionalLongStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/OptionalLongStringConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.OptionalLong;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link OptionalLong} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class OptionalLongStringConverter implements StringConverter<OptionalLong> {
+    private static LongStringConverter LONG_CONVERTER = LongStringConverter.create();
+
+    private OptionalLongStringConverter() { }
+
+    public static OptionalLongStringConverter create() {
+        return new OptionalLongStringConverter();
+    }
+
+    @Override
+    public TypeToken<OptionalLong> type() {
+        return TypeToken.of(OptionalLong.class);
+    }
+
+    @Override
+    public String toString(OptionalLong object) {
+        if (!object.isPresent()) {
+            return null;
+        }
+        return LONG_CONVERTER.toString(object.getAsLong());
+    }
+
+    @Override
+    public OptionalLong fromString(String string) {
+        if (string == null) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(LONG_CONVERTER.fromString(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/PeriodStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/PeriodStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.Period;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Period} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class PeriodStringConverter implements StringConverter<Period> {
+    private PeriodStringConverter() { }
+
+    public static PeriodStringConverter create() {
+        return new PeriodStringConverter();
+    }
+
+    @Override
+    public TypeToken<Period> type() {
+        return TypeToken.of(Period.class);
+    }
+
+    @Override
+    public Period fromString(String string) {
+        return Period.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/SdkBytesStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/SdkBytesStringConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+/**
+ * A converter between {@link SdkBytes} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class SdkBytesStringConverter implements StringConverter<SdkBytes> {
+    private SdkBytesStringConverter() { }
+
+    public static SdkBytesStringConverter create() {
+        return new SdkBytesStringConverter();
+    }
+
+    @Override
+    public TypeToken<SdkBytes> type() {
+        return TypeToken.of(SdkBytes.class);
+    }
+
+    @Override
+    public String toString(SdkBytes object) {
+        return BinaryUtils.toBase64(object.asByteArray());
+    }
+
+    @Override
+    public SdkBytes fromString(String string) {
+        return SdkBytes.fromByteArray(BinaryUtils.fromBase64(string));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ShortStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ShortStringConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Short} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class ShortStringConverter implements StringConverter<Short>, PrimitiveConverter<Short> {
+    private ShortStringConverter() { }
+
+    public static ShortStringConverter create() {
+        return new ShortStringConverter();
+    }
+
+    @Override
+    public TypeToken<Short> type() {
+        return TypeToken.of(Short.class);
+    }
+
+    @Override
+    public TypeToken<Short> primitiveType() {
+        return TypeToken.of(short.class);
+    }
+
+    @Override
+    public Short fromString(String string) {
+        return Short.valueOf(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/StringBufferStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/StringBufferStringConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link StringBuffer} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class StringBufferStringConverter implements StringConverter<StringBuffer> {
+    private StringBufferStringConverter() { }
+
+    public static StringBufferStringConverter create() {
+        return new StringBufferStringConverter();
+    }
+
+    @Override
+    public TypeToken<StringBuffer> type() {
+        return TypeToken.of(StringBuffer.class);
+    }
+
+    @Override
+    public StringBuffer fromString(String string) {
+        return new StringBuffer(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/StringBuilderStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/StringBuilderStringConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link StringBuilder} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class StringBuilderStringConverter implements StringConverter<StringBuilder> {
+    private StringBuilderStringConverter() { }
+
+    public static StringBuilderStringConverter create() {
+        return new StringBuilderStringConverter();
+    }
+
+    @Override
+    public TypeToken<StringBuilder> type() {
+        return TypeToken.of(StringBuilder.class);
+    }
+
+    @Override
+    public StringBuilder fromString(String string) {
+        return new StringBuilder(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/StringStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/StringStringConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link String} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class StringStringConverter implements StringConverter<String> {
+    private StringStringConverter() { }
+
+    public static StringStringConverter create() {
+        return new StringStringConverter();
+    }
+
+    @Override
+    public TypeToken<String> type() {
+        return TypeToken.of(String.class);
+    }
+
+    @Override
+    public String toString(String object) {
+        return object;
+    }
+
+    @Override
+    public String fromString(String string) {
+        return string;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/UriStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/UriStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.net.URI;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link URI} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class UriStringConverter implements StringConverter<URI> {
+    private UriStringConverter() { }
+
+    public static UriStringConverter create() {
+        return new UriStringConverter();
+    }
+
+    @Override
+    public TypeToken<URI> type() {
+        return TypeToken.of(URI.class);
+    }
+
+    @Override
+    public URI fromString(String string) {
+        return URI.create(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/UrlStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/UrlStringConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link URL} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class UrlStringConverter implements StringConverter<URL> {
+    private UrlStringConverter() { }
+
+    public static UrlStringConverter create() {
+        return new UrlStringConverter();
+    }
+
+    @Override
+    public TypeToken<URL> type() {
+        return TypeToken.of(URL.class);
+    }
+
+    @Override
+    public URL fromString(String string) {
+        try {
+            return new URL(string);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("URL format was incorrect: " + string, e);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/UuidStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/UuidStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.util.UUID;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link UUID} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class UuidStringConverter implements StringConverter<UUID> {
+    private UuidStringConverter() { }
+
+    public static UuidStringConverter create() {
+        return new UuidStringConverter();
+    }
+
+    @Override
+    public TypeToken<UUID> type() {
+        return TypeToken.of(UUID.class);
+    }
+
+    @Override
+    public UUID fromString(String string) {
+        return UUID.fromString(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/YearMonthStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/YearMonthStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.YearMonth;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link YearMonth} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class YearMonthStringConverter implements StringConverter<YearMonth> {
+    private YearMonthStringConverter() { }
+
+    public static YearMonthStringConverter create() {
+        return new YearMonthStringConverter();
+    }
+
+    @Override
+    public TypeToken<YearMonth> type() {
+        return TypeToken.of(YearMonth.class);
+    }
+
+    @Override
+    public YearMonth fromString(String string) {
+        return YearMonth.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/YearStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/YearStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.Year;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link Year} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class YearStringConverter implements StringConverter<Year> {
+    private YearStringConverter() { }
+
+    public static YearStringConverter create() {
+        return new YearStringConverter();
+    }
+
+    @Override
+    public TypeToken<Year> type() {
+        return TypeToken.of(Year.class);
+    }
+
+    @Override
+    public Year fromString(String string) {
+        return Year.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ZoneIdStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ZoneIdStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.ZoneId;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link ZoneId} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class ZoneIdStringConverter implements StringConverter<ZoneId> {
+    private ZoneIdStringConverter() { }
+
+    public static ZoneIdStringConverter create() {
+        return new ZoneIdStringConverter();
+    }
+
+    @Override
+    public TypeToken<ZoneId> type() {
+        return TypeToken.of(ZoneId.class);
+    }
+
+    @Override
+    public ZoneId fromString(String string) {
+        return ZoneId.of(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ZoneOffsetStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ZoneOffsetStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.ZoneOffset;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link ZoneOffset} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class ZoneOffsetStringConverter implements StringConverter<ZoneOffset> {
+    private ZoneOffsetStringConverter() { }
+
+    public static ZoneOffsetStringConverter create() {
+        return new ZoneOffsetStringConverter();
+    }
+
+    @Override
+    public TypeToken<ZoneOffset> type() {
+        return TypeToken.of(ZoneOffset.class);
+    }
+
+    @Override
+    public ZoneOffset fromString(String string) {
+        return ZoneOffset.of(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ZonedDateTimeStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/converter/string/bundled/ZonedDateTimeStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converter.string.bundled;
+
+import java.time.ZonedDateTime;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.converter.string.StringConverter;
+
+/**
+ * A converter between {@link ZonedDateTime} and {@link String}.
+ */
+@SdkPublicApi
+@ThreadSafe
+@Immutable
+public class ZonedDateTimeStringConverter implements StringConverter<ZonedDateTime> {
+    private ZonedDateTimeStringConverter() { }
+
+    public static ZonedDateTimeStringConverter create() {
+        return new ZonedDateTimeStringConverter();
+    }
+
+    @Override
+    public TypeToken<ZonedDateTime> type() {
+        return TypeToken.of(ZonedDateTime.class);
+    }
+
+    @Override
+    public ZonedDateTime fromString(String string) {
+        return ZonedDateTime.parse(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/AttributeValueType.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/AttributeValueType.java
@@ -28,7 +28,8 @@ public enum AttributeValueType {
     N(ScalarAttributeType.N),        // number
     NS,                              // number set
     S(ScalarAttributeType.S),        // string
-    SS;                              // string set
+    SS,                              // string set
+    NULL;                            // null
 
     private final ScalarAttributeType scalarAttributeType;
 


### PR DESCRIPTION
String converters that are used for converting from Java types to string. This is 1 of 4 PRs for adding attribute converters to DDB.

1. String Converters
2. Attribute Converters without collections
3. Collection Attribute Converters
4. Wiring

## Testing
String converters are tested as part of attribute converters in PR: https://github.com/aws/aws-sdk-java-v2/pull/1652
