### PR TITLE
Refactoring plus unit tests to assert no additional DNS caching for a…

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
@@ -19,7 +19,6 @@ import static software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration.
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
@@ -28,7 +27,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -40,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
@@ -75,11 +74,14 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         }
     };
 
+    // IMPORTANT: If the default bootstrap provider is changed, ensure that the new implementation is compliant with
+    // DNS resolver testing in BootstrapProviderTest, specifically that no caching of hostname lookups is taking place.
+    private static final Function<Builder, BootstrapProvider> DEFAULT_BOOTSTRAP_PROVIDER =
+        b -> new BootstrapProvider(b.sdkEventLoopGroup, b.configuration, b.sdkChannelOptions);
+
     private final Map<URI, Boolean> shouldProxyForHostCache = new ConcurrentHashMap<>();
 
 
-    private final SdkChannelOptions sdkChannelOptions;
-    private final SdkEventLoopGroup sdkEventLoopGroup;
     private final NettyConfiguration configuration;
     private final Protocol protocol;
     private final long maxStreams;
@@ -87,10 +89,9 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
     private final int initialWindowSize;
     private final SslProvider sslProvider;
     private final ProxyConfiguration proxyConfiguration;
+    private final BootstrapProvider bootstrapProvider;
 
-    private AwaitCloseChannelPoolMap(Builder builder) {
-        this.sdkChannelOptions = builder.sdkChannelOptions;
-        this.sdkEventLoopGroup = builder.sdkEventLoopGroup;
+    private AwaitCloseChannelPoolMap(Builder builder, Function<Builder, BootstrapProvider> createBootStrapProvider) {
         this.configuration = builder.configuration;
         this.protocol = builder.protocol;
         this.maxStreams = builder.maxStreams;
@@ -98,12 +99,22 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         this.initialWindowSize = builder.initialWindowSize;
         this.sslProvider = builder.sslProvider;
         this.proxyConfiguration = builder.proxyConfiguration;
+        this.bootstrapProvider = createBootStrapProvider.apply(builder);
+    }
+
+    private AwaitCloseChannelPoolMap(Builder builder) {
+        this(builder, DEFAULT_BOOTSTRAP_PROVIDER);
     }
 
     @SdkTestInternalApi
-    AwaitCloseChannelPoolMap(Builder builder, Map<URI, Boolean> shouldProxyForHostCache) {
-        this(builder);
-        this.shouldProxyForHostCache.putAll(shouldProxyForHostCache);
+    AwaitCloseChannelPoolMap(Builder builder,
+                             Map<URI, Boolean> shouldProxyForHostCache,
+                             BootstrapProvider bootstrapProvider) {
+        this(builder, bootstrapProvider == null ? DEFAULT_BOOTSTRAP_PROVIDER : b -> bootstrapProvider);
+
+        if (shouldProxyForHostCache != null) {
+            this.shouldProxyForHostCache.putAll(shouldProxyForHostCache);
+        }
     }
 
     public static Builder builder() {
@@ -172,17 +183,7 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
     private Bootstrap createBootstrap(URI poolKey) {
         String host = bootstrapHost(poolKey);
         int port = bootstrapPort(poolKey);
-
-        Bootstrap bootstrap =
-                new Bootstrap()
-                        .group(sdkEventLoopGroup.eventLoopGroup())
-                        .channelFactory(sdkEventLoopGroup.channelFactory())
-                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.connectTimeoutMillis())
-                        // TODO run some performance tests with and without this.
-                        .remoteAddress(InetSocketAddress.createUnresolved(host, port));
-        sdkChannelOptions.channelOptions().forEach(bootstrap::option);
-
-        return bootstrap;
+        return bootstrapProvider.createBootstrap(host, port);
     }
 
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/BootstrapProvider.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/BootstrapProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelOption;
+import java.net.InetSocketAddress;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+
+/**
+ * The primary purpose of this Bootstrap provider is to ensure that all Bootstraps created by it are 'unresolved'
+ * InetSocketAddress. This is to prevent Netty from caching the resolved address of a host and then re-using it in
+ * subsequent connection attempts, and instead deferring to the JVM to handle address resolution and caching.
+ */
+@SdkInternalApi
+public class BootstrapProvider {
+    private final SdkEventLoopGroup sdkEventLoopGroup;
+    private final NettyConfiguration nettyConfiguration;
+    private final SdkChannelOptions sdkChannelOptions;
+
+
+    BootstrapProvider(SdkEventLoopGroup sdkEventLoopGroup,
+                      NettyConfiguration nettyConfiguration,
+                      SdkChannelOptions sdkChannelOptions) {
+        this.sdkEventLoopGroup = sdkEventLoopGroup;
+        this.nettyConfiguration = nettyConfiguration;
+        this.sdkChannelOptions = sdkChannelOptions;
+    }
+
+    /**
+     * Creates a Bootstrap for a specific host and port with an unresolved InetSocketAddress as the remoteAddress.
+     * @param host The unresolved remote hostname
+     * @param port The remote port
+     * @return A newly created Bootstrap using the configuration this provider was initialized with, and having an
+     * unresolved remote address.
+     */
+    public Bootstrap createBootstrap(String host, int port) {
+        Bootstrap bootstrap =
+            new Bootstrap()
+                .group(sdkEventLoopGroup.eventLoopGroup())
+                .channelFactory(sdkEventLoopGroup.channelFactory())
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, nettyConfiguration.connectTimeoutMillis())
+                .remoteAddress(InetSocketAddress.createUnresolved(host, port));
+        sdkChannelOptions.channelOptions().forEach(bootstrap::option);
+
+        return bootstrap;
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
@@ -23,11 +23,6 @@ import static org.mockito.Mockito.verify;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TLS_KEY_MANAGERS_PROVIDER;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.netty.channel.Channel;
-import io.netty.channel.pool.ChannelPool;
-import io.netty.handler.ssl.SslProvider;
-import io.netty.util.concurrent.Future;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,10 +30,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.netty.channel.Channel;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.util.concurrent.Future;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.TlsKeyManagersProvider;
 import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
@@ -95,6 +99,63 @@ public class AwaitCloseChannelPoolMapTest {
     }
 
     @Test
+    public void get_callsInjectedBootstrapProviderCorrectly() {
+        BootstrapProvider bootstrapProvider = Mockito.spy(
+            new BootstrapProvider(SdkEventLoopGroup.builder().build(),
+                                  new NettyConfiguration(GLOBAL_HTTP_DEFAULTS),
+                                  new SdkChannelOptions()));
+
+        URI targetUri = URI.create("https://some-awesome-service-1234.amazonaws.com:8080");
+
+        AwaitCloseChannelPoolMap.Builder builder =
+            AwaitCloseChannelPoolMap.builder()
+                                    .sdkChannelOptions(new SdkChannelOptions())
+                                    .sdkEventLoopGroup(SdkEventLoopGroup.builder().build())
+                                    .configuration(new NettyConfiguration(GLOBAL_HTTP_DEFAULTS))
+                                    .protocol(Protocol.HTTP1_1)
+                                    .maxStreams(100)
+                                    .sslProvider(SslProvider.OPENSSL);
+
+        channelPoolMap = new AwaitCloseChannelPoolMap(builder, null, bootstrapProvider);
+        channelPoolMap.get(targetUri);
+
+        verify(bootstrapProvider).createBootstrap("some-awesome-service-1234.amazonaws.com", 8080);
+    }
+
+    @Test
+    public void get_usingProxy_callsInjectedBootstrapProviderCorrectly() {
+        BootstrapProvider bootstrapProvider = Mockito.spy(
+            new BootstrapProvider(SdkEventLoopGroup.builder().build(),
+                                  new NettyConfiguration(GLOBAL_HTTP_DEFAULTS),
+                                  new SdkChannelOptions()));
+
+        URI targetUri = URI.create("https://some-awesome-service-1234.amazonaws.com:8080");
+        Map<URI, Boolean> shouldProxyCache =  new HashMap<>();
+        shouldProxyCache.put(targetUri, true);
+
+        ProxyConfiguration proxyConfiguration =
+            ProxyConfiguration.builder()
+                              .host("localhost")
+                              .port(mockProxy.port())
+                              .build();
+
+        AwaitCloseChannelPoolMap.Builder builder =
+            AwaitCloseChannelPoolMap.builder()
+                                    .proxyConfiguration(proxyConfiguration)
+                                    .sdkChannelOptions(new SdkChannelOptions())
+                                    .sdkEventLoopGroup(SdkEventLoopGroup.builder().build())
+                                    .configuration(new NettyConfiguration(GLOBAL_HTTP_DEFAULTS))
+                                    .protocol(Protocol.HTTP1_1)
+                                    .maxStreams(100)
+                                    .sslProvider(SslProvider.OPENSSL);
+
+        channelPoolMap = new AwaitCloseChannelPoolMap(builder, shouldProxyCache, bootstrapProvider);
+        channelPoolMap.get(targetUri);
+
+        verify(bootstrapProvider).createBootstrap("localhost", mockProxy.port());
+    }
+
+    @Test
     public void usingProxy_usesCachedValueWhenPresent() {
         URI targetUri = URI.create("https://some-awesome-service-1234.amazonaws.com");
 
@@ -117,7 +178,7 @@ public class AwaitCloseChannelPoolMapTest {
                 .maxStreams(100)
                 .sslProvider(SslProvider.OPENSSL);
 
-        channelPoolMap = new AwaitCloseChannelPoolMap(builder, shouldProxyCache);
+        channelPoolMap = new AwaitCloseChannelPoolMap(builder, shouldProxyCache, null);
 
         // The target host does not exist so acquiring a channel should fail unless we're configured to connect to
         // the mock proxy host for this URI.

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/BootstrapProviderTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/BootstrapProviderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BootstrapProviderTest {
+    private final BootstrapProvider bootstrapProvider =
+        new BootstrapProvider(SdkEventLoopGroup.builder().build(),
+                              new NettyConfiguration(GLOBAL_HTTP_DEFAULTS),
+                              new SdkChannelOptions());
+
+    // IMPORTANT: This unit test asserts that the bootstrap provider creates bootstraps using 'unresolved
+    // InetSocketAddress'. If this test is replaced or removed, perhaps due to a different implementation of
+    // SocketAddress, a different test must be created that ensures that the hostname will be resolved on every
+    // connection attempt and not cached between connection attempts.
+    @Test
+    public void createBootstrap_usesUnresolvedInetSocketAddress() {
+        Bootstrap bootstrap = bootstrapProvider.createBootstrap("some-awesome-service-1234.amazonaws.com", 443);
+
+        SocketAddress socketAddress = bootstrap.config().remoteAddress();
+
+        assertThat(socketAddress).isInstanceOf(InetSocketAddress.class);
+        InetSocketAddress inetSocketAddress = (InetSocketAddress)socketAddress;
+
+        assertThat(inetSocketAddress.isUnresolved()).isTrue();
+    }
+}


### PR DESCRIPTION
…synchronous requests using the Netty client is taking place

<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit (https://github.com/aws/aws-sdk-java-v2/commit/c0ba29106d30696e443f46a5c7e6ee6c2bd5548b) modified the behavior of the Netty Async client to no longer cache host-name resolutions. This change is a minor refactor of the code plus additional unit tests that will help sure that future changes to the code do not regress on this behavior.

## Testing
Unit tests

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
