### PR TITLE
DDB Enhanced: Add support for a 'key item' in operations that take a key

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
@@ -152,12 +152,12 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * mappedTable.delete(DeleteItemEnhancedRequest.builder().key(key).build()).join();
+     * MyItem previouslyPersistedItem = mappedTable.delete(DeleteItemEnhancedRequest.builder().key(key).build()).join();
      * }
      * </pre>
      *
      * @param request A {@link DeleteItemEnhancedRequest} with key and optional directives for deleting an item from the table.
-     * @return a {@link CompletableFuture} of the deleted item
+     * @return a {@link CompletableFuture} of the item that was persisted in the database before it was deleted.
      */
     default CompletableFuture<T> deleteItem(DeleteItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
@@ -179,13 +179,13 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * mappedTable.delete(r -> r.key(key)).join();
+     * MyItem previouslyPersistedItem = mappedTable.delete(r -> r.key(key)).join();
      * }
      * </pre>
      *
      * @param requestConsumer A {@link Consumer} of {@link DeleteItemEnhancedRequest} with key and
      * optional directives for deleting an item from the table.
-     * @return a {@link CompletableFuture} of the deleted item
+     * @return a {@link CompletableFuture} of the item that was persisted in the database before it was deleted.
      */
     default CompletableFuture<T> deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
@@ -201,14 +201,36 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * mappedTable.delete(key);
+     * MyItem previouslyPersistedItem = mappedTable.delete(key).join;
      * }
      * </pre>
      *
      * @param key A {@link Key} that will be used to match a specific record to delete from the database table.
-     * @return a {@link CompletableFuture} of the deleted item
+     * @return a {@link CompletableFuture} of the item that was persisted in the database before it was deleted.
      */
     default CompletableFuture<T> deleteItem(Key key) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Deletes a single item from the mapped table using just the key of a supplied modelled 'key item' object.
+     * <p>
+     * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem previouslyPersistedItem = mappedTable.deleteItem(keyItem).join();
+     * }
+     * </pre>
+     *
+     * @param keyItem A modelled item with the primary key fields set that will be used to match a specific record to
+     *                delete from the database table.
+     * @return a {@link CompletableFuture} of the item that was persisted in the database before it was deleted.
+     */
+    default CompletableFuture<T> deleteItem(T keyItem) {
         throw new UnsupportedOperationException();
     }
 
@@ -230,7 +252,7 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * </pre>
      *
      * @param request A {@link GetItemEnhancedRequest} with key and optional directives for retrieving an item from the table.
-     * @return a {@link CompletableFuture} of the retrieved item
+     * @return a {@link CompletableFuture} of the item that was persisted in the database before it was deleted.
      */
     default CompletableFuture<T> getItem(GetItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
@@ -274,7 +296,7 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * MyItem item = mappedTable.getItem(key);
+     * MyItem item = mappedTable.getItem(key).join();
      * }
      * </pre>
      *
@@ -282,6 +304,28 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * @return a {@link CompletableFuture} of the retrieved item
      */
     default CompletableFuture<T> getItem(Key key) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Retrieves a single item from the mapped table using just the key of a supplied modelled 'key item'.
+     * <p>
+     * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.getItem(keyItem).join();
+     * }
+     * </pre>
+     *
+     * @param keyItem A modelled item with the primary key fields set that will be used to match a specific record to
+     *                retrieve from the database table.
+     * @return a {@link CompletableFuture} of the retrieved item
+     */
+    default CompletableFuture<T> getItem(T keyItem) {
         throw new UnsupportedOperationException();
     }
 
@@ -588,7 +632,7 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * MyItem item = mappedTable.updateItem(item);
+     * MyItem item = mappedTable.updateItem(item).join();
      * }
      * </pre>
      *

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
@@ -32,8 +32,8 @@ import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
  * Synchronous interface for running commands against an object that is linked to a specific DynamoDb table resource
  * and therefore knows how to map records from that table into a modelled object.
  * <p>
- * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from breaking
- * implementing classes.
+ * By default, all command methods throw an {@link UnsupportedOperationException} to prevent interface extensions from
+ * breaking implementing classes.
  * <p>
  * @param <T> The type of the modelled object.
  */
@@ -55,10 +55,10 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * <p>
      * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
      * <p>
-     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
-     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
-     * library to wait for/check the status of a created table. You must provide this functionality yourself.
-     * Consult the CreateTable documentation for further details and constraints.
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous
+     * operation and that the table may not immediately be available for writes and reads. Currently, there is no
+     * mechanism supported within this library to wait for/check the status of a created table. You must provide this
+     * functionality yourself. Consult the CreateTable documentation for further details and constraints.
      * <p>
      * Example:
      * <pre>
@@ -86,13 +86,13 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * <p>
      * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
      * <p>
-     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
-     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
-     * library to wait for/check the status of a created table. You must provide this functionality yourself.
-     * Consult the CreateTable documentation for further details and constraints.
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous
+     * operation and that the table may not immediately be available for writes and reads. Currently, there is no
+     * mechanism supported within this library to wait for/check the status of a created table. You must provide this
+     * functionality yourself. Consult the CreateTable documentation for further details and constraints.
      * <p>
