### PR TITLE
Updating getBucketLocation call to use Waiter for eventual consistency

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/CreateBucketIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/CreateBucketIntegrationTest.java
@@ -21,8 +21,8 @@ import org.junit.AfterClass;
 import org.junit.Test;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
 import software.amazon.awssdk.services.s3.utils.S3TestUtils;
+import software.amazon.awssdk.testutils.Waiter;
 
 public class CreateBucketIntegrationTest extends S3IntegrationTestBase {
 
@@ -44,9 +44,8 @@ public class CreateBucketIntegrationTest extends S3IntegrationTestBase {
     public void createBucket_InUsEast1_Succeeds() {
         US_EAST_1_CLIENT.createBucket(CreateBucketRequest.builder().bucket(US_EAST_1_BUCKET_NAME).build());
 
-        String region = US_EAST_1_CLIENT.getBucketLocation(GetBucketLocationRequest.builder()
-                                                                         .bucket(US_EAST_1_BUCKET_NAME)
-                                                                         .build())
+        String region = Waiter.run(() -> US_EAST_1_CLIENT.getBucketLocation(r -> r.bucket(US_EAST_1_BUCKET_NAME)))
+                              .orFail()
                               .locationConstraintAsString();
         assertThat(region).isEqualToIgnoringCase("");
     }
@@ -56,7 +55,9 @@ public class CreateBucketIntegrationTest extends S3IntegrationTestBase {
         S3Client client = S3Client.builder().region(Region.US_WEST_2).credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).build();
         client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
 
-        String region = client.getBucketLocation(GetBucketLocationRequest.builder().bucket(BUCKET_NAME).build()).locationConstraintAsString();
+        String region = Waiter.run(() -> client.getBucketLocation(r -> r.bucket(BUCKET_NAME)))
+                              .orFail()
+                              .locationConstraintAsString();
         assertThat(region).isEqualToIgnoringCase("us-west-2");
     }
 


### PR DESCRIPTION
Integ test was failing because getBucketLocation was returning a NoSuchBucketException due to eventual consistency. Added a waiter to the call so that it will retry a few times before failing.