### PR TITLE
Adding custom AttributeConverterProvider and AttributeConverter to DD…

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClientPreview-fe7f89e.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClientPreview-fe7f89e.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client [Preview]",
+    "description": "The enhanced DDB client table schema now supports custom AttributeConverterProviders, and StaticAttribute can take individual AttributeConverter to override default attribute converter behavior."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttribute.java
@@ -64,6 +64,7 @@ public final class StaticAttribute<T, R> {
     private final BiConsumer<T, R> setter;
     private final Collection<StaticAttributeTag> tags;
     private final EnhancedType<R> type;
+    private final AttributeConverter<R> attributeConverter;
 
     private StaticAttribute(Builder<T, R> builder) {
         this.name = Validate.paramNotNull(builder.name, "name");
@@ -71,6 +72,7 @@ public final class StaticAttribute<T, R> {
         this.setter = Validate.paramNotNull(builder.setter, "setter");
         this.tags = builder.tags == null ? Collections.emptyList() : Collections.unmodifiableCollection(builder.tags);
         this.type = Validate.paramNotNull(builder.type, "type");
+        this.attributeConverter = builder.attributeConverter;
     }
 
     /**
@@ -129,6 +131,14 @@ public final class StaticAttribute<T, R> {
     }
 
     /**
+     * A custom {@link AttributeConverter} that will be used to convert this attribute.
+     * @see Builder#attributeConverter
+     */
+    public AttributeConverter<R> attributeConverter() {
+        return this.attributeConverter;
+    }
+
+    /**
      * Converts an instance of this class to a {@link Builder} that can be used to modify and reconstruct it.
      */
     public Builder<T, R> toBuilder() {
@@ -145,7 +155,7 @@ public final class StaticAttribute<T, R> {
     }
 
     private AttributeConverter<R> converterFrom(AttributeConverterProvider attributeConverterProvider) {
-        return attributeConverterProvider.converterFor(type);
+        return (attributeConverter != null) ? attributeConverter : attributeConverterProvider.converterFor(type);
     }
 
     /**
@@ -159,6 +169,7 @@ public final class StaticAttribute<T, R> {
         private Function<T, R> getter;
         private BiConsumer<T, R> setter;
         private List<StaticAttributeTag> tags;
+        private AttributeConverter<R> attributeConverter;
 
         private Builder(EnhancedType<R> type) {
             this.type = type;
@@ -213,6 +224,15 @@ public final class StaticAttribute<T, R> {
             }
 
             this.tags.add(tag);
+            return this;
+        }
+
+        /**
+         * An {@link AttributeConverter} for the attribute type ({@link EnhancedType}), that can convert this attribute.
+         * It overrides any converter for this type provided by the table schema {@link AttributeConverterProvider}.
+         */
+        public Builder<T, R> attributeConverter(AttributeConverter<R> attributeConverter) {
+            this.attributeConverter = attributeConverter;
             return this;
         }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchema.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -76,13 +77,18 @@ public final class StaticTableSchema<T> implements TableSchema<T> {
     private final Supplier<T> newItemSupplier;
     private final Map<String, ResolvedStaticAttribute<T>> indexedMappers;
     private final StaticTableMetadata tableMetadata;
+    private final AttributeConverterProvider attributeConverterProvider;
 
     private StaticTableSchema(Builder<T> builder) {
         StaticTableMetadata.Builder tableMetadataBuilder = StaticTableMetadata.builder();
 
+        this.attributeConverterProvider = builder.attributeConverterProvider != null ?
+                                          builder.attributeConverterProvider :
+                                          DEFAULT_ATTRIBUTE_CONVERTER;
+
         // Resolve declared attributes and find converters for them
         Stream<ResolvedStaticAttribute<T>> attributesStream = builder.attributes == null ?
-            Stream.empty() : builder.attributes.stream().map(a -> a.resolve(DEFAULT_ATTRIBUTE_CONVERTER));
+            Stream.empty() : builder.attributes.stream().map(a -> a.resolve(this.attributeConverterProvider));
 
         // Merge resolved declared attributes and additional attributes that were added by extend or flatten
         List<ResolvedStaticAttribute<T>> mutableAttributeMappers = new ArrayList<>();
@@ -136,6 +142,7 @@ public final class StaticTableSchema<T> implements TableSchema<T> {
         private List<StaticAttribute<T, ?>> attributes;
         private Supplier<T> newItemSupplier;
         private List<StaticTableTag> tags;
+        private AttributeConverterProvider attributeConverterProvider;
 
         private Builder(Class<T> itemClass) {
             this.itemClass = itemClass;
@@ -274,6 +281,19 @@ public final class StaticTableSchema<T> implements TableSchema<T> {
         }
 
         /**
+         * Adds an {@link AttributeConverterProvider} to the table schema. The {@link AttributeConverterProvider} must
+         * provide {@link AttributeConverter}s for all types used in the schema.
+         * <p>
+         * By default, the table schema has an internal AttributeConverterProvider which provides standard converters
+         * for most primitive and common Java types. Use custom AttributeConverterProvider only when you have specific
+         * needs for type conversion that the defaults do not cover.
+         */
+        public Builder<T> attributeConverterProvider(AttributeConverterProvider attributeConverterProvider) {
+            this.attributeConverterProvider = attributeConverterProvider;
+            return this;
+        }
+
+        /**
          * Builds a {@link StaticTableSchema} based on the values this builder has been configured with
          */
         public StaticTableSchema<T> build() {
@@ -356,6 +376,14 @@ public final class StaticTableSchema<T> implements TableSchema<T> {
         AttributeValue attributeValue = attributeMapper.attributeGetterMethod().apply(item);
 
         return isNullAttributeValue(attributeValue) ? null : attributeValue;
+    }
+
+    /**
+     * The table schema {@link AttributeConverterProvider}.
+     * @see Builder#attributeConverterProvider
+     */
+    public AttributeConverterProvider attributeConverterProvider() {
+        return this.attributeConverterProvider;
     }
 
     private T constructNewItem() {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchemaTest.java
@@ -24,6 +24,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.nullAttributeValue;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
 
@@ -43,7 +45,12 @@ import java.util.function.Consumer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
@@ -51,6 +58,7 @@ import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemC
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithSort;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+@RunWith(MockitoJUnitRunner.class)
 public class StaticTableSchemaTest {
     private static final String TABLE_TAG_KEY = "table-tag-key";
     private static final String TABLE_TAG_VALUE = "table-tag-value";
@@ -770,6 +778,12 @@ public class StaticTableSchemaTest {
         }
     }
 
+    @Mock
+    private AttributeConverterProvider provider;
+
+    @Mock
+    private AttributeConverter<String> attributeConverter;
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -1343,6 +1357,44 @@ public class StaticTableSchemaTest {
                          .flatten(superclassTableSchema,
                                   FakeBrokenClass::getAbstractObject,
                                   FakeBrokenClass::setAbstractObject);
+    }
+
+    @Test
+    public void addAttributeConverterProvider() {
+        when(provider.converterFor(EnhancedType.of(String.class))).thenReturn(attributeConverter);
+
+        StaticTableSchema<FakeMappedItem> tableSchema =
+            StaticTableSchema.builder(FakeMappedItem.class)
+                             .newItemSupplier(FakeMappedItem::new)
+                             .addAttribute(String.class, a -> a.name("aString")
+                                                               .getter(FakeMappedItem::getAString)
+                                                               .setter(FakeMappedItem::setAString))
+                             .attributeConverterProvider(provider)
+                             .build();
+
+        assertThat(tableSchema.attributeConverterProvider(), is(provider));
+    }
+
+    @Test
+    public void usesCustomAttributeConverterProvider() {
+        String originalString = "test-string";
+        String expectedString = "test-string-custom";
+
+        when(provider.converterFor(EnhancedType.of(String.class))).thenReturn(attributeConverter);
+        when(attributeConverter.transformFrom(any())).thenReturn(AttributeValue.builder().s(expectedString).build());
+
+        StaticTableSchema<FakeMappedItem> tableSchema =
+            StaticTableSchema.builder(FakeMappedItem.class)
+                             .newItemSupplier(FakeMappedItem::new)
+                             .addAttribute(String.class, a -> a.name("aString")
+                                                               .getter(FakeMappedItem::getAString)
+                                                               .setter(FakeMappedItem::setAString))
+                             .attributeConverterProvider(provider)
+                             .build();
+
+        Map<String, AttributeValue> resultMap = tableSchema.itemToMap(FakeMappedItem.builder().aString(originalString).build(),
+                                                                      false);
+        assertThat(resultMap.get("aString").s(), is(expectedString));
     }
 
     private <R> void verifyAttribute(EnhancedType<R> attributeType,


### PR DESCRIPTION
…B Enhanced static table schema and static attribute

## Description
Adds the ability to supply a custom `AttributeConverterProvider` to the static table schema `StaticTableSchema`. The custom class must provide converters for all attributes for the schema. In addition, it's possible to override converters at the attribute level by creating a `StaticAttribute` with a custom `AttributeConverter`.

Tracking DDB enhanced client features: [Issue #35](https://github.com/aws/aws-sdk-java-v2/issues/35). 

## Motivation and Context
Users should have the ability to provide custom converters for types that aren't covered by the default attribute converters or have specific requirements that require overrides.  

## Testing
Unit tested. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