-     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
-     * manually via {@link CreateTableEnhancedRequest#builder()}.
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to
+     * create one manually via {@link CreateTableEnhancedRequest#builder()}.
      * <p>
      * Example:
      * <pre>
@@ -106,8 +106,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * }
      * </pre>
      *
-     * @param requestConsumer A {@link Consumer} of {@link CreateTableEnhancedRequest.Builder} containing optional parameters
-     * for table creation.
+     * @param requestConsumer A {@link Consumer} of {@link CreateTableEnhancedRequest.Builder} containing optional
+     *                        parameters for table creation.
      */
     default void createTable(Consumer<CreateTableEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
@@ -118,10 +118,10 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * <p>
      * Use {@link DynamoDbEnhancedClient#table(String, TableSchema)} to define the mapped table resource.
      * <p>
-     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous operation and that
-     * the table may not immediately be available for writes and reads. Currently, there is no mechanism supported within this
-     * library to wait for/check the status of a created table. You must provide this functionality yourself.
-     * Consult the CreateTable documentation for further details and constraints.
+     * This operation calls the low-level DynamoDB API CreateTable operation. Note that this is an asynchronous
+     * operation and that the table may not immediately be available for writes and reads. Currently, there is no
+     * mechanism supported within this library to wait for/check the status of a created table. You must provide this
+     * functionality yourself. Consult the CreateTable documentation for further details and constraints.
      * <p>
      * Example:
      * <pre>
@@ -149,12 +149,13 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * mappedTable.delete(DeleteItemEnhancedRequest.builder().key(key).build());
+     * MyItem previouslyPersistedItem = mappedTable.delete(DeleteItemEnhancedRequest.builder().key(key).build());
      * }
      * </pre>
      *
-     * @param request A {@link DeleteItemEnhancedRequest} with key and optional directives for deleting an item from the table.
-     * @return The deleted item
+     * @param request A {@link DeleteItemEnhancedRequest} with key and optional directives for deleting an item from the
+     *                table.
+     * @return The item that was persisted in the database before it was deleted.
      */
     default T deleteItem(DeleteItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
@@ -169,20 +170,20 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
      * further details and constraints.
      * <p>
-     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
-     * manually via {@link DeleteItemEnhancedRequest#builder()}.
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to
+     * create one manually via {@link DeleteItemEnhancedRequest#builder()}.
      * <p>
      * Example:
      * <pre>
      * {@code
      *
-     * mappedTable.delete(r -> r.key(key));
+     * MyItem previouslyPersistedItem = mappedTable.delete(r -> r.key(key));
      * }
      * </pre>
      *
      * @param requestConsumer A {@link Consumer} of {@link DeleteItemEnhancedRequest} with key and
      * optional directives for deleting an item from the table.
-     * @return The deleted item
+     * @return The item that was persisted in the database before it was deleted.
      */
     default T deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
@@ -198,14 +199,36 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * <pre>
      * {@code
      *
-     * mappedTable.delete(key);
+     * MyItem previouslyPersistedItem = mappedTable.delete(key);
      * }
      * </pre>
      *
      * @param key A {@link Key} that will be used to match a specific record to delete from the database table.
-     * @return The deleted item
+     * @return The item that was persisted in the database before it was deleted.
      */
     default T deleteItem(Key key) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Deletes a single item from the mapped table using just the key of a supplied modelled 'key item' object.
+     * <p>
+     * This operation calls the low-level DynamoDB API DeleteItem operation. Consult the DeleteItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem previouslyPersistedItem = mappedTable.deleteItem(keyItem);
+     * }
+     * </pre>
+     *
+     * @param keyItem A modelled item with the primary key fields set that will be used to match a specific record to
+     *                delete from the database table.
+     * @return The item that was persisted in the database before it was deleted.
+     */
+    default T deleteItem(T keyItem) {
         throw new UnsupportedOperationException();
     }
 
@@ -243,8 +266,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
      * further details and constraints.
      * <p>
-     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
-     * manually via {@link GetItemEnhancedRequest#builder()}.
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to
+     * create one manually via {@link GetItemEnhancedRequest#builder()}.
      * <p>
      * Example:
      * <pre>
@@ -254,8 +277,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * }
      * </pre>
      *
-     * @param requestConsumer A {@link Consumer} of {@link GetItemEnhancedRequest.Builder} with key and optional directives
-     * for retrieving an item from the table.
+     * @param requestConsumer A {@link Consumer} of {@link GetItemEnhancedRequest.Builder} with key and optional
+     *                        directives for retrieving an item from the table.
      * @return The retrieved item
      */
     default T getItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
@@ -284,8 +307,30 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
     }
 
     /**
-     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a list of
-     * items matching the given conditions.
+     * Retrieves a single item from the mapped table using just the key of a supplied modelled 'key item'.
+     * <p>
+     * This operation calls the low-level DynamoDB API GetItem operation. Consult the GetItem documentation for
+     * further details and constraints.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *
+     * MyItem item = mappedTable.getItem(keyItem);
+     * }
+     * </pre>
+     *
+     * @param keyItem A modelled item with the primary key fields set that will be used to match a specific record to
+     *                retrieve from the database table.
+     * @return The retrieved item
+     */
+    default T getItem(T keyItem) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a
+     * list of items matching the given conditions.
      * <p>
      * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
      * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
@@ -318,8 +363,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
     }
 
     /**
-     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a list of
-     * items matching the given conditions.
+     * Executes a query against the primary index of the table using a {@link QueryConditional} expression to retrieve a
+     * list of items matching the given conditions.
      * <p>
      * The result is accessed through iterable pages (see {@link Page}) in an interactive way; each time a
      * result page is retrieved, a query call is made to DynamoDb to get those entries. If no matches are found,
@@ -332,8 +377,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * This operation calls the low-level DynamoDB API Query operation. Consult the Query documentation for
      * further details and constraints.
      * <p>
-     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
-     * manually via {@link DeleteItemEnhancedRequest#builder()}.
+     * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to
+     * create one manually via {@link DeleteItemEnhancedRequest#builder()}.
      * <p>
      * Example:
      * <pre>
@@ -344,8 +389,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * }
      * </pre>
      *
-     * @param requestConsumer A {@link Consumer} of {@link QueryEnhancedRequest} defining the query conditions and how to
-     * handle the results.
+     * @param requestConsumer A {@link Consumer} of {@link QueryEnhancedRequest} defining the query conditions and how
+     *                        to handle the results.
      * @return an iterator of type {@link SdkIterable} with paginated results (see {@link Page}).
      */
     default SdkIterable<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
@@ -381,8 +426,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
     }
 
     /**
-     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be replaced with
-     * this item.
+     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be
+     * replaced with this item.
      * <p>
      * The additional configuration parameters that the enhanced client supports are defined
      * in the {@link PutItemEnhancedRequest}.
@@ -406,8 +451,8 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
     }
 
     /**
-     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be replaced with
-     * this item.
+     * Puts a single item in the mapped table. If the table contains an item with the same primary key, it will be
+     * replaced with this item.
      * <p>
      * The additional configuration parameters that the enhanced client supports are defined
      * in the {@link PutItemEnhancedRequest}.

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
@@ -127,6 +127,11 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
     }
 
     @Override
+    public CompletableFuture<T> deleteItem(T keyItem) {
+        return deleteItem(keyFrom(keyItem));
+    }
+
+    @Override
     public CompletableFuture<T> getItem(GetItemEnhancedRequest request) {
         TableOperation<T, ?, ?, T> operation = GetItemOperation.create(request);
         return operation.executeOnPrimaryIndexAsync(tableSchema, tableName, extension, dynamoDbClient);
@@ -142,6 +147,11 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
     @Override
     public CompletableFuture<T> getItem(Key key) {
         return getItem(r -> r.key(key));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(T keyItem) {
+        return getItem(keyFrom(keyItem));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
@@ -129,6 +129,11 @@ public class DefaultDynamoDbTable<T> implements DynamoDbTable<T> {
     }
 
     @Override
+    public T deleteItem(T keyItem) {
+        return deleteItem(keyFrom(keyItem));
+    }
+
+    @Override
     public T getItem(GetItemEnhancedRequest request) {
         TableOperation<T, ?, ?, T> operation = GetItemOperation.create(request);
         return operation.executeOnPrimaryIndex(tableSchema, tableName, extension, dynamoDbClient);
@@ -144,6 +149,11 @@ public class DefaultDynamoDbTable<T> implements DynamoDbTable<T> {
     @Override
     public T getItem(Key key) {
         return getItem(r -> r.key(key));
+    }
+
+    @Override
+    public T getItem(T keyItem) {
+        return getItem(keyFrom(keyItem));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatch.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ReadBatch.java
@@ -142,6 +142,14 @@ public final class ReadBatch {
          */
         Builder<T> addGetItem(Key key);
 
+        /**
+         * Adds a GetItem request to the builder.
+         *
+         * @param keyItem an item that will have its key fields used to match a record to retrieve from the database.
+         * @return a builder of this type
+         */
+        Builder<T> addGetItem(T keyItem);
+
         ReadBatch build();
     }
 
@@ -204,16 +212,19 @@ public final class ReadBatch {
         private BuilderImpl() {
         }
 
+        @Override
         public Builder<T> mappedTableResource(MappedTableResource<T> mappedTableResource) {
             this.mappedTableResource = mappedTableResource;
             return this;
         }
 
+        @Override
         public Builder<T> addGetItem(GetItemEnhancedRequest request) {
             requests.add(request);
             return this;
         }
 
+        @Override
         public Builder<T> addGetItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
             GetItemEnhancedRequest.Builder builder = GetItemEnhancedRequest.builder();
             requestConsumer.accept(builder);
@@ -225,6 +236,12 @@ public final class ReadBatch {
             return addGetItem(r -> r.key(key));
         }
 
+        @Override
+        public Builder<T> addGetItem(T keyItem) {
+            return addGetItem(this.mappedTableResource.keyFrom(keyItem));
+        }
+
+        @Override
         public ReadBatch build() {
             return new ReadBatch(this);
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetItemsEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetItemsEnhancedRequest.java
@@ -19,7 +19,6 @@ import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUt
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -97,28 +96,11 @@ public final class TransactGetItemsEnhancedRequest {
          *
          * @param mappedTableResource the table where the key is located
          * @param request A {@link GetItemEnhancedRequest}
-         * @param <T> the type of modelled objects in the table
          * @return a builder of this type
          */
-        public <T> Builder addGetItem(MappedTableResource<T> mappedTableResource, GetItemEnhancedRequest request) {
+        public Builder addGetItem(MappedTableResource<?> mappedTableResource, GetItemEnhancedRequest request) {
             itemSupplierList.add(() -> generateTransactWriteItem(mappedTableResource, GetItemOperation.create(request)));
             return this;
-        }
-
-        /**
-         * Adds a primary lookup key and it's associated table to the transaction by accepting a consumer of
-         * {@link GetItemEnhancedRequest.Builder}.
-         *
-         * @param mappedTableResource the table where the key is located
-         * @param requestConsumer a {@link Consumer} of {@link GetItemEnhancedRequest}
-         * @param <T> the type of modelled objects in the table
-         * @return a builder of this type
-         */
-        public <T> Builder addGetItem(MappedTableResource<T> mappedTableResource,
-                                      Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
-            GetItemEnhancedRequest.Builder builder = GetItemEnhancedRequest.builder();
-            requestConsumer.accept(builder);
-            return addGetItem(mappedTableResource, builder.build());
         }
 
         /**
@@ -126,12 +108,23 @@ public final class TransactGetItemsEnhancedRequest {
          *
          * @param mappedTableResource the table where the key is located
          * @param key the primary key of an item to retrieve as part of the transaction
+         * @return a builder of this type
+         */
+        public Builder addGetItem(MappedTableResource<?> mappedTableResource, Key key) {
+            return addGetItem(mappedTableResource, GetItemEnhancedRequest.builder().key(key).build());
+        }
+
+        /**
+         * Adds a primary lookup key and it's associated table to the transaction.
+         *
+         * @param mappedTableResource the table where the key is located
+         * @param keyItem an item that will have its key fields used to match a record to retrieve from the database
          * @param <T> the type of modelled objects in the table
          * @return a builder of this type
          */
         public <T> Builder addGetItem(MappedTableResource<T> mappedTableResource,
-                                      Key key) {
-            return addGetItem(mappedTableResource, r -> r.key(key));
+                                      T keyItem) {
+            return addGetItem(mappedTableResource, mappedTableResource.keyFrom(keyItem));
         }
 
         /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequest.java
@@ -154,24 +154,6 @@ public final class TransactWriteItemsEnhancedRequest {
         }
 
         /**
-         * Adds a primary lookup key for the item to delete, and it's associated table, to the transaction by accepting a consumer
-         * of {@link DeleteItemEnhancedRequest.Builder}. For more information on the delete action, see the low-level operation
-         * description in for instance {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)} and how to construct the
-         * low-level request in {@link DeleteItemEnhancedRequest}.
-         *
-         * @param mappedTableResource the table where the key is located
-         * @param requestConsumer a {@link Consumer} of {@link DeleteItemEnhancedRequest}
-         * @param <T> the type of modelled objects in the table
-         * @return a builder of this type
-         */
-        public <T> Builder addDeleteItem(MappedTableResource<T> mappedTableResource,
-                                         Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
-            DeleteItemEnhancedRequest.Builder builder = DeleteItemEnhancedRequest.builder();
-            requestConsumer.accept(builder);
-            return addDeleteItem(mappedTableResource, builder.build());
-        }
-
-        /**
          * Adds a primary lookup key for the item to delete, and it's associated table, to the transaction. For more
          * information on the delete action, see the low-level operation description in for instance
          * {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)}.
@@ -182,7 +164,21 @@ public final class TransactWriteItemsEnhancedRequest {
          * @return a builder of this type
          */
         public <T> Builder addDeleteItem(MappedTableResource<T> mappedTableResource, Key key) {
-            return addDeleteItem(mappedTableResource, r -> r.key(key));
+            return addDeleteItem(mappedTableResource, DeleteItemEnhancedRequest.builder().key(key).build());
+        }
+
+        /**
+         * Adds a primary lookup key for the item to delete, and it's associated table, to the transaction. For more
+         * information on the delete action, see the low-level operation description in for instance
+         * {@link DynamoDbTable#deleteItem(DeleteItemEnhancedRequest)}.
+         *
+         * @param mappedTableResource the table where the key is located
+         * @param keyItem an item that will have its key fields used to match a record to retrieve from the database
+         * @param <T> the type of modelled objects in the table
+         * @return a builder of this type
+         */
+        public <T> Builder addDeleteItem(MappedTableResource<T> mappedTableResource, T keyItem) {
+            return addDeleteItem(mappedTableResource, mappedTableResource.keyFrom(keyItem));
         }
 
         /**
@@ -201,24 +197,6 @@ public final class TransactWriteItemsEnhancedRequest {
         }
 
         /**
-         * Adds an item to be written, and it's associated table, to the transaction by accepting a consumer
-         * of {@link PutItemEnhancedRequest.Builder}. For more information on the put action,
-         * see the low-level operation description in for instance {@link DynamoDbTable#putItem(PutItemEnhancedRequest)}
-         * and how to construct the low-level request in {@link PutItemEnhancedRequest}.
-         *
-         * @param mappedTableResource the table to write the item to
-         * @param requestConsumer a {@link Consumer} of {@link PutItemEnhancedRequest}
-         * @param <T> the type of modelled objects in the table
-         * @return a builder of this type
-         */
-        public <T> Builder addPutItem(MappedTableResource<T> mappedTableResource, Class<? extends T> itemClass,
-                                      Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
-            PutItemEnhancedRequest.Builder<T> builder = PutItemEnhancedRequest.builder(itemClass);
-            requestConsumer.accept(builder);
-            return addPutItem(mappedTableResource, builder.build());
-        }
-
-        /**
          * Adds an item to be written, and it's associated table, to the transaction. For more information on the put
          * action, see the low-level operation description in for instance
          * {@link DynamoDbTable#putItem(PutItemEnhancedRequest)}.
@@ -231,8 +209,9 @@ public final class TransactWriteItemsEnhancedRequest {
         public <T> Builder addPutItem(MappedTableResource<T> mappedTableResource, T item) {
             return addPutItem(
                 mappedTableResource,
-                mappedTableResource.tableSchema().itemType().rawClass(),
-                r -> r.item(item));
+                PutItemEnhancedRequest.builder(mappedTableResource.tableSchema().itemType().rawClass())
+                                      .item(item)
+                                      .build());
         }
 
         /**
@@ -254,24 +233,6 @@ public final class TransactWriteItemsEnhancedRequest {
         }
 
         /**
-         * Adds an item to be written, and it's associated table, to the transaction by accepting a consumer
-         * of {@link PutItemEnhancedRequest.Builder}. For more information on the update action,
-         * see the low-level operation description in for instance {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)}
-         * and how to construct the low-level request in {@link UpdateItemEnhancedRequest}.
-         *
-         * @param mappedTableResource the table to write the item to
-         * @param requestConsumer a {@link Consumer} of {@link UpdateItemEnhancedRequest}
-         * @param <T> the type of modelled objects in the table
-         * @return a builder of this type
-         */
-        public <T> Builder addUpdateItem(MappedTableResource<T> mappedTableResource, Class<? extends T> itemClass,
-                                         Consumer<UpdateItemEnhancedRequest.Builder<T>> requestConsumer) {
-            UpdateItemEnhancedRequest.Builder<T> builder = UpdateItemEnhancedRequest.builder(itemClass);
-            requestConsumer.accept(builder);
-            return addUpdateItem(mappedTableResource, builder.build());
-        }
-
-        /**
          * Adds an item to be updated, and it's associated table, to the transaction. For more information on the update
          * action, see the low-level operation description in for instance
          * {@link DynamoDbTable#updateItem(UpdateItemEnhancedRequest)}.
@@ -284,8 +245,9 @@ public final class TransactWriteItemsEnhancedRequest {
         public <T> Builder addUpdateItem(MappedTableResource<T> mappedTableResource, T item) {
             return addUpdateItem(
                 mappedTableResource,
-                mappedTableResource.tableSchema().itemType().rawClass(),
-                r -> r.item(item));
+                UpdateItemEnhancedRequest.builder(mappedTableResource.tableSchema().itemType().rawClass())
+                                         .item(item)
+                                         .build());
         }
 
         /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/WriteBatch.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/WriteBatch.java
@@ -146,6 +146,14 @@ public final class WriteBatch {
         Builder<T> addDeleteItem(Key key);
 
         /**
+         * Adds a DeleteItem request to the builder.
+         *
+         * @param keyItem an item that will have its key fields used to match a record to delete from the database.
+         * @return a builder of this type
+         */
+        Builder<T> addDeleteItem(T keyItem);
+
+        /**
          * Adds a {@link PutItemEnhancedRequest} to the builder, this request should contain the item
          * to be written.
          *
@@ -203,6 +211,11 @@ public final class WriteBatch {
         @Override
         public Builder<T> addDeleteItem(Key key) {
             return addDeleteItem(r -> r.key(key));
+        }
+
+        @Override
+        public Builder<T> addDeleteItem(T keyItem) {
+            return addDeleteItem(this.mappedTableResource.keyFrom(keyItem));
         }
 
         public Builder<T> addPutItem(PutItemEnhancedRequest<T> request) {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncBasicCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncBasicCrudTest.java
@@ -266,7 +266,12 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
                               .setAttribute3("three");
 
         mappedTable.putItem(r -> r.item(record)).join();
-        Record result = mappedTable.getItem(r -> r.key(k -> k.partitionValue("id-value").sortValue("sort-value"))).join();
+
+        Record keyItem = new Record();
+        keyItem.setId("id-value");
+        keyItem.setSort("sort-value");
+
+        Record result = mappedTable.getItem(keyItem).join();
 
         assertThat(result, is(record));
     }
@@ -312,6 +317,25 @@ public class AsyncBasicCrudTest extends LocalDynamoDbAsyncTestBase {
         mappedTable.putItem(record).join();
         Record beforeDeleteResult =
             mappedTable.deleteItem(Key.builder().partitionValue("id-value").sortValue("sort-value").build()).join();
+        Record afterDeleteResult =
+            mappedTable.getItem(Key.builder().partitionValue("id-value").sortValue("sort-value").build()).join();
+
+        assertThat(beforeDeleteResult, is(record));
+        assertThat(afterDeleteResult, is(nullValue()));
+    }
+
+    @Test
+    public void putThenDeleteItem_usingKeyItemForm() {
+        Record record = new Record()
+            .setId("id-value")
+            .setSort("sort-value")
+            .setAttribute("one")
+            .setAttribute2("two")
+            .setAttribute3("three");
+
+        mappedTable.putItem(record).join();
+        Record beforeDeleteResult =
+            mappedTable.deleteItem(record).join();
         Record afterDeleteResult =
             mappedTable.getItem(Key.builder().partitionValue("id-value").sortValue("sort-value").build()).join();
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncTransactGetItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncTransactGetItemsTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
@@ -154,10 +155,10 @@ public class AsyncTransactGetItemsTest extends LocalDynamoDbAsyncTestBase {
 
         TransactGetItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactGetItemsEnhancedRequest.builder()
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(1)))
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(1).build())
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(1).build())
                                            .build();
 
         List<Document> results = enhancedAsyncClient.transactGetItems(transactGetItemsEnhancedRequest).join();
@@ -175,10 +176,10 @@ public class AsyncTransactGetItemsTest extends LocalDynamoDbAsyncTestBase {
 
         TransactGetItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactGetItemsEnhancedRequest.builder()
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(5)))
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(5).build())
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(1).build())
                                            .build();
 
         List<Document> results = enhancedAsyncClient.transactGetItems(transactGetItemsEnhancedRequest).join();

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncTransactWriteItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/AsyncTransactWriteItemsTest.java
@@ -183,7 +183,7 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
     public void singlePut() {
         enhancedAsyncClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
+                                             .addPutItem(mappedTable1, RECORDS_1.get(0))
                                              .build()).join();
 
         Record1 record = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0))).join();
@@ -194,8 +194,8 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
     public void multiplePut() {
         enhancedAsyncClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
-                                             .addPutItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(0)))
+                                             .addPutItem(mappedTable1, RECORDS_1.get(0))
+                                             .addPutItem(mappedTable2, RECORDS_2.get(0))
                                              .build()).join();
 
         Record1 record1 = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0))).join();
@@ -208,7 +208,7 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
     public void singleUpdate() {
         enhancedAsyncClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(0))
                                              .build()).join();
 
         Record1 record = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0))).join();
@@ -219,8 +219,8 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
     public void multipleUpdate() {
         enhancedAsyncClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
-                                             .addUpdateItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(0)))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(0))
+                                             .addUpdateItem(mappedTable2, RECORDS_2.get(0))
                                              .build()).join();
 
         Record1 record1 = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0))).join();
@@ -235,7 +235,7 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
 
         enhancedAsyncClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addDeleteItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
+                                             .addDeleteItem(mappedTable1, RECORDS_1.get(0))
                                              .build()).join();
 
         Record1 record = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0))).join();
@@ -249,8 +249,8 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
 
         enhancedAsyncClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addDeleteItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
-                                             .addDeleteItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
+                                             .addDeleteItem(mappedTable1, RECORDS_1.get(0))
+                                             .addDeleteItem(mappedTable2, RECORDS_2.get(0))
                                              .build()).join();
 
         Record1 record1 = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0))).join();
@@ -326,9 +326,9 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
                                                                                             .key(key)
                                                                                             .conditionExpression(conditionExpression)
                                                                                             .build())
-                                             .addPutItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(1)))
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(1)))
-                                             .addDeleteItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
+                                             .addPutItem(mappedTable2, RECORDS_2.get(1))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(1))
+                                             .addDeleteItem(mappedTable2, RECORDS_2.get(0))
                                              .build();
         enhancedAsyncClient.transactWriteItems(transactWriteItemsEnhancedRequest).join();
 
@@ -352,13 +352,13 @@ public class AsyncTransactWriteItemsTest extends LocalDynamoDbAsyncTestBase {
 
         TransactWriteItemsEnhancedRequest transactWriteItemsEnhancedRequest =
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(1)))
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(1)))
+                                             .addPutItem(mappedTable2, RECORDS_2.get(1))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(1))
                                              .addConditionCheck(mappedTable1, ConditionCheck.builder()
                                                                                             .key(key)
                                                                                             .conditionExpression(conditionExpression)
                                                                                             .build())
-                                             .addDeleteItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
+                                             .addDeleteItem(mappedTable2, RECORDS_2.get(0))
                                              .build();
 
         try {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicCrudTest.java
@@ -258,7 +258,12 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
                               .setAttribute3("three");
 
         mappedTable.putItem(r -> r.item(record));
-        Record result = mappedTable.getItem(r -> r.key(k -> k.partitionValue("id-value").sortValue("sort-value")));
+
+        Record keyItem = new Record();
+        keyItem.setId("id-value");
+        keyItem.setSort("sort-value");
+
+        Record result = mappedTable.getItem(keyItem);
 
         assertThat(result, is(record));
     }
@@ -304,6 +309,25 @@ public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
         mappedTable.putItem(record);
         Record beforeDeleteResult =
             mappedTable.deleteItem(Key.builder().partitionValue("id-value").sortValue("sort-value").build());
+        Record afterDeleteResult =
+            mappedTable.getItem(Key.builder().partitionValue("id-value").sortValue("sort-value").build());
+
+        assertThat(beforeDeleteResult, is(record));
+        assertThat(afterDeleteResult, is(nullValue()));
+    }
+
+    @Test
+    public void putThenDeleteItem_usingKeyItemForm() {
+        Record record = new Record()
+            .setId("id-value")
+            .setSort("sort-value")
+            .setAttribute("one")
+            .setAttribute2("two")
+            .setAttribute3("three");
+
+        mappedTable.putItem(record);
+        Record beforeDeleteResult =
+            mappedTable.deleteItem(record);
         Record afterDeleteResult =
             mappedTable.getItem(Key.builder().partitionValue("id-value").sortValue("sort-value").build());
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/TransactGetItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/TransactGetItemsTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
@@ -150,10 +151,10 @@ public class TransactGetItemsTest extends LocalDynamoDbSyncTestBase {
 
         TransactGetItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactGetItemsEnhancedRequest.builder()
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(1)))
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(1).build())
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(1).build())
                                            .build();
 
         List<Document> results = enhancedClient.transactGetItems(transactGetItemsEnhancedRequest);
@@ -171,10 +172,10 @@ public class TransactGetItemsTest extends LocalDynamoDbSyncTestBase {
 
         TransactGetItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactGetItemsEnhancedRequest.builder()
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
-                                           .addGetItem(mappedTable2, r -> r.key(k -> k.partitionValue(5)))
-                                           .addGetItem(mappedTable1, r -> r.key(k -> k.partitionValue(1)))
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(0).build())
+                                           .addGetItem(mappedTable2, Key.builder().partitionValue(5).build())
+                                           .addGetItem(mappedTable1, Key.builder().partitionValue(1).build())
                                            .build();
 
         List<Document> results = enhancedClient.transactGetItems(transactGetItemsEnhancedRequest);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/TransactWriteItemsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/TransactWriteItemsTest.java
@@ -177,7 +177,7 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
     public void singlePut() {
         enhancedClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
+                                             .addPutItem(mappedTable1, RECORDS_1.get(0))
                                              .build());
 
         Record1 record = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0)));
@@ -188,8 +188,8 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
     public void multiplePut() {
         enhancedClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
-                                             .addPutItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(0)))
+                                             .addPutItem(mappedTable1, RECORDS_1.get(0))
+                                             .addPutItem(mappedTable2, RECORDS_2.get(0))
                                              .build());
 
         Record1 record1 = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0)));
@@ -202,7 +202,7 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
     public void singleUpdate() {
         enhancedClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(0))
                                              .build());
 
         Record1 record = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0)));
@@ -213,8 +213,8 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
     public void multipleUpdate() {
         enhancedClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(0)))
-                                             .addUpdateItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(0)))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(0))
+                                             .addUpdateItem(mappedTable2, RECORDS_2.get(0))
                                              .build());
 
         Record1 record1 = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0)));
@@ -229,7 +229,7 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
 
         enhancedClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addDeleteItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
+                                             .addDeleteItem(mappedTable1, RECORDS_1.get(0))
                                              .build());
 
         Record1 record = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0)));
@@ -243,8 +243,8 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
 
         enhancedClient.transactWriteItems(
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addDeleteItem(mappedTable1, r -> r.key(k -> k.partitionValue(0)))
-                                             .addDeleteItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
+                                             .addDeleteItem(mappedTable1, RECORDS_1.get(0))
+                                             .addDeleteItem(mappedTable2, RECORDS_2.get(0))
                                              .build());
 
         Record1 record1 = mappedTable1.getItem(r -> r.key(k -> k.partitionValue(0)));
@@ -319,9 +319,9 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
                                                                                             .key(key)
                                                                                             .conditionExpression(conditionExpression)
                                                                                             .build())
-                                             .addPutItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(1)))
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(1)))
-                                             .addDeleteItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
+                                             .addPutItem(mappedTable2, RECORDS_2.get(1))
+                                             .addUpdateItem(mappedTable1,RECORDS_1.get(1))
+                                             .addDeleteItem(mappedTable2, RECORDS_2.get(0))
                                              .build();
 
         enhancedClient.transactWriteItems(transactWriteItemsEnhancedRequest);
@@ -346,13 +346,13 @@ public class TransactWriteItemsTest extends LocalDynamoDbSyncTestBase {
 
         TransactWriteItemsEnhancedRequest transactWriteItemsEnhancedRequest =
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(mappedTable2, Record2.class, r -> r.item(RECORDS_2.get(1)))
-                                             .addUpdateItem(mappedTable1, Record1.class, r -> r.item(RECORDS_1.get(1)))
+                                             .addPutItem(mappedTable2, RECORDS_2.get(1))
+                                             .addUpdateItem(mappedTable1, RECORDS_1.get(1))
                                              .addConditionCheck(mappedTable1, ConditionCheck.builder()
                                                                                             .key(key)
                                                                                             .conditionExpression(conditionExpression)
                                                                                             .build())
-                                             .addDeleteItem(mappedTable2, r -> r.key(k -> k.partitionValue(0)))
+                                             .addDeleteItem(mappedTable2, RECORDS_2.get(0))
                                              .build();
 
         try {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperationTest.java
@@ -136,6 +136,36 @@ public class BatchGetItemOperationTest {
     }
 
     @Test
+    public void getServiceCall_usingKeyItemForm_makesTheRightCallAndReturnsResponse() {
+        BatchGetItemEnhancedRequest batchGetItemEnhancedRequest =
+            BatchGetItemEnhancedRequest.builder()
+                                       .readBatches(ReadBatch.builder(FakeItem.class)
+                                                             .mappedTableResource(fakeItemMappedTable)
+                                                             .addGetItem(FAKE_ITEMS.get(0))
+                                                             .build())
+                                       .build();
+
+        BatchGetItemOperation operation = BatchGetItemOperation.create(batchGetItemEnhancedRequest);
+
+        BatchGetItemRequest batchGetItemRequest =
+            BatchGetItemRequest.builder()
+                               .requestItems(singletonMap("test-table",
+                                                          KeysAndAttributes.builder()
+                                                                           .keys(singletonList(FAKE_ITEM_MAPS.get(0)))
+                                                                           .build()))
+                               .build();
+
+        BatchGetItemIterable expectedResponse = mock(BatchGetItemIterable.class);
+        when(mockDynamoDbClient.batchGetItemPaginator(any(BatchGetItemRequest.class))).thenReturn(expectedResponse);
+
+        SdkIterable<BatchGetItemResponse> response =
+            operation.serviceCall(mockDynamoDbClient).apply(batchGetItemRequest);
+
+        assertThat(response, sameInstance(expectedResponse));
+        verify(mockDynamoDbClient).batchGetItemPaginator(batchGetItemRequest);
+    }
+
+    @Test
     public void generateRequest_multipleBatches_multipleTableSchemas() {
         BatchGetItemEnhancedRequest batchGetItemEnhancedRequest =
             BatchGetItemEnhancedRequest.builder()

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactGetItemsOperationTest.java
@@ -131,10 +131,10 @@ public class TransactGetItemsOperationTest {
     }
 
     @Test
-    public void getServiceCall_makesTheRightCallAndReturnsResponse() {
+    public void getServiceCall_makesTheRightCallAndReturnsResponse_usingKeyItemForm() {
         TransactGetItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactGetItemsEnhancedRequest.builder()
-                                           .addGetItem(fakeItemMappedTable, r -> r.key(FAKE_ITEM_KEYS.get(0)))
+                                           .addGetItem(fakeItemMappedTable, FAKE_ITEMS.get(0))
                                            .build();
 
         TransactGetItemsOperation operation = TransactGetItemsOperation.create(transactGetItemsEnhancedRequest);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactWriteItemsOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/TransactWriteItemsOperationTest.java
@@ -83,7 +83,7 @@ public class TransactWriteItemsOperationTest {
     public void generateRequest_singleTransaction() {
         TransactWriteItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(fakeItemMappedTable, FakeItem.class, r -> r.item(fakeItem1))
+                                             .addPutItem(fakeItemMappedTable, fakeItem1)
                                              .build();
 
         TransactWriteItemsOperation operation = TransactWriteItemsOperation.create(transactGetItemsEnhancedRequest);
@@ -100,8 +100,8 @@ public class TransactWriteItemsOperationTest {
     public void generateRequest_multipleTransactions() {
         TransactWriteItemsEnhancedRequest transactGetItemsEnhancedRequest =
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(fakeItemMappedTable, FakeItem.class, r -> r.item(fakeItem1))
-                                             .addPutItem(fakeItemMappedTable, FakeItem.class, r -> r.item(fakeItem2))
+                                             .addPutItem(fakeItemMappedTable, fakeItem1)
+                                             .addPutItem(fakeItemMappedTable, fakeItem2)
                                              .build();
 
         TransactWriteItemsOperation operation = TransactWriteItemsOperation.create(transactGetItemsEnhancedRequest);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetItemsEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactGetItemsEnhancedRequestTest.java
@@ -68,8 +68,8 @@ public class TransactGetItemsEnhancedRequestTest {
 
         TransactGetItemsEnhancedRequest builtObject =
             TransactGetItemsEnhancedRequest.builder()
-                                           .addGetItem(fakeItemMappedTable, r -> r.key(k -> k.partitionValue(fakeItem.getId())))
-                                           .addGetItem(fakeItemMappedTable, r -> r.key(k -> k.partitionValue(fakeItem.getId())))
+                                           .addGetItem(fakeItemMappedTable, fakeItem)
+                                           .addGetItem(fakeItemMappedTable, fakeItem)
                                            .build();
 
         assertThat(builtObject.transactGetItems(), is(getTransactGetItems(fakeItem)));

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/TransactWriteItemsEnhancedRequestTest.java
@@ -80,9 +80,9 @@ public class TransactWriteItemsEnhancedRequestTest {
 
         TransactWriteItemsEnhancedRequest builtObject =
             TransactWriteItemsEnhancedRequest.builder()
-                                             .addPutItem(fakeItemMappedTable, FakeItem.class, r -> r.item(fakeItem))
-                                             .addDeleteItem(fakeItemMappedTable, r -> r.key(k -> k.partitionValue(fakeItem.getId())))
-                                             .addUpdateItem(fakeItemMappedTable, FakeItem.class, r -> r.item(fakeItem))
+                                             .addPutItem(fakeItemMappedTable, fakeItem)
+                                             .addDeleteItem(fakeItemMappedTable, fakeItem)
+                                             .addUpdateItem(fakeItemMappedTable, fakeItem)
                                              .addConditionCheck(fakeItemMappedTable, r -> r.key(k -> k.partitionValue(fakeItem.getId()))
                                                                                            .conditionExpression(conditionExpression))
                                              .build();


### PR DESCRIPTION
Adding the new KeyItem/Item shortcut form to TransactGetItems and TransactWriteItems enhanced requests caused ambiguity resolving the difference between that overloaded method and the method that takes a consumer builder. We decided that keyItem was the more convenient of the two convenience methods so chopped the consumer builder version just from those operations.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
