### PR TITLE
DynamoDb Enhanced Client : changed the way extensions are loaded, loa…

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedAsyncClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedAsyncClient.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
  * Asynchronous interface for running commands against a DynamoDb database.
  */
 @SdkPublicApi
-public interface DynamoDbEnhancedAsyncClient {
+public interface DynamoDbEnhancedAsyncClient extends DynamoDbEnhancedResource {
 
     /**
      * Returns a mapped table that can be used to execute commands that work with mapped items against that table.
@@ -90,11 +90,23 @@ public interface DynamoDbEnhancedAsyncClient {
     /**
      * The builder definition for a {@link DynamoDbEnhancedAsyncClient}.
      */
-    interface Builder {
-        Builder dynamoDbClient(DynamoDbAsyncClient dynamoDbAsyncClient);
+    interface Builder extends DynamoDbEnhancedResource.Builder {
+        /**
+         * The regular low-level SDK client to use with the enhanced client.
+         * @param dynamoDbClient an initialized {@link DynamoDbAsyncClient}
+         */
+        Builder dynamoDbClient(DynamoDbAsyncClient dynamoDbClient);
 
-        Builder extendWith(DynamoDbEnhancedClientExtension dynamoDbEnhancedClientExtension);
+        @Override
+        Builder extensions(DynamoDbEnhancedClientExtension... dynamoDbEnhancedClientExtensions);
 
+        @Override
+        Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions);
+
+        /**
+         * Builds an enhanced client based on the settings supplied to this builder
+         * @return An initialized {@link DynamoDbEnhancedAsyncClient}
+         */
         DynamoDbEnhancedAsyncClient build();
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
@@ -34,7 +34,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
  * Synchronous interface for running commands against a DynamoDb database.
  */
 @SdkPublicApi
-public interface DynamoDbEnhancedClient {
+public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
 
     /**
      * Returns a mapped table that can be used to execute commands that work with mapped items against that table.
@@ -88,11 +88,23 @@ public interface DynamoDbEnhancedClient {
     /**
      * The builder definition for a {@link DynamoDbEnhancedClient}.
      */
-    interface Builder {
+    interface Builder extends DynamoDbEnhancedResource.Builder {
+        /**
+         * The regular low-level SDK client to use with the enhanced client.
+         * @param dynamoDbClient an initialized {@link DynamoDbClient}
+         */
         Builder dynamoDbClient(DynamoDbClient dynamoDbClient);
 
-        Builder extendWith(DynamoDbEnhancedClientExtension dynamoDbEnhancedClientExtension);
+        @Override
+        Builder extensions(DynamoDbEnhancedClientExtension... dynamoDbEnhancedClientExtensions);
 
+        @Override
+        Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions);
+
+        /**
+         * Builds an enhanced client based on the settings supplied to this builder
+         * @return An initialized {@link DynamoDbEnhancedClient}
+         */
         DynamoDbEnhancedClient build();
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClientExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClientExtension.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.enhanced.dynamodb;
 import java.util.Map;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.enhanced.dynamodb.extensions.ChainExtension;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.ReadModification;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
@@ -29,9 +28,9 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * is written to the database, and one called just after a record is read from the database. This gives the extension the
  * opportunity to act as an invisible layer between the application and the database and transform the data accordingly.
  * <p>
- * Only one extension can be loaded with an enhanced client. In order to combine multiple extensions, the
- * {@link ChainExtension} should be used and initialized with all the component extensions to combine together
- * into a chain.
+ * Multiple extensions can be used with the enhanced client, but the order in which they are loaded is important. For
+ * instance one extension may overwrite the value of an attribute that another extension then includes in a checksum
+ * calculation.
  */
 @SdkPublicApi
 public interface DynamoDbEnhancedClientExtension {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedResource.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedResource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import java.util.List;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Shared interface components for {@link DynamoDbEnhancedClient} and {@link DynamoDbEnhancedAsyncClient}. Any common
+ * methods implemented by both of those classes or their builders are declared here.
+ */
+@SdkPublicApi
+public interface DynamoDbEnhancedResource {
+    /**
+     * Shared interface components for the builders of {@link DynamoDbEnhancedClient} and
+     * {@link DynamoDbEnhancedAsyncClient}
+     */
+    interface Builder {
+        /**
+         * Specifies the extensions to load with the enhanced client. The extensions will be loaded in the strict order
+         * they are supplied here. Calling this method will override any bundled extensions that are loaded by default,
+         * namely the {@link software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension}, so this
+         * extension must be included in the supplied list otherwise it will not be loaded. Providing an empty list here
+         * will cause no extensions to get loaded, effectively dropping the default ones.
+         *
+         * @param dynamoDbEnhancedClientExtensions a list of extensions to load with the enhanced client
+         */
+        Builder extensions(DynamoDbEnhancedClientExtension... dynamoDbEnhancedClientExtensions);
+
+        /**
+         * Specifies the extensions to load with the enhanced client. The extensions will be loaded in the strict order
+         * they are supplied here. Calling this method will override any bundled extensions that are loaded by default,
+         * namely the {@link software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension}, so this
+         * extension must be included in the supplied list otherwise it will not be loaded. Providing an empty list here
+         * will cause no extensions to get loaded, effectively dropping the default ones.
+         *
+         * @param dynamoDbEnhancedClientExtensions a list of extensions to load with the enhanced client
+         */
+        Builder extensions(List<DynamoDbEnhancedClientExtension> dynamoDbEnhancedClientExtensions);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/annotations/DynamoDbVersionAttribute.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.VersionedRecordExtensionAttributeTags;
+import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.VersionRecordAttributeTags;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.BeanTableSchemaAttributeTag;
 
 /**
@@ -32,6 +32,6 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.BeanTableSche
 @SdkPublicApi
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@BeanTableSchemaAttributeTag(VersionedRecordExtensionAttributeTags.class)
+@BeanTableSchemaAttributeTag(VersionRecordAttributeTags.class)
 public @interface DynamoDbVersionAttribute {
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/ExtensionResolver.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/ExtensionResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.client;
+
+import java.util.Collections;
+import java.util.List;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension;
+import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtension;
+
+/**
+ * Static module to assist with the initialization of an extension for a DynamoDB Enhanced Client based on supplied
+ * configuration.
+ */
+@SdkInternalApi
+public final class ExtensionResolver {
+    private static final DynamoDbEnhancedClientExtension DEFAULT_VERSIONED_RECORD_EXTENSION =
+        VersionedRecordExtension.builder().build();
+    private static final List<DynamoDbEnhancedClientExtension> DEFAULT_EXTENSIONS =
+        Collections.singletonList(DEFAULT_VERSIONED_RECORD_EXTENSION);
+
+    private ExtensionResolver() {
+    }
+
+    /**
+     * Static provider for the default extensions that are bundled with the DynamoDB Enhanced Client. Currently this is
+     * just the {@link software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension}.
+     *
+     * These extensions will be used by default unless overridden in the enhanced client builder.
+     */
+    public static List<DynamoDbEnhancedClientExtension> defaultExtensions() {
+        return DEFAULT_EXTENSIONS;
+    }
+
+    /**
+     * Resolves a list of extensions into a single extension. If the list is a singleton, will just return that extension
+     * otherwise it will combine them with the {@link software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtension}
+     * meta-extension using the order provided in the list.
+     *
+     * @param extensions A list of extensions to be combined in strict order
+     * @return A single extension that combines all the supplied extensions or null if no extensions were provided
+     */
+    public static DynamoDbEnhancedClientExtension resolveExtensions(List<DynamoDbEnhancedClientExtension> extensions) {
+        if (extensions == null || extensions.isEmpty()) {
+            return null;
+        }
+
+        if (extensions.size() == 1) {
+            return extensions.get(0);
+        }
+
+        return ChainExtension.create(extensions);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.enhanced.dynamodb.extensions;
+package software.amazon.awssdk.enhanced.dynamodb.internal.extensions;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -22,10 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.ReadModification;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -51,7 +53,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * UpdateItem acts as both a write operation and a read operation so the chain will be called both ways within a
  * single operation.
  */
-@SdkPublicApi
+@SdkInternalApi
 public final class ChainExtension implements DynamoDbEnhancedClientExtension {
     private final Deque<DynamoDbEnhancedClientExtension> extensionChain;
 
@@ -66,6 +68,15 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
      */
     public static ChainExtension create(DynamoDbEnhancedClientExtension... extensions) {
         return new ChainExtension(Arrays.asList(extensions));
+    }
+
+    /**
+     * Construct a new instance of {@link ChainExtension}.
+     * @param extensions A list of {@link DynamoDbEnhancedClientExtension} to chain together.
+     * @return A constructed {@link ChainExtension} object.
+     */
+    public static ChainExtension create(List<DynamoDbEnhancedClientExtension> extensions) {
+        return new ChainExtension(extensions);
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/VersionRecordAttributeTags.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/VersionRecordAttributeTags.java
@@ -21,8 +21,8 @@ import software.amazon.awssdk.enhanced.dynamodb.extensions.annotations.DynamoDbV
 import software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeTag;
 
 @SdkInternalApi
-public final class VersionedRecordExtensionAttributeTags {
-    private VersionedRecordExtensionAttributeTags() {
+public final class VersionRecordAttributeTags {
+    private VersionRecordAttributeTags() {
     }
 
     public static AttributeTag attributeTagFor(DynamoDbVersionAttribute annotation) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchWriteItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchWriteItemOperation.java
@@ -36,8 +36,8 @@ import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 import software.amazon.awssdk.utils.CollectionUtils;
 
 @SdkInternalApi
-public class BatchWriteItemOperation implements DatabaseOperation<BatchWriteItemRequest,
-                                 BatchWriteItemResponse, BatchWriteResult> {
+public class BatchWriteItemOperation
+    implements DatabaseOperation<BatchWriteItemRequest, BatchWriteItemResponse, BatchWriteResult> {
 
     private final BatchWriteItemEnhancedRequest request;
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
@@ -117,7 +117,9 @@ public class PutItemOperation<T>
             throw new IllegalArgumentException("A mapper extension inserted a conditionExpression in a PutItem "
                                                + "request as part of a BatchWriteItemRequest. This is not supported by "
                                                + "DynamoDb. An extension known to do this is the "
-                                               + "VersionedRecordExtension.");
+                                               + "VersionedRecordExtension which is loaded by default unless overridden. "
+                                               + "To fix this use a table schema that does not "
+                                               + "have a versioned attribute in it or do not load the offending extension.");
         }
 
         return WriteRequest.builder().putRequest(PutRequest.builder().item(putItemRequest.item()).build()).build();

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
+import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtension;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/VersionedRecordTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/VersionedRecordTest.java
@@ -101,7 +101,7 @@ public class VersionedRecordTest extends LocalDynamoDbSyncTestBase {
 
     private DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
                                                                           .dynamoDbClient(getDynamoDbClient())
-                                                                          .extendWith(VersionedRecordExtension.builder().build())
+                                                                          .extensions(VersionedRecordExtension.builder().build())
                                                                           .build();
 
     private DynamoDbTable<Record> mappedTable = enhancedClient.table(getConcreteTableName("table-name"), TABLE_SCHEMA);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/ExtensionResolverTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/ExtensionResolverTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.client;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.ReadModification;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExtensionResolverTest {
+    @Mock
+    private DynamoDbEnhancedClientExtension mockExtension1;
+    @Mock
+    private DynamoDbEnhancedClientExtension mockExtension2;
+
+    @Before
+    public void stubMocks() {
+        when(mockExtension1.beforeWrite(any(), any(), any())).thenReturn(WriteModification.builder().build());
+        when(mockExtension2.beforeWrite(any(), any(), any())).thenReturn(WriteModification.builder().build());
+        when(mockExtension1.afterRead(any(), any(), any())).thenReturn(ReadModification.builder().build());
+        when(mockExtension2.afterRead(any(), any(), any())).thenReturn(ReadModification.builder().build());
+    }
+
+    @Test
+    public void resolveExtensions_null() {
+        assertThat(ExtensionResolver.resolveExtensions(null)).isNull();
+    }
+
+    @Test
+    public void resolveExtensions_empty() {
+        assertThat(ExtensionResolver.resolveExtensions(emptyList())).isNull();
+    }
+
+    @Test
+    public void resolveExtensions_singleton() {
+        assertThat(ExtensionResolver.resolveExtensions(singletonList(mockExtension1))).isSameAs(mockExtension1);
+    }
+
+    @Test
+    public void resolveExtensions_multiple_beforeWrite_correctCallingOrder() {
+        DynamoDbEnhancedClientExtension extension =
+            ExtensionResolver.resolveExtensions(Arrays.asList(mockExtension1, mockExtension2));
+
+        extension.beforeWrite(null, null, null);
+        InOrder inOrder = Mockito.inOrder(mockExtension1, mockExtension2);
+        inOrder.verify(mockExtension1).beforeWrite(any(), any(), any());
+        inOrder.verify(mockExtension2).beforeWrite(any(), any(), any());
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void resolveExtensions_multiple_afterRead_correctCallingOrder() {
+        DynamoDbEnhancedClientExtension extension =
+            ExtensionResolver.resolveExtensions(Arrays.asList(mockExtension1, mockExtension2));
+
+        extension.afterRead(null, null, null);
+        InOrder inOrder = Mockito.inOrder(mockExtension1, mockExtension2);
+        inOrder.verify(mockExtension2).afterRead(any(), any(), any());
+        inOrder.verify(mockExtension1).afterRead(any(), any(), any());
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void defaultExtensions_isImmutable() {
+        List<DynamoDbEnhancedClientExtension> defaultExtensions = ExtensionResolver.defaultExtensions();
+        assertThatThrownBy(() -> defaultExtensions.add(mockExtension1)).isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperationTest.java
@@ -103,7 +103,7 @@ public class BatchGetItemOperationTest {
 
     @Before
     public void setupMappedTables() {
-        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).build();
+        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions().build();
         fakeItemMappedTable = enhancedClient.table(TABLE_NAME, FakeItem.getTableSchema());
         fakeItemWithSortMappedTable = enhancedClient.table(TABLE_NAME_2, FakeItemWithSort.getTableSchema());
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchWriteItemOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchWriteItemOperationTest.java
@@ -105,11 +105,11 @@ public class BatchWriteItemOperationTest {
 
     @Before
     public void setupMappedTables() {
-        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).build();
+        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions().build();
         fakeItemMappedTable = enhancedClient.table(TABLE_NAME, FakeItem.getTableSchema());
         fakeItemWithSortMappedTable = enhancedClient.table(TABLE_NAME_2, FakeItemWithSort.getTableSchema());
         DynamoDbEnhancedClient dynamoDbEnhancedClientWithExtension =
-            DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extendWith(mockExtension).build();
+            DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions(mockExtension).build();
         fakeItemMappedTableWithExtension = dynamoDbEnhancedClientWithExtension.table(TABLE_NAME, FakeItem.getTableSchema());
         fakeItemWithSortMappedTableWithExtension = dynamoDbEnhancedClientWithExtension.table(TABLE_NAME_2,
                                                                                              FakeItemWithSort.getTableSchema());

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperationTest.java
@@ -98,7 +98,7 @@ public class TransactGetItemsOperationTest {
 
     @Before
     public void setupMappedTables() {
-        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).build();
+        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions().build();
         fakeItemMappedTable = enhancedClient.table(TABLE_NAME, FakeItem.getTableSchema());
         fakeItemWithSortMappedTable = enhancedClient.table(TABLE_NAME_2, FakeItemWithSort.getTableSchema());
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactWriteItemsOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactWriteItemsOperationTest.java
@@ -35,7 +35,6 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
-import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithSort;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -74,11 +73,10 @@ public class TransactWriteItemsOperationTest {
 
     private DynamoDbEnhancedClient enhancedClient;
     private DynamoDbTable<FakeItem> fakeItemMappedTable;
-    private DynamoDbTable<FakeItemWithSort> fakeItemWithSortMappedTable;
 
     @Before
     public void setupMappedTables() {
-        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).build();
+        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions().build();
         fakeItemMappedTable = enhancedClient.table(TABLE_NAME, FakeItem.getTableSchema());
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetResultPageTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetResultPageTest.java
@@ -52,7 +52,7 @@ public class TransactGetResultPageTest {
     private DynamoDbTable<FakeItem> createMappedTable(DynamoDbEnhancedClientExtension dynamoDbEnhancedClientExtension) {
         return DynamoDbEnhancedClient.builder()
                                      .dynamoDbClient(mockDynamoDbClient)
-                                     .extendWith(dynamoDbEnhancedClientExtension)
+                                     .extensions(dynamoDbEnhancedClientExtension)
                                      .build()
                                      .table(TABLE_NAME, FakeItem.getTableSchema());
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequestTest.java
@@ -56,7 +56,7 @@ public class TransactWriteItemsEnhancedRequestTest {
 
     @Before
     public void setupMappedTables() {
-        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).build();
+        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions().build();
         fakeItemMappedTable = enhancedClient.table(TABLE_NAME, FakeItem.getTableSchema());
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/WriteBatchTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/WriteBatchTest.java
@@ -50,7 +50,7 @@ public class WriteBatchTest {
 
     @Before
     public void setupMappedTables() {
-        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).build();
+        enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(mockDynamoDbClient).extensions().build();
         fakeItemMappedTable = enhancedClient.table(TABLE_NAME, FakeItem.getTableSchema());
     }
 


### PR DESCRIPTION
…ds VersionedRecordExtension by default

## Motivation and Context
Many customers are going to want to use versioned records, and for those that don't if they don't tag any attributes on their table as 'version attributes' the extension will not get in the way so it made sense to load it by default.

We are leaving the door open in the future to provide meta-extensions that can do intelligent ordering of multiple extensions if such a thing is possible, but for now the order must be specified manually.

Relates to https://github.com/aws/aws-sdk-java-v2/issues/35

## Testing
Unit tests

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
