### PR TITLE
ddb enhanced client javadoc for operations

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClientPreview-13ba31f.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClientPreview-13ba31f.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client [Preview]",
+    "description": "Adds javadoc to operation methods and request/response objects."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/Document.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/Document.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * A document representing a table item in the form of a map containing attributes and values.
+ * <p>
+ * Use the {@link #getItem(MappedTableResource)} method to transform the collection of attributes into a typed item.
+ */
+@SdkPublicApi
+public interface Document {
+
+    /**
+     * Get the table item associated with the table schema in the mapped table resource.
+     *
+     * @param mappedTableResource the mapped table resource this item was retrieved from
+     * @param <T> the type of items in the mapped table resource
+     * @return the item constructed from the document
+     */
+    <T> T getItem(MappedTableResource<T> mappedTableResource);
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncIndex.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncIndex.java
@@ -16,38 +16,165 @@
 package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 
 /**
  * Asynchronous interface for running commands against an object that is linked to a specific DynamoDb secondary index
  * and knows how to map records from the table that index is linked to into a modelled object.
+ * <p>
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
+ * implementing classes.
  *
  * @param <T> The type of the modelled object.
  */
 @SdkPublicApi
 public interface DynamoDbAsyncIndex<T> {
 
+    /**
+     * Executes a query against a secondary index using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * QueryConditional queryConditional = QueryConditional.equalTo(Key.builder().partitionValue("id-value").build());
+     * SdkPublisher<Page<MyItem>> publisher = mappedIndex.query(QueryEnhancedRequest.builder()
+     *                                                                              .queryConditional(queryConditional)
+     *                                                                              .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link QueryEnhancedRequest} defining the query conditions and how
+     * to handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> query(QueryEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Executes a query against a secondary index using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link QueryEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher =
+     *     mappedIndex.query(r -> r.queryConditional(QueryConditional.equalTo(k -> k.partitionValue("id-value"))));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link QueryEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table against a secondary index and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.scan(ScanEnhancedRequest.builder().consistentRead(true).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link ScanEnhancedRequest} defining how to handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> scan(ScanEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table against a secondary index and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link ScanEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.scan(r -> r.limit(5));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link ScanEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> scan(Consumer<ScanEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table against a secondary index and retrieves all items using default settings.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.scan();
+     * }
+     * </pre>
+     *
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> scan() {
         throw new UnsupportedOperationException();
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
@@ -25,6 +24,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
@@ -32,6 +32,9 @@ import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 /**
  * Asynchronous interface for running commands against an object that is linked to a specific DynamoDb table resource
  * and therefore knows how to map records from that table into a modelled object.
+ * <p>
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
+ * implementing classes.
  *
  * @param <T> The type of the modelled object.
  */
@@ -47,67 +50,439 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      */
     DynamoDbAsyncIndex<T> index(String indexName);
 
+    /**
+     * Creates a new table in DynamoDb with the name and schema already defined for this DynamoDbTable
+     * together with additional parameters specified in the supplied request object, {@link CreateTableEnhancedRequest}.
+     * <p>
+     * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
+     * <p>
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
+     * the table may not immediately be available for writes and reads.
+     * Consult the CreateTable documentation for further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * ProvisionedThroughput provisionedThroughput = ProvisionedThroughput.builder()
+     *                                                                    .readCapacityUnits(50L)
+     *                                                                    .writeCapacityUnits(50L)
+     *                                                                    .build();
+     * mappedTable.createTable(CreateTableEnhancedRequest.builder()
+     *                                                   .provisionedThroughput(provisionedThroughput)
+     *                                                   .build())
+     *            .join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link CreateTableEnhancedRequest} containing optional parameters for table creation.
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> createTable(CreateTableEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Creates a new table in DynamoDb with the name and schema already defined for this DynamoDbTable
+     * together with additional parameters specified in the supplied request object, {@link CreateTableEnhancedRequest}.
+     * <p>
+     * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
+     * <p>
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
+     * the table may not immediately be available for writes and reads.
+     * Consult the CreateTable documentation for further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link CreateTableEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * ProvisionedThroughput provisionedThroughput = ProvisionedThroughput.builder()
+     *                                                                    .readCapacityUnits(50L)
+     *                                                                    .writeCapacityUnits(50L)
+     *                                                                    .build();
+     * mappedTable.createTable(r -> r.provisionedThroughput(provisionedThroughput)).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link CreateTableEnhancedRequest.Builder} containing optional parameters
+     * for table creation.
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> createTable(Consumer<CreateTableEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Creates a new table in DynamoDb with the name and schema already defined for this DynamoDbTable.
+     * <p>
+     * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
+     * <p>
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
+     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
+     * library to wait for/check the status of a created table. You must provide this functionality yourself.
+     * Consult the CreateTable documentation for further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.createTable().join();
+     * }
+     * </pre>
+     *
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> createTable() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Deletes a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link DeleteItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.delete(DeleteItemEnhancedRequest.builder().key(key).build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link DeleteItemEnhancedRequest} with key and optional directives for deleting an item from the table.
+     * @return a {@link CompletableFuture} of the deleted item
+     */
     default CompletableFuture<T> deleteItem(DeleteItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Deletes a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link DeleteItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link DeleteItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.delete(r -> r.key(key)).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link DeleteItemEnhancedRequest} with key and
+     * optional directives for deleting an item from the table.
+     * @return a {@link CompletableFuture} of the deleted item
+     */
     default CompletableFuture<T> deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link GetItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.getItem(GetItemEnhancedRequest.builder().key(key).build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link GetItemEnhancedRequest} with key and optional directives for retrieving an item from the table.
+     * @return a {@link CompletableFuture} of the retrieved item
+     */
     default CompletableFuture<T> getItem(GetItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link GetItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link GetItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.getItem(r -> r.key(key)).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link GetItemEnhancedRequest.Builder} with key and optional directives
+     * for retrieving an item from the table.
+     * @return a {@link CompletableFuture} of the retrieved item
+     */
     default CompletableFuture<T> getItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * QueryConditional queryConditional = QueryConditional.equalTo(Key.builder().partitionValue("id-value").build());
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.query(QueryEnhancedRequest.builder()
+     *                                                                              .queryConditional(queryConditional)
+     *                                                                              .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link QueryEnhancedRequest} defining the query conditions and how
+     * to handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> query(QueryEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link QueryEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher =
+     *     mappedTable.query(r -> r.queryConditional(QueryConditional.equalTo(k -> k.partitionValue("id-value"))));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link QueryEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be replaced with
+     * this item.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link PutItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API PutItem operation. Consult the PutItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.putItem(PutItemEnhancedRequest.builder(MyItem.class).item(item).build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link PutItemEnhancedRequest} that includes the item to enter into
+     * the table, its class and optional directives.
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> putItem(PutItemEnhancedRequest<T> request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be replaced with
+     * this item.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link PutItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API PutItem operation. Consult the PutItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.putItem(MyItem.class, r -> r.item(item)).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link PutItemEnhancedRequest.Builder} that includes the item
+     * to enter into the table, its class and optional directives.
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> putItem(Class<? extends T> itemClass,
                                             Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.scan(ScanEnhancedRequest.builder().consistentRead(true).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link ScanEnhancedRequest} defining how to handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> scan(ScanEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.scan(r -> r.limit(5));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link ScanEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> scan(Consumer<ScanEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table and retrieves all items using default settings.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<Page<MyItem>> publisher = mappedTable.scan();
+     * }
+     * </pre>
+     *
+     * @return a publisher {@link SdkPublisher} with paginated results (see {@link Page}).
+     */
     default SdkPublisher<Page<T>> scan() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Updates an item in the mapped table, or adds it if it doesn't exist.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link UpdateItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API UpdateItem operation. Consult the UpdateItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.updateItem(UpdateItemEnhancedRequest.builder(MyItem.class).item(item).build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link UpdateItemEnhancedRequest} that includes the item to be updated,
+     * its class and optional directives.
+     * @return a {@link CompletableFuture} of the updated item
+     */
     default CompletableFuture<T> updateItem(UpdateItemEnhancedRequest<T> request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Updates an item in the mapped table, or adds it if it doesn't exist.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link UpdateItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API UpdateItem operation. Consult the UpdateItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.updateItem(MyItem.class, r -> r.item(item)).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link UpdateItemEnhancedRequest.Builder} that includes the item
+     * to be updated, its class and optional directives.
+     * @return a {@link CompletableFuture} of the updated item
+     */
     default CompletableFuture<T> updateItem(Class<? extends T> itemClass,
                                             Consumer<UpdateItemEnhancedRequest.Builder<T>> requestConsumer) {
         throw new UnsupportedOperationException();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedAsyncClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedAsyncClient.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.enhanced.dynamodb;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbEnhancedAsyncClient;
@@ -26,13 +25,20 @@ import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedReques
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
+import software.amazon.awssdk.enhanced.dynamodb.model.ConditionCheck;
+import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
 /**
  * Asynchronous interface for running commands against a DynamoDb database.
+ * <p>
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
+ * implementing classes.
  */
 @SdkPublicApi
 public interface DynamoDbEnhancedAsyncClient extends DynamoDbEnhancedResource {
@@ -47,35 +53,356 @@ public interface DynamoDbEnhancedAsyncClient extends DynamoDbEnhancedResource {
      */
     <T> DynamoDbAsyncTable<T> table(String tableName, TableSchema<T> tableSchema);
 
+    /**
+     * Retrieves items from one or more tables by their primary keys, see {@link Key}. BatchGetItem is a composite operation
+     * where the request contains one batch of {@link GetItemEnhancedRequest} per targeted table.
+     * The operation makes several calls to the database; each time you iterate over the result to retrieve a page,
+     * a call is made for the items on that page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchGetItemEnhancedRequest}.
+     * <p>
+     * <b>Partial results</b>. A single call to DynamoDb has restraints on how much data can be retrieved.
+     * If those limits are exceeded, the call yields a partial result. This may also be the case if
+     * provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically
+     * retries any unprocessed keys returned from DynamoDb in subsequent calls for pages.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchGetItem operation. Consult the BatchGetItem documentation for
+     * further details and constraints as well as current limits of data retrieval.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<BatchGetResultPage> batchResults = enhancedClient.batchGetItem(
+     *     BatchGetItemEnhancedRequest.builder()
+     *                                .readBatches(ReadBatch.builder(FirstItem.class)
+     *                                                      .mappedTableResource(firstItemTable)
+     *                                                      .addGetItem(GetItemEnhancedRequest.builder().key(key1).build())
+     *                                                      .addGetItem(GetItemEnhancedRequest.builder().key(key2).build())
+     *                                                      .build(),
+     *                                             ReadBatch.builder(SecondItem.class)
+     *                                                      .mappedTableResource(secondItemTable)
+     *                                                      .addGetItem(GetItemEnhancedRequest.builder().key(key3).build())
+     *                                                      .build())
+     *                                .build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link BatchGetItemEnhancedRequest} containing keys grouped by tables.
+     * @return a publisher {@link SdkPublisher} with paginated results of type {@link BatchGetResultPage}.
+     */
     default SdkPublisher<BatchGetResultPage> batchGetItem(BatchGetItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves items from one or more tables by their primary keys, see {@link Key}. BatchGetItem is a composite operation
+     * where the request contains one batch of {@link GetItemEnhancedRequest} per targeted table.
+     * The operation makes several calls to the database; each time you iterate over the result to retrieve a page,
+     * a call is made for the items on that page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchGetItemEnhancedRequest}.
+     * <p>
+     * <b>Partial results</b>. A single call to DynamoDb has restraints on how much data can be retrieved.
+     * If those limits are exceeded, the call yields a partial result. This may also be the case if
+     * provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically
+     * retries any unprocessed keys returned from DynamoDb in subsequent calls for pages.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchGetItem operation. Consult the BatchGetItem documentation for
+     * further details and constraints as well as current limits of data retrieval.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link BatchGetItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * SdkPublisher<BatchGetResultPage> batchResults = enhancedClient.batchGetItem(r -> r.addReadBatches(
+     *     ReadBatch.builder(FirstItem.class)
+     *              .mappedTableResource(firstItemTable)
+     *              .addGetItem(i -> i.key(key1))
+     *              .addGetItem(i -> i.key(key2))
+     *              .build(),
+     *     ReadBatch.builder(SecondItem.class)
+     *              .mappedTableResource(secondItemTable)
+     *              .addGetItem(i -> i.key(key3))
+     *              .build())).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link BatchGetItemEnhancedRequest.Builder} containing keys grouped by tables.
+     * @return a publisher {@link SdkPublisher} with paginated results of type {@link BatchGetResultPage}.
+     */
     default SdkPublisher<BatchGetResultPage> batchGetItem(Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts and/or deletes multiple items in one or more tables. BatchWriteItem is a composite operation where the request
+     * contains one batch of (a mix of) {@link PutItemEnhancedRequest} and {@link DeleteItemEnhancedRequest} per targeted table.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchWriteItemEnhancedRequest}.
+     * <p>
+     * <b>Note: </b> BatchWriteItem cannot update items. Instead, use the individual updateItem operation
+     * {@link DynamoDbAsyncTable#updateItem(UpdateItemEnhancedRequest)}.
+     * <p>
+     * <b>Partial updates</b><br>Each delete or put call is atomic, but the operation as a whole is not.
+     * If individual operations fail due to exceeded provisional throughput internal DynamoDb processing failures,
+     * the failed requests can be retrieved through the result, see {@link BatchWriteResult}.
+     * <p>
+     * There are some conditions that cause the whole batch operation to fail. These include non-existing tables, erroneously
+     * defined primary key attributes, attempting to put and delete the same item as well as referring more than once to the same
+     * hash and range (sort) key.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchWriteItem operation. Consult the BatchWriteItem documentation for
+     * further details and constraints, current limits of data to write and/or delete, how to handle partial updates and retries
+     * and under which conditions the operation will fail.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * BatchWriteResult batchResult = enhancedClient.batchWriteItem(
+     *     BatchWriteItemEnhancedRequest.builder()
+     *                                  .writeBatches(WriteBatch.builder(FirstItem.class)
+     *                                                          .mappedTableResource(firstItemTable)
+     *                                                          .addPutItem(PutItemEnhancedRequest.builder().item(item1).build())
+     *                                                          .addDeleteItem(DeleteItemEnhancedRequest.builder()
+     *                                                                                                  .key(key2)
+     *                                                                                                  .build())
+     *                                                          .build(),
+     *                                                WriteBatch.builder(SecondItem.class)
+     *                                                          .mappedTableResource(secondItemTable)
+     *                                                          .addPutItem(PutItemEnhancedRequest.builder().item(item3).build())
+     *                                                          .build())
+     *                                  .build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link BatchWriteItemEnhancedRequest} containing keys and items grouped by tables.
+     * @return a {@link CompletableFuture} of {@link BatchWriteResult}, containing any unprocessed requests.
+     */
     default CompletableFuture<BatchWriteResult> batchWriteItem(BatchWriteItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts and/or deletes multiple items in one or more tables. BatchWriteItem is a composite operation where the request
+     * contains one batch of (a mix of) {@link PutItemEnhancedRequest} and {@link DeleteItemEnhancedRequest} per targeted table.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchWriteItemEnhancedRequest}.
+     * <p>
+     * <b>Note: </b> BatchWriteItem cannot update items. Instead, use the individual updateItem operation
+     * {@link DynamoDbAsyncTable#updateItem(Class, Consumer)}.
+     * <p>
+     * <b>Partial updates</b><br>Each delete or put call is atomic, but the operation as a whole is not.
+     * If individual operations fail due to exceeded provisional throughput internal DynamoDb processing failures,
+     * the failed requests can be retrieved through the result, see {@link BatchWriteResult}.
+     * <p>
+     * There are some conditions that cause the whole batch operation to fail. These include non-existing tables, erroneously
+     * defined primary key attributes, attempting to put and delete the same item as well as referring more than once to the same
+     * hash and range (sort) key.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchWriteItem operation. Consult the BatchWriteItem documentation for
+     * further details and constraints, current limits of data to write and/or delete, how to handle partial updates and retries
+     * and under which conditions the operation will fail.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link BatchWriteItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * BatchWriteResult batchResult = enhancedClient.batchWriteItem(r -> r.writeBatches(
+     *     WriteBatch.builder(FirstItem.class)
+     *               .mappedTableResource(firstItemTable)
+     *               .addPutItem(i -> i.item(item1))
+     *               .addDeleteItem(i -> i.key(key2))
+     *               .build(),
+     *     WriteBatch.builder(SecondItem.class)
+     *               .mappedTableResource(secondItemTable)
+     *               .addPutItem(i -> i.item(item3))
+     *               .build())).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link BatchWriteItemEnhancedRequest} containing keys and items grouped by
+     * tables.
+     * @return a {@link CompletableFuture} of {@link BatchWriteResult}, containing any unprocessed requests.
+     */
     default CompletableFuture<BatchWriteResult> batchWriteItem(Consumer<BatchWriteItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
-    default CompletableFuture<List<TransactGetResultPage>> transactGetItems(TransactGetItemsEnhancedRequest request) {
+    /**
+     * Retrieves multiple items from one or more tables in a single atomic transaction. TransactGetItem is a composite operation
+     * where the request contains a set of up to 25 get requests, each containing a table reference and a
+     * {@link GetItemEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactGetItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactGetItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item, for instance
+     * updating and reading at the same time.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactGetItems operation. Consult the TransactGetItems documentation for
+     * further details and constraints.
+     * <p>
+     * Examples:
+     * <pre>
+     * {@code
+     *
+     * List<TransactGetResultPage> results = enhancedClient.transactGetItems(
+     *            TransactGetItemsEnhancedRequest.builder()
+     *                                           .addGetItem(firstItemTable, GetItemEnhancedRequest.builder().key(key1).build())
+     *                                           .addGetItem(firstItemTable, GetItemEnhancedRequest.builder().key(key2).build())
+     *                                           .addGetItem(firstItemTable, GetItemEnhancedRequest.builder().key(key3).build())
+     *                                           .addGetItem(secondItemTable, GetItemEnhancedRequest.builder().key(key4).build())
+     *                                           .build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link TransactGetItemsEnhancedRequest} containing keys with table references.
+     * @return a {@link CompletableFuture} containing a list of {@link Document} with the results.
+     */
+    default CompletableFuture<List<Document>> transactGetItems(TransactGetItemsEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
-    default CompletableFuture<List<TransactGetResultPage>> transactGetItems(
+    /**
+     * Retrieves multiple items from one or more tables in a single atomic transaction. TransactGetItem is a composite operation
+     * where the request contains a set of up to 25 get requests, each containing a table reference and a
+     * {@link GetItemEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactGetItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactGetItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item, for instance
+     * updating and reading at the same time.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactGetItems operation. Consult the TransactGetItems documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link TransactGetItemsEnhancedRequest#builder()}.
+     * <p>
+     * Examples:
+     * <pre>
+     * {@code
+     *
+     * List<TransactGetResultPage> results =  = enhancedClient.transactGetItems(
+     *     r -> r.addGetItem(firstItemTable, i -> i.key(k -> k.partitionValue(0)))
+     *           .addGetItem(firstItemTable, i -> i.key(k -> k.partitionValue(1)))
+     *           .addGetItem(firstItemTable, i -> i.key(k -> k.partitionValue(2)))
+     *           .addGetItem(secondItemTable, i -> i.key(k -> k.partitionValue(0)))).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link TransactGetItemsEnhancedRequest} containing keys with table references.
+     * @return a {@link CompletableFuture} containing a list of {@link Document} with the results.
+     */
+    default CompletableFuture<List<Document>> transactGetItems(
         Consumer<TransactGetItemsEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Writes and/or modifies multiple items from one or more tables in a single atomic transaction. TransactGetItem is a
+     * composite operation where the request contains a set of up to 25 action requests, each containing a table reference and
+     * one of the following requests:
+     * <ul>
+     *     <li>Condition check of item - {@link ConditionCheck}</li>
+     *     <li>Delete item - {@link DeleteItemEnhancedRequest}</li>
+     *     <li>Put item - {@link PutItemEnhancedRequest}</li>
+     *     <li>Update item - {@link UpdateItemEnhancedRequest}</li>
+     * </ul>
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactWriteItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactWriteItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item. If the request
+     * contains condition checks that aren't met, this will also cause rejection.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactWriteItems operation. Consult the TransactWriteItems documentation
+     * for further details and constraints, current limits of data to write and/or delete and under which conditions the operation
+     * will fail.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * enhancedClient.transactWriteItems(
+     *     TransactWriteItemsEnhancedRequest.builder()
+     *                                      .addPutItem(firstItemTable, PutItemEnhancedRequest.builder().item(item1).build())
+     *                                      .addDeleteItem(firstItemTable, DeleteItemEnhancedRequest.builder().key(key2).build())
+     *                                      .addConditionCheck(firstItemTable,
+     *                                                         ConditionCheck.builder()
+     *                                                                       .key(key3)
+     *                                                                       .conditionExpression(conditionExpression)
+     *                                                                       .build())
+     *                                      .addUpdateItem(secondItemTable,
+     *                                                     UpdateItemEnhancedRequest.builder().item(item4).build())
+     *                                      .build()).join();
+     * }
+     * </pre>
+     *
+     * @param request A {@link BatchWriteItemEnhancedRequest} containing keys grouped by tables.
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> transactWriteItems(TransactWriteItemsEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Writes and/or modifies multiple items from one or more tables in a single atomic transaction. TransactGetItem is a
+     * composite operation where the request contains a set of up to 25 action requests, each containing a table reference and
+     * one of the following requests:
+     * <ul>
+     *     <li>Condition check of item - {@link ConditionCheck}</li>
+     *     <li>Delete item - {@link DeleteItemEnhancedRequest}</li>
+     *     <li>Put item - {@link PutItemEnhancedRequest}</li>
+     *     <li>Update item - {@link UpdateItemEnhancedRequest}</li>
+     * </ul>
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactWriteItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactWriteItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item. If the request
+     * contains condition checks that aren't met, this will also cause rejection.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactWriteItems operation. Consult the TransactWriteItems documentation
+     * for further details and constraints, current limits of data to write and/or delete and under which conditions the operation
+     * will fail.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link TransactWriteItemsEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * enhancedClient.transactWriteItems(r -> r.addPutItem(firstItemTable, i -> i.item(item1))
+     *                                         .addDeleteItem(firstItemTable, i -> i.key(k -> k.partitionValue(2)))
+     *                                         .addConditionCheck(firstItemTable, i -> i.key(key3)
+     *                                                                                  .conditionExpression(conditionExpression))
+     *                                         .addUpdateItem(secondItemTable, i -> i.item(item4))).join();
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link TransactWriteItemsEnhancedRequest} containing keys and items grouped by
+     * tables.
+     * @return a {@link CompletableFuture} of {@link Void}.
+     */
     default CompletableFuture<Void> transactWriteItems(Consumer<TransactWriteItemsEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.List;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbEnhancedClient;
@@ -25,13 +24,20 @@ import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedReques
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
+import software.amazon.awssdk.enhanced.dynamodb.model.ConditionCheck;
+import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 /**
  * Synchronous interface for running commands against a DynamoDb database.
+ * <p>
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
+ * implementing classes.
  */
 @SdkPublicApi
 public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
@@ -42,38 +48,361 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
      * @param tableName The name of the physical table persisted by DynamoDb.
      * @param tableSchema A {@link TableSchema} that maps the table to a modelled object.
      * @return A {@link DynamoDbTable} object that can be used to execute table operations against.
-     * @param <T> THe modelled object type being mapped to this table.
+     * @param <T> The modelled object type being mapped to this table.
      */
     <T> DynamoDbTable<T> table(String tableName, TableSchema<T> tableSchema);
 
+    /**
+     * Retrieves items from one or more tables by their primary keys, see {@link Key}. BatchGetItem is a composite operation
+     * where the request contains one batch of {@link GetItemEnhancedRequest} per targeted table.
+     * The operation makes several calls to the database; each time you iterate over the result to retrieve a page,
+     * a call is made for the items on that page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchGetItemEnhancedRequest}.
+     * <p>
+     * <b>Partial results</b>. A single call to DynamoDb has restraints on how much data can be retrieved.
+     * If those limits are exceeded, the call yields a partial result. This may also be the case if
+     * provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically
+     * retries any unprocessed keys returned from DynamoDb in subsequent calls for pages.
+     * <p>
+     * This operation calls the low-level DynamoDb API BatchGetItem operation. Consult the BatchGetItem documentation for
+     * further details and constraints as well as current limits of data retrieval.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<BatchGetResultPage> batchResults = enhancedClient.batchGetItem(
+     *            BatchGetItemEnhancedRequest.builder()
+     *                                       .readBatches(ReadBatch.builder(FirstItem.class)
+     *                                                             .mappedTableResource(firstItemTable)
+     *                                                             .addGetItem(GetItemEnhancedRequest.builder().key(key1).build())
+     *                                                             .addGetItem(GetItemEnhancedRequest.builder().key(key2).build())
+     *                                                             .build(),
+     *                                                    ReadBatch.builder(SecondItem.class)
+     *                                                             .mappedTableResource(secondItemTable)
+     *                                                             .addGetItem(GetItemEnhancedRequest.builder().key(key3).build())
+     *                                                             .build())
+     *                                       .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link BatchGetItemEnhancedRequest} containing keys grouped by tables.
+     * @return an iterator of type {@link SdkIterable} with paginated results of type {@link BatchGetResultPage}.
+     */
     default SdkIterable<BatchGetResultPage> batchGetItem(BatchGetItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves items from one or more tables by their primary keys, see {@link Key}. BatchGetItem is a composite operation
+     * where the request contains one batch of {@link GetItemEnhancedRequest} per targeted table.
+     * The operation makes several calls to the database; each time you iterate over the result to retrieve a page,
+     * a call is made for the items on that page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchGetItemEnhancedRequest}.
+     * <p>
+     * <b>Partial results</b>. A single call to DynamoDb has restraints on how much data can be retrieved.
+     * If those limits are exceeded, the call yields a partial result. This may also be the case if
+     * provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically
+     * retries any unprocessed keys returned from DynamoDb in subsequent calls for pages.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchGetItem operation. Consult the BatchGetItem documentation for
+     * further details and constraints as well as current limits of data retrieval.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link BatchGetItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<BatchGetResultPage> batchResults = enhancedClient.batchGetItem(r -> r.addReadBatches(
+     *     ReadBatch.builder(FirstItem.class)
+     *              .mappedTableResource(firstItemTable)
+     *              .addGetItem(i -> i.key(key1))
+     *              .addGetItem(i -> i.key(key2))
+     *              .build(),
+     *     ReadBatch.builder(SecondItem.class)
+     *              .mappedTableResource(secondItemTable)
+     *              .addGetItem(i -> i.key(key3))
+     *              .build()));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link BatchGetItemEnhancedRequest.Builder} containing keys grouped by tables.
+     * @return an iterator of type {@link SdkIterable} with paginated results of type {@link BatchGetResultPage}.
+     */
     default SdkIterable<BatchGetResultPage> batchGetItem(Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts and/or deletes multiple items in one or more tables. BatchWriteItem is a composite operation where the request
+     * contains one batch of (a mix of) {@link PutItemEnhancedRequest} and {@link DeleteItemEnhancedRequest} per targeted table.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchWriteItemEnhancedRequest}.
+     * <p>
+     * <b>Note: </b> BatchWriteItem cannot update items. Instead, use the individual updateItem operation
+     * {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)}.
+     * <p>
+     * <b>Partial updates</b><br>Each delete or put call is atomic, but the operation as a whole is not.
+     * If individual operations fail due to exceeded provisional throughput internal DynamoDb processing failures,
+     * the failed requests can be retrieved through the result, see {@link BatchWriteResult}.
+     * <p>
+     * There are some conditions that cause the whole batch operation to fail. These include non-existing tables, erroneously
+     * defined primary key attributes, attempting to put and delete the same item as well as referring more than once to the same
+     * hash and range (sort) key.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchWriteItem operation. Consult the BatchWriteItem documentation for
+     * further details and constraints, current limits of data to write and/or delete, how to handle partial updates and retries
+     * and under which conditions the operation will fail.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * BatchWriteResult batchResult = enhancedClient.batchWriteItem(
+     *     BatchWriteItemEnhancedRequest.builder()
+     *                                  .writeBatches(WriteBatch.builder(FirstItem.class)
+     *                                                          .mappedTableResource(firstItemTable)
+     *                                                          .addPutItem(PutItemEnhancedRequest.builder().item(item1).build())
+     *                                                          .addDeleteItem(DeleteItemEnhancedRequest.builder()
+     *                                                                                                  .key(key2)
+     *                                                                                                  .build())
+     *                                                          .build(),
+     *                                                WriteBatch.builder(SecondItem.class)
+     *                                                          .mappedTableResource(secondItemTable)
+     *                                                          .addPutItem(PutItemEnhancedRequest.builder().item(item3).build())
+     *                                                          .build())
+     *                                  .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link BatchWriteItemEnhancedRequest} containing keys and items grouped by tables.
+     * @return a {@link BatchWriteResult} containing any unprocessed requests.
+     */
     default BatchWriteResult batchWriteItem(BatchWriteItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts and/or deletes multiple items in one or more tables. BatchWriteItem is a composite operation where the request
+     * contains one batch of (a mix of) {@link PutItemEnhancedRequest} and {@link DeleteItemEnhancedRequest} per targeted table.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link BatchWriteItemEnhancedRequest}.
+     * <p>
+     * <b>Note: </b> BatchWriteItem cannot update items. Instead, use the individual updateItem operation
+     * {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)}.
+     * <p>
+     * <b>Partial updates</b><br>Each delete or put call is atomic, but the operation as a whole is not.
+     * If individual operations fail due to exceeded provisional throughput internal DynamoDb processing failures,
+     * the failed requests can be retrieved through the result, see {@link BatchWriteResult}.
+     * <p>
+     * There are some conditions that cause the whole batch operation to fail. These include non-existing tables, erroneously
+     * defined primary key attributes, attempting to put and delete the same item as well as referring more than once to the same
+     * hash and range (sort) key.
+     * <p>
+     * This operation calls the low-level DynamoDB API BatchWriteItem operation. Consult the BatchWriteItem documentation for
+     * further details and constraints, current limits of data to write and/or delete, how to handle partial updates and retries
+     * and under which conditions the operation will fail.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link BatchWriteItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * BatchWriteResult batchResult = enhancedClient.batchWriteItem(r -> r.writeBatches(
+     *     WriteBatch.builder(FirstItem.class)
+     *               .mappedTableResource(firstItemTable)
+     *               .addPutItem(i -> i.item(item1))
+     *               .addDeleteItem(i -> i.key(key2))
+     *               .build(),
+     *     WriteBatch.builder(SecondItem.class)
+     *               .mappedTableResource(secondItemTable)
+     *               .addPutItem(i -> i.item(item3))
+     *               .build()));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link BatchWriteItemEnhancedRequest} containing keys and items grouped by
+     * tables.
+     * @return a {@link BatchWriteResult} containing any unprocessed requests.
+     */
     default BatchWriteResult batchWriteItem(Consumer<BatchWriteItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
-    default List<TransactGetResultPage> transactGetItems(TransactGetItemsEnhancedRequest request) {
+    /**
+     * Retrieves multiple items from one or more tables in a single atomic transaction. TransactGetItem is a composite operation
+     * where the request contains a set of up to 25 get requests, each containing a table reference and a
+     * {@link GetItemEnhancedRequest}. The list of results correspond to the ordering of the request definitions; for example
+     * the third addGetItem() call on the request builder will match the third result (index 2) of the result.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactGetItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactGetItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item, for instance
+     * updating and reading at the same time.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactGetItems operation. Consult the TransactGetItems documentation for
+     * further details and constraints.
+     * <p>
+     * Examples:
+     * <pre>
+     * {@code
+     *
+     * List<TransactGetResultPage> results = enhancedClient.transactGetItems(
+     *            TransactGetItemsEnhancedRequest.builder()
+     *                                           .addGetItem(firstItemTable, GetItemEnhancedRequest.builder().key(key1).build())
+     *                                           .addGetItem(firstItemTable, GetItemEnhancedRequest.builder().key(key2).build())
+     *                                           .addGetItem(firstItemTable, GetItemEnhancedRequest.builder().key(key3).build())
+     *                                           .addGetItem(secondItemTable, GetItemEnhancedRequest.builder().key(key4).build())
+     *                                           .build());
+     * MyItem item = results.get(3).getItem(secondItemTable);
+     * }
+     * </pre>
+     *
+     * @param request A {@link TransactGetItemsEnhancedRequest} containing keys with table references.
+     * @return a list of {@link Document} with the results.
+     */
+    default List<Document> transactGetItems(TransactGetItemsEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
-    default List<TransactGetResultPage> transactGetItems(Consumer<TransactGetItemsEnhancedRequest.Builder> requestConsumer) {
+    /**
+     * Retrieves multiple items from one or more tables in a single atomic transaction. TransactGetItem is a composite operation
+     * where the request contains a set of up to 25 get requests, each containing a table reference and a
+     * {@link GetItemEnhancedRequest}. The list of results correspond to the ordering of the request definitions; for example
+     * the third addGetItem() call on the request builder will match the third result (index 2) of the result.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactGetItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactGetItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item, for instance
+     * updating and reading at the same time.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactGetItems operation. Consult the TransactGetItems documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link TransactGetItemsEnhancedRequest#builder()}.
+     * <p>
+     * Examples:
+     * <pre>
+     * {@code
+     *
+     * List<TransactGetResultPage> results = enhancedClient.transactGetItems(
+     *     r -> r.addGetItem(firstItemTable, i -> i.key(k -> k.partitionValue(0)))
+     *           .addGetItem(firstItemTable, i -> i.key(k -> k.partitionValue(1)))
+     *           .addGetItem(firstItemTable, i -> i.key(k -> k.partitionValue(2)))
+     *           .addGetItem(secondItemTable, i -> i.key(k -> k.partitionValue(0))));
+     * MyItem item = results.get(3).getItem(secondItemTable);
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link TransactGetItemsEnhancedRequest} containing keys with table references.
+     * @return a list of {@link Document} with the results.
+     */
+    default List<Document> transactGetItems(Consumer<TransactGetItemsEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Writes and/or modifies multiple items from one or more tables in a single atomic transaction. TransactGetItem is a
+     * composite operation where the request contains a set of up to 25 action requests, each containing a table reference and
+     * one of the following requests:
+     * <ul>
+     *     <li>Condition check of item - {@link ConditionCheck}</li>
+     *     <li>Delete item - {@link DeleteItemEnhancedRequest}</li>
+     *     <li>Put item - {@link PutItemEnhancedRequest}</li>
+     *     <li>Update item - {@link UpdateItemEnhancedRequest}</li>
+     * </ul>
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactWriteItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactWriteItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item. If the request
+     * contains condition checks that aren't met, this will also cause rejection.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactWriteItems operation. Consult the TransactWriteItems documentation
+     * for further details and constraints, current limits of data to write and/or delete and under which conditions the operation
+     * will fail.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * result = enhancedClient.transactWriteItems(
+     *     TransactWriteItemsEnhancedRequest.builder()
+     *                                      .addPutItem(firstItemTable, PutItemEnhancedRequest.builder().item(item1).build())
+     *                                      .addDeleteItem(firstItemTable, DeleteItemEnhancedRequest.builder().key(key2).build())
+     *                                      .addConditionCheck(firstItemTable,
+     *                                                         ConditionCheck.builder()
+     *                                                                       .key(key3)
+     *                                                                       .conditionExpression(conditionExpression)
+     *                                                                       .build())
+     *                                      .addUpdateItem(secondItemTable,
+     *                                                     UpdateItemEnhancedRequest.builder().item(item4).build())
+     *                                      .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link BatchWriteItemEnhancedRequest} containing keys grouped by tables.
+     */
     default Void transactWriteItems(TransactWriteItemsEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Writes and/or modifies multiple items from one or more tables in a single atomic transaction. TransactGetItem is a
+     * composite operation where the request contains a set of up to 25 action requests, each containing a table reference and
+     * one of the following requests:
+     * <ul>
+     *     <li>Condition check of item - {@link ConditionCheck}</li>
+     *     <li>Delete item - {@link DeleteItemEnhancedRequest}</li>
+     *     <li>Put item - {@link PutItemEnhancedRequest}</li>
+     *     <li>Update item - {@link UpdateItemEnhancedRequest}</li>
+     * </ul>
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link TransactWriteItemsEnhancedRequest}.
+     * <p>
+     * DynamoDb will reject a call to TransactWriteItems if the call exceeds limits such as provisioned throughput or allowed size
+     * of items, if the request contains errors or if there are conflicting operations accessing the same item. If the request
+     * contains condition checks that aren't met, this will also cause rejection.
+     * <p>
+     * This operation calls the low-level DynamoDB API TransactWriteItems operation. Consult the TransactWriteItems documentation
+     * for further details and constraints, current limits of data to write and/or delete and under which conditions the operation
+     * will fail.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link TransactWriteItemsEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * result = enhancedClient.transactWriteItems(r -> r.addPutItem(firstItemTable, i -> i.item(item1))
+     *                                                  .addDeleteItem(firstItemTable, i -> i.key(k -> k.partitionValue(2)))
+     *                                                  .addConditionCheck(firstItemTable,
+     *                                                                 i -> i.key(key3).conditionExpression(conditionExpression))
+     *                                                  .addUpdateItem(secondItemTable, i -> i.item(item4)));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer a {@link Consumer} of {@link TransactWriteItemsEnhancedRequest} containing keys and items grouped
+     * by tables.
+     */
     default Void transactWriteItems(Consumer<TransactWriteItemsEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbIndex.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbIndex.java
@@ -16,38 +16,165 @@
 package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 
 /**
  * Synchronous interface for running commands against an object that is linked to a specific DynamoDb secondary index
  * and knows how to map records from the table that index is linked to into a modelled object.
+ * <p>
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
+ * implementing classes.
  *
  * @param <T> The type of the modelled object.
  */
 @SdkPublicApi
 public interface DynamoDbIndex<T> {
 
+    /**
+     * Executes a query against a secondary index using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * QueryConditional queryConditional = QueryConditional.equalTo(Key.builder().partitionValue("id-value").build());
+     * Iterator<Page<MyItem>> results = mappedIndex.query(QueryEnhancedRequest.builder()
+     *                                                                        .queryConditional(queryConditional)
+     *                                                                        .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link QueryEnhancedRequest} defining the query conditions and how
+     * to handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> query(QueryEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Executes a query against a secondary index using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link QueryEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results =
+     *     mappedIndex.query(r -> r.queryConditional(QueryConditional.equalTo(k -> k.partitionValue("id-value"))));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link QueryEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table against a secondary index and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results = mappedTable.scan(ScanEnhancedRequest.builder().consistentRead(true).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link ScanEnhancedRequest} defining how to handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> scan(ScanEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table against a secondary index and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link ScanEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results = mappedTable.scan(r -> r.limit(5));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link ScanEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> scan(Consumer<ScanEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table against a secondary index and retrieves all items using default settings.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results = mappedTable.scan();
+     * }
+     * </pre>
+     *
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> scan() {
         throw new UnsupportedOperationException();
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
@@ -24,6 +23,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
@@ -31,7 +31,10 @@ import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 /**
  * Synchronous interface for running commands against an object that is linked to a specific DynamoDb table resource
  * and therefore knows how to map records from that table into a modelled object.
- *
+ * <p>
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
+ * implementing classes.
+ * <p>
  * @param <T> The type of the modelled object.
  */
 @SdkPublicApi
@@ -46,66 +49,434 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      */
     DynamoDbIndex<T> index(String indexName);
 
+    /**
+     * Creates a new table in DynamoDb with the name and schema already defined for this DynamoDbTable
+     * together with additional parameters specified in the supplied request object, {@link CreateTableEnhancedRequest}.
+     * <p>
+     * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
+     * <p>
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
+     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
+     * library to wait for/check the status of a created table. You must provide this functionality yourself.
+     * Consult the CreateTable documentation for further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * ProvisionedThroughput provisionedThroughput = ProvisionedThroughput.builder()
+     *                                                                    .readCapacityUnits(50L)
+     *                                                                    .writeCapacityUnits(50L)
+     *                                                                    .build();
+     * mappedTable.createTable(CreateTableEnhancedRequest.builder()
+     *                                                   .provisionedThroughput(provisionedThroughput)
+     *                                                   .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link CreateTableEnhancedRequest} containing optional parameters for table creation.
+     */
     default Void createTable(CreateTableEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Creates a new table in DynamoDb with the name and schema already defined for this DynamoDbTable
+     * together with additional parameters specified in the supplied request object, {@link CreateTableEnhancedRequest}.
+     * <p>
+     * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
+     * <p>
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
+     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
+     * library to wait for/check the status of a created table. You must provide this functionality yourself.
+     * Consult the CreateTable documentation for further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link CreateTableEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * ProvisionedThroughput provisionedThroughput = ProvisionedThroughput.builder()
+     *                                                                    .readCapacityUnits(50L)
+     *                                                                    .writeCapacityUnits(50L)
+     *                                                                    .build();
+     * mappedTable.createTable(r -> r.provisionedThroughput(provisionedThroughput));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link CreateTableEnhancedRequest.Builder} containing optional parameters
+     * for table creation.
+     */
     default Void createTable(Consumer<CreateTableEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Creates a new table in DynamoDb with the name and schema already defined for this DynamoDbTable.
+     * <p>
+     * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
+     * <p>
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
+     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
+     * library to wait for/check the status of a created table. You must provide this functionality yourself.
+     * Consult the CreateTable documentation for further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.createTable();
+     * }
+     * </pre>
+     *
+     */
     default Void createTable() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Deletes a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link DeleteItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.delete(DeleteItemEnhancedRequest.builder().key(key).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link DeleteItemEnhancedRequest} with key and optional directives for deleting an item from the table.
+     * @return The deleted item
+     */
     default T deleteItem(DeleteItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Deletes a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link DeleteItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link DeleteItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.delete(r -> r.key(key));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link DeleteItemEnhancedRequest} with key and
+     * optional directives for deleting an item from the table.
+     * @return The deleted item
+     */
     default T deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link GetItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.getItem(GetItemEnhancedRequest.builder().key(key).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link GetItemEnhancedRequest} with key and optional directives for retrieving an item from the table.
+     * @return The retrieved item
+     */
     default T getItem(GetItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Retrieves a single item from the mapped table using a supplied primary {@link Key}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link GetItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link GetItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.getItem(r -> r.key(key));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link GetItemEnhancedRequest.Builder} with key and optional directives
+     * for retrieving an item from the table.
+     * @return The retrieved item
+     */
     default T getItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * QueryConditional queryConditional = QueryConditional.equalTo(Key.builder().partitionValue("id-value").build());
+     * Iterator<Page<MyItem>> results = mappedTable.query(QueryEnhancedRequest.builder()
+     *                                                                        .queryConditional(queryConditional)
+     *                                                                        .build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link QueryEnhancedRequest} defining the query conditions and how
+     * to handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> query(QueryEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a list of
+     * items matching the given conditions.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page. Results are sorted by sort key value in
+     * ascending order by default; this behavior can be overridden in the {@link QueryEnhancedRequest}.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link QueryEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
+     * further details and constraints.
+     * <p>
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
+     * manually via {@link DeleteItemEnhancedRequest#builder()}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results =
+     *     mappedTable.query(r -> r.queryConditional(QueryConditional.equalTo(k -> k.partitionValue("id-value"))));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link QueryEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be replaced with
+     * this item.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link PutItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API PutItem operation. Consult the PutItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.putItem(PutItemEnhancedRequest.builder(MyItem.class).item(item).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link PutItemEnhancedRequest} that includes the item to enter into
+     * the table, its class and optional directives.
+     */
     default Void putItem(PutItemEnhancedRequest<T> request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be replaced with
+     * this item.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link PutItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API PutItem operation. Consult the PutItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * mappedTable.putItem(MyItem.class, r -> r.item(item));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link PutItemEnhancedRequest.Builder} that includes the item
+     * to enter into the table, its class and optional directives.
+     */
     default Void putItem(Class<? extends T> itemClass, Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results = mappedTable.scan(ScanEnhancedRequest.builder().consistentRead(true).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link ScanEnhancedRequest} defining how to handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> scan(ScanEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table and retrieves all items.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link ScanEnhancedRequest}.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results = mappedTable.scan(r -> r.limit(5));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link ScanEnhancedRequest} defining the query conditions and how to
+     * handle the results.
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> scan(Consumer<ScanEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Scans the table and retrieves all items using default settings.
+     * <p>
+     * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
+     * result page is retrieved, a scan call is made to DynamoDb to get those entries. If no matches are found,
+     * the resulting iterator will contain an empty page.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * Iterator<Page<MyItem>> results = mappedTable.scan();
+     * }
+     * </pre>
+     *
+     * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
+     */
     default SdkIterable<Page<T>> scan() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Updates an item in the mapped table, or adds it if it doesn't exist.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link UpdateItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API UpdateItem operation. Consult the UpdateItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.updateItem(UpdateItemEnhancedRequest.builder(MyItem.class).item(item).build());
+     * }
+     * </pre>
+     *
+     * @param request A {@link UpdateItemEnhancedRequest} that includes the item to be updated,
+     * its class and optional directives.
+     * @return The updated item
+     */
     default T updateItem(UpdateItemEnhancedRequest<T> request) {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Updates an item in the mapped table, or adds it if it doesn't exist.
+     * <p>
+     * The additional configuration parameters that the enhanced client supports are defined
+     * in the {@link UpdateItemEnhancedRequest}.
+     * <p>
+     * This operation calls the low-level DynamoDB API UpdateItem operation. Consult the UpdateItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.updateItem(MyItem.class, r -> r.item(item));
+     * }
+     * </pre>
+     *
+     * @param requestConsumer A {@link Consumer} of {@link UpdateItemEnhancedRequest.Builder} that includes the item
+     * to be updated, its class and optional directives.
+     * @return The updated item
+     */
     default T updateItem(Class<? extends T> itemClass, Consumer<UpdateItemEnhancedRequest.Builder<T>> requestConsumer) {
         throw new UnsupportedOperationException();
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/DefaultDocument.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/DefaultDocument.java
@@ -13,27 +13,27 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.enhanced.dynamodb.model;
+package software.amazon.awssdk.enhanced.dynamodb.internal;
 
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.readAndTransformSingleItem;
 
 import java.util.Map;
-
-import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-@SdkPublicApi
-public final class TransactGetResultPage {
+@SdkInternalApi
+public final class DefaultDocument implements Document {
     private final Map<String, AttributeValue> itemMap;
 
-    private TransactGetResultPage(Map<String, AttributeValue> itemMap) {
+    private DefaultDocument(Map<String, AttributeValue> itemMap) {
         this.itemMap = itemMap;
     }
 
-    public static TransactGetResultPage create(Map<String, AttributeValue> itemMap) {
-        return new TransactGetResultPage(itemMap);
+    public static DefaultDocument create(Map<String, AttributeValue> itemMap) {
+        return new DefaultDocument(itemMap);
     }
 
     public <T> T getItem(MappedTableResource<T> mappedTableResource) {
@@ -52,7 +52,7 @@ public final class TransactGetResultPage {
             return false;
         }
 
-        TransactGetResultPage that = (TransactGetResultPage) o;
+        DefaultDocument that = (DefaultDocument) o;
 
         return itemMap != null ? itemMap.equals(that.itemMap) : that.itemMap == null;
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClient.java
@@ -20,9 +20,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -35,7 +35,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.utils.Validate;
@@ -92,13 +91,13 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
     }
 
     @Override
-    public CompletableFuture<List<TransactGetResultPage>> transactGetItems(TransactGetItemsEnhancedRequest request) {
+    public CompletableFuture<List<Document>> transactGetItems(TransactGetItemsEnhancedRequest request) {
         TransactGetItemsOperation operation = TransactGetItemsOperation.create(request);
         return operation.executeAsync(dynamoDbClient, extension);
     }
 
     @Override
-    public CompletableFuture<List<TransactGetResultPage>> transactGetItems(
+    public CompletableFuture<List<Document>> transactGetItems(
         Consumer<TransactGetItemsEnhancedRequest.Builder> requestConsumer) {
         TransactGetItemsEnhancedRequest.Builder builder = TransactGetItemsEnhancedRequest.builder();
         requestConsumer.accept(builder);

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClient.java
@@ -19,9 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -34,7 +34,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.utils.Validate;
@@ -87,13 +86,13 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
     }
 
     @Override
-    public List<TransactGetResultPage> transactGetItems(TransactGetItemsEnhancedRequest request) {
+    public List<Document> transactGetItems(TransactGetItemsEnhancedRequest request) {
         TransactGetItemsOperation operation = TransactGetItemsOperation.create(request);
         return operation.execute(dynamoDbClient, extension);
     }
 
     @Override
-    public List<TransactGetResultPage> transactGetItems(
+    public List<Document> transactGetItems(
         Consumer<TransactGetItemsEnhancedRequest.Builder> requestConsumer) {
 
         TransactGetItemsEnhancedRequest.Builder builder = TransactGetItemsEnhancedRequest.builder();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/DeleteItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/DeleteItemOperation.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.operations;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
@@ -124,7 +123,7 @@ public class DeleteItemOperation<T>
         if (this.request.conditionExpression() != null) {
             requestBuilder = requestBuilder.conditionExpression(this.request.conditionExpression().expression());
 
-            // Avoiding adding empty collections that the low level SDK will propagate to DynamoDB where it causes error.
+            // Avoiding adding empty collections that the low level SDK will propagate to DynamoDb where it causes error.
             if (!this.request.conditionExpression().expressionNames().isEmpty()) {
                 requestBuilder = requestBuilder.expressionAttributeNames(this.request.conditionExpression().expressionNames());
             }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.operations;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
@@ -158,7 +157,7 @@ public class PutItemOperation<T>
         if (mergedConditionExpression != null) {
             requestBuilder = requestBuilder.conditionExpression(mergedConditionExpression.expression());
 
-            // Avoiding adding empty collections that the low level SDK will propagate to DynamoDB where it causes error.
+            // Avoiding adding empty collections that the low level SDK will propagate to DynamoDb where it causes error.
             if (mergedConditionExpression.expressionValues() != null && !mergedConditionExpression.expressionValues().isEmpty()) {
                 requestBuilder = requestBuilder.expressionAttributeValues(mergedConditionExpression.expressionValues());
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperation.java
@@ -19,11 +19,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.internal.DefaultDocument;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.TransactGetItemsRequest;
@@ -31,7 +31,7 @@ import software.amazon.awssdk.services.dynamodb.model.TransactGetItemsResponse;
 
 @SdkInternalApi
 public class TransactGetItemsOperation
-    implements DatabaseOperation<TransactGetItemsRequest, TransactGetItemsResponse, List<TransactGetResultPage>> {
+    implements DatabaseOperation<TransactGetItemsRequest, TransactGetItemsResponse, List<Document>> {
 
     private TransactGetItemsEnhancedRequest request;
 
@@ -63,11 +63,11 @@ public class TransactGetItemsOperation
     }
 
     @Override
-    public List<TransactGetResultPage> transformResponse(TransactGetItemsResponse response,
-                                                         DynamoDbEnhancedClientExtension extension) {
+    public List<Document> transformResponse(TransactGetItemsResponse response,
+                                            DynamoDbEnhancedClientExtension extension) {
         return response.responses()
                        .stream()
-                       .map(r -> r == null ? null : TransactGetResultPage.create(r.item()))
+                       .map(r -> r == null ? null : DefaultDocument.create(r.item()))
                        .collect(Collectors.toList());
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperation.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
@@ -232,7 +231,7 @@ public class UpdateItemOperation<T>
                                                                        this.request.conditionExpression().expression(), " AND ");
         }
 
-        // Avoiding adding empty collections that the low level SDK will propagate to DynamoDB where it causes error.
+        // Avoiding adding empty collections that the low level SDK will propagate to DynamoDb where it causes error.
         if (expressionNames != null && !expressionNames.isEmpty()) {
             requestBuilder = requestBuilder.expressionAttributeNames(expressionNames);
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbFlatten.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbFlatten.java
@@ -19,11 +19,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
- * This annotation is used to flatten all the attributes of a separate DynamoDB bean that is stored in the current bean
+ * This annotation is used to flatten all the attributes of a separate DynamoDb bean that is stored in the current bean
  * object and add them as top level attributes to the record that is read and written to the database. The target bean
  * to flatten must be specified as part of this annotation.
  */

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbPartitionKey.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbPartitionKey.java
@@ -19,13 +19,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.BeanTableSchemaAttributeTags;
 
 /**
- * Denotes this attribute as being the primary partition key of the DynamoDB table. This attribute must map to a
- * DynamoDB scalar type (string, number or binary) to be valid. Every mapped table schema must have exactly one of these.
+ * Denotes this attribute as being the primary partition key of the DynamoDb table. This attribute must map to a
+ * DynamoDb scalar type (string, number or binary) to be valid. Every mapped table schema must have exactly one of these.
  */
 @SdkPublicApi
 @Target({ElementType.METHOD})

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbSortKey.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbSortKey.java
@@ -19,13 +19,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.BeanTableSchemaAttributeTags;
 
 /**
- * Denotes this attribute as being the optional primary sort key of the DynamoDB table. This attribute must map to a
- * DynamoDB scalar type (string, number or binary) to be valid.
+ * Denotes this attribute as being the optional primary sort key of the DynamoDb table. This attribute must map to a
+ * DynamoDb scalar type (string, number or binary) to be valid.
  */
 @SdkPublicApi
 @Target({ElementType.METHOD})

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetItemEnhancedRequest.java
@@ -20,9 +20,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 
+/**
+ * Defines parameters used for the batchGetItem() operation (such as
+ * {@link DynamoDbEnhancedClient#batchGetItem(BatchGetItemEnhancedRequest)}).
+ * <p>
+ * A request contains references to keys and tables organized into one {@link ReadBatch} object per queried table.
+ */
 @SdkPublicApi
 public final class BatchGetItemEnhancedRequest {
 
@@ -32,14 +38,23 @@ public final class BatchGetItemEnhancedRequest {
         this.readBatches = getListIfExist(builder.readBatches);
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder toBuilder() {
         return new Builder().readBatches(readBatches);
     }
 
+    /**
+     * Returns the collection of {@link ReadBatch} in this request object.
+     */
     public Collection<ReadBatch> readBatches() {
         return readBatches;
     }
@@ -67,22 +82,44 @@ public final class BatchGetItemEnhancedRequest {
         return readBatches != null ? Collections.unmodifiableList(readBatches) : null;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     */
     public static final class Builder {
         private List<ReadBatch> readBatches;
 
         private Builder() {
         }
 
+        /**
+         * Sets a collection of read batches to use in the batchGetItem operation.
+         *
+         * @param readBatches the collection of read batches
+         * @return a builder of this type
+         */
         public Builder readBatches(Collection<ReadBatch> readBatches) {
             this.readBatches = readBatches != null ? new ArrayList<>(readBatches) : null;
             return this;
         }
 
+        /**
+         * Sets one or more read batches to use in the batchGetItem operation.
+         *
+         * @param readBatches one or more {@link ReadBatch}, separated by comma.
+         * @return a builder of this type
+         */
         public Builder readBatches(ReadBatch... readBatches) {
             this.readBatches = Arrays.asList(readBatches);
             return this;
         }
 
+        /**
+         * Adds a read batch to the collection of batches on this builder.
+         * If this is the first batch, the method creates a new list.
+         *
+         * @param readBatch a single read batch
+         * @return a builder of this type
+         */
         public Builder addReadBatch(ReadBatch readBatch) {
             if (readBatches == null) {
                 readBatches = new ArrayList<>();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPage.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPage.java
@@ -21,14 +21,21 @@ import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUt
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 
+/**
+ * Defines one result page with retrieved items in the result of a batchGetItem() operation, such as
+ * {@link DynamoDbEnhancedClient#batchGetItem(BatchGetItemEnhancedRequest)}.
+ * <p>
+ * Use the {@link #getResultsForTable(MappedTableResource)} method once for each table present in the request
+ * to retrieve items from that table in the page.
+ */
 @SdkPublicApi
 public final class BatchGetResultPage {
     private final BatchGetItemResponse batchGetItemResponse;
@@ -39,10 +46,21 @@ public final class BatchGetResultPage {
         this.dynamoDbEnhancedClientExtension = builder.dynamoDbEnhancedClientExtension;
     }
 
+    /**
+     * Creates a newly initialized builder for a result object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Retrieve all items on this result page belonging to the supplied table. Call this method once for each table present in the
+     * batch request.
+     *
+     * @param mappedTable the table to retrieve items for
+     * @param <T> the type of the table items
+     * @return a list of items
+     */
     public <T> List<T> getResultsForTable(MappedTableResource<T> mappedTable) {
         List<Map<String, AttributeValue>> results =
             batchGetItemResponse.responses()
@@ -56,6 +74,9 @@ public final class BatchGetResultPage {
                       .collect(Collectors.toList());
     }
 
+    /**
+     * A builder that is used to create a result object with the desired parameters.
+     */
     public static final class Builder {
 
         private BatchGetItemResponse batchGetItemResponse;
@@ -64,11 +85,24 @@ public final class BatchGetResultPage {
         private Builder() {
         }
 
+        /**
+         * Adds a response to the result object. Required.
+         *
+         * @param batchGetItemResponse
+         * @return a builder of this type
+         */
         public Builder batchGetItemResponse(BatchGetItemResponse batchGetItemResponse) {
             this.batchGetItemResponse = batchGetItemResponse;
             return this;
         }
 
+        /**
+         * Adds a mapper extension that can be used to modify the values read from the database.
+         * @see DynamoDbEnhancedClientExtension
+         *
+         * @param dynamoDbEnhancedClientExtension the supplied mapper extension
+         * @return a builder of this type
+         */
         public Builder mapperExtension(DynamoDbEnhancedClientExtension dynamoDbEnhancedClientExtension) {
             this.dynamoDbEnhancedClientExtension = dynamoDbEnhancedClientExtension;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchWriteItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchWriteItemEnhancedRequest.java
@@ -20,9 +20,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 
+/**
+ * Defines parameters used for the batchWriteItem() operation (such as
+ * {@link DynamoDbEnhancedClient#batchWriteItem(BatchWriteItemEnhancedRequest)}).
+ * <p>
+ * A request contains references to keys for delete actions and items for put actions,
+ * organized into one {@link WriteBatch} object per accessed table.
+ */
 @SdkPublicApi
 public final class BatchWriteItemEnhancedRequest {
 
@@ -32,14 +39,23 @@ public final class BatchWriteItemEnhancedRequest {
         this.writeBatches = getListIfExist(builder.writeBatches);
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder toBuilder() {
         return new Builder().writeBatches(writeBatches);
     }
 
+    /**
+     * Returns the collection of {@link WriteBatch} in this request object.
+     */
     public Collection<WriteBatch> writeBatches() {
         return writeBatches;
     }
@@ -67,22 +83,44 @@ public final class BatchWriteItemEnhancedRequest {
         return writeBatches != null ? Collections.unmodifiableList(writeBatches) : null;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     */
     public static final class Builder {
         private List<WriteBatch> writeBatches;
 
         private Builder() {
         }
 
+        /**
+         * Sets a collection of write batches to use in the batchWriteItem operation.
+         *
+         * @param writeBatches the collection of write batches
+         * @return a builder of this type
+         */
         public Builder writeBatches(Collection<WriteBatch> writeBatches) {
             this.writeBatches = writeBatches != null ? new ArrayList<>(writeBatches) : null;
             return this;
         }
 
+        /**
+         * Sets one or more write batches to use in the batchWriteItem operation.
+         *
+         * @param writeBatches one or more {@link WriteBatch}, separated by comma.
+         * @return a builder of this type
+         */
         public Builder writeBatches(WriteBatch... writeBatches) {
             this.writeBatches = Arrays.asList(writeBatches);
             return this;
         }
 
+        /**
+         * Adds a write batch to the collection of batches on this builder.
+         * If this is the first batch, the method creates a new list.
+         *
+         * @param writeBatch a single write batch
+         * @return a builder of this type
+         */
         public Builder addWriteBatch(WriteBatch writeBatch) {
             if (writeBatches == null) {
                 writeBatches = new ArrayList<>();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchWriteResult.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchWriteResult.java
@@ -21,14 +21,26 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
 import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutRequest;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
+/**
+ * Defines the result of the batchWriteItem() operation, such as
+ * {@link DynamoDbEnhancedClient#batchWriteItem(BatchWriteItemEnhancedRequest)}. The result describes any unprocessed items
+ * after the operation completes.
+ * <ul>
+ *     <li>Use the {@link #unprocessedPutItemsForTable(DynamoDbTable)} method once for each table present in the request
+ *  to get any unprocessed items from a put action on that table.</li>
+ *     <li>Use the {@link #unprocessedDeleteItemsForTable(DynamoDbTable)} method once for each table present in the request
+ *  to get any unprocessed items from a delete action on that table.</li>
+ * </ul>
+ *
+ */
 @SdkPublicApi
 public final class BatchWriteResult {
     private final Map<String, List<WriteRequest>> unprocessedRequests;
@@ -37,10 +49,21 @@ public final class BatchWriteResult {
         this.unprocessedRequests = Collections.unmodifiableMap(builder.unprocessedRequests);
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Retrieve any unprocessed put action items belonging to the supplied table from the result .
+     * Call this method once for each table present in the batch request.
+     *
+     * @param mappedTable the table to retrieve unprocessed items for
+     * @param <T> the type of the table items
+     * @return a list of items
+     */
     public <T> List<T> unprocessedPutItemsForTable(DynamoDbTable<T> mappedTable) {
         List<WriteRequest> writeRequests =
             unprocessedRequests.getOrDefault(mappedTable.tableName(),
@@ -57,6 +80,14 @@ public final class BatchWriteResult {
                             .collect(Collectors.toList());
     }
 
+    /**
+     * Retrieve any unprocessed delete action items belonging to the supplied table from the result .
+     * Call this method once for each table present in the batch request.
+     *
+     * @param mappedTable the table to retrieve unprocessed items for
+     * @param <T> the type of the table items
+     * @return a list of items
+     */
     public <T> List<T> unprocessedDeleteItemsForTable(DynamoDbTable<T> mappedTable) {
         List<WriteRequest> writeRequests =
             unprocessedRequests.getOrDefault(mappedTable.tableName(),
@@ -70,12 +101,21 @@ public final class BatchWriteResult {
                             .collect(Collectors.toList());
     }
 
+    /**
+     * A builder that is used to create a result with the desired parameters.
+     */
     public static final class Builder {
         private Map<String, List<WriteRequest>> unprocessedRequests;
 
         private Builder() {
         }
 
+        /**
+         * Add a map of unprocessed requests to this result object.
+         *
+         * @param unprocessedRequests the map of table to write request representing the unprocessed requests
+         * @return a builder of this type
+         */
         public Builder unprocessedRequests(Map<String, List<WriteRequest>> unprocessedRequests) {
             this.unprocessedRequests =
                 unprocessedRequests.entrySet()

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ConditionCheck.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ConditionCheck.java
@@ -16,8 +16,8 @@
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -26,6 +26,16 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationCon
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.TransactableWriteOperation;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 
+/**
+ * Use ConditionCheck as a part of the composite operation transactGetItems (for example
+ * {@link DynamoDbEnhancedClient#transactGetItems(TransactGetItemsEnhancedRequest)}) to determine
+ * if the other actions that are part of the same transaction should take effect.
+ * <p>
+ * A valid ConditionCheck object should contain a reference to the primary key of the table that finds items with a matching key,
+ * together with a condition (of type {@link Expression}) to evaluate the primary key.
+ *
+ * @param <T> The type of the modelled object.
+ */
 @SdkPublicApi
 public final class ConditionCheck<T> implements TransactableWriteOperation<T> {
     private final Key key;
@@ -36,10 +46,16 @@ public final class ConditionCheck<T> implements TransactableWriteOperation<T> {
         this.conditionExpression = conditionExpression;
     }
 
+    /**
+     * Creates a newly initialized builder for this object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the object.
+     */
     public Builder toBuilder() {
         return new Builder().key(key).conditionExpression(conditionExpression);
     }
@@ -63,10 +79,16 @@ public final class ConditionCheck<T> implements TransactableWriteOperation<T> {
                                 .build();
     }
 
+    /**
+     * Returns the primary {@link Key} that the condition is valid for, or null if it doesn't exist.
+     */
     public Key key() {
         return key;
     }
 
+    /**
+     * Returns the condition {@link Expression} set on this object, or null if it doesn't exist.
+     */
     public Expression conditionExpression() {
         return conditionExpression;
     }
@@ -96,6 +118,11 @@ public final class ConditionCheck<T> implements TransactableWriteOperation<T> {
         return result;
     }
 
+    /**
+     * A builder that is used to create a condition check with the desired parameters.
+     * <p>
+     * A valid builder must define both a {@link Key} and an {@link Expression}.
+     */
     public static final class Builder  {
         private Key key;
         private Expression conditionExpression;
@@ -103,17 +130,40 @@ public final class ConditionCheck<T> implements TransactableWriteOperation<T> {
         private Builder() {
         }
 
+        /**
+         * Sets the primary {@link Key} that will be used together with the condition expression.
+         *
+         * @param key the primary key to use in the operation.
+         * @return a builder of this type
+         */
         public Builder key(Key key) {
             this.key = key;
             return this;
         }
 
+        /**
+         * Sets the primary {@link Key} that will be used together with the condition expression
+         * on the builder by accepting a consumer of {@link Key.Builder}.
+         *
+         * @param keyConsumer a {@link Consumer} of {@link Key}
+         * @return a builder of this type
+         */
         public Builder key(Consumer<Key.Builder> keyConsumer) {
             Key.Builder builder = Key.builder();
             keyConsumer.accept(builder);
             return key(builder.build());
         }
 
+        /**
+         * Defines a logical expression on the attributes of table items that match the supplied primary key value(s).
+         * If the expression evaluates to true, the transaction operation succeeds. If the expression evaluates to false,
+         * the transaction will not succeed.
+         * <p>
+         * See {@link Expression} for condition syntax and examples.
+         *
+         * @param conditionExpression a condition written as an {@link Expression}
+         * @return a builder of this type
+         */
         public Builder conditionExpression(Expression conditionExpression) {
             this.conditionExpression = conditionExpression;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/CreateTableEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/CreateTableEnhancedRequest.java
@@ -17,10 +17,18 @@ package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.Arrays;
 import java.util.Collection;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 
+/**
+ * Defines parameters used to create a DynamoDb table using the createTable() operation (such as
+ * {@link DynamoDbTable#createTable(CreateTableEnhancedRequest)} or
+ * {@link DynamoDbAsyncTable#createTable(CreateTableEnhancedRequest)}).
+ * <p>
+ * All parameters are optional.
+ */
 @SdkPublicApi
 public final class CreateTableEnhancedRequest {
     private final ProvisionedThroughput provisionedThroughput;
@@ -33,24 +41,39 @@ public final class CreateTableEnhancedRequest {
         this.globalSecondaryIndices = builder.globalSecondaryIndices;
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder toBuilder() {
         return builder().provisionedThroughput(provisionedThroughput)
                         .localSecondaryIndices(localSecondaryIndices)
                         .globalSecondaryIndices(globalSecondaryIndices);
     }
 
+    /**
+     * Returns the provisioned throughput value set on this request object, or null if it has not been set.
+     */
     public ProvisionedThroughput provisionedThroughput() {
         return provisionedThroughput;
     }
 
+    /**
+     * Returns the local secondary index set on this request object, or null if it has not been set.
+     */
     public Collection<LocalSecondaryIndex> localSecondaryIndices() {
         return localSecondaryIndices;
     }
 
+    /**
+     * Returns the global secondary index set on this request object, or null if it has not been set.
+     */
     public Collection<GlobalSecondaryIndex> globalSecondaryIndices() {
         return globalSecondaryIndices;
     }
@@ -86,6 +109,9 @@ public final class CreateTableEnhancedRequest {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     */
     public static final class Builder {
         private ProvisionedThroughput provisionedThroughput;
         private Collection<LocalSecondaryIndex> localSecondaryIndices;
@@ -94,26 +120,67 @@ public final class CreateTableEnhancedRequest {
         private Builder() {
         }
 
+        /**
+         * Sets the provisioned throughput for this table. Use this parameter to set the table's
+         * read and write capacity units.
+         * <p>
+         * See the DynamoDb documentation for more information on default throughput values.
+         *
+         * @param provisionedThroughput
+         * @return
+         */
         public Builder provisionedThroughput(ProvisionedThroughput provisionedThroughput) {
             this.provisionedThroughput = provisionedThroughput;
             return this;
         }
 
+        /**
+         * Defines a local secondary index for this table.
+         * <p>
+         * See {@link LocalSecondaryIndex} for more information on creating and using a local secondary index.
+         *
+         * @param localSecondaryIndices
+         * @return
+         */
         public Builder localSecondaryIndices(Collection<LocalSecondaryIndex> localSecondaryIndices) {
             this.localSecondaryIndices = localSecondaryIndices;
             return this;
         }
 
+        /**
+         * Defines a local secondary index for this table.
+         * <p>
+         * See {@link LocalSecondaryIndex} for more information on creating and using a local secondary index.
+         *
+         * @param localSecondaryIndices
+         * @return
+         */
         public Builder localSecondaryIndices(LocalSecondaryIndex... localSecondaryIndices) {
             this.localSecondaryIndices = Arrays.asList(localSecondaryIndices);
             return this;
         }
 
+        /**
+         * Defines a global secondary index for this table.
+         * <p>
+         * See {@link GlobalSecondaryIndex} for more information on creating and using a global secondary index.
+         *
+         * @param globalSecondaryIndices
+         * @return
+         */
         public Builder globalSecondaryIndices(Collection<GlobalSecondaryIndex> globalSecondaryIndices) {
             this.globalSecondaryIndices = globalSecondaryIndices;
             return this;
         }
 
+        /**
+         * Defines a global secondary index for this table.
+         * <p>
+         * See {@link GlobalSecondaryIndex} for more information on creating and using a global secondary index.
+         *
+         * @param globalSecondaryIndices
+         * @return
+         */
         public Builder globalSecondaryIndices(GlobalSecondaryIndex... globalSecondaryIndices) {
             this.globalSecondaryIndices = Arrays.asList(globalSecondaryIndices);
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/DeleteItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/DeleteItemEnhancedRequest.java
@@ -16,11 +16,19 @@
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 
+/**
+ * Defines parameters used to remove an item from a DynamoDb table using the deleteItem() operation (such as
+ * {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)} or
+ * {@link DynamoDbAsyncTable#deleteItem(DeleteItemEnhancedRequest)}).
+ * <p>
+ * A valid request object must contain a primary {@link Key} to reference the item to delete.
+ */
 @SdkPublicApi
 public final class DeleteItemEnhancedRequest {
 
@@ -32,18 +40,30 @@ public final class DeleteItemEnhancedRequest {
         this.conditionExpression = builder.conditionExpression;
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder toBuilder() {
         return builder().key(key).conditionExpression(conditionExpression);
     }
 
+    /**
+     * Returns the primary {@link Key} for the item to delete.
+     */
     public Key key() {
         return key;
     }
 
+    /**
+     * Returns the condition {@link Expression} set on this request object, or null if it doesn't exist.
+     */
     public Expression conditionExpression() {
         return conditionExpression;
     }
@@ -67,6 +87,11 @@ public final class DeleteItemEnhancedRequest {
         return key != null ? key.hashCode() : 0;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * <b>Note</b>: A valid request builder must define a {@link Key}.
+     */
     public static final class Builder {
         private Key key;
         private Expression conditionExpression;
@@ -74,17 +99,39 @@ public final class DeleteItemEnhancedRequest {
         private Builder() {
         }
 
+        /**
+         * Sets the primary {@link Key} that will be used to match the item to delete.
+         *
+         * @param key the primary key to use in the request.
+         * @return a builder of this type
+         */
         public Builder key(Key key) {
             this.key = key;
             return this;
         }
 
+        /**
+         * Sets the primary {@link Key} that will be used to match the item to delete
+         * on the builder by accepting a consumer of {@link Key.Builder}.
+         *
+         * @param keyConsumer a {@link Consumer} of {@link Key}
+         * @return a builder of this type
+         */
         public Builder key(Consumer<Key.Builder> keyConsumer) {
             Key.Builder builder = Key.builder();
             keyConsumer.accept(builder);
             return key(builder.build());
         }
 
+        /**
+         * Defines a logical expression on an item's attribute values which, if evaluating to true,
+         * will allow the delete operation to succeed. If evaluating to false, the operation will not succeed.
+         * <p>
+         * See {@link Expression} for condition syntax and examples.
+         *
+         * @param conditionExpression a condition written as an {@link Expression}
+         * @return a builder of this type
+         */
         public Builder conditionExpression(Expression conditionExpression) {
             this.conditionExpression = conditionExpression;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/GetItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/GetItemEnhancedRequest.java
@@ -16,10 +16,17 @@
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.function.Consumer;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 
+/**
+ * Defines parameters used to retrieve an item from a DynamoDb table using the getItem() operation (such as
+ * {@link DynamoDbTable#getItem(GetItemEnhancedRequest)} or {@link DynamoDbAsyncTable#getItem(GetItemEnhancedRequest)}).
+ * <p>
+ * A valid request object must contain a primary {@link Key} to reference the item to get.
+ */
 @SdkPublicApi
 public final class GetItemEnhancedRequest {
 
@@ -31,18 +38,31 @@ public final class GetItemEnhancedRequest {
         this.consistentRead = builder.consistentRead;
     }
 
+    /**
+     * All requests must be constructed using a Builder.
+     * @return a builder of this type
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * @return a builder with all existing values set
+     */
     public Builder toBuilder() {
         return builder().key(key).consistentRead(consistentRead);
     }
 
+    /**
+     * @return whether or not this request will use consistent read
+     */
     public Boolean consistentRead() {
         return this.consistentRead;
     }
 
+    /**
+     * Returns the primary {@link Key} for the item to get.
+     */
     public Key key() {
         return this.key;
     }
@@ -71,6 +91,11 @@ public final class GetItemEnhancedRequest {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * <b>Note</b>: A valid request builder must define a {@link Key}.
+     */
     public static final class Builder {
         private Key key;
         private Boolean consistentRead;
@@ -78,16 +103,38 @@ public final class GetItemEnhancedRequest {
         private Builder() {
         }
 
+        /**
+         * Determines the read consistency model: If set to true, the operation uses strongly consistent reads; otherwise,
+         * the operation uses eventually consistent reads.
+         * <p>
+         * By default, the value of this property is set to <em>false</em>.
+         *
+         * @param consistentRead sets consistency model of the operation to use strong consistency
+         * @return a builder of this type
+         */
         public Builder consistentRead(Boolean consistentRead) {
             this.consistentRead = consistentRead;
             return this;
         }
 
+        /**
+         * Sets the primary {@link Key} that will be used to match the item to retrieve.
+         *
+         * @param key the primary key to use in the request.
+         * @return a builder of this type
+         */
         public Builder key(Key key) {
             this.key = key;
             return this;
         }
 
+        /**
+         * Sets the primary {@link Key} that will be used to match the item to retrieve
+         * by accepting a consumer of {@link Key.Builder}.
+         *
+         * @param keyConsumer a {@link Consumer} of {@link Key}
+         * @return a builder of this type
+         */
         public Builder key(Consumer<Key.Builder> keyConsumer) {
             Key.Builder builder = Key.builder();
             keyConsumer.accept(builder);

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/Page.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/Page.java
@@ -17,12 +17,13 @@ package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.List;
 import java.util.Map;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An immutable object that holds a page of queried or scanned results from DynamoDb.
+ * <p>
+ * Contains a reference to the last evaluated key for the current page; see {@link #lastEvaluatedKey()} for more information.
  * @param <T> The modelled type of the object that has been read.
  */
 @SdkPublicApi
@@ -66,7 +67,7 @@ public final class Page<T> {
     }
 
     /**
-     * Returns the 'lastEvaluatedKey' that DynamoDB returned from the last page query or scan. This key can be used
+     * Returns the 'lastEvaluatedKey' that DynamoDb returned from the last page query or scan. This key can be used
      * to continue the query or scan if passed into a request.
      * @return The 'lastEvaluatedKey' from the last query or scan operation or null if the no more pages are available.
      */

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
@@ -16,8 +16,17 @@
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 
+/**
+ * Defines parameters used to write an item to a DynamoDb table using the putItem() operation (such as
+ * {@link DynamoDbTable#putItem(PutItemEnhancedRequest)} or {@link DynamoDbAsyncTable#putItem(PutItemEnhancedRequest)}).
+ * <p>
+ * A valid request object must contain the item that should be written to the table.
+ * @param <T> The type of the modelled object.
+ */
 @SdkPublicApi
 public final class PutItemEnhancedRequest<T> {
 
@@ -29,18 +38,34 @@ public final class PutItemEnhancedRequest<T> {
         this.conditionExpression = builder.conditionExpression;
     }
 
+    /**
+     * Creates a newly initialized builder for the request object.
+     *
+     * @param itemClass the class that items in this table map to
+     * @param <T> The type of the modelled object, corresponding to itemClass
+     * @return a PutItemEnhancedRequest builder
+     */
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
         return new Builder<>();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder<T> toBuilder() {
         return new Builder<T>().item(item).conditionExpression(conditionExpression);
     }
 
+    /**
+     * Returns the item for this put operation request.
+     */
     public T item() {
         return item;
     }
 
+    /**
+     * Returns the condition {@link Expression} set on this request object, or null if it doesn't exist.
+     */
     public Expression conditionExpression() {
         return conditionExpression;
     }
@@ -64,6 +89,11 @@ public final class PutItemEnhancedRequest<T> {
         return item != null ? item.hashCode() : 0;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * <b>Note</b>: A valid request builder must define an item.
+     */
     public static final class Builder<T> {
         private T item;
         private Expression conditionExpression;
@@ -71,11 +101,26 @@ public final class PutItemEnhancedRequest<T> {
         private Builder() {
         }
 
+        /**
+         * Sets the item to write to DynamoDb. Required.
+         *
+         * @param item the item to write
+         * @return a builder of this type
+         */
         public Builder<T> item(T item) {
             this.item = item;
             return this;
         }
 
+        /**
+         * Defines a logical expression on an item's attribute values which, if evaluating to true,
+         * will allow the delete operation to succeed. If evaluating to false, the operation will not succeed.
+         * <p>
+         * See {@link Expression} for condition syntax and examples.
+         *
+         * @param conditionExpression a condition written as an {@link Expression}
+         * @return a builder of this type
+         */
         public Builder<T> conditionExpression(Expression conditionExpression) {
             this.conditionExpression = conditionExpression;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryEnhancedRequest.java
@@ -17,11 +17,21 @@ package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+/**
+ * Defines parameters used to when querying a DynamoDb table or index using the query() operation (such as
+ * {@link DynamoDbTable#query(QueryEnhancedRequest)} or {@link DynamoDbAsyncIndex#query(QueryEnhancedRequest)}).
+ * <p>
+ * A valid request object must contain a {@link QueryConditional} condition specifying how DynamoDb
+ * should match items in the table.
+ * <p>
+ * All other parameters are optional.
+ */
 @SdkPublicApi
 public final class QueryEnhancedRequest {
 
@@ -41,10 +51,16 @@ public final class QueryEnhancedRequest {
         this.filterExpression = builder.filterExpression;
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder toBuilder() {
         return builder().queryConditional(queryConditional)
                         .exclusiveStartKey(exclusiveStartKey)
@@ -54,26 +70,45 @@ public final class QueryEnhancedRequest {
                         .filterExpression(filterExpression);
     }
 
+    /**
+     * Returns the matching condition of the query.
+     */
     public QueryConditional queryConditional() {
         return queryConditional;
     }
 
+    /**
+     * Returns the value of the exclusive start key set on this request object, or null if it doesn't exist.
+     */
     public Map<String, AttributeValue> exclusiveStartKey() {
         return exclusiveStartKey;
     }
 
+    /**
+     * Returns the value of scan index forward, meaning an ascending result sort order, or true if it
+     * has not been set.
+     */
     public Boolean scanIndexForward() {
         return scanIndexForward;
     }
 
+    /**
+     * Returns the value of limit set on this request object, or null if it doesn't exist.
+     */
     public Integer limit() {
         return limit;
     }
 
+    /**
+     * Returns the value of consistent read, or false if it has not been set.
+     */
     public Boolean consistentRead() {
         return consistentRead;
     }
 
+    /**
+     * Returns the return result filter {@link Expression} set on this request object, or null if it doesn't exist.
+     */
     public Expression filterExpression() {
         return filterExpression;
     }
@@ -121,6 +156,11 @@ public final class QueryEnhancedRequest {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * A valid builder must set the {@link #queryConditional} parameter. Other parameters are optional.
+     */
     public static final class Builder {
         private QueryConditional queryConditional;
         private Map<String, AttributeValue> exclusiveStartKey;
@@ -132,31 +172,84 @@ public final class QueryEnhancedRequest {
         private Builder() {
         }
 
+        /**
+         * Determines the matching conditions for this query request. See {@link QueryConditional} for examples
+         * and constraints. <b>Required</b>.
+         *
+         * @param queryConditional the query conditions
+         * @return a builder of this type
+         */
         public Builder queryConditional(QueryConditional queryConditional) {
             this.queryConditional = queryConditional;
             return this;
         }
 
+        /**
+         * Results are sorted by sort key in ascending order if {@link #scanIndexForward} is true. If its false, the
+         * order is descending. The default value is true.
+         *
+         * @param scanIndexForward the sort order
+         * @return a builder of this type
+         */
         public Builder scanIndexForward(Boolean scanIndexForward) {
             this.scanIndexForward = scanIndexForward;
             return this;
         }
 
+        /**
+         * The primary key of the first item that this operation will evaluate. By default, the operation will evaluate
+         * the whole dataset. If used, normally this parameter is populated with the value that was returned for
+         * {@link Page#lastEvaluatedKey()} in the previous operation.
+         *
+         * @param exclusiveStartKey the primary key value where DynamoDb should start to evaluate items
+         * @return a builder of this type
+         */
         public Builder exclusiveStartKey(Map<String, AttributeValue> exclusiveStartKey) {
             this.exclusiveStartKey = exclusiveStartKey != null ? new HashMap<>(exclusiveStartKey) : null;
             return this;
         }
 
+        /**
+         * Sets a limit on how many items to evaluate in the query. If not set, the operation uses
+         * the maximum values allowed.
+         * <p>
+         * <b>Note:</b>The limit does not refer to the number of items to return, but how many items
+         * the database should evaluate while executing the query. Use limit together with {@link Page#lastEvaluatedKey()}
+         * and {@link #exclusiveStartKey} in subsequent query calls to evaluate <em>limit</em> items per call.
+         *
+         * @param limit the maximum number of items to evalute
+         * @return a builder of this type
+         */
         public Builder limit(Integer limit) {
             this.limit = limit;
             return this;
         }
 
+        /**
+         * Determines the read consistency model: If set to true, the operation uses strongly consistent reads; otherwise,
+         * the operation uses eventually consistent reads.
+         * <p>
+         * By default, the value of this property is set to <em>false</em>.
+         *
+         * @param consistentRead sets consistency model of the operation to use strong consistency
+         * @return a builder of this type
+         */
         public Builder consistentRead(Boolean consistentRead) {
             this.consistentRead = consistentRead;
             return this;
         }
 
+        /**
+         * Refines the query results by applying the filter expression on the results returned
+         * from the query and discards items that do not match. See {@link Expression} for examples
+         * and constraints.
+         * <p>
+         * <b>Note:</b> Using the filter expression does not reduce the cost of the query, since it is applied
+         * <em>after</em> the database has found matching items.
+         *
+         * @param filterExpression an expression that filters results of evaluating the query
+         * @return a builder of this type
+         */
         public Builder filterExpression(Expression filterExpression) {
             this.filterExpression = filterExpression;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatch.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatch.java
@@ -20,13 +20,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 
+/**
+ * Defines a collection of primary keys for items in a table, stored as {@link KeysAndAttributes}, and
+ * used for the batchGetItem() operation (such as
+ * {@link DynamoDbEnhancedClient#batchGetItem(BatchGetItemEnhancedRequest)}) as part of a
+ * {@link BatchGetItemEnhancedRequest}.
+ * <p>
+ * A valid request object should contain one or more primary keys.
+ */
 @SdkPublicApi
 public final class ReadBatch {
     private final String tableName;
@@ -37,14 +46,27 @@ public final class ReadBatch {
         this.keysAndAttributes = generateKeysAndAttributes(builder.requests, builder.mappedTableResource);
     }
 
+    /**
+     * Creates a newly initialized builder for a read batch.
+     *
+     * @param itemClass the class that items in this table map to
+     * @param <T> The type of the modelled object, corresponding to itemClass
+     * @return a ReadBatch builder
+     */
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
         return new BuilderImpl<>();
     }
 
+    /**
+     * Returns the table name associated with this batch.
+     */
     public String tableName() {
         return tableName;
     }
 
+    /**
+     * Returns the collection of keys and attributes, see {@link KeysAndAttributes}, in this read batch.
+     */
     public KeysAndAttributes keysAndAttributes() {
         return keysAndAttributes;
     }
@@ -77,11 +99,39 @@ public final class ReadBatch {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * A valid builder must define a {@link MappedTableResource} and add at least one
+     * {@link GetItemEnhancedRequest}.
+     *
+     * @param <T> the type that items in this table map to
+     */
     public interface Builder<T> {
+
+        /**
+         * Sets the mapped table resource (table) that the items in this read batch should come from.
+         *
+         * @param mappedTableResource the table reference
+         * @return a builder of this type
+         */
         Builder<T> mappedTableResource(MappedTableResource<T> mappedTableResource);
 
+        /**
+         * Adds a {@link GetItemEnhancedRequest} with a primary {@link Key} to the builder.
+         *
+         * @param request A {@link GetItemEnhancedRequest}
+         * @return a builder of this type
+         */
         Builder<T> addGetItem(GetItemEnhancedRequest request);
 
+        /**
+         * Adds a {@link GetItemEnhancedRequest} with a primary {@link Key} to the builder by accepting a consumer of
+         * {@link GetItemEnhancedRequest.Builder}.
+         *
+         * @param requestConsumer a {@link Consumer} of {@link GetItemEnhancedRequest}
+         * @return a builder of this type
+         */
         Builder<T> addGetItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer);
 
         ReadBatch build();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ScanEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ScanEnhancedRequest.java
@@ -17,11 +17,17 @@ package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+/**
+ * Defines parameters used to when scanning a DynamoDb table or index using the scan() operation (such as
+ * {@link DynamoDbTable#scan(ScanEnhancedRequest)}).
+ * <p>
+ * All parameters are optional.
+ */
 @SdkPublicApi
 public final class ScanEnhancedRequest {
 
@@ -37,10 +43,16 @@ public final class ScanEnhancedRequest {
         this.filterExpression = builder.filterExpression;
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder toBuilder() {
         return builder().exclusiveStartKey(exclusiveStartKey)
                         .limit(limit)
@@ -48,18 +60,30 @@ public final class ScanEnhancedRequest {
                         .filterExpression(filterExpression);
     }
 
+    /**
+     * Returns the value of the exclusive start key set on this request object, or null if it doesn't exist.
+     */
     public Map<String, AttributeValue> exclusiveStartKey() {
         return exclusiveStartKey;
     }
 
+    /**
+     * Returns the value of limit set on this request object, or null if it doesn't exist.
+     */
     public Integer limit() {
         return limit;
     }
 
+    /**
+     * Returns the value of consistent read, or false if it has not been set.
+     */
     public Boolean consistentRead() {
         return consistentRead;
     }
 
+    /**
+     * Returns the return result filter {@link Expression} set on this request object, or null if it doesn't exist.
+     */
     public Expression filterExpression() {
         return filterExpression;
     }
@@ -97,6 +121,9 @@ public final class ScanEnhancedRequest {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     */
     public static final class Builder {
         private Map<String, AttributeValue> exclusiveStartKey;
         private Integer limit;
@@ -106,21 +133,60 @@ public final class ScanEnhancedRequest {
         private Builder() {
         }
 
+        /**
+         * The primary key of the first item that this operation will evaluate. By default, the operation will evaluate
+         * the whole dataset. If used, normally this parameter is populated with the value that was returned for
+         * {@link Page#lastEvaluatedKey()} in the previous operation.
+         *
+         * @param exclusiveStartKey the primary key value where DynamoDb should start to evaluate items
+         * @return a builder of this type
+         */
         public Builder exclusiveStartKey(Map<String, AttributeValue> exclusiveStartKey) {
             this.exclusiveStartKey = exclusiveStartKey != null ? new HashMap<>(exclusiveStartKey) : null;
             return this;
         }
 
+        /**
+         * Sets a limit on how many items to evaluate in the scan. If not set, the operation uses
+         * the maximum values allowed.
+         * <p>
+         * <b>Note:</b>The limit does not refer to the number of items to return, but how many items
+         * the database should evaluate while executing the scan. Use limit together with {@link Page#lastEvaluatedKey()}
+         * and {@link #exclusiveStartKey} in subsequent scan calls to evaluate <em>limit</em> items per call.
+         *
+         * @param limit the maximum number of items to evalute
+         * @return a builder of this type
+         */
         public Builder limit(Integer limit) {
             this.limit = limit;
             return this;
         }
 
+        /**
+         * Determines the read consistency model: If set to true, the operation uses strongly consistent reads; otherwise,
+         * the operation uses eventually consistent reads.
+         * <p>
+         * By default, the value of this property is set to <em>false</em>.
+         *
+         * @param consistentRead sets consistency model of the operation to use strong consistency if true
+         * @return a builder of this type
+         */
         public Builder consistentRead(Boolean consistentRead) {
             this.consistentRead = consistentRead;
             return this;
         }
 
+        /**
+         * Refines the scan results by applying the filter expression on the results returned
+         * from the scan and discards items that do not match. See {@link Expression} for examples
+         * and constraints.
+         * <p>
+         * <b>Note:</b> Using the filter expression does not reduce the cost of the scan, since it is applied
+         * <em>after</em> the database has found matching items.
+         *
+         * @param filterExpression an expression that filters results of evaluating the scan
+         * @return a builder of this type
+         */
         public Builder filterExpression(Expression filterExpression) {
             this.filterExpression = filterExpression;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetItemsEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetItemsEnhancedRequest.java
@@ -21,14 +21,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.GetItemOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.TransactableReadOperation;
 import software.amazon.awssdk.services.dynamodb.model.TransactGetItem;
 
+/**
+ * Defines parameters used for the transaction operation transactGetItems() (such as
+ * {@link DynamoDbEnhancedClient#transactGetItems(TransactGetItemsEnhancedRequest)}).
+ * <p>
+ * A request contains references to the primary keys for the items this operation will search for.
+ * It's populated with one or more {@link GetItemEnhancedRequest}, each associated with with the table where the item is located.
+ * On initialization, these requests are transformed into {@link TransactGetItem} and stored in the request.
+ * .
+ */
 @SdkPublicApi
 public final class TransactGetItemsEnhancedRequest {
 
@@ -38,10 +47,16 @@ public final class TransactGetItemsEnhancedRequest {
         this.transactGetItems = getItemsFromSupplier(builder.itemSupplierList);
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns the list of {@link TransactGetItem} that represents all lookup keys in the request.
+     */
     public List<TransactGetItem> transactGetItems() {
         return transactGetItems;
     }
@@ -65,17 +80,39 @@ public final class TransactGetItemsEnhancedRequest {
         return transactGetItems != null ? transactGetItems.hashCode() : 0;
     }
 
+    /**
+     * A builder that is used to create a transaction object with the desired parameters.
+     * <p>
+     * A valid builder should contain at least one {@link GetItemEnhancedRequest} added through addGetItem().
+     */
     public static final class Builder {
         private List<Supplier<TransactGetItem>> itemSupplierList = new ArrayList<>();
 
         private Builder() {
         }
 
+        /**
+         * Adds a primary lookup key and it's associated table to the transaction.
+         *
+         * @param mappedTableResource the table where the key is located
+         * @param request A {@link GetItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addGetItem(MappedTableResource<T> mappedTableResource, GetItemEnhancedRequest request) {
             itemSupplierList.add(() -> generateTransactWriteItem(mappedTableResource, GetItemOperation.create(request)));
             return this;
         }
 
+        /**
+         * Adds a primary lookup key and it's associated table to the transaction by accepting a consumer of
+         * {@link GetItemEnhancedRequest.Builder}.
+         *
+         * @param mappedTableResource the table where the key is located
+         * @param requestConsumer a {@link Consumer} of {@link GetItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addGetItem(MappedTableResource<T> mappedTableResource,
                                       Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
             GetItemEnhancedRequest.Builder builder = GetItemEnhancedRequest.builder();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequest.java
@@ -21,8 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DeleteItemOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationContext;
@@ -31,6 +32,20 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.operations.Transactable
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.UpdateItemOperation;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 
+/**
+ * Defines parameters used for the transaction operation transactWriteItems() (such as
+ * {@link DynamoDbEnhancedClient#transactWriteItems(TransactWriteItemsEnhancedRequest)}).
+ * <p>
+ * A request contains parameters for the different actions available in the operation:
+ * <ul>
+ *     <li>Write/Update items through put and update actions</li>
+ *     <li>Delete items</li>
+ *     <li>Use a condition check</li>
+ * </ul>
+ * It's populated with one or more low-level requests, such as {@link PutItemEnhancedRequest} and each low-level action request
+ * is associated with with the table where the action should be applied.
+ * On initialization, these requests are transformed into {@link TransactWriteItem} and stored in the request.
+ */
 @SdkPublicApi
 public final class TransactWriteItemsEnhancedRequest {
 
@@ -40,10 +55,16 @@ public final class TransactWriteItemsEnhancedRequest {
         this.transactWriteItems = getItemsFromSupplier(builder.itemSupplierList);
     }
 
+    /**
+     * Creates a newly initialized builder for a request object.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns the list of {@link TransactWriteItem} that represents all actions in the request.
+     */
     public List<TransactWriteItem> transactWriteItems() {
         return transactWriteItems;
     }
@@ -67,17 +88,47 @@ public final class TransactWriteItemsEnhancedRequest {
         return transactWriteItems != null ? transactWriteItems.hashCode() : 0;
     }
 
+    /**
+     * A builder that is used to create a transaction object with the desired parameters.
+     * <p>
+     * A valid builder should contain at least one low-level request such as {@link DeleteItemEnhancedRequest}.
+     */
     public static final class Builder {
         private List<Supplier<TransactWriteItem>> itemSupplierList = new ArrayList<>();
 
         private Builder() {
         }
 
+        /**
+         * Adds a condition check for a primary key in the associated table to the transaction.
+         * <p>
+         * <b>Note:</b> The condition check should be applied to an item that is not modified by another action in the
+         * same transaction. See {@link ConditionCheck} for more information on how to build a condition check, and the
+         * DynamoDb TransactWriteItems documentation for more information on how a condition check affects the transaction.
+         *
+         * @param mappedTableResource the table on which to apply the condition check
+         * @param request A {@link ConditionCheck} definition
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addConditionCheck(MappedTableResource<T> mappedTableResource, ConditionCheck<T> request) {
             itemSupplierList.add(() -> generateTransactWriteItem(mappedTableResource, request));
             return this;
         }
 
+        /**
+         * Adds a condition check for a primary key in the associated table to the transaction by accepting a consumer
+         * of {@link ConditionCheck.Builder}.
+         * <p>
+         * <b>Note:</b> The condition check should be applied to an item that is not modified by another action in the
+         * same transaction. See {@link ConditionCheck} for more information on how to build a condition check, and the
+         * DynamoDb TransactWriteItems documentation for more information on how a condition check affects the transaction.
+         *
+         * @param mappedTableResource the table on which to apply the condition check
+         * @param requestConsumer a {@link Consumer} of {@link DeleteItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addConditionCheck(MappedTableResource<T> mappedTableResource,
                                              Consumer<ConditionCheck.Builder> requestConsumer) {
             ConditionCheck.Builder builder = ConditionCheck.builder();
@@ -85,11 +136,33 @@ public final class TransactWriteItemsEnhancedRequest {
             return addConditionCheck(mappedTableResource, builder.build());
         }
 
+        /**
+         * Adds a primary lookup key for the item to delete, and it's associated table, to the transaction. For more information
+         * on the delete action, see the low-level operation description in for instance
+         * {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)} and how to construct the low-level request in
+         * {@link DeleteItemEnhancedRequest}.
+         *
+         * @param mappedTableResource the table where the key is located
+         * @param request A {@link DeleteItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addDeleteItem(MappedTableResource<T> mappedTableResource, DeleteItemEnhancedRequest request) {
             itemSupplierList.add(() -> generateTransactWriteItem(mappedTableResource, DeleteItemOperation.create(request)));
             return this;
         }
 
+        /**
+         * Adds a primary lookup key for the item to delete, and it's associated table, to the transaction by accepting a consumer
+         * of {@link DeleteItemEnhancedRequest.Builder}. For more information on the delete action, see the low-level operation
+         * description in for instance {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)} and how to construct the
+         * low-level request in {@link DeleteItemEnhancedRequest}.
+         *
+         * @param mappedTableResource the table where the key is located
+         * @param requestConsumer a {@link Consumer} of {@link DeleteItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addDeleteItem(MappedTableResource<T> mappedTableResource,
                                       Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
             DeleteItemEnhancedRequest.Builder builder = DeleteItemEnhancedRequest.builder();
@@ -97,11 +170,32 @@ public final class TransactWriteItemsEnhancedRequest {
             return addDeleteItem(mappedTableResource, builder.build());
         }
 
+        /**
+         * Adds an item to be written, and it's associated table, to the transaction. For more information on the put action,
+         * see the low-level operation description in for instance {@link DynamoDbTable#putItem(PutItemEnhancedRequest)}
+         * and how to construct the low-level request in {@link PutItemEnhancedRequest}.
+         *
+         * @param mappedTableResource the table to write the item to
+         * @param request A {@link PutItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addPutItem(MappedTableResource<T> mappedTableResource, PutItemEnhancedRequest<T> request) {
             itemSupplierList.add(() -> generateTransactWriteItem(mappedTableResource, PutItemOperation.create(request)));
             return this;
         }
 
+        /**
+         * Adds an item to be written, and it's associated table, to the transaction by accepting a consumer
+         * of {@link PutItemEnhancedRequest.Builder}. For more information on the put action,
+         * see the low-level operation description in for instance {@link DynamoDbTable#putItem(PutItemEnhancedRequest)}
+         * and how to construct the low-level request in {@link PutItemEnhancedRequest}.
+         *
+         * @param mappedTableResource the table to write the item to
+         * @param requestConsumer a {@link Consumer} of {@link PutItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addPutItem(MappedTableResource<T> mappedTableResource, Class<? extends T> itemClass,
                                       Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
             PutItemEnhancedRequest.Builder<T> builder = PutItemEnhancedRequest.builder(itemClass);
@@ -109,11 +203,32 @@ public final class TransactWriteItemsEnhancedRequest {
             return addPutItem(mappedTableResource, builder.build());
         }
 
+        /**
+         * Adds an item to be updated, and it's associated table, to the transaction. For more information on the update action,
+         * see the low-level operation description in for instance {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)}
+         * and how to construct the low-level request in {@link UpdateItemEnhancedRequest}.
+         *
+         * @param mappedTableResource the table to write the item to
+         * @param request A {@link UpdateItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addUpdateItem(MappedTableResource<T> mappedTableResource, UpdateItemEnhancedRequest<T> request) {
             itemSupplierList.add(() -> generateTransactWriteItem(mappedTableResource, UpdateItemOperation.create(request)));
             return this;
         }
 
+        /**
+         * Adds an item to be written, and it's associated table, to the transaction by accepting a consumer
+         * of {@link PutItemEnhancedRequest.Builder}. For more information on the update action,
+         * see the low-level operation description in for instance {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)}
+         * and how to construct the low-level request in {@link UpdateItemEnhancedRequest}.
+         *
+         * @param mappedTableResource the table to write the item to
+         * @param requestConsumer a {@link Consumer} of {@link UpdateItemEnhancedRequest}
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
         public <T> Builder addUpdateItem(MappedTableResource<T> mappedTableResource, Class<? extends T> itemClass,
                                          Consumer<UpdateItemEnhancedRequest.Builder<T>> requestConsumer) {
             UpdateItemEnhancedRequest.Builder<T> builder = UpdateItemEnhancedRequest.builder(itemClass);

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
@@ -16,8 +16,21 @@
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+/**
+ * Defines parameters used to update an item to a DynamoDb table using the updateItem() operation (such as
+ * {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)} or
+ * {@link DynamoDbAsyncTable#updateItem(UpdateItemEnhancedRequest)}).
+ * <p>
+ * A valid request object must contain the item that should be written to the table.
+ *
+ * @param <T> The type of the modelled object.
+ */
 @SdkPublicApi
 public final class UpdateItemEnhancedRequest<T> {
 
@@ -31,22 +44,41 @@ public final class UpdateItemEnhancedRequest<T> {
         this.conditionExpression = builder.conditionExpression;
     }
 
+    /**
+     * Creates a newly initialized builder for the request object.
+     *
+     * @param itemClass the class that items in this table map to
+     * @param <T> The type of the modelled object, corresponding to itemClass
+     * @return a UpdateItemEnhancedRequest builder
+     */
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
         return new Builder<>();
     }
 
+    /**
+     * Returns a builder initialized with all existing values on the request object.
+     */
     public Builder<T> toBuilder() {
         return new Builder<T>().item(item).ignoreNulls(ignoreNulls);
     }
 
+    /**
+     * Returns the item for this update operation request.
+     */
     public T item() {
         return item;
     }
 
+    /**
+     * Returns if the update operation should ignore attributes with null values, or false if it has not been set.
+     */
     public Boolean ignoreNulls() {
         return ignoreNulls;
     }
 
+    /**
+     * Returns the condition {@link Expression} set on this request object, or null if it doesn't exist.
+     */
     public Expression conditionExpression() {
         return conditionExpression;
     }
@@ -75,6 +107,11 @@ public final class UpdateItemEnhancedRequest<T> {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * <b>Note</b>: A valid request builder must define an item.
+     */
     public static final class Builder<T> {
         private T item;
         private Boolean ignoreNulls;
@@ -83,16 +120,40 @@ public final class UpdateItemEnhancedRequest<T> {
         private Builder() {
         }
 
+        /**
+         *  Sets if the update operation should ignore attributes with null values. By default, the value is false.
+         *  <p>
+         *  If set to true, any null values in the Java object will not be written to the table.
+         *  If set to false, null values in the Java object will be written to the table (as an {@link AttributeValue} of type
+         *  'nul' in the output map, see {@link TableSchema#itemToMap(Object, boolean)}).
+         * @param ignoreNulls the boolean value
+         * @return a builder of this type
+         */
         public Builder<T> ignoreNulls(Boolean ignoreNulls) {
             this.ignoreNulls = ignoreNulls;
             return this;
         }
 
+        /**
+         * Defines a logical expression on an item's attribute values which, if evaluating to true,
+         * will allow the delete operation to succeed. If evaluating to false, the operation will not succeed.
+         * <p>
+         * See {@link Expression} for condition syntax and examples.
+         *
+         * @param conditionExpression a condition written as an {@link Expression}
+         * @return a builder of this type
+         */
         public Builder<T> conditionExpression(Expression conditionExpression) {
             this.conditionExpression = conditionExpression;
             return this;
         }
 
+        /**
+         * Sets the item to write to DynamoDb. Required.
+         *
+         * @param item the item to write
+         * @return a builder of this type
+         */
         public Builder<T> item(T item) {
             this.item = item;
             return this;

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/WriteBatch.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/WriteBatch.java
@@ -22,8 +22,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.BatchableWriteOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DeleteItemOperation;
@@ -31,6 +32,14 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationCon
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.PutItemOperation;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
+/**
+ * Defines a collection of references to keys for delete actions and items for put actions
+ * for one specific table. A WriteBatch is part of a {@link BatchWriteItemEnhancedRequest}
+ * and used in a batchWriteItem() operation (such as
+ * {@link DynamoDbEnhancedClient#batchWriteItem(BatchWriteItemEnhancedRequest)}).
+ * <p>
+ * A valid write batch should contain one or more delete or put action reference.
+ */
 @SdkPublicApi
 public final class WriteBatch {
     private final String tableName;
@@ -41,14 +50,27 @@ public final class WriteBatch {
         this.writeRequests = getItemsFromSupplier(builder.itemSupplierList);
     }
 
+    /**
+     * Creates a newly initialized builder for a write batch.
+     *
+     * @param itemClass the class that items in this table map to
+     * @param <T> The type of the modelled object, corresponding to itemClass
+     * @return a WriteBatch builder
+     */
     public static <T> Builder<T> builder(Class<? extends T> itemClass) {
         return new BuilderImpl<>(itemClass);
     }
 
+    /**
+     * Returns the table name associated with this batch.
+     */
     public String tableName() {
         return tableName;
     }
 
+    /**
+     * Returns the collection of write requests in this writek batch.
+     */
     public Collection<WriteRequest> writeRequests() {
         return writeRequests;
     }
@@ -79,15 +101,58 @@ public final class WriteBatch {
         return result;
     }
 
+    /**
+     * A builder that is used to create a request with the desired parameters.
+     * <p>
+     * A valid builder must define a {@link MappedTableResource} and add at least one
+     * {@link DeleteItemEnhancedRequest} or {@link PutItemEnhancedRequest}.
+     *
+     * @param <T> the type that items in this table map to
+     */
     public interface Builder<T> {
+
+        /**
+         * Sets the mapped table resource (table) that the items in this write batch should come from.
+         *
+         * @param mappedTableResource the table reference
+         * @return a builder of this type
+         */
         Builder<T> mappedTableResource(MappedTableResource<T> mappedTableResource);
 
+        /**
+         * Adds a {@link DeleteItemEnhancedRequest} to the builder, this request should contain
+         * the primary {@link Key} to an item to be deleted.
+         *
+         * @param request A {@link DeleteItemEnhancedRequest}
+         * @return a builder of this type
+         */
         Builder<T> addDeleteItem(DeleteItemEnhancedRequest request);
 
+        /**
+         * Adds a {@link DeleteItemEnhancedRequest} to the builder, this request should contain
+         * the primary {@link Key} to an item to be deleted.
+         *
+         * @param requestConsumer a {@link Consumer} of {@link DeleteItemEnhancedRequest}
+         * @return a builder of this type
+         */
         Builder<T> addDeleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer);
 
+        /**
+         * Adds a {@link PutItemEnhancedRequest} to the builder, this request should contain the item
+         * to be written.
+         *
+         * @param request A {@link PutItemEnhancedRequest}
+         * @return a builder of this type
+         */
         Builder<T> addPutItem(PutItemEnhancedRequest<T> request);
 
+        /**
+         * Adds a {@link PutItemEnhancedRequest} to the builder, this request should contain the item
+         * to be written.
+         *
+         * @param requestConsumer a {@link Consumer} of {@link PutItemEnhancedRequest}
+         * @return a builder of this type
+         */
         Builder<T> addPutItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer);
 
         WriteBatch build();

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncBasicCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncBasicCrudTest.java
@@ -213,7 +213,8 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
                                           GlobalSecondaryIndex.create(
                                               "gsi_1",
                                               Projection.builder().projectionType(ProjectionType.ALL).build(),
-                                              getDefaultProvisionedThroughput()))).join();
+                                              getDefaultProvisionedThroughput())))
+                   .join();
     }
 
     @After

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncTransactGetItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncTransactGetItemsTest.java
@@ -28,14 +28,15 @@ import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.internal.DefaultDocument;
 import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
 import software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 
 public class AsyncTransactGetItemsTest extends LocalDynamoDbAsyncTestBase {
@@ -158,7 +159,7 @@ public class AsyncTransactGetItemsTest extends LocalDynamoDbAsyncTestBase {
                                            .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
                                            .build();
 
-        List<TransactGetResultPage> results = enhancedAsyncClient.transactGetItems(transactGetItemsEnhancedRequest).join();
+        List<Document> results = enhancedAsyncClient.transactGetItems(transactGetItemsEnhancedRequest).join();
 
         assertThat(results.size(), is(4));
         assertThat(results.get(0).getItem(mappedTable1), is(RECORDS_1.get(0)));
@@ -179,7 +180,7 @@ public class AsyncTransactGetItemsTest extends LocalDynamoDbAsyncTestBase {
                                            .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
                                            .build();
 
-        List<TransactGetResultPage> results = enhancedAsyncClient.transactGetItems(transactGetItemsEnhancedRequest).join();
+        List<Document> results = enhancedAsyncClient.transactGetItems(transactGetItemsEnhancedRequest).join();
 
         assertThat(results.size(), is(4));
         assertThat(results.get(0).getItem(mappedTable1), is(RECORDS_1.get(0)));

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/TransactGetItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/TransactGetItemsTest.java
@@ -28,13 +28,14 @@ import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.internal.DefaultDocument;
 import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 
 public class TransactGetItemsTest extends LocalDynamoDbSyncTestBase {
@@ -152,7 +153,7 @@ public class TransactGetItemsTest extends LocalDynamoDbSyncTestBase {
                                            .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
                                            .build();
 
-        List<TransactGetResultPage> results = enhancedClient.transactGetItems(transactGetItemsEnhancedRequest);
+        List<Document> results = enhancedClient.transactGetItems(transactGetItemsEnhancedRequest);
 
         assertThat(results.size(), is(4));
         assertThat(results.get(0).getItem(mappedTable1), is(RECORDS_1.get(0)));
@@ -173,7 +174,7 @@ public class TransactGetItemsTest extends LocalDynamoDbSyncTestBase {
                                            .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
                                            .build();
 
-        List<TransactGetResultPage> results = enhancedClient.transactGetItems(transactGetItemsEnhancedRequest);
+        List<Document> results = enhancedClient.transactGetItems(transactGetItemsEnhancedRequest);
 
         assertThat(results.size(), is(4));
         assertThat(results.get(0).getItem(mappedTable1), is(RECORDS_1.get(0)));

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/DefaultDocumentTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/DefaultDocumentTest.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.enhanced.dynamodb.model;
+package software.amazon.awssdk.enhanced.dynamodb.internal;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -39,7 +40,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TransactGetResultPageTest {
+public class DefaultDocumentTest {
     private static final String TABLE_NAME = "table-name";
 
     @Mock
@@ -60,9 +61,9 @@ public class TransactGetResultPageTest {
     public void noExtension_mapsToItem() {
         FakeItem fakeItem = FakeItem.createUniqueFakeItem();
         Map<String, AttributeValue> fakeItemMap = FakeItem.getTableSchema().itemToMap(fakeItem, true);
-        TransactGetResultPage transactGetResultPage = TransactGetResultPage.create(fakeItemMap);
+        Document defaultDocument = DefaultDocument.create(fakeItemMap);
 
-        assertThat(transactGetResultPage.getItem(createMappedTable(null)), is(fakeItem));
+        assertThat(defaultDocument.getItem(createMappedTable(null)), is(fakeItem));
     }
 
     @Test
@@ -74,10 +75,10 @@ public class TransactGetResultPageTest {
         when(mockDynamoDbEnhancedClientExtension.afterRead(anyMap(), any(), any()))
             .thenReturn(ReadModification.builder().transformedItem(fakeItemMap2).build());
 
-        TransactGetResultPage transactGetResultPage = TransactGetResultPage.create(fakeItemMap);
+        Document defaultDocument = DefaultDocument.create(fakeItemMap);
 
         DynamoDbTable<FakeItem> mappedTable = createMappedTable(mockDynamoDbEnhancedClientExtension);
-        assertThat(transactGetResultPage.getItem(mappedTable), is(fakeItem2));
+        assertThat(defaultDocument.getItem(mappedTable), is(fakeItem2));
         verify(mockDynamoDbEnhancedClientExtension).afterRead(fakeItemMap,
                                                               OperationContext.create(mappedTable.tableName()),
                                                               FakeItem.getTableMetadata());
@@ -85,16 +86,16 @@ public class TransactGetResultPageTest {
 
     @Test
     public void nullMapReturnsNullItem() {
-        TransactGetResultPage transactGetResultPage = TransactGetResultPage.create(null);
+        Document defaultDocument = DefaultDocument.create(null);
 
-        assertThat(transactGetResultPage.getItem(createMappedTable(null)), is(nullValue()));
+        assertThat(defaultDocument.getItem(createMappedTable(null)), is(nullValue()));
     }
 
     @Test
     public void emptyMapReturnsNullItem() {
-        TransactGetResultPage transactGetResultPage = TransactGetResultPage.create(emptyMap());
+        Document defaultDocument = DefaultDocument.create(emptyMap());
 
-        assertThat(transactGetResultPage.getItem(createMappedTable(null)), is(nullValue()));
+        assertThat(defaultDocument.getItem(createMappedTable(null)), is(nullValue()));
     }
 
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperationTest.java
@@ -38,14 +38,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithSort;
+import software.amazon.awssdk.enhanced.dynamodb.internal.DefaultDocument;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetResultPage;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Get;
@@ -167,12 +168,12 @@ public class TransactGetItemsOperationTest {
                                                                     .responses(itemResponses)
                                                                     .build();
 
-        List<TransactGetResultPage> result = operation.transformResponse(response, null);
+        List<Document> result = operation.transformResponse(response, null);
 
-        assertThat(result, contains(TransactGetResultPage.create(FAKE_ITEM_MAPS.get(0)),
-                                    TransactGetResultPage.create(FAKESORT_ITEM_MAPS.get(0)),
-                                    TransactGetResultPage.create(FAKESORT_ITEM_MAPS.get(1)),
-                                    TransactGetResultPage.create(FAKE_ITEM_MAPS.get(1))));
+        assertThat(result, contains(DefaultDocument.create(FAKE_ITEM_MAPS.get(0)),
+                                    DefaultDocument.create(FAKESORT_ITEM_MAPS.get(0)),
+                                    DefaultDocument.create(FAKESORT_ITEM_MAPS.get(1)),
+                                    DefaultDocument.create(FAKE_ITEM_MAPS.get(1))));
     }
 
     @Test
@@ -205,10 +206,10 @@ public class TransactGetItemsOperationTest {
                                                                     .responses(itemResponses)
                                                                     .build();
 
-        List<TransactGetResultPage> result = operation.transformResponse(response, null);
+        List<Document> result = operation.transformResponse(response, null);
 
-        assertThat(result, contains(TransactGetResultPage.create(FAKE_ITEM_MAPS.get(0)),
-                                    TransactGetResultPage.create(FAKESORT_ITEM_MAPS.get(0)),
+        assertThat(result, contains(DefaultDocument.create(FAKE_ITEM_MAPS.get(0)),
+                                    DefaultDocument.create(FAKESORT_ITEM_MAPS.get(0)),
                                     null));
     }
 
@@ -224,11 +225,11 @@ public class TransactGetItemsOperationTest {
                                                                     .responses(itemResponses)
                                                                     .build();
 
-        List<TransactGetResultPage> result = operation.transformResponse(response, null);
+        List<Document> result = operation.transformResponse(response, null);
 
-        assertThat(result, contains(TransactGetResultPage.create(FAKE_ITEM_MAPS.get(0)),
-                                    TransactGetResultPage.create(FAKESORT_ITEM_MAPS.get(0)),
-                                    TransactGetResultPage.create(emptyMap())));
+        assertThat(result, contains(DefaultDocument.create(FAKE_ITEM_MAPS.get(0)),
+                                    DefaultDocument.create(FAKESORT_ITEM_MAPS.get(0)),
+                                    DefaultDocument.create(emptyMap())));
     }
 
     private static TransactGetItemsEnhancedRequest emptyRequest() {


### PR DESCRIPTION
## Description
Adds and/or updates javadoc for client, table and index operation methods, both synchronous and asynchronous, as well as the request and response objects used for any operation.  See [Issue #35](https://github.com/aws/aws-sdk-java-v2/issues/35). 

## Motivation and Context
Because of the iterative method used in developing the library, major refactoring driven by usability goals meant there was a large gap in the documentation coverage. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
