### PR TITLE
Rename QueryConditional methods

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/Key.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/Key.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.enhanced.dynamodb;
 
+import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.nullAttributeValue;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +25,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * An object that represents a key that can be used to either identify a specific record or form part of a query
@@ -38,6 +41,8 @@ public final class Key {
     private final AttributeValue sortValue;
 
     private Key(Builder builder) {
+        Validate.isTrue(builder.partitionValue != null && !builder.partitionValue.equals(nullAttributeValue()),
+                        "partitionValue should not be null");
         this.partitionValue = builder.partitionValue;
         this.sortValue = builder.sortValue;
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/conditional/SingleKeyItemConditional.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/conditional/SingleKeyItemConditional.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * sort key value comparison. The partition key value will always have an equivalence comparison applied.
  * <p>
  * This class is used by higher-level (more specific) {@link QueryConditional} implementations such as
- * {@link QueryConditional#greaterThan(Key)} to reduce code duplication.
+ * {@link QueryConditional#sortGreaterThan(Key)} to reduce code duplication.
  */
 @SdkInternalApi
 public class SingleKeyItemConditional implements QueryConditional {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryConditional.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryConditional.java
@@ -31,9 +31,11 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.conditional.SingleKeyIt
  * any specific table or schema and can be re-used in different contexts.
  * <p>
  * Example:
+ * <pr>
  * {@code
- * QueryConditional partitionValueGreaterThanTen = QueryConditional.greaterThan(k -> k.partitionValue(10));
+ * QueryConditional sortValueGreaterThanTen = QueryConditional.sortGreaterThan(k -> k.partitionValue(10).sortValue(4));
  * }
+ * </pr>
  */
 @SdkPublicApi
 public interface QueryConditional {
@@ -41,7 +43,7 @@ public interface QueryConditional {
      * Creates a {@link QueryConditional} that matches when the key of an index is equal to a specific value.
      * @param key the literal key used to compare the value of the index against
      */
-    static QueryConditional equalTo(Key key) {
+    static QueryConditional keyEqualTo(Key key) {
         return new EqualToConditional(key);
     }
 
@@ -49,17 +51,17 @@ public interface QueryConditional {
      * Creates a {@link QueryConditional} that matches when the key of an index is equal to a specific value.
      * @param keyConsumer 'builder consumer' for the literal key used to compare the value of the index against
      */
-    static QueryConditional equalTo(Consumer<Key.Builder> keyConsumer) {
+    static QueryConditional keyEqualTo(Consumer<Key.Builder> keyConsumer) {
         Key.Builder builder = Key.builder();
         keyConsumer.accept(builder);
-        return equalTo(builder.build());
+        return keyEqualTo(builder.build());
     }
 
     /**
      * Creates a {@link QueryConditional} that matches when the key of an index is greater than a specific value.
      * @param key the literal key used to compare the value of the index against
      */
-    static QueryConditional greaterThan(Key key) {
+    static QueryConditional sortGreaterThan(Key key) {
         return new SingleKeyItemConditional(key, ">");
     }
 
@@ -67,10 +69,10 @@ public interface QueryConditional {
      * Creates a {@link QueryConditional} that matches when the key of an index is greater than a specific value.
      * @param keyConsumer 'builder consumer' for the literal key used to compare the value of the index against
      */
-    static QueryConditional greaterThan(Consumer<Key.Builder> keyConsumer) {
+    static QueryConditional sortGreaterThan(Consumer<Key.Builder> keyConsumer) {
         Key.Builder builder = Key.builder();
         keyConsumer.accept(builder);
-        return greaterThan(builder.build());
+        return sortGreaterThan(builder.build());
     }
 
     /**
@@ -78,7 +80,7 @@ public interface QueryConditional {
      * value.
      * @param key the literal key used to compare the value of the index against
      */
-    static QueryConditional greaterThanOrEqualTo(Key key) {
+    static QueryConditional sortGreaterThanOrEqualTo(Key key) {
         return new SingleKeyItemConditional(key, ">=");
     }
 
@@ -87,17 +89,17 @@ public interface QueryConditional {
      * value.
      * @param keyConsumer 'builder consumer' for the literal key used to compare the value of the index against
      */
-    static QueryConditional greaterThanOrEqualTo(Consumer<Key.Builder> keyConsumer) {
+    static QueryConditional sortGreaterThanOrEqualTo(Consumer<Key.Builder> keyConsumer) {
         Key.Builder builder = Key.builder();
         keyConsumer.accept(builder);
-        return greaterThanOrEqualTo(builder.build());
+        return sortGreaterThanOrEqualTo(builder.build());
     }
 
     /**
      * Creates a {@link QueryConditional} that matches when the key of an index is less than a specific value.
      * @param key the literal key used to compare the value of the index against
      */
-    static QueryConditional lessThan(Key key) {
+    static QueryConditional sortLessThan(Key key) {
         return new SingleKeyItemConditional(key, "<");
     }
 
@@ -105,10 +107,10 @@ public interface QueryConditional {
      * Creates a {@link QueryConditional} that matches when the key of an index is less than a specific value.
      * @param keyConsumer 'builder consumer' for the literal key used to compare the value of the index against
      */
-    static QueryConditional lessThan(Consumer<Key.Builder> keyConsumer) {
+    static QueryConditional sortLessThan(Consumer<Key.Builder> keyConsumer) {
         Key.Builder builder = Key.builder();
         keyConsumer.accept(builder);
-        return lessThan(builder.build());
+        return sortLessThan(builder.build());
     }
 
     /**
@@ -116,7 +118,7 @@ public interface QueryConditional {
      * value.
      * @param key the literal key used to compare the value of the index against
      */
-    static QueryConditional lessThanOrEqualTo(Key key) {
+    static QueryConditional sortLessThanOrEqualTo(Key key) {
         return new SingleKeyItemConditional(key, "<=");
     }
 
@@ -125,10 +127,10 @@ public interface QueryConditional {
      * value.
      * @param keyConsumer 'builder consumer' for the literal key used to compare the value of the index against
      */
-    static QueryConditional lessThanOrEqualTo(Consumer<Key.Builder> keyConsumer) {
+    static QueryConditional sortLessThanOrEqualTo(Consumer<Key.Builder> keyConsumer) {
         Key.Builder builder = Key.builder();
         keyConsumer.accept(builder);
-        return lessThanOrEqualTo(builder.build());
+        return sortLessThanOrEqualTo(builder.build());
     }
 
     /**
@@ -136,7 +138,7 @@ public interface QueryConditional {
      * @param keyFrom the literal key used to compare the start of the range to compare the value of the index against
      * @param keyTo the literal key used to compare the end of the range to compare the value of the index against
      */
-    static QueryConditional between(Key keyFrom, Key keyTo) {
+    static QueryConditional sortBetween(Key keyFrom, Key keyTo) {
         return new BetweenConditional(keyFrom, keyTo);
     }
 
@@ -147,19 +149,19 @@ public interface QueryConditional {
      * @param keyToConsumer 'builder consumer' for the literal key used to compare the end of the range to compare the
      *                      value of the index against
      */
-    static QueryConditional between(Consumer<Key.Builder> keyFromConsumer, Consumer<Key.Builder> keyToConsumer) {
+    static QueryConditional sortBetween(Consumer<Key.Builder> keyFromConsumer, Consumer<Key.Builder> keyToConsumer) {
         Key.Builder builderFrom = Key.builder();
         Key.Builder builderTo = Key.builder();
         keyFromConsumer.accept(builderFrom);
         keyToConsumer.accept(builderTo);
-        return between(builderFrom.build(), builderTo.build());
+        return sortBetween(builderFrom.build(), builderTo.build());
     }
 
     /**
      * Creates a {@link QueryConditional} that matches when the key of an index begins with a specific value.
      * @param key the literal key used to compare the start of the value of the index against
      */
-    static QueryConditional beginsWith(Key key) {
+    static QueryConditional sortBeginsWith(Key key) {
         return new BeginsWithConditional(key);
     }
 
@@ -168,10 +170,10 @@ public interface QueryConditional {
      * @param keyConsumer 'builder consumer'  the literal key used to compare the start of the value of the index
      *                    against
      */
-    static QueryConditional beginsWith(Consumer<Key.Builder> keyConsumer) {
+    static QueryConditional sortBeginsWith(Consumer<Key.Builder> keyConsumer) {
         Key.Builder builder = Key.builder();
         keyConsumer.accept(builder);
-        return beginsWith(builder.build());
+        return sortBeginsWith(builder.build());
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/KeyTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/KeyTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -116,5 +117,15 @@ public class KeyTest {
         Key keyClone = key.toBuilder().build();
 
         assertThat(key, is(equalTo(keyClone)));
+    }
+
+    @Test
+    public void nullPartitionKey_shouldThrowException() {
+        AttributeValue attributeValue = null;
+        assertThatThrownBy(() ->  Key.builder().partitionValue(attributeValue).build())
+         .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("partitionValue should not be null");
+
+        assertThatThrownBy(() ->  Key.builder().partitionValue(AttributeValue.builder().nul(true).build()).build())
+            .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("partitionValue should not be null");
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncBasicQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncBasicQueryTest.java
@@ -23,8 +23,8 @@ import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primarySortKey;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.between;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.equalTo;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.sortBetween;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +45,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
@@ -147,7 +148,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
         insertRecords();
 
         SdkPublisher<Page<Record>> publisher =
-            mappedTable.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("id-value"))));
+            mappedTable.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("id-value"))));
         
         List<Page<Record>> results = drainPublisher(publisher, 1);
         Page<Record> page = results.get(0);
@@ -170,7 +171,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
 
         SdkPublisher<Page<Record>> publisher =
             mappedTable.query(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue("id-value")))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))
                                                   .filterExpression(expression)
                                                   .build());
 
@@ -187,7 +188,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
         insertRecords();
         Key fromKey = Key.builder().partitionValue("id-value").sortValue(3).build();
         Key toKey = Key.builder().partitionValue("id-value").sortValue(5).build();
-        SdkPublisher<Page<Record>> publisher = mappedTable.query(r -> r.queryConditional(between(fromKey, toKey)));
+        SdkPublisher<Page<Record>> publisher = mappedTable.query(r -> r.queryConditional(QueryConditional.sortBetween(fromKey, toKey)));
 
         List<Page<Record>> results = drainPublisher(publisher, 1);
         Page<Record> page = results.get(0);
@@ -202,7 +203,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
         insertRecords();
         SdkPublisher<Page<Record>> publisher =
             mappedTable.query(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue("id-value")))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))
                                                   .limit(5)
                                                   .build());
 
@@ -228,7 +229,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
     @Test
     public void queryEmpty() {
         SdkPublisher<Page<Record>> publisher =
-            mappedTable.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("id-value"))));
+            mappedTable.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("id-value"))));
 
         List<Page<Record>> results = drainPublisher(publisher, 1);
         Page<Record> page = results.get(0);
@@ -245,7 +246,7 @@ public class AsyncBasicQueryTest extends LocalDynamoDbAsyncTestBase {
         insertRecords();
         SdkPublisher<Page<Record>> publisher =
             mappedTable.query(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue("id-value")))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))
                                                   .exclusiveStartKey(exclusiveStartKey)
                                                   .build());
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncIndexQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncIndexQueryTest.java
@@ -25,8 +25,8 @@ import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTag
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primarySortKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondaryPartitionKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondarySortKey;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.between;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.equalTo;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.sortBetween;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +48,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
@@ -205,7 +206,7 @@ public class AsyncIndexQueryTest extends LocalDynamoDbAsyncTestBase {
         insertRecords();
 
         SdkPublisher<Page<Record>> publisher =
-            keysOnlyMappedIndex.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("gsi-id-value"))));
+            keysOnlyMappedIndex.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value"))));
 
         List<Page<Record>> results = drainPublisher(publisher, 1);
         Page<Record> page = results.get(0);
@@ -220,7 +221,7 @@ public class AsyncIndexQueryTest extends LocalDynamoDbAsyncTestBase {
         Key fromKey = Key.builder().partitionValue("gsi-id-value").sortValue(3).build();
         Key toKey = Key.builder().partitionValue("gsi-id-value").sortValue(5).build();
 
-        SdkPublisher<Page<Record>> publisher = keysOnlyMappedIndex.query(r -> r.queryConditional(between(fromKey, toKey)));
+        SdkPublisher<Page<Record>> publisher = keysOnlyMappedIndex.query(r -> r.queryConditional(QueryConditional.sortBetween(fromKey, toKey)));
 
         List<Page<Record>> results = drainPublisher(publisher, 1);
         Page<Record> page = results.get(0);
@@ -235,7 +236,7 @@ public class AsyncIndexQueryTest extends LocalDynamoDbAsyncTestBase {
         insertRecords();
         SdkPublisher<Page<Record>> publisher =
             keysOnlyMappedIndex.query(QueryEnhancedRequest.builder()
-                                                          .queryConditional(equalTo(k -> k.partitionValue("gsi-id-value")))
+                                                          .queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value")))
                                                           .limit(5)
                                                           .build());
 
@@ -266,7 +267,7 @@ public class AsyncIndexQueryTest extends LocalDynamoDbAsyncTestBase {
     @Test
     public void queryEmpty() {
         SdkPublisher<Page<Record>> publisher =
-            keysOnlyMappedIndex.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("gsi-id-value"))));
+            keysOnlyMappedIndex.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value"))));
 
         List<Page<Record>> results = drainPublisher(publisher, 1);
         Page<Record> page = results.get(0);
@@ -286,7 +287,7 @@ public class AsyncIndexQueryTest extends LocalDynamoDbAsyncTestBase {
 
         SdkPublisher<Page<Record>> publisher =
             keysOnlyMappedIndex.query(QueryEnhancedRequest.builder()
-                                                          .queryConditional(equalTo(k -> k.partitionValue("gsi-id-value")))
+                                                          .queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value")))
                                                           .exclusiveStartKey(expectedLastEvaluatedKey)
                                                           .build());
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicQueryTest.java
@@ -23,8 +23,9 @@ import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primarySortKey;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.between;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.equalTo;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.sortBeginsWith;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.sortBetween;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -145,7 +146,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
         insertRecords();
 
         Iterator<Page<Record>> results =
-            mappedTable.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("id-value")))).iterator();
+            mappedTable.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))).iterator();
 
         assertThat(results.hasNext(), is(true));
         Page<Record> page = results.next();
@@ -169,7 +170,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
 
         Iterator<Page<Record>> results =
             mappedTable.query(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue("id-value")))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))
                                                   .filterExpression(expression)
                                                   .build())
                        .iterator();
