### PR TITLE
Add tests for dynamodb enhanced client batchGetItem operation

### DIFF
--- a/services-custom/dynamodb-enhanced/pom.xml
+++ b/services-custom/dynamodb-enhanced/pom.xml
@@ -142,6 +142,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
             <scope>test</scope>

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/AsyncBatchGetItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/AsyncBatchGetItemTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mocktests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeTags.primaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.Attributes.attribute;
+import static software.amazon.awssdk.enhanced.dynamodb.mocktests.BatchGetTestUtils.stubResponseWithUnprocessedKeys;
+import static software.amazon.awssdk.enhanced.dynamodb.mocktests.BatchGetTestUtils.stubSuccessfulResponse;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mocktests.BatchGetTestUtils.Record;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
+import software.amazon.awssdk.enhanced.dynamodb.model.ReadBatch;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+public class AsyncBatchGetItemTest {
+
+    private DynamoDbAsyncClient dynamoDbClient;
+    private DynamoDbEnhancedAsyncClient enhancedClient;
+    private DynamoDbAsyncTable<Record> table;
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    @Before
+    public void setup() {
+
+        dynamoDbClient = DynamoDbAsyncClient.builder()
+                                            .region(Region.US_WEST_2)
+                                            .credentialsProvider(() -> AwsBasicCredentials.create("foo", "bar"))
+                                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                            .build();
+        enhancedClient = DynamoDbEnhancedAsyncClient.builder()
+                                                    .dynamoDbClient(dynamoDbClient)
+                                                    .build();
+        StaticTableSchema<Record> tableSchema = StaticTableSchema.builder(Record.class)
+                                                                 .newItemSupplier(Record::new)
+                                                                 .attributes(attribute("id", TypeToken.of(Integer.class),
+                                                                                       Record::getId,
+                                                                                       Record::setId).as(primaryPartitionKey()))
+                                                                 .build();
+        table = enhancedClient.table("table", tableSchema);
+    }
+
+    @Test
+    public void successfulResponseWithoutUnprocessedKeys_NoNextPage() throws InterruptedException {
+        stubSuccessfulResponse();
+        SdkPublisher<BatchGetResultPage> batchGetResultPages = enhancedClient.batchGetItem(r -> r.readBatches(
+            ReadBatch.builder(Record.class)
+                     .mappedTableResource(table)
+                     .build()));
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        VerifyPageSubscriber verifyPageSubscriber = new VerifyPageSubscriber(countDownLatch);
+        batchGetResultPages.subscribe(verifyPageSubscriber);
+        countDownLatch.await(1000, TimeUnit.SECONDS);
+        assertThat(verifyPageSubscriber.pages.size()).isEqualTo(1);
+        assertThat(verifyPageSubscriber.pages.get(0).getResultsForTable(table).size()).isEqualTo(3);
+    }
+
+    @Test
+    public void responseWithUnprocessedKeys_iteratePage_shouldFetchUnprocessedKeys() throws InterruptedException {
+        stubResponseWithUnprocessedKeys();
+        SdkPublisher<BatchGetResultPage> batchGetResultPages = enhancedClient.batchGetItem(r -> r.readBatches(
+            ReadBatch.builder(Record.class)
+                     .mappedTableResource(table)
+                     .build()));
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        VerifyPageSubscriber verifyPageSubscriber = new VerifyPageSubscriber(countDownLatch);
+        batchGetResultPages.subscribe(verifyPageSubscriber);
+        countDownLatch.await(1000, TimeUnit.SECONDS);
+        assertThat(verifyPageSubscriber.pages.size()).isEqualTo(2);
+        assertThat(verifyPageSubscriber.pages.get(0).getResultsForTable(table).size()).isEqualTo(2);
+        assertThat(verifyPageSubscriber.pages.get(1).getResultsForTable(table).size()).isEqualTo(1);
+    }
+
+    private static final class VerifyPageSubscriber implements Subscriber<BatchGetResultPage> {
+        private Subscription subscription;
+        private List<BatchGetResultPage> pages = new ArrayList<>();
+        private CountDownLatch countDownLatch;
+
+        VerifyPageSubscriber(CountDownLatch countDownLatch) {
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.subscription = s;
+            subscription.request(1);
+        }
+
+        @Override
+        public void onNext(BatchGetResultPage batchGetResultPage) {
+            pages.add(batchGetResultPage);
+            subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            countDownLatch.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            countDownLatch.countDown();
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/BatchGetItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/BatchGetItemTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mocktests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.AttributeTags.primaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.Attributes.attribute;
+import static software.amazon.awssdk.enhanced.dynamodb.mocktests.BatchGetTestUtils.stubResponseWithUnprocessedKeys;
+import static software.amazon.awssdk.enhanced.dynamodb.mocktests.BatchGetTestUtils.stubSuccessfulResponse;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TypeToken;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mocktests.BatchGetTestUtils.Record;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
+import software.amazon.awssdk.enhanced.dynamodb.model.ReadBatch;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class BatchGetItemTest {
+
+    private DynamoDbClient dynamoDbClient;
+    private DynamoDbEnhancedClient enhancedClient;
+    private DynamoDbTable<Record> table;
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    @Before
+    public void setup() {
+
+        dynamoDbClient = DynamoDbClient.builder()
+                                       .region(Region.US_WEST_2)
+                                       .credentialsProvider(() -> AwsBasicCredentials.create("foo", "bar"))
+                                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                       .build();
+        enhancedClient = DynamoDbEnhancedClient.builder()
+                                               .dynamoDbClient(dynamoDbClient)
+                                               .build();
+        StaticTableSchema<Record> tableSchema = StaticTableSchema.builder(Record.class)
+                                                                 .newItemSupplier(Record::new)
+                                                                 .attributes(attribute("id", TypeToken.of(Integer.class),
+                                                                                       Record::getId,
+                                                                                       Record::setId).as(primaryPartitionKey()))
+                                                                 .build();
+        table = enhancedClient.table("table", tableSchema);
+    }
+
+    @Test
+    public void successfulResponseWithoutUnprocessedKeys_NoNextPage() {
+        stubSuccessfulResponse();
+        SdkIterable<BatchGetResultPage> batchGetResultPages = enhancedClient.batchGetItem(r -> r.readBatches(
+            ReadBatch.builder(Record.class)
+                     .mappedTableResource(table)
+                     .addGetItem(i -> i.key(k -> k.partitionValue(0)))
+                     .build()));
+
+        assertThat(batchGetResultPages.stream().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseWithUnprocessedKeys_iteratePage_shouldFetchUnprocessedKeys() {
+        stubResponseWithUnprocessedKeys();
+        SdkIterable<BatchGetResultPage> batchGetResultPages = enhancedClient.batchGetItem(r -> r.readBatches(
+            ReadBatch.builder(Record.class)
+                     .mappedTableResource(table)
+                     .addGetItem(i -> i.key(k -> k.partitionValue("1")))
+                     .build()));
+
+        Iterator<BatchGetResultPage> iterator = batchGetResultPages.iterator();
+        BatchGetResultPage firstPage = iterator.next();
+        List<Record> resultsForTable = firstPage.getResultsForTable(table);
+        assertThat(resultsForTable.size()).isEqualTo(2);
+        BatchGetResultPage secondPage = iterator.next();
+        assertThat(secondPage.getResultsForTable(table).size()).isEqualTo(1);
+        assertThat(iterator).isEmpty();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/BatchGetTestUtils.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/BatchGetTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mocktests;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+public class BatchGetTestUtils {
+
+    private BatchGetTestUtils() {
+    }
+
+    static final String RESPONSE_WITHOUT_UNPROCESSED_KEYS = "{\"Responses\":{\"table\":[{\"id\":{\"N\":\"1\"},"
+                                                            + "\"value\":{\"N\":\"2\"}},{\"id\":{\"N\":\"2\"},"
+                                                            + "\"value\":{\"N\":\"0\"}},{\"id\":{\"N\":\"0\"},"
+                                                            + "\"value\":{\"N\":\"0\"}}]},\"UnprocessedKeys\":{}}";
+
+    static final String RESPONSE_WITH_UNPROCESSED_KEYS = "{\"Responses\":{\"table\":[{\"id\":{\"N\":\"1\"},"
+                                                         + "\"value\":{\"N\":\"2\"}},{\"id\":{\"N\":\"0\"},"
+                                                         + "\"value\":{\"N\":\"0\"}}]},\"UnprocessedKeys\":{\"table"
+                                                         + "\": {\"Keys\": [{\"id\": {\"N\": \"2\"}}]}}}";
+
+    static final String RESPONSE_WITH_UNPROCESSED_KEYS_PROCESSED = "{\"Responses\":{\"table\":[{\"id\":{\"N\":\"2\"},"
+                                                                   + "\"value\":{\"N\":\"0\"}}]},\"UnprocessedKeys\":{}}";
+
+    static void stubSuccessfulResponse() {
+        stubFor(post(anyUrl())
+                    .willReturn(aResponse().withStatus(200).withBody(RESPONSE_WITHOUT_UNPROCESSED_KEYS)));
+    }
+
+    static void stubResponseWithUnprocessedKeys() {
+        stubFor(post(anyUrl())
+                    .inScenario("unprocessed keys")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willSetStateTo("first attempt")
+                    .willReturn(aResponse().withStatus(200)
+                                           .withBody(RESPONSE_WITH_UNPROCESSED_KEYS)));
+
+        stubFor(post(anyUrl())
+                    .inScenario("unprocessed keys")
+                    .whenScenarioStateIs("first attempt")
+                    .willSetStateTo("second attempt")
+                    .willReturn(aResponse().withStatus(200)
+                                           .withBody(RESPONSE_WITH_UNPROCESSED_KEYS_PROCESSED)));
+    }
+
+
+    static final class Record {
+        private int id;
+
+        Integer getId() {
+            return id;
+        }
+
+        Record setId(Integer id) {
+            this.id = id;
+            return this;
+        }
+    }
+
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add tests against mock server to test paginating the results of batchGetItem operation with unprocessed keys.


## Motivation and Context
Currently we don't have any tests to verify batchGetItem with unprocessed keys.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
