### PR TITLE
Output all values for one header in one line separated by comma

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -296,12 +296,16 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
                 continue;
             }
             String key = lowerCase(header);
-
+            appendCompactedString(buffer, key);
+            buffer.append(":");
             for (String headerValue : headers.get(header)) {
-                appendCompactedString(buffer, key);
-                buffer.append(":");
                 if (headerValue != null) {
                     appendCompactedString(buffer, headerValue);
+                    buffer.append(",");
+                }
+                int commaPos = buffer.lastIndexOf(",");
+                if(commaPos == (buffer.length() - 1)) {
+            	    buffer.deleteCharAt(commaPos);
                 }
                 buffer.append("\n");
             }


### PR DESCRIPTION
Client side creates canonical request with header:value on separate lines if header has multiple values:
content-type:application/x-amz-json-1.0
content-type:application/json
Server side hashes same request as one line:
content-type:application/x-amz-json-1.0,application/json

It causes Savings Plans request DescribeSavingsPlans to fail

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
