### PR TITLE
Use signing date when deriving signing key

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-ba3be37.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-ba3be37.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Fix an issue where the signing key is created only once at the start of the request for event streaming requests. This causes requests that span two or more days to have signing errors once the date changes because the signing key was derived only once using the date at the beginning of the request."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4Signer.java
@@ -15,16 +15,15 @@
 
 package software.amazon.awssdk.auth.signer.internal;
 
-import static software.amazon.awssdk.utils.DateUtils.numberOfDaysSinceEpoch;
 import static software.amazon.awssdk.utils.StringUtils.lowerCase;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -160,24 +159,28 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
      * http://docs.aws.amazon
      * .com/general/latest/gr/sigv4-calculate-signature.html
      */
-    protected byte[] deriveSigningKey(AwsCredentials credentials, Aws4SignerRequestParams signerRequestParams) {
+    protected final byte[] deriveSigningKey(AwsCredentials credentials, Aws4SignerRequestParams signerRequestParams) {
+        return deriveSigningKey(credentials,
+                Instant.ofEpochMilli(signerRequestParams.getRequestSigningDateTimeMilli()),
+                signerRequestParams.getRegionName(),
+                signerRequestParams.getServiceSigningName());
+    }
 
-        String cacheKey = computeSigningCacheKeyName(credentials, signerRequestParams);
-        long daysSinceEpochSigningDate = numberOfDaysSinceEpoch(signerRequestParams.getRequestSigningDateTimeMilli());
-
+    protected final byte[] deriveSigningKey(AwsCredentials credentials, Instant signingInstant, String region, String service) {
+        String cacheKey = createSigningCacheKeyName(credentials, region, service);
         SignerKey signerKey = SIGNER_CACHE.get(cacheKey);
 
-        if (signerKey != null && daysSinceEpochSigningDate == signerKey.getNumberOfDaysSinceEpoch()) {
+        if (signerKey != null && signerKey.isValidForDate(signingInstant)) {
             return signerKey.getSigningKey();
         }
 
         LOG.trace(() -> "Generating a new signing key as the signing key not available in the cache for the date: " +
-            TimeUnit.DAYS.toMillis(daysSinceEpochSigningDate));
+                signingInstant.toEpochMilli());
         byte[] signingKey = newSigningKey(credentials,
-            signerRequestParams.getFormattedRequestSigningDate(),
-            signerRequestParams.getRegionName(),
-            signerRequestParams.getServiceSigningName());
-        SIGNER_CACHE.add(cacheKey, new SignerKey(daysSinceEpochSigningDate, signingKey));
+                Aws4SignerUtils.formatDateStamp(signingInstant),
+                region,
+                service);
+        SIGNER_CACHE.add(cacheKey, new SignerKey(signingInstant, signingKey));
         return signingKey;
     }
 
@@ -228,14 +231,10 @@ public abstract class AbstractAws4Signer<T extends Aws4SignerParams, U extends A
         return stringToSign;
     }
 
