### PR TITLE
DDB Enhanced Client adds bean annotations for attribute converter pro…

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableSchema.java
@@ -285,8 +285,8 @@ public final class StaticTableSchema<T> implements TableSchema<T> {
          * A higher-precedence {@link AttributeConverterProvider} than the default one provided by the table schema.
          * The {@link AttributeConverterProvider} must provide {@link AttributeConverter}s for all types used in the schema.
          * <p>
-         * The table schema default provider has an internal AttributeConverterProvider which provides standard converters
-         * for most primitive and common Java types. Use custom AttributeConverterProvider only when you have specific
+         * The table schema has a default, internal, AttributeConverterProvider which provides standard converters
+         * for most primitive and common Java types. Use custom AttributeConverterProvider when you have specific
          * needs for type conversion that the defaults do not cover.
          */
         public Builder<T> attributeConverterProvider(AttributeConverterProvider attributeConverterProvider) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbConvertedBy.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbConvertedBy.java
@@ -22,22 +22,16 @@ import java.lang.annotation.Target;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
-import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
 
 /**
- * Class level annotation that identifies this class as being a DynamoDb mappable entity. Any class used to initialize
- * a {@link BeanTableSchema} must have this annotation. If a class is used as a document within another DynamoDbBean,
- * it will also require this annotation.
- * <p>
- * Using {@link AttributeConverterProvider}s is optional and, if used, the supplied provider supersedes the default
- * converter provided by the table schema. The converter must provide {@link AttributeConverter}s for all types used
- * in the schema. The table schema default AttributeConverterProvider provides standard converters for most primitive
- * and common Java types. Use custom AttributeConverterProviders when you have specific needs for type conversion
+ * Associates a custom {@link AttributeConverter} with this attribute. This annotation is optional and takes
+ * precedence over any converter for this type provided by the table schema {@link AttributeConverterProvider}
+ * if it exists. Use custom AttributeConverterProvider when you have specific needs for type conversion
  * that the defaults do not cover.
  */
-@Target({ElementType.TYPE})
+@Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @SdkPublicApi
-public @interface DynamoDbBean {
-    Class<? extends AttributeConverterProvider>[] converterProviders() default {};
+public @interface DynamoDbConvertedBy {
+    Class<? extends AttributeConverter> value();
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/AttributeConverterBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/AttributeConverterBean.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+import java.util.Objects;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@DynamoDbBean
+public class AttributeConverterBean {
+    private String id;
+
+    @DynamoDbPartitionKey
+    public String getId() {
+        return this.id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    private AttributeItem attributeItem;
+
+    @DynamoDbConvertedBy(CustomAttributeConverter.class)
+    public AttributeItem getAttributeItem() {
+        return attributeItem;
+    }
+    public void setAttributeItem(AttributeItem attributeItem) {
+        this.attributeItem = attributeItem;
+    }
+
+    private Integer integerAttribute;
+    public Integer getIntegerAttribute() {
+        return integerAttribute;
+    }
+    public void setIntegerAttribute(Integer integerAttribute) {
+        this.integerAttribute = integerAttribute;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AttributeConverterBean that = (AttributeConverterBean) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(integerAttribute, that.integerAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, integerAttribute);
+    }
+
+    public static class CustomAttributeConverter implements AttributeConverter<AttributeItem> {
+
+        public CustomAttributeConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(AttributeItem input) {
+            return EnhancedAttributeValue.fromString(input.innerValue).toAttributeValue();
+        }
+
+        @Override
+        public AttributeItem transformTo(AttributeValue input) {
+            return null;
+        }
+
+        @Override
+        public EnhancedType<AttributeItem> type() {
+            return EnhancedType.of(AttributeItem.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class AttributeItem {
+        String innerValue;
+
+        public String getInnerValue() {
+            return innerValue;
+        }
+
+        public void setInnerValue(String innerValue) {
+            this.innerValue = innerValue;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/AttributeConverterNoConstructorBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/AttributeConverterNoConstructorBean.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@DynamoDbBean
+public class AttributeConverterNoConstructorBean extends AbstractBean {
+
+    private String id;
+
+    @DynamoDbConvertedBy(AttributeConverterNoConstructorBean.CustomAttributeConverter.class)
+    public String getId() {
+        return this.id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public static class CustomAttributeConverter implements AttributeConverter {
+
+        private CustomAttributeConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return null;
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return null;
+        }
+
+        @Override
+        public EnhancedType type() {
+            return null;
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return null;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/ConverterBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/ConverterBean.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.IntegerStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@DynamoDbBean(converterProviders = ConverterBean.CustomAttributeConverterProvider.class)
+public class ConverterBean {
+    private String id;
+    private Integer integerAttribute;
+
+    @DynamoDbPartitionKey
+    public String getId() {
+        return this.id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getIntegerAttribute() {
+        return integerAttribute;
+    }
+    public void setIntegerAttribute(Integer integerAttribute) {
+        this.integerAttribute = integerAttribute;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConverterBean that = (ConverterBean) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(integerAttribute, that.integerAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, integerAttribute);
+    }
+
+    public static class CustomAttributeConverterProvider implements AttributeConverterProvider {
+
+        private final Map<EnhancedType<?>, AttributeConverter<?>> converterCache = ImmutableMap.of(
+            EnhancedType.of(String.class), new CustomStringAttributeConverter(),
+            EnhancedType.of(Integer.class), new CustomIntegerAttributeConverter()
+        );
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            return (AttributeConverter<T>) converterCache.get(enhancedType);
+        }
+    }
+
+    private static class CustomStringAttributeConverter implements AttributeConverter<String> {
+
+        final static String DEFAULT_SUFFIX = "-custom";
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return EnhancedAttributeValue.fromString(input + DEFAULT_SUFFIX).toAttributeValue();
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            return input.s();
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    private static class CustomIntegerAttributeConverter implements AttributeConverter<Integer> {
+
+        final static Integer DEFAULT_INCREMENT = 10;
+
+        @Override
+        public AttributeValue transformFrom(Integer input) {
+            return EnhancedAttributeValue.fromNumber(IntegerStringConverter.create().toString(input + DEFAULT_INCREMENT))
+                                         .toAttributeValue();
+        }
+
+        @Override
+        public Integer transformTo(AttributeValue input) {
+            return Integer.valueOf(input.n());
+        }
+
+        @Override
+        public EnhancedType<Integer> type() {
+            return EnhancedType.of(Integer.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.N;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/ConverterNoConstructorBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/ConverterNoConstructorBean.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@DynamoDbBean(converterProviders = ConverterNoConstructorBean.CustomAttributeConverterProvider.class)
+public class ConverterNoConstructorBean extends AbstractBean {
+
+    public static class CustomAttributeConverterProvider implements AttributeConverterProvider {
+
+        private CustomAttributeConverterProvider() {
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
…viders and attribute converters

## Description
* Adds an optional attribute to supply an `AttributeConverterProvider` to the `@DynamoDbBean` annotation. 
* Adds another annotation `DynamoDbConvertedBy` to be used on a DDB bean attribute when that attribute needs a specific converter. This converter overrides any attribute converter provider supplied converters. 

Tracking DDB enhanced client features: [Issue #35](https://github.com/aws/aws-sdk-java-v2/issues/35). 

## Motivation and Context
These annotation enhancements enrich the DBB Enhanced Client bean features and allow users to customize how their beans are converted to and from DDB format. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
