### PR TITLE
Fix merging of single value headers

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-11b8422.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-11b8422.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Use the last seen HTTP/1.1 header value for headers defined to only appear once in an HTTP message instead of merging them all into a list. The order in which header values are inspected is: headers set by the request marshaller, overridden headers set on the client, then finally overridden headers set on the SDK request object. See https://tools.ietf.org/html/rfc2616#section-4.2 for more information."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
@@ -173,6 +173,10 @@ public abstract class RequestOverrideConfiguration {
 
         /**
          * Add a single header to be set on the HTTP request.
+         * <p>
+         * This overrides any values for the given header set on the request by default by the SDK, as well as header
+         * overrides set at the client level using
+         * {@link software.amazon.awssdk.core.client.config.ClientOverrideConfiguration}.
          *
          * <p>
          * This overrides any values already configured with this header name in the builder.
@@ -188,6 +192,10 @@ public abstract class RequestOverrideConfiguration {
 
         /**
          * Add a single header with multiple values to be set on the HTTP request.
+         * <p>
+         * This overrides any values for the given header set on the request by default by the SDK, as well as header
+         * overrides set at the client level using
+         * {@link software.amazon.awssdk.core.client.config.ClientOverrideConfiguration}.
          *
          * <p>
          * This overrides any values already configured with this header name in the builder.
@@ -200,6 +208,10 @@ public abstract class RequestOverrideConfiguration {
 
         /**
          * Add additional headers to be set on the HTTP request.
+         * <p>
+         * This overrides any values for the given headers set on the request by default by the SDK, as well as header
+         * overrides set at the client level using
+         * {@link software.amazon.awssdk.core.client.config.ClientOverrideConfiguration}.
          *
          * <p>
          * This completely overrides any values currently configured in the builder.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -179,6 +179,8 @@ public final class ClientOverrideConfiguration
 
         /**
          * Add a single header to be set on the HTTP request.
+         * <p>
+         * This overrides any values for the given header set on the request by default by the SDK.
          *
          * <p>
          * This overrides any values already configured with this header name in the builder.
@@ -194,6 +196,8 @@ public final class ClientOverrideConfiguration
 
         /**
          * Add a single header with multiple values to be set on the HTTP request.
+         * <p>
+         * This overrides any values for the given header set on the request by default by the SDK.
          *
          * <p>
          * This overrides any values already configured with this header name in the builder.
@@ -206,6 +210,8 @@ public final class ClientOverrideConfiguration
 
         /**
          * Configure headers to be set on the HTTP request.
+         * <p>
+         * This overrides any values for the given headers set on the request by default by the SDK.
          *
          * <p>
          * This overrides any values currently configured in the builder.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStage.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.internal.http.pipeline.MutableRequestToRequestPipeline;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 /**
  * Merge customer supplied headers into the marshalled request.
@@ -52,7 +53,13 @@ public class MergeCustomHeadersStage implements MutableRequestToRequestPipeline 
     private final Map<String, List<String>> mergeHeaders(Map<String, List<String>>... headers) {
         Map<String, List<String>> result = new LinkedHashMap<>();
         for (Map<String, List<String>> header : headers) {
-            header.forEach((k, v) -> result.computeIfAbsent(k, ignored -> new ArrayList<>()).addAll(v));
+            header.forEach((headerName, headerValues) -> {
+                List<String> resultHeaderValues = result.computeIfAbsent(headerName, ignored -> new ArrayList<>());
+                if (SdkHttpUtils.isSingleHeader(headerName)) {
+                    resultHeaderValues.clear();
+                }
+                resultHeaderValues.addAll(headerValues);
+            });
         }
         return result;
     }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStageTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.http.pipeline.stages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.SdkRequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.core.http.NoopTestRequest;
+import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
+import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
+import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndRequestTimerTestUtils;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import utils.ValidSdkObjects;
+
+@RunWith(Parameterized.class)
+public class MergeCustomHeadersStageTest {
+    // List of headers that may appear only once in a request; i.e. is not a list of values.
+    // Taken from https://github.com/apache/httpcomponents-client/blob/81c1bc4dc3ca5a3134c5c60e8beff08be2fd8792/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java#L69-L85 with modifications:
+    // removed: accept-ranges, if-match, if-none-match, vary since it looks like they're defined as lists
+    private static final Set<String> SINGLE_HEADERS = Stream.of("age", "authorization",
+            "content-length", "content-location", "content-md5", "content-range", "content-type",
+            "date", "etag", "expires", "from", "host", "if-modified-since", "if-range",
+            "if-unmodified-since", "last-modified", "location", "max-forwards",
+            "proxy-authorization", "range", "referer", "retry-after", "server", "user-agent")
+            .collect(Collectors.toSet());
+
+    @Parameterized.Parameters(name = "Header = {0}")
+    public static Collection<Object> data() {
+        return Arrays.asList(SINGLE_HEADERS.toArray(new Object[0]));
+    }
+
+    @Parameterized.Parameter
+    public String singleHeaderName;
+
+    @Test
+    public void singleHeader_inMarshalledRequest_overriddenOnClient() throws Exception {
+        SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
+
+        RequestExecutionContext ctx = requestContext(NoopTestRequest.builder().build());
+        requestBuilder.putHeader(singleHeaderName, "marshaller");
+
+        Map<String, List<String>> clientHeaders = new HashMap<>();
+        clientHeaders.put(singleHeaderName, Collections.singletonList("client"));
+
+        HttpClientDependencies clientDeps = HttpClientDependencies.builder()
+                .clientConfiguration(SdkClientConfiguration.builder()
+                        .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, clientHeaders)
+                        .build())
+                .build();
+        MergeCustomHeadersStage stage = new MergeCustomHeadersStage(clientDeps);
+
+        stage.execute(requestBuilder, ctx);
+
+        assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("client");
+    }
+
+    @Test
+    public void singleHeader_inMarshalledRequest_overriddenOnRequest() throws Exception {
+        SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
+        requestBuilder.putHeader(singleHeaderName, "marshaller");
+
+        RequestExecutionContext ctx = requestContext(NoopTestRequest.builder()
+                .overrideConfiguration(SdkRequestOverrideConfiguration.builder()
+                        .putHeader(singleHeaderName, "request").build())
+                .build());
+
+        HttpClientDependencies clientDeps = HttpClientDependencies.builder()
+                .clientConfiguration(SdkClientConfiguration.builder()
+                        .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, Collections.emptyMap())
+                        .build())
+                .build();
+        MergeCustomHeadersStage stage = new MergeCustomHeadersStage(clientDeps);
+
+        stage.execute(requestBuilder, ctx);
+
+        assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request");
+    }
+
+    @Test
+    public void singleHeader_inClient_overriddenOnRequest() throws Exception {
+        SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
+
+        RequestExecutionContext ctx = requestContext(NoopTestRequest.builder()
+                .overrideConfiguration(SdkRequestOverrideConfiguration.builder()
+                        .putHeader(singleHeaderName, "request").build())
+                .build());
+
+        Map<String, List<String>> clientHeaders = new HashMap<>();
+        clientHeaders.put(singleHeaderName, Collections.singletonList("client"));
+        HttpClientDependencies clientDeps = HttpClientDependencies.builder()
+                .clientConfiguration(SdkClientConfiguration.builder()
+                        .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, clientHeaders)
+                        .build())
+                .build();
+        MergeCustomHeadersStage stage = new MergeCustomHeadersStage(clientDeps);
+
+        stage.execute(requestBuilder, ctx);
+
+        assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request");
+    }
+
+    @Test
+    public void singleHeader_inMarshalledRequest_inClient_inRequest() throws Exception {
+        SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
+        requestBuilder.putHeader(singleHeaderName, "marshaller");
+
+        RequestExecutionContext ctx = requestContext(NoopTestRequest.builder()
+                .overrideConfiguration(SdkRequestOverrideConfiguration.builder()
+                        .putHeader(singleHeaderName, "request").build())
+                .build());
+
+        Map<String, List<String>> clientHeaders = new HashMap<>();
+        clientHeaders.put(singleHeaderName, Collections.singletonList("client"));
+        HttpClientDependencies clientDeps = HttpClientDependencies.builder()
+                .clientConfiguration(SdkClientConfiguration.builder()
+                        .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, clientHeaders)
+                        .build())
+                .build();
+        MergeCustomHeadersStage stage = new MergeCustomHeadersStage(clientDeps);
+
+        stage.execute(requestBuilder, ctx);
+
+        assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request");
+    }
+
+    @Test
+    public void singleHeader_inRequestAsList_keepsMultipleValues() throws Exception {
+        SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
+        requestBuilder.putHeader(singleHeaderName, "marshaller");
+
+        RequestExecutionContext ctx = requestContext(NoopTestRequest.builder()
+                .overrideConfiguration(SdkRequestOverrideConfiguration.builder()
+                        .putHeader(singleHeaderName, Arrays.asList("request", "request2", "request3"))
+                        .build())
+                .build());
+
+        Map<String, List<String>> clientHeaders = new HashMap<>();
+        HttpClientDependencies clientDeps = HttpClientDependencies.builder()
+                .clientConfiguration(SdkClientConfiguration.builder()
+                        .option(SdkClientOption.ADDITIONAL_HTTP_HEADERS, clientHeaders)
+                        .build())
+                .build();
+        MergeCustomHeadersStage stage = new MergeCustomHeadersStage(clientDeps);
+
+        stage.execute(requestBuilder, ctx);
+
+        assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request", "request2", "request3");
+    }
+
+    private RequestExecutionContext requestContext(SdkRequest request) {
+        ExecutionContext executionContext = ClientExecutionAndRequestTimerTestUtils.executionContext(ValidSdkObjects.sdkHttpFullRequest().build());
+        return RequestExecutionContext.builder()
+                .executionContext(executionContext)
+                .originalRequest(request)
+                .build();
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,6 +56,16 @@ public final class SdkHttpUtils {
                             Pattern.quote("%7E") +
                             "|" +
                             Pattern.quote("%2F"));
+
+    // List of headers that may appear only once in a request; i.e. is not a list of values.
+    // Taken from https://github.com/apache/httpcomponents-client/blob/81c1bc4dc3ca5a3134c5c60e8beff08be2fd8792/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java#L69-L85 with modifications:
+    // removed: accept-ranges, if-match, if-none-match, vary since it looks like they're defined as lists
+    private static final Set<String> SINGLE_HEADERS = Stream.of("age", "authorization",
+            "content-length", "content-location", "content-md5", "content-range", "content-type",
+            "date", "etag", "expires", "from", "host", "if-modified-since", "if-range",
+            "if-unmodified-since", "last-modified", "location", "max-forwards",
+            "proxy-authorization", "range", "referer", "retry-after", "server", "user-agent")
+            .collect(Collectors.toSet());
 
     private SdkHttpUtils() {}
 
@@ -296,5 +307,9 @@ public final class SdkHttpUtils {
      */
     public static Optional<String> firstMatchingHeader(Map<String, List<String>> headers, String header) {
         return allMatchingHeaders(headers, header).findFirst();
+    }
+
+    public static boolean isSingleHeader(String h) {
+        return SINGLE_HEADERS.contains(StringUtils.lowerCase(h));
     }
 }


### PR DESCRIPTION
## Description
Use the last seen HTTP/1.1 header value for headers defined to only appear once in an HTTP message instead of merging them all into a list. The order in which header values are inspected is: headers set on the request, overridden headers set on the client, then finally overridden headers set on an SDK request. See https://tools.ietf.org/html/rfc2616#section-4.2 for more information.

## Motivation and Context
Bug fix.

## Testing
`mvn clean install`. Will run integ tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