-
-    /**
-     * Computes the name to be used to reference the signing key in the cache.
-     */
-    private String computeSigningCacheKeyName(AwsCredentials credentials,
-                                              Aws4SignerRequestParams signerRequestParams) {
-        return credentials.secretAccessKey() + "-" + signerRequestParams.getRegionName() + "-" +
-               signerRequestParams.getServiceSigningName();
+    private String createSigningCacheKeyName(AwsCredentials credentials,
+                                             String regionName,
+                                             String serviceName) {
+        return credentials.secretAccessKey() + "-" + regionName + "-" + serviceName;
     }
 
     /**

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/BaseAsyncAws4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/BaseAsyncAws4Signer.java
@@ -20,7 +20,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -57,11 +56,8 @@ public abstract class BaseAsyncAws4Signer extends BaseAws4Signer implements Asyn
     @SdkTestInternalApi
     protected final AsyncRequestBody signAsync(SdkHttpFullRequest request, AsyncRequestBody asyncRequestBody,
                                                Aws4SignerRequestParams requestParams, Aws4SignerParams signingParams) {
-        AwsCredentials sanitizedCredentials = sanitizeCredentials(signingParams.awsCredentials());
-        byte[] signingKey = deriveSigningKey(sanitizedCredentials, requestParams);
-
         String headerSignature = getHeaderSignature(request);
-        return transformRequestProvider(headerSignature, signingKey, requestParams, signingParams, asyncRequestBody);
+        return transformRequestProvider(headerSignature, requestParams, signingParams, asyncRequestBody);
     }
 
     /**
@@ -70,7 +66,6 @@ public abstract class BaseAsyncAws4Signer extends BaseAws4Signer implements Asyn
      * Can be overriden by subclasses to provide specific signing method
      */
     protected abstract AsyncRequestBody transformRequestProvider(String headerSignature,
-                                                                 byte[] signingKey,
                                                                  Aws4SignerRequestParams signerRequestParams,
                                                                  Aws4SignerParams signerParams,
                                                                  AsyncRequestBody asyncRequestBody);

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/SignerKey.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/SignerKey.java
@@ -15,8 +15,10 @@
 
 package software.amazon.awssdk.auth.signer.internal;
 
+import java.time.Instant;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.DateUtils;
 
 /**
  * Holds the signing key and the number of days since epoch for the date for
@@ -26,29 +28,25 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public final class SignerKey {
 
-    private final long numberOfDaysSinceEpoch;
+    private final long daysSinceEpoch;
 
     private final byte[] signingKey;
 
-    public SignerKey(long numberOfDaysSinceEpoch, byte[] signingKey) {
-        if (numberOfDaysSinceEpoch <= 0L) {
+    public SignerKey(Instant date, byte[] signingKey) {
+        if (date == null) {
             throw new IllegalArgumentException(
-                    "Not able to cache signing key. Signing date to be cached is invalid");
+                    "Not able to cache signing key. Signing date to be is null");
         }
         if (signingKey == null) {
             throw new IllegalArgumentException(
                     "Not able to cache signing key. Signing Key to be cached are null");
         }
-        this.numberOfDaysSinceEpoch = numberOfDaysSinceEpoch;
+        this.daysSinceEpoch = DateUtils.numberOfDaysSinceEpoch(date.toEpochMilli());
         this.signingKey = signingKey.clone();
     }
 
-    /**
-     * Returns the number of days since epoch for the date used for generating
-     * signing key.
-     */
-    public long getNumberOfDaysSinceEpoch() {
-        return numberOfDaysSinceEpoch;
+    public boolean isValidForDate(Instant other) {
+        return daysSinceEpoch == DateUtils.numberOfDaysSinceEpoch(other.toEpochMilli());
     }
 
     /**

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/EventStreamAws4SignerTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/EventStreamAws4SignerTest.java
@@ -73,7 +73,7 @@ public class EventStreamAws4SignerTest {
         Map<String, HeaderValue> lastMessageHeaders = signedMessages.get(2).getHeaders();
         assertThat(lastMessageHeaders.get(":date").getTimestamp()).isEqualTo("2020-01-02T00:00:00Z");
         assertThat(Base64.getEncoder().encodeToString(lastMessageHeaders.get(":chunk-signature").getByteArray()))
-            .isEqualTo("vgDFcmKOVDUSSzKaBzcj0v9gUSgCK5IwnQ4dMB38NlE=");
+            .isEqualTo("UTRGo0D7BQytiVkH1VofR/8f3uFsM4V5QR1A8grr1+M=");
 
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/SignerKeyTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/SignerKeyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Instant;
+import org.junit.Test;
+
+public class SignerKeyTest {
+
+    @Test
+    public void isValidForDate_dayBefore_false() {
+        Instant signerDate = Instant.parse("2020-03-03T23:59:59Z");
+        SignerKey key = new SignerKey(signerDate, new byte[0]);
+        Instant dayBefore = Instant.parse("2020-03-02T23:59:59Z");
+
+        assertThat(key.isValidForDate(dayBefore)).isFalse();
+    }
+
+    @Test
+    public void isValidForDate_sameDay_true() {
+        Instant signerDate = Instant.parse("2020-03-03T23:59:59Z");
+        SignerKey key = new SignerKey(signerDate, new byte[0]);
+        Instant sameDay = Instant.parse("2020-03-03T01:02:03Z");
+
+        assertThat(key.isValidForDate(sameDay)).isTrue();
+    }
+
+    @Test
+    public void isValidForDate_dayAfter_false() {
+        Instant signerDate = Instant.parse("2020-03-03T23:59:59Z");
+        SignerKey key = new SignerKey(signerDate, new byte[0]);
+        Instant dayAfter = Instant.parse("2020-03-04T00:00:00Z");
+
+        assertThat(key.isValidForDate(dayAfter)).isFalse();
+    }
+}


### PR DESCRIPTION
## Description
Fix an issue where the signing key is created only once at the start of the
request for event streaming requests. This causes requests that span two more
more days to have signing errors once the date changes because the signing key
was derived only once using the date at the beginning of the request.

## Motivation and Context
Bug fix.

## Testing
 - `mvn clean install`
 - ~~Running integ tests~~ integ test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