@@ -188,7 +189,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
         insertRecords();
         Key fromKey = Key.builder().partitionValue("id-value").sortValue(3).build();
         Key toKey = Key.builder().partitionValue("id-value").sortValue(5).build();
-        Iterator<Page<Record>> results = mappedTable.query(r -> r.queryConditional(between(fromKey, toKey))).iterator();
+        Iterator<Page<Record>> results = mappedTable.query(r -> r.queryConditional(sortBetween(fromKey, toKey))).iterator();
 
         assertThat(results.hasNext(), is(true));
         Page<Record> page = results.next();
@@ -204,7 +205,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
         insertRecords();
         Iterator<Page<Record>> results =
             mappedTable.query(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue("id-value")))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))
                                                   .limit(5)
                                                   .build())
                        .iterator();
@@ -233,7 +234,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
     @Test
     public void queryEmpty() {
         Iterator<Page<Record>> results =
-            mappedTable.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("id-value")))).iterator();
+            mappedTable.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))).iterator();
         assertThat(results.hasNext(), is(true));
         Page<Record> page = results.next();
         assertThat(results.hasNext(), is(false));
@@ -249,7 +250,7 @@ public class BasicQueryTest extends LocalDynamoDbSyncTestBase {
         insertRecords();
         Iterator<Page<Record>> results =
             mappedTable.query(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue("id-value")))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue("id-value")))
                                                   .exclusiveStartKey(exclusiveStartKey)
                                                   .build())
                        .iterator();

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/IndexQueryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/IndexQueryTest.java
@@ -25,8 +25,8 @@ import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTag
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primarySortKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondaryPartitionKey;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondarySortKey;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.between;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.equalTo;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.sortBetween;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -47,6 +47,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
@@ -203,7 +204,7 @@ public class IndexQueryTest extends LocalDynamoDbSyncTestBase {
         insertRecords();
 
         Iterator<Page<Record>> results =
-            keysOnlyMappedIndex.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("gsi-id-value")))).iterator();
+            keysOnlyMappedIndex.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value")))).iterator();
 
         assertThat(results.hasNext(), is(true));
         Page<Record> page = results.next();
