### PR TITLE
Fix stale javadocs and remove unnecessary use of AtomicReference

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/AttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/AttributeConverter.java
@@ -46,11 +46,13 @@ public interface AttributeConverter<T> {
      *
      * <p>
      * Example:
+     * <pre>
      * {@code
      * InstantAsStringAttributeConverter converter = InstantAsStringAttributeConverter.create();
-     * assertEquals(converter.toAttributeValue(Instant.EPOCH),
-     *              ItemAttributeValue.fromString("1970-01-01T00:00:00Z"));
+     * assertEquals(converter.transformFrom(Instant.EPOCH),
+     *              EnhancedAttributeValue.fromString("1970-01-01T00:00:00Z").toAttributeValue());
      * }
+     * </pre>
      */
     AttributeValue transformFrom(T input);
 
@@ -59,12 +61,13 @@ public interface AttributeConverter<T> {
      * conversion fails, or the input is null.
      *
      * <p>
+     * <pre>
      * Example:
      * {@code
      * InstantAsStringAttributeConverter converter = InstantAsStringAttributeConverter.create();
-     * assertEquals(converter.fromAttributeValue(ItemAttributeValue.fromString("1970-01-01T00:00:00Z")),
+     * assertEquals(converter.transformTo(EnhancedAttributeValue.fromString("1970-01-01T00:00:00Z").toAttributeValue()),
      *              Instant.EPOCH);
-     * }
+     * <pre>
      */
     T transformTo(AttributeValue input);
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -18,9 +18,9 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.extensions;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
@@ -34,19 +34,23 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * extension. The order in which extensions will be used depends on the operation, for write operations they will be
  * called in forward order, for read operations they will be called in reverse order. For example :-
  *
+ * <p>
  * If you create a chain of three extensions:
- * ChainMapperExtension.of(extension1, extension2, extension3);
+ * ChainMapperExtension.create(extension1, extension2, extension3);
  *
+ * <p>
  * When performing any kind of write operation (eg: PutItem, UpdateItem) the beforeWrite() method will be called in
  * forward order:
  *
  * {@literal extension1 -> extension2 -> extension3}
  *
+ * <p>
  * So the output of extension1 will be passed into extension2, and then the output of extension2 into extension3 and
  * so on. For operations that read (eg: GetItem, UpdateItem) the afterRead() method will be called in reverse order:
  *
  * {@literal extension3 -> extension2 -> extension1}
  *
+ * <p>
  * This is designed to create a layered pattern when dealing with multiple extensions. One thing to note is that
  * UpdateItem acts as both a write operation and a read operation so the chain will be called both ways within a
  * single operation.
@@ -88,38 +92,40 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
      */
     @Override
     public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
-        AtomicReference<Map<String, AttributeValue>> transformedItem = new AtomicReference<>();
-        AtomicReference<Expression> conditionalExpression = new AtomicReference<>();
+        Map<String, AttributeValue> transformedItem = null;
+        Expression conditionalExpression = null;
 
-        this.extensionChain.forEach(extension -> {
-            Map<String, AttributeValue> itemToTransform = transformedItem.get() == null ? context.items() : transformedItem.get();
+        for (DynamoDbEnhancedClientExtension extension : this.extensionChain) {
+            Map<String, AttributeValue> itemToTransform = transformedItem == null ? context.items() : transformedItem;
+
             DynamoDbExtensionContext.BeforeWrite beforeWrite =
                 DefaultDynamoDbExtensionContext.builder()
                                                .items(itemToTransform)
                                                .operationContext(context.operationContext())
                                                .tableMetadata(context.tableMetadata())
                                                .build();
+
             WriteModification writeModification = extension.beforeWrite(beforeWrite);
 
             if (writeModification.transformedItem() != null) {
-                transformedItem.set(writeModification.transformedItem());
+                transformedItem = writeModification.transformedItem();
             }
 
             if (writeModification.additionalConditionalExpression() != null) {
-                if (conditionalExpression.get() == null) {
-                    conditionalExpression.set(writeModification.additionalConditionalExpression());
+                if (conditionalExpression == null) {
+                    conditionalExpression = writeModification.additionalConditionalExpression();
                 } else {
-                    conditionalExpression.set(
-                        Expression.join(conditionalExpression.get(),
+                    conditionalExpression =
+                        Expression.join(conditionalExpression,
                                         writeModification.additionalConditionalExpression(),
-                                        " AND "));
+                                        " AND ");
                 }
             }
-        });
+        }
 
         return WriteModification.builder()
-                                .transformedItem(transformedItem.get())
-                                .additionalConditionalExpression(conditionalExpression.get())
+                                .transformedItem(transformedItem)
+                                .additionalConditionalExpression(conditionalExpression)
                                 .build();
     }
 
@@ -132,25 +138,29 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
      */
     @Override
     public ReadModification afterRead(DynamoDbExtensionContext.AfterRead context) {
-        AtomicReference<Map<String, AttributeValue>> transformedItem = new AtomicReference<>();
+        Map<String, AttributeValue> transformedItem = null;
 
-        this.extensionChain.descendingIterator().forEachRemaining(extension -> {
-            Map<String, AttributeValue> itemToTransform = transformedItem.get() == null ? context.items() : transformedItem.get();
+        Iterator<DynamoDbEnhancedClientExtension> iterator = extensionChain.descendingIterator();
+
+        while (iterator.hasNext()) {
+            Map<String, AttributeValue> itemToTransform =
+                transformedItem == null ? context.items() : transformedItem;
+
             DynamoDbExtensionContext.AfterRead afterRead =
                 DefaultDynamoDbExtensionContext.builder().items(itemToTransform)
                                                .operationContext(context.operationContext())
                                                .tableMetadata(context.tableMetadata())
                                                .build();
 
-            ReadModification readModification = extension.afterRead(afterRead);
+            ReadModification readModification = iterator.next().afterRead(afterRead);
 
             if (readModification.transformedItem() != null) {
-                transformedItem.set(readModification.transformedItem());
+                transformedItem = readModification.transformedItem();
             }
-        });
+        }
 
         return ReadModification.builder()
-                               .transformedItem(transformedItem.get())
+                               .transformedItem(transformedItem)
                                .build();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fix stale javadocs 
- Remove unnecessary use of `AtomicReference`

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
