### PR TITLE
DynamoDb Enhanced Client: all uses of 'ByteBuffer' changed to 'SdkBytes'

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/AttributeValues.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/AttributeValues.java
@@ -15,9 +15,8 @@
 
 package software.amazon.awssdk.enhanced.dynamodb;
 
-import java.nio.ByteBuffer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeTypes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -62,11 +61,11 @@ public final class AttributeValues {
     }
 
     /**
-     * Creates a literal binary {@link AttributeValue} from a Java {@link ByteBuffer}.
-     * @param value A {@link ByteBuffer} to create the literal from.
+     * Creates a literal binary {@link AttributeValue} from raw bytes.
+     * @param value bytes to create the literal from.
      * @return An {@link AttributeValue} of type B that represents the binary literal.
      */
-    public static AttributeValue binaryValue(ByteBuffer value) {
+    public static AttributeValue binaryValue(SdkBytes value) {
         return AttributeTypes.binaryType().objectToAttributeValue(value);
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/AttributeTypes.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/AttributeTypes.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.mapper;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -96,18 +95,15 @@ public final class AttributeTypes {
         return numberSetType(Float::parseFloat);
     }
 
-    public static AttributeType<ByteBuffer> binaryType() {
-        return StaticAttributeType.create(byteBuffer -> AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build(),
-            attributeValue -> attributeValue.b().asByteBuffer(),
-            AttributeValueType.B);
+    public static AttributeType<SdkBytes> binaryType() {
+        return StaticAttributeType.create(sdkBytes -> AttributeValue.builder().b(sdkBytes).build(),
+                AttributeValue::b, AttributeValueType.B);
     }
 
-    public static AttributeType<Set<ByteBuffer>> binarySetType() {
+    public static AttributeType<Set<SdkBytes>> binarySetType() {
         return StaticAttributeType.create(
-            bbSet -> AttributeValue.builder()
-                                   .bs(bbSet.stream().map(SdkBytes::fromByteBuffer).collect(Collectors.toList()))
-                                   .build(),
-            attributeValue -> attributeValue.bs().stream().map(SdkBytes::asByteBuffer).collect(Collectors.toSet()),
+            bbSet -> AttributeValue.builder().bs(bbSet).build(),
+            attributeValue -> Collections.unmodifiableSet(new HashSet<>(attributeValue.bs())),
             AttributeValueType.BS);
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/Attributes.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/Attributes.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.mapper;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +22,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 
 @SdkPublicApi
@@ -32,8 +32,8 @@ public final class Attributes {
     }
 
     public static <T> Attribute.AttributeSupplier<T> binaryAttribute(String attributeName,
-                                                                     Function<T, ByteBuffer> getAttributeMethod,
-                                                                     BiConsumer<T, ByteBuffer> updateItemMethod) {
+                                                                     Function<T, SdkBytes> getAttributeMethod,
+                                                                     BiConsumer<T, SdkBytes> updateItemMethod) {
         return Attribute.create(
             attributeName,
             getAttributeMethod,
@@ -42,8 +42,8 @@ public final class Attributes {
     }
 
     public static <T> Attribute.AttributeSupplier<T> binarySetAttribute(String attributeName,
-                                                                        Function<T, Set<ByteBuffer>> getAttributeMethod,
-                                                                        BiConsumer<T, Set<ByteBuffer>> updateItemMethod) {
+                                                                        Function<T, Set<SdkBytes>> getAttributeMethod,
+                                                                        BiConsumer<T, Set<SdkBytes>> updateItemMethod) {
         return Attribute.create(
             attributeName,
             getAttributeMethod,

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -121,7 +121,7 @@ public final class BeanTableSchema<T> implements TableSchema<T> {
         map.put(TypeToken.of(double.class), AttributeTypes.doubleNumberType());
         map.put(TypeToken.of(Float.class), AttributeTypes.floatNumberType());
         map.put(TypeToken.of(float.class), AttributeTypes.floatNumberType());
-        map.put(TypeToken.of(ByteBuffer.class), AttributeTypes.binaryType());
+        map.put(TypeToken.of(SdkBytes.class), AttributeTypes.binaryType());
         map.put(TypeToken.setOf(String.class), AttributeTypes.stringSetType());
         map.put(TypeToken.setOf(Integer.class), AttributeTypes.integerNumberSetType());
         map.put(TypeToken.setOf(Long.class), AttributeTypes.longNumberSetType());
@@ -129,7 +129,7 @@ public final class BeanTableSchema<T> implements TableSchema<T> {
         map.put(TypeToken.setOf(Byte.class), AttributeTypes.byteNumberSetType());
         map.put(TypeToken.setOf(Double.class), AttributeTypes.doubleNumberSetType());
         map.put(TypeToken.setOf(Float.class), AttributeTypes.floatNumberSetType());
-        map.put(TypeToken.setOf(ByteBuffer.class), AttributeTypes.binarySetType());
+        map.put(TypeToken.setOf(SdkBytes.class), AttributeTypes.binarySetType());
 
         ATTRIBUTE_TYPES_MAP = Collections.unmodifiableMap(map);
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/FakeItemWithBinaryKey.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/FakeItemWithBinaryKey.java
@@ -18,9 +18,9 @@ package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeTags.primaryPartitionKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.Attributes.binaryAttribute;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 
 public class FakeItemWithBinaryKey {
@@ -32,17 +32,17 @@ public class FakeItemWithBinaryKey {
                                 .as(primaryPartitionKey()))
                          .build();
 
-    private ByteBuffer id;
+    private SdkBytes id;
 
     public static StaticTableSchema<FakeItemWithBinaryKey> getTableSchema() {
         return FAKE_ITEM_WITH_BINARY_KEY_SCHEMA;
     }
 
-    public ByteBuffer getId() {
+    public SdkBytes getId() {
         return id;
     }
 
-    public void setId(ByteBuffer id) {
+    public void setId(SdkBytes id) {
         this.id = id;
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchemaTest.java
@@ -26,7 +26,6 @@ import static software.amazon.awssdk.enhanced.dynamodb.AttributeValues.binaryVal
 import static software.amazon.awssdk.enhanced.dynamodb.AttributeValues.numberValue;
 import static software.amazon.awssdk.enhanced.dynamodb.AttributeValues.stringValue;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -481,31 +480,29 @@ public class BeanTableSchemaTest {
     }
 
     @Test
-    public void setBean_byteBufferSet() {
-        ByteBuffer buffer1 = ByteBuffer.wrap("one".getBytes(StandardCharsets.UTF_8));
-        ByteBuffer buffer2 = ByteBuffer.wrap("two".getBytes(StandardCharsets.UTF_8));
-        ByteBuffer buffer3 = ByteBuffer.wrap("three".getBytes(StandardCharsets.UTF_8));
+    public void setBean_binarySet() {
+        SdkBytes buffer1 = SdkBytes.fromString("one", StandardCharsets.UTF_8);
+        SdkBytes buffer2 = SdkBytes.fromString("two", StandardCharsets.UTF_8);
+        SdkBytes buffer3 = SdkBytes.fromString("three", StandardCharsets.UTF_8);
 
         BeanTableSchema<SetBean> beanTableSchema = BeanTableSchema.create(SetBean.class);
         SetBean setBean = new SetBean();
         setBean.setId("id-value");
-        LinkedHashSet<ByteBuffer> byteBufferSet = new LinkedHashSet<>();
-        byteBufferSet.add(buffer1);
-        byteBufferSet.add(buffer2);
-        byteBufferSet.add(buffer3);
-        setBean.setByteBufferSet(byteBufferSet);
+        LinkedHashSet<SdkBytes> binarySet = new LinkedHashSet<>();
+        binarySet.add(buffer1);
+        binarySet.add(buffer2);
+        binarySet.add(buffer3);
+        setBean.setBinarySet(binarySet);
 
         Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(setBean, true);
 
         AttributeValue expectedAttributeValue = AttributeValue.builder()
-                                                              .bs(SdkBytes.fromByteBuffer(buffer1),
-                                                                  SdkBytes.fromByteBuffer(buffer2),
-                                                                  SdkBytes.fromByteBuffer(buffer3))
+                                                              .bs(buffer1, buffer2, buffer3)
                                                               .build();
 
         assertThat(itemMap.size(), is(2));
         assertThat(itemMap, hasEntry("id", stringValue("id-value")));
-        assertThat(itemMap, hasEntry("byteBufferSet", expectedAttributeValue));
+        assertThat(itemMap, hasEntry("binarySet", expectedAttributeValue));
 
         SetBean reverse = beanTableSchema.mapToItem(itemMap);
         assertThat(reverse, is(equalTo(setBean)));
@@ -574,7 +571,7 @@ public class BeanTableSchemaTest {
     public void commonTypesBean() {
         BeanTableSchema<CommonTypesBean> beanTableSchema = BeanTableSchema.create(CommonTypesBean.class);
         CommonTypesBean commonTypesBean = new CommonTypesBean();
-        ByteBuffer binaryLiteral = ByteBuffer.wrap("test-string".getBytes(StandardCharsets.UTF_8));
+        SdkBytes binaryLiteral = SdkBytes.fromString("test-string", StandardCharsets.UTF_8);
 
         commonTypesBean.setId("id-value");
         commonTypesBean.setBooleanAttribute(true);
@@ -584,7 +581,7 @@ public class BeanTableSchemaTest {
         commonTypesBean.setByteAttribute((byte) 45);
         commonTypesBean.setDoubleAttribute(56.7);
         commonTypesBean.setFloatAttribute((float) 67.8);
-        commonTypesBean.setByteBufferAttribute(binaryLiteral);
+        commonTypesBean.setBinaryAttribute(binaryLiteral);
 
         Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(commonTypesBean, true);
 
@@ -597,7 +594,7 @@ public class BeanTableSchemaTest {
         assertThat(itemMap, hasEntry("byteAttribute", numberValue(45)));
         assertThat(itemMap, hasEntry("doubleAttribute", numberValue(56.7)));
         assertThat(itemMap, hasEntry("floatAttribute", numberValue(67.8)));
-        assertThat(itemMap, hasEntry("byteBufferAttribute", binaryValue(binaryLiteral)));
+        assertThat(itemMap, hasEntry("binaryAttribute", binaryValue(binaryLiteral)));
 
         CommonTypesBean reverse = beanTableSchema.mapToItem(itemMap);
         assertThat(reverse, is(equalTo(commonTypesBean)));

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchemaTest.java
@@ -30,7 +30,7 @@ import static software.amazon.awssdk.enhanced.dynamodb.mapper.Attributes.boolAtt
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.Attributes.integerNumberAttribute;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.Attributes.stringAttribute;
 
-import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -89,7 +89,7 @@ public class StaticTableSchemaTest {
         private double aPrimitiveDouble;
         private Float aFloat;
         private float aPrimitiveFloat;
-        private ByteBuffer aBytebuffer;
+        private SdkBytes aBinaryValue;
         private FakeDocument aFakeDocument;
         private Set<String> aStringSet;
         private Set<Integer> anIntegerSet;
@@ -98,7 +98,7 @@ public class StaticTableSchemaTest {
         private Set<Short> aShortSet;
         private Set<Double> aDoubleSet;
         private Set<Float> aFloatSet;
-        private Set<ByteBuffer> aByteBufferSet;
+        private Set<SdkBytes> aBinarySet;
         private List<Integer> anIntegerList;
         private List<List<FakeDocument>> aNestedStructure;
         private Map<String, String> aStringMap;
@@ -109,10 +109,10 @@ public class StaticTableSchemaTest {
         FakeMappedItem(boolean aPrimitiveBoolean, Boolean aBoolean, String aString, Integer anInteger,
                        int aPrimitiveInteger, Byte aByte, byte aPrimitiveByte, Long aLong, long aPrimitiveLong,
                        Short aShort, short aPrimitiveShort, Double aDouble, double aPrimitiveDouble, Float aFloat,
-                       float aPrimitiveFloat, ByteBuffer aBytebuffer, FakeDocument aFakeDocument,
+                       float aPrimitiveFloat, SdkBytes aBinaryValue, FakeDocument aFakeDocument,
                        Set<String> aStringSet, Set<Integer> anIntegerSet, Set<Byte> aByteSet,
                        Set<Long> aLongSet, Set<Short> aShortSet, Set<Double> aDoubleSet, Set<Float> aFloatSet,
-                       Set<ByteBuffer> aByteBufferSet, List<Integer> anIntegerList,
+                       Set<SdkBytes> aBinarySet, List<Integer> anIntegerList,
                        List<List<FakeDocument>> aNestedStructure, Map<String, String> aStringMap) {
             this.aPrimitiveBoolean = aPrimitiveBoolean;
             this.aBoolean = aBoolean;
@@ -129,7 +129,7 @@ public class StaticTableSchemaTest {
             this.aPrimitiveDouble = aPrimitiveDouble;
             this.aFloat = aFloat;
             this.aPrimitiveFloat = aPrimitiveFloat;
-            this.aBytebuffer = aBytebuffer;
+            this.aBinaryValue = aBinaryValue;
             this.aFakeDocument = aFakeDocument;
             this.aStringSet = aStringSet;
             this.anIntegerSet = anIntegerSet;
@@ -138,7 +138,7 @@ public class StaticTableSchemaTest {
             this.aShortSet = aShortSet;
             this.aDoubleSet = aDoubleSet;
             this.aFloatSet = aFloatSet;
-            this.aByteBufferSet = aByteBufferSet;
+            this.aBinarySet = aBinarySet;
             this.anIntegerList = anIntegerList;
             this.aNestedStructure = aNestedStructure;
             this.aStringMap = aStringMap;
@@ -268,12 +268,12 @@ public class StaticTableSchemaTest {
             this.aPrimitiveFloat = aPrimitiveFloat;
         }
 
-        ByteBuffer getABytebuffer() {
-            return aBytebuffer;
+        SdkBytes getABinaryValue() {
+            return aBinaryValue;
         }
 
-        void setABytebuffer(ByteBuffer aBytebuffer) {
-            this.aBytebuffer = aBytebuffer;
+        void setABinaryValue(SdkBytes aBinaryValue) {
+            this.aBinaryValue = aBinaryValue;
         }
 
         FakeDocument getAFakeDocument() {
@@ -340,12 +340,12 @@ public class StaticTableSchemaTest {
             this.aFloatSet = aFloatSet;
         }
 
-        Set<ByteBuffer> getAByteBufferSet() {
-            return aByteBufferSet;
+        Set<SdkBytes> getABinarySet() {
+            return aBinarySet;
         }
 
-        void setAByteBufferSet(Set<ByteBuffer> aByteBufferSet) {
-            this.aByteBufferSet = aByteBufferSet;
+        void setABinarySet(Set<SdkBytes> aBinarySet) {
+            this.aBinarySet = aBinarySet;
         }
 
         List<Integer> getAnIntegerList() {
@@ -392,7 +392,7 @@ public class StaticTableSchemaTest {
                    Objects.equals(aShort, that.aShort) &&
                    Objects.equals(aDouble, that.aDouble) &&
                    Objects.equals(aFloat, that.aFloat) &&
-                   Objects.equals(aBytebuffer, that.aBytebuffer) &&
+                   Objects.equals(aBinaryValue, that.aBinaryValue) &&
                    Objects.equals(aFakeDocument, that.aFakeDocument) &&
                    Objects.equals(aStringSet, that.aStringSet) &&
                    Objects.equals(anIntegerSet, that.anIntegerSet) &&
@@ -401,7 +401,7 @@ public class StaticTableSchemaTest {
                    Objects.equals(aShortSet, that.aShortSet) &&
                    Objects.equals(aDoubleSet, that.aDoubleSet) &&
                    Objects.equals(aFloatSet, that.aFloatSet) &&
-                   Objects.equals(aByteBufferSet, that.aByteBufferSet) &&
+                   Objects.equals(aBinarySet, that.aBinarySet) &&
                    Objects.equals(anIntegerList, that.anIntegerList) &&
                    Objects.equals(aNestedStructure, that.aNestedStructure) &&
                    Objects.equals(aStringMap, that.aStringMap);
@@ -411,8 +411,8 @@ public class StaticTableSchemaTest {
         public int hashCode() {
             return Objects.hash(aPrimitiveBoolean, aBoolean, aString, anInteger, aPrimitiveInteger, aByte,
                                 aPrimitiveByte, aLong, aPrimitiveLong, aShort, aPrimitiveShort, aDouble,
-                                aPrimitiveDouble, aFloat, aPrimitiveFloat, aBytebuffer, aFakeDocument, aStringSet,
-                                anIntegerSet, aByteSet, aLongSet, aShortSet, aDoubleSet, aFloatSet, aByteBufferSet,
+                                aPrimitiveDouble, aFloat, aPrimitiveFloat, aBinaryValue, aFakeDocument, aStringSet,
+                                anIntegerSet, aByteSet, aLongSet, aShortSet, aDoubleSet, aFloatSet, aBinarySet,
                                 anIntegerList, aNestedStructure, aStringMap);
         }
 
@@ -432,7 +432,7 @@ public class StaticTableSchemaTest {
             private double aPrimitiveDouble;
             private Float aFloat;
             private float aPrimitiveFloat;
-            private ByteBuffer aBytebuffer;
+            private SdkBytes aBinaryValue;
             private FakeDocument aFakeDocument;
             private Set<String> aStringSet;
             private Set<Integer> anIntegerSet;
@@ -441,7 +441,7 @@ public class StaticTableSchemaTest {
             private Set<Short> aShortSet;
             private Set<Double> aDoubleSet;
             private Set<Float> aFloatSet;
-            private Set<ByteBuffer> aByteBufferSet;
+            private Set<SdkBytes> aBinarySet;
             private List<Integer> anIntegerList;
             private List<List<FakeDocument>> aNestedStructure;
             private Map<String, String> aStringMap;
@@ -521,8 +521,8 @@ public class StaticTableSchemaTest {
                 return this;
             }
 
-            Builder aBytebuffer(ByteBuffer aBytebuffer) {
-                this.aBytebuffer = aBytebuffer;
+            Builder aBinaryValue(SdkBytes aBinaryValue) {
+                this.aBinaryValue = aBinaryValue;
                 return this;
             }
 
@@ -566,8 +566,8 @@ public class StaticTableSchemaTest {
                 return this;
             }
 
-            Builder aByteBufferSet(Set<ByteBuffer> aByteBufferSet) {
-                this.aByteBufferSet = aByteBufferSet;
+            Builder aBinarySet(Set<SdkBytes> aBinarySet) {
+                this.aBinarySet = aBinarySet;
                 return this;
             }
 
@@ -589,9 +589,9 @@ public class StaticTableSchemaTest {
             public FakeMappedItem build() {
                 return new FakeMappedItem(aPrimitiveBoolean, aBoolean, aString, anInteger, aPrimitiveInteger, aByte,
                                           aPrimitiveByte, aLong, aPrimitiveLong, aShort, aPrimitiveShort, aDouble,
-                                          aPrimitiveDouble, aFloat, aPrimitiveFloat, aBytebuffer, aFakeDocument,
+                                          aPrimitiveDouble, aFloat, aPrimitiveFloat, aBinaryValue, aFakeDocument,
                                           aStringSet, anIntegerSet, aByteSet, aLongSet, aShortSet, aDoubleSet,
-                                          aFloatSet, aByteBufferSet, anIntegerList, aNestedStructure, aStringMap);
+                                          aFloatSet, aBinarySet, anIntegerList, aNestedStructure, aStringMap);
             }
         }
     }
@@ -913,13 +913,13 @@ public class StaticTableSchemaTest {
 
 
     @Test
-    public void mapperCanHandleByteBuffer() {
-        ByteBuffer byteBuffer = ByteBuffer.wrap("test".getBytes(UTF_8));
+    public void mapperCanHandleBinary() {
+        SdkBytes sdkBytes = SdkBytes.fromString("test", UTF_8);
         verifyNullableAttribute(Attributes.binaryAttribute("value",
-                                                 FakeMappedItem::getABytebuffer,
-                                                 FakeMappedItem::setABytebuffer),
-                                FakeMappedItem.builder().aBytebuffer(byteBuffer).build(),
-                                AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build());
+                                                 FakeMappedItem::getABinaryValue,
+                                                 FakeMappedItem::setABinaryValue),
+                                FakeMappedItem.builder().aBinaryValue(sdkBytes).build(),
+                                AttributeValue.builder().b(sdkBytes).build());
     }
 
     @Test
@@ -1038,18 +1038,18 @@ public class StaticTableSchemaTest {
     }
 
     @Test
-    public void mapperCanHandleByteBufferSet() {
-        ByteBuffer byteBuffer1 = ByteBuffer.wrap("one".getBytes(UTF_8));
-        ByteBuffer byteBuffer2 = ByteBuffer.wrap("two".getBytes(UTF_8));
-        ByteBuffer byteBuffer3 = ByteBuffer.wrap("three".getBytes(UTF_8));
-        Set<ByteBuffer> byteBuffer = new HashSet<>(asList(byteBuffer1, byteBuffer2, byteBuffer3));
-        List<SdkBytes> sdkBytes = byteBuffer.stream().map(SdkBytes::fromByteBuffer).collect(toList());
+    public void mapperCanHandleBinarySet() {
+        SdkBytes sdkBytes1 = SdkBytes.fromString("one", UTF_8);
+        SdkBytes sdkBytes2 = SdkBytes.fromString("two", UTF_8);
+        SdkBytes sdkBytes3 = SdkBytes.fromString("three", UTF_8);
+        Set<SdkBytes> sdkBytesSet = new HashSet<>(asList(sdkBytes1, sdkBytes2, sdkBytes3));
+        List<SdkBytes> sdkBytesList = new ArrayList<>(sdkBytesSet);
 
         verifyNullableAttribute(Attributes.binarySetAttribute("value",
-                                                              FakeMappedItem::getAByteBufferSet,
-                                                              FakeMappedItem::setAByteBufferSet),
-                                FakeMappedItem.builder().aByteBufferSet(byteBuffer).build(),
-                                AttributeValue.builder().bs(sdkBytes).build());
+                                                              FakeMappedItem::getABinarySet,
+                                                              FakeMappedItem::setABinarySet),
+                                FakeMappedItem.builder().aBinarySet(sdkBytesSet).build(),
+                                AttributeValue.builder().bs(sdkBytesList).build());
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/CommonTypesBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/CommonTypesBean.java
@@ -15,9 +15,9 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
@@ -31,7 +31,7 @@ public class CommonTypesBean {
     private Byte byteAttribute;
     private Double doubleAttribute;
     private Float floatAttribute;
-    private ByteBuffer byteBufferAttribute;
+    private SdkBytes binaryAttribute;
 
     @DynamoDbPartitionKey
     public String getId() {
@@ -98,12 +98,12 @@ public class CommonTypesBean {
         this.floatAttribute = floatAttribute;
     }
 
-    public ByteBuffer getByteBufferAttribute() {
-        return byteBufferAttribute;
+    public SdkBytes getBinaryAttribute() {
+        return binaryAttribute;
     }
 
-    public void setByteBufferAttribute(ByteBuffer byteBufferAttribute) {
-        this.byteBufferAttribute = byteBufferAttribute;
+    public void setBinaryAttribute(SdkBytes binaryAttribute) {
+        this.binaryAttribute = binaryAttribute;
     }
 
     @Override
@@ -119,11 +119,11 @@ public class CommonTypesBean {
             Objects.equals(byteAttribute, that.byteAttribute) &&
             Objects.equals(doubleAttribute, that.doubleAttribute) &&
             Objects.equals(floatAttribute, that.floatAttribute) &&
-            Objects.equals(byteBufferAttribute, that.byteBufferAttribute);
+            Objects.equals(binaryAttribute, that.binaryAttribute);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, booleanAttribute, integerAttribute, longAttribute, shortAttribute, byteAttribute, doubleAttribute, floatAttribute, byteBufferAttribute);
+        return Objects.hash(id, booleanAttribute, integerAttribute, longAttribute, shortAttribute, byteAttribute, doubleAttribute, floatAttribute, binaryAttribute);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/SetBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/SetBean.java
@@ -15,10 +15,10 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.Set;
 
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
@@ -32,7 +32,7 @@ public class SetBean {
     private Set<Byte> byteSet;
     private Set<Double> doubleSet;
     private Set<Float> floatSet;
-    private Set<ByteBuffer> byteBufferSet;
+    private Set<SdkBytes> binarySet;
 
     @DynamoDbPartitionKey
     public String getId() {
@@ -97,12 +97,12 @@ public class SetBean {
         this.floatSet = floatSet;
     }
 
-    public Set<ByteBuffer> getByteBufferSet() {
-        return byteBufferSet;
+    public Set<SdkBytes> getBinarySet() {
+        return binarySet;
     }
 
-    public void setByteBufferSet(Set<ByteBuffer> byteBufferSet) {
-        this.byteBufferSet = byteBufferSet;
+    public void setBinarySet(Set<SdkBytes> binarySet) {
+        this.binarySet = binarySet;
     }
 
     @Override
@@ -118,11 +118,11 @@ public class SetBean {
             Objects.equals(byteSet, setBean.byteSet) &&
             Objects.equals(doubleSet, setBean.doubleSet) &&
             Objects.equals(floatSet, setBean.floatSet) &&
-            Objects.equals(byteBufferSet, setBean.byteBufferSet);
+            Objects.equals(binarySet, setBean.binarySet);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, stringSet, integerSet, longSet, shortSet, byteSet, doubleSet, floatSet, byteBufferSet);
+        return Objects.hash(id, stringSet, integerSet, longSet, shortSet, byteSet, doubleSet, floatSet, binarySet);
     }
 }


### PR DESCRIPTION
## Description
Changed all representations of binary data (for dynamoDB) to use SdkBytes instead of ByteBuffer. This better matches the interface of the SDK and is easier for customers to use.

Relates to https://github.com/aws/aws-sdk-java-v2/issues/35

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
