### PR TITLE
DynamoDB Enhanced: Added static constructors to TableSchema interface

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/TableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/TableSchema.java
@@ -17,8 +17,9 @@ package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.Collection;
 import java.util.Map;
-
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -30,6 +31,30 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  */
 @SdkPublicApi
 public interface TableSchema<T> {
+
+    /**
+     * Returns a builder for the {@link StaticTableSchema} implementation of this interface which allows all attributes,
+     * tags and table structure to be directly declared in the builder.
+     * @param itemClass The class of the item this {@link TableSchema} will map records to.
+     * @param <T> The type of the item this {@link TableSchema} will map records to.
+     * @return A newly initialized {@link StaticTableSchema.Builder}.
+     */
+    static <T> StaticTableSchema.Builder<T> builder(Class<T> itemClass) {
+        return StaticTableSchema.builder(itemClass);
+    }
+
+    /**
+     * Scans a bean class that has been annotated with DynamoDb bean annotations and then returns a
+     * {@link BeanTableSchema} implementation of this interface that can map records to and from items of that bean
+     * class.
+     * @param beanClass The bean class this {@link TableSchema} will map records to.
+     * @param <T> The type of the item this {@link TableSchema} will map records to.
+     * @return An initialized {@link BeanTableSchema}.
+     */
+    static <T> BeanTableSchema<T> fromBean(Class<T> beanClass) {
+        return BeanTableSchema.create(beanClass);
+    }
+
     /**
      * Takes a raw DynamoDb SDK representation of a record in a table and maps it to a Java object. A new object is
      * created to fulfil this operation.

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/TableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/TableSchemaTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SimpleBean;
+
+public class TableSchemaTest {
+
+    @Test
+    public void builder_constructsStaticTableSchemaBuilder() {
+        StaticTableSchema.Builder<FakeItem> builder = TableSchema.builder(FakeItem.class);
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    public void fromBean_constructsBeanTableSchema() {
+        BeanTableSchema<SimpleBean> beanBeanTableSchema = TableSchema.fromBean(SimpleBean.class);
+        assertThat(beanBeanTableSchema).isNotNull();
+    }
+}


### PR DESCRIPTION
Making it easier for customers to discover the different implementations of TableSchema.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