@@ -219,7 +220,7 @@ public class IndexQueryTest extends LocalDynamoDbSyncTestBase {
         Key fromKey = Key.builder().partitionValue("gsi-id-value").sortValue(3).build();
         Key toKey = Key.builder().partitionValue("gsi-id-value").sortValue(5).build();
         Iterator<Page<Record>> results =
-            keysOnlyMappedIndex.query(r -> r.queryConditional(between(fromKey, toKey))).iterator();
+            keysOnlyMappedIndex.query(r -> r.queryConditional(QueryConditional.sortBetween(fromKey, toKey))).iterator();
 
         assertThat(results.hasNext(), is(true));
         Page<Record> page = results.next();
@@ -235,7 +236,7 @@ public class IndexQueryTest extends LocalDynamoDbSyncTestBase {
         insertRecords();
         Iterator<Page<Record>> results =
             keysOnlyMappedIndex.query(QueryEnhancedRequest.builder()
-                                                          .queryConditional(equalTo(k -> k.partitionValue("gsi-id-value")))
+                                                          .queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value")))
                                                           .limit(5)
                                                           .build())
                                .iterator();
@@ -270,7 +271,7 @@ public class IndexQueryTest extends LocalDynamoDbSyncTestBase {
     @Test
     public void queryEmpty() {
         Iterator<Page<Record>> results =
-            keysOnlyMappedIndex.query(r -> r.queryConditional(equalTo(k -> k.partitionValue("gsi-id-value")))).iterator();
+            keysOnlyMappedIndex.query(r -> r.queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value")))).iterator();
         assertThat(results.hasNext(), is(true));
         Page<Record> page = results.next();
         assertThat(results.hasNext(), is(false));
@@ -288,7 +289,7 @@ public class IndexQueryTest extends LocalDynamoDbSyncTestBase {
         expectedLastEvaluatedKey.put("gsi_sort", numberValue(KEYS_ONLY_RECORDS.get(7).getGsiSort()));
         Iterator<Page<Record>> results =
             keysOnlyMappedIndex.query(QueryEnhancedRequest.builder()
-                                                          .queryConditional(equalTo(k -> k.partitionValue("gsi-id-value")))
+                                                          .queryConditional(keyEqualTo(k -> k.partitionValue("gsi-id-value")))
                                                           .exclusiveStartKey(expectedLastEvaluatedKey).build())
                                .iterator();
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/QueryOperationConditionalTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/QueryOperationConditionalTest.java
@@ -54,8 +54,8 @@ public class QueryOperationConditionalTest {
 
     @Test
     public void equalTo_hashOnly() {
-        Expression expression = QueryConditional.equalTo(getKey(fakeItem)).expression(FakeItem.getTableSchema(),
-                                                                                      TableMetadata.primaryIndexName());
+        Expression expression = QueryConditional.keyEqualTo(getKey(fakeItem)).expression(FakeItem.getTableSchema(),
+                                                                                         TableMetadata.primaryIndexName());
 
         assertThat(expression.expression(), is(ID_KEY + " = " + ID_VALUE));
         assertThat(expression.expressionNames(), hasEntry(ID_KEY, "id"));
@@ -65,13 +65,13 @@ public class QueryOperationConditionalTest {
     @Test(expected = IllegalArgumentException.class)
     public void equalTo_hashOnly_notSet_throwsIllegalArgumentException() {
         fakeItem.setId(null);
-        QueryConditional.equalTo(getKey(fakeItem))
+        QueryConditional.keyEqualTo(getKey(fakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
     public void equalTo_hashAndRangeKey_bothSet() {
-        Expression expression = QueryConditional.equalTo(getKey(fakeItemWithSort))
+        Expression expression = QueryConditional.keyEqualTo(getKey(fakeItemWithSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         verifyExpression(expression, "=");
@@ -80,13 +80,13 @@ public class QueryOperationConditionalTest {
     @Test(expected = IllegalArgumentException.class)
     public void equalTo_hashAndRangeKey_hashNotSet_throwsIllegalArgumentException() {
         fakeItemWithSort.setId(null);
-        QueryConditional.equalTo(getKey(fakeItemWithSort))
+        QueryConditional.keyEqualTo(getKey(fakeItemWithSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
     public void equalTo_hashAndRangeKey_hashOnlySet() {
-        Expression expression = QueryConditional.equalTo(getKey(fakeItemWithoutSort))
+        Expression expression = QueryConditional.keyEqualTo(getKey(fakeItemWithoutSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         assertThat(expression.expression(), is(ID_KEY + " = " + ID_VALUE));
@@ -96,7 +96,7 @@ public class QueryOperationConditionalTest {
 
     @Test
     public void greaterThan_hashAndRangeKey_bothSet() {
-        Expression expression = QueryConditional.greaterThan(getKey(fakeItemWithSort))
+        Expression expression = QueryConditional.sortGreaterThan(getKey(fakeItemWithSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         verifyExpression(expression, ">");
@@ -104,19 +104,19 @@ public class QueryOperationConditionalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void greaterThan_hashOnly_throwsIllegalArgumentException() {
-        QueryConditional.greaterThan(getKey(fakeItem))
+        QueryConditional.sortGreaterThan(getKey(fakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void greaterThan_hashAndSort_onlyHashSet_throwsIllegalArgumentException() {
-        QueryConditional.greaterThan(getKey(fakeItemWithoutSort))
+        QueryConditional.sortGreaterThan(getKey(fakeItemWithoutSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
     public void greaterThanOrEqualTo_hashAndRangeKey_bothSet() {
-        Expression expression = QueryConditional.greaterThanOrEqualTo(getKey(fakeItemWithSort))
+        Expression expression = QueryConditional.sortGreaterThanOrEqualTo(getKey(fakeItemWithSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         verifyExpression(expression, ">=");
@@ -124,19 +124,19 @@ public class QueryOperationConditionalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void greaterThanOrEqualTo_hashOnly_throwsIllegalArgumentException() {
-        QueryConditional.greaterThanOrEqualTo(getKey(fakeItem))
+        QueryConditional.sortGreaterThanOrEqualTo(getKey(fakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void greaterThanOrEqualTo_hashAndSort_onlyHashSet_throwsIllegalArgumentException() {
-        QueryConditional.greaterThanOrEqualTo(getKey(fakeItemWithoutSort))
+        QueryConditional.sortGreaterThanOrEqualTo(getKey(fakeItemWithoutSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
     public void lessThan_hashAndRangeKey_bothSet() {
-        Expression expression = QueryConditional.lessThan(getKey(fakeItemWithSort))
+        Expression expression = QueryConditional.sortLessThan(getKey(fakeItemWithSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         verifyExpression(expression, "<");
@@ -144,19 +144,19 @@ public class QueryOperationConditionalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void lessThan_hashOnly_throwsIllegalArgumentException() {
-        QueryConditional.lessThan(getKey(fakeItem))
+        QueryConditional.sortLessThan(getKey(fakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void lessThan_hashAndSort_onlyHashSet_throwsIllegalArgumentException() {
-        QueryConditional.lessThan(getKey(fakeItemWithoutSort))
+        QueryConditional.sortLessThan(getKey(fakeItemWithoutSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
     public void lessThanOrEqualTo_hashAndRangeKey_bothSet() {
-        Expression expression = QueryConditional.lessThanOrEqualTo(getKey(fakeItemWithSort))
+        Expression expression = QueryConditional.sortLessThanOrEqualTo(getKey(fakeItemWithSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         verifyExpression(expression, "<=");
@@ -164,19 +164,19 @@ public class QueryOperationConditionalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void lessThanOrEqualTo_hashOnly_throwsIllegalArgumentException() {
-        QueryConditional.lessThanOrEqualTo(getKey(fakeItem))
+        QueryConditional.sortLessThanOrEqualTo(getKey(fakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void lessThanOrEqualTo_hashAndSort_onlyHashSet_throwsIllegalArgumentException() {
-        QueryConditional.lessThanOrEqualTo(getKey(fakeItemWithoutSort))
+        QueryConditional.sortLessThanOrEqualTo(getKey(fakeItemWithoutSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
     public void beginsWith_hashAndRangeKey_bothSet() {
-        Expression expression = QueryConditional.beginsWith(getKey(fakeItemWithSort))
+        Expression expression = QueryConditional.sortBeginsWith(getKey(fakeItemWithSort))
                                                 .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         String expectedExpression = String.format("%s = %s AND begins_with ( %s, %s )", ID_KEY, ID_VALUE, SORT_KEY,
@@ -190,20 +190,20 @@ public class QueryOperationConditionalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void beginsWith_hashOnly_throwsIllegalArgumentException() {
-        QueryConditional.beginsWith(getKey(fakeItem))
+        QueryConditional.sortBeginsWith(getKey(fakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void beginsWith_hashAndSort_onlyHashSet_throwsIllegalArgumentException() {
-        QueryConditional.beginsWith(getKey(fakeItemWithoutSort))
+        QueryConditional.sortBeginsWith(getKey(fakeItemWithoutSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void beginsWith_numericRange_throwsIllegalArgumentException() {
         FakeItemWithNumericSort fakeItemWithNumericSort = FakeItemWithNumericSort.createUniqueFakeItemWithSort();
-        QueryConditional.beginsWith(getKey(fakeItemWithNumericSort)).expression(FakeItemWithNumericSort.getTableSchema(), TableMetadata.primaryIndexName());
+        QueryConditional.sortBeginsWith(getKey(fakeItemWithNumericSort)).expression(FakeItemWithNumericSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test
@@ -213,7 +213,7 @@ public class QueryOperationConditionalTest {
         AttributeValue otherFakeItemWithSortSortValue =
             AttributeValue.builder().s(otherFakeItemWithSort.getSort()).build();
 
-        Expression expression = QueryConditional.between(getKey(fakeItemWithSort), getKey(otherFakeItemWithSort))
+        Expression expression = QueryConditional.sortBetween(getKey(fakeItemWithSort), getKey(otherFakeItemWithSort))
             .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
 
         String expectedExpression = String.format("%s = %s AND %s BETWEEN %s AND %s", ID_KEY, ID_VALUE, SORT_KEY,
@@ -229,19 +229,19 @@ public class QueryOperationConditionalTest {
     @Test(expected = IllegalArgumentException.class)
     public void between_hashOnly_throwsIllegalArgumentException() {
         FakeItem otherFakeItem = createUniqueFakeItem();
-        QueryConditional.between(getKey(fakeItem), getKey(otherFakeItem))
+        QueryConditional.sortBetween(getKey(fakeItem), getKey(otherFakeItem))
                         .expression(FakeItem.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void between_hashAndSort_onlyFirstSortSet_throwsIllegalArgumentException() {
-        QueryConditional.between(getKey(fakeItemWithSort), getKey(fakeItemWithoutSort))
+        QueryConditional.sortBetween(getKey(fakeItemWithSort), getKey(fakeItemWithoutSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void between_hashAndSort_onlySecondSortSet_throwsIllegalArgumentException() {
-        QueryConditional.between(getKey(fakeItemWithoutSort), getKey(fakeItemWithSort))
+        QueryConditional.sortBetween(getKey(fakeItemWithoutSort), getKey(fakeItemWithSort))
                         .expression(FakeItemWithSort.getTableSchema(), TableMetadata.primaryIndexName());
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/QueryOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/QueryOperationTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,7 +29,7 @@ import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.Fa
 import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithIndices.createUniqueFakeItemWithIndices;
 import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithSort.createUniqueFakeItemWithSort;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.equalTo;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -78,7 +77,7 @@ public class QueryOperationTest {
     private final FakeItem keyItem = createUniqueFakeItem();
     private final QueryOperation<FakeItem> queryOperation =
         QueryOperation.create(QueryEnhancedRequest.builder()
-                                                  .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                  .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                   .build());
 
     @Mock
@@ -156,7 +155,7 @@ public class QueryOperationTest {
         FakeItemWithIndices fakeItem = createUniqueFakeItemWithIndices();
         QueryOperation<FakeItemWithIndices> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(fakeItem.getGsiId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(fakeItem.getGsiId())))
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItemWithIndices.getTableSchema(), GSI_1_CONTEXT, null);
 
@@ -167,7 +166,7 @@ public class QueryOperationTest {
     public void generateRequest_ascending() {
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .scanIndexForward(true)
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItem.getTableSchema(),
@@ -181,7 +180,7 @@ public class QueryOperationTest {
     public void generateRequest_descending() {
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .scanIndexForward(false)
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItem.getTableSchema(),
@@ -195,7 +194,7 @@ public class QueryOperationTest {
     public void generateRequest_limit() {
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .limit(123)
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItem.getTableSchema(),
@@ -215,7 +214,7 @@ public class QueryOperationTest {
 
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .filterExpression(filterExpression)
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItem.getTableSchema(),
@@ -232,7 +231,7 @@ public class QueryOperationTest {
 
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .filterExpression(filterExpression)
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItem.getTableSchema(),
@@ -253,7 +252,7 @@ public class QueryOperationTest {
                                                 .build();
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .filterExpression(filterExpression)
                                                       .build());
         queryToTest.generateRequest(FakeItem.getTableSchema(), PRIMARY_CONTEXT, null);
@@ -263,7 +262,7 @@ public class QueryOperationTest {
     public void generateRequest_consistentRead() {
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .consistentRead(true)
                                                       .build());
         QueryRequest queryRequest = queryToTest.generateRequest(FakeItem.getTableSchema(),
@@ -278,7 +277,7 @@ public class QueryOperationTest {
         FakeItem exclusiveStartKey = createUniqueFakeItem();
         QueryOperation<FakeItem> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .exclusiveStartKey(FakeItem.getTableSchema()
                                                                                  .itemToMap(exclusiveStartKey,
                                                                                             FakeItem.getTableMetadata()
@@ -301,7 +300,7 @@ public class QueryOperationTest {
 
         QueryOperation<FakeItemWithIndices> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .exclusiveStartKey(FakeItemWithIndices.getTableSchema()
                                                                                             .itemToMap(exclusiveStartKey,
                                                                                                        keyFields))
@@ -326,7 +325,7 @@ public class QueryOperationTest {
         FakeItemWithSort exclusiveStartKey = createUniqueFakeItemWithSort();
         QueryOperation<FakeItemWithSort> queryToTest =
             QueryOperation.create(QueryEnhancedRequest.builder()
-                                                      .queryConditional(equalTo(k -> k.partitionValue(keyItem.getId())))
+                                                      .queryConditional(keyEqualTo(k -> k.partitionValue(keyItem.getId())))
                                                       .exclusiveStartKey(
                                                           FakeItemWithSort.getTableSchema()
                                                                           .itemToMap(

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryEnhancedRequestTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.numberValue;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
-import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.equalTo;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +58,7 @@ public class QueryEnhancedRequestTest {
                                                 .expressionValues(expressionValues)
                                                 .build();
 
-        QueryConditional queryConditional = equalTo(k -> k.partitionValue("id-value"));
+        QueryConditional queryConditional = keyEqualTo(k -> k.partitionValue("id-value"));
 
         QueryEnhancedRequest builtObject = QueryEnhancedRequest.builder()
                                                                .exclusiveStartKey(exclusiveStartKey)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- rename: `equalTo` -> `keyEqualTo`
- add sort prefix to all other sort query conditional methods, eg: `greaterThan` -> `sortGreaterThan`
- add `partitionKey` validation in `Key`


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
