### PR TITLE
DDB Enhanced client: flattened batch get items

### DIFF
--- a/services-custom/dynamodb-enhanced/README.md
+++ b/services-custom/dynamodb-enhanced/README.md
@@ -123,12 +123,12 @@ fully documented in the Javadoc of the interfaces referenced in these examples.
    PageIterable<Customer> customers = customerTable.scan();
    
    // BatchGetItem
-   batchResults = enhancedClient.batchGetItem(r -> r.addReadBatch(ReadBatch.builder(Customer.class)
-                                                                           .mappedTableResource(customerTable)
-                                                                           .addGetItem(key1)
-                                                                           .addGetItem(key2)
-                                                                           .addGetItem(key3)
-                                                                           .build()));
+   BatchGetResultPageIterable batchResults = enhancedClient.batchGetItem(r -> r.addReadBatch(ReadBatch.builder(Customer.class)
+                                                                               .mappedTableResource(customerTable)
+                                                                               .addGetItem(key1)
+                                                                               .addGetItem(key2)
+                                                                               .addGetItem(key3)
+                                                                               .build()));
    
    // BatchWriteItem
    batchResults = enhancedClient.batchWriteItem(r -> r.addWriteBatch(WriteBatch.builder(Customer.class)

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
 import software.amazon.awssdk.enhanced.dynamodb.model.ConditionCheck;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRe
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
 
 /**
  * Synchronous interface for running commands against a DynamoDb database.
@@ -66,14 +68,14 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
      * provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically
      * retries any unprocessed keys returned from DynamoDb in subsequent calls for pages.
      * <p>
-     * This operation calls the low-level DynamoDb API BatchGetItem operation. Consult the BatchGetItem documentation for
-     * further details and constraints as well as current limits of data retrieval.
+     * This operation calls the low-level {@link DynamoDbClient#batchGetItemPaginator} operation. Consult the BatchGetItem
+     * documentation for further details and constraints as well as current limits of data retrieval.
      * <p>
      * Example:
      * <pre>
      * {@code
      *
-     * Iterator<BatchGetResultPage> batchResults = enhancedClient.batchGetItem(
+     * BatchGetResultPageIterable batchResults = enhancedClient.batchGetItem(
      *            BatchGetItemEnhancedRequest.builder()
      *                                       .readBatches(ReadBatch.builder(FirstItem.class)
      *                                                             .mappedTableResource(firstItemTable)
@@ -88,10 +90,36 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
      * }
      * </pre>
      *
+     * <p>
+     * The result can be accessed either through iterable {@link BatchGetResultPage}s or flattened results belonging to the
+     * supplied table across all pages.
+     *
+     * <p>
+     * 1) Iterating through pages
+     * <pre>
+     * {@code
+     * batchResults.forEach(page -> {
+     *     page.resultsForTable(firstItemTable).forEach(item -> System.out.println(item));
+     *     page.resultsForTable(secondItemTable).forEach(item -> System.out.println(item));
+     * });
+     * }
+     * </pre>
+     *
+     * <p>
+     * 2) Iterating through results across all pages
+     * <pre>
+     * {@code
+     * results.resultsForTable(firstItemTable).forEach(item -> System.out.println(item));
+     * results.resultsForTable(secondItemTable).forEach(item -> System.out.println(item));
+     * }
+     * </pre>
+     *
      * @param request A {@link BatchGetItemEnhancedRequest} containing keys grouped by tables.
      * @return an iterator of type {@link SdkIterable} with paginated results of type {@link BatchGetResultPage}.
+     * @see #batchGetItem(Consumer)
+     * @see DynamoDbClient#batchGetItemPaginator
      */
-    default SdkIterable<BatchGetResultPage> batchGetItem(BatchGetItemEnhancedRequest request) {
+    default BatchGetResultPageIterable batchGetItem(BatchGetItemEnhancedRequest request) {
         throw new UnsupportedOperationException();
     }
 
@@ -101,17 +129,6 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
      * The operation makes several calls to the database; each time you iterate over the result to retrieve a page,
      * a call is made for the items on that page.
      * <p>
-     * The additional configuration parameters that the enhanced client supports are defined
-     * in the {@link BatchGetItemEnhancedRequest}.
-     * <p>
-     * <b>Partial results</b>. A single call to DynamoDb has restraints on how much data can be retrieved.
-     * If those limits are exceeded, the call yields a partial result. This may also be the case if
-     * provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically
-     * retries any unprocessed keys returned from DynamoDb in subsequent calls for pages.
-     * <p>
-     * This operation calls the low-level DynamoDB API BatchGetItem operation. Consult the BatchGetItem documentation for
-     * further details and constraints as well as current limits of data retrieval.
-     * <p>
      * <b>Note:</b> This is a convenience method that creates an instance of the request builder avoiding the need to create one
      * manually via {@link BatchGetItemEnhancedRequest#builder()}.
      * <p>
@@ -119,7 +136,7 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
      * <pre>
      * {@code
      *
-     * Iterator<BatchGetResultPage> batchResults = enhancedClient.batchGetItem(r -> r.addReadBatches(
+     * BatchGetResultPageIterable batchResults = enhancedClient.batchGetItem(r -> r.addReadBatches(
      *     ReadBatch.builder(FirstItem.class)
      *              .mappedTableResource(firstItemTable)
      *              .addGetItem(i -> i.key(key1))
@@ -134,8 +151,10 @@ public interface DynamoDbEnhancedClient extends DynamoDbEnhancedResource {
      *
      * @param requestConsumer a {@link Consumer} of {@link BatchGetItemEnhancedRequest.Builder} containing keys grouped by tables.
      * @return an iterator of type {@link SdkIterable} with paginated results of type {@link BatchGetResultPage}.
+     * @see #batchGetItem(BatchGetItemEnhancedRequest)
+     * @see DynamoDbClient#batchGetItemPaginator(BatchGetItemRequest)
      */
-    default SdkIterable<BatchGetResultPage> batchGetItem(Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
+    default BatchGetResultPageIterable batchGetItem(Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedAsyncClient.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
@@ -31,7 +30,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.operations.BatchWriteIt
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.TransactGetItemsOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.TransactWriteItemsOperation;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPagePublisher;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
@@ -58,13 +57,13 @@ public final class DefaultDynamoDbEnhancedAsyncClient implements DynamoDbEnhance
     }
 
     @Override
-    public SdkPublisher<BatchGetResultPage> batchGetItem(BatchGetItemEnhancedRequest request) {
+    public BatchGetResultPagePublisher batchGetItem(BatchGetItemEnhancedRequest request) {
         BatchGetItemOperation operation = BatchGetItemOperation.create(request);
-        return operation.executeAsync(dynamoDbClient, extension);
+        return BatchGetResultPagePublisher.create(operation.executeAsync(dynamoDbClient, extension));
     }
 
     @Override
-    public SdkPublisher<BatchGetResultPage> batchGetItem(
+    public BatchGetResultPagePublisher batchGetItem(
         Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
 
         BatchGetItemEnhancedRequest.Builder builder = BatchGetItemEnhancedRequest.builder();

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClient.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbEnhancedClient.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.Document;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
@@ -30,7 +29,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.operations.BatchWriteIt
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.TransactGetItemsOperation;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.TransactWriteItemsOperation;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRequest;
@@ -57,13 +56,13 @@ public final class DefaultDynamoDbEnhancedClient implements DynamoDbEnhancedClie
     }
 
     @Override
-    public SdkIterable<BatchGetResultPage> batchGetItem(BatchGetItemEnhancedRequest request) {
+    public BatchGetResultPageIterable batchGetItem(BatchGetItemEnhancedRequest request) {
         BatchGetItemOperation operation = BatchGetItemOperation.create(request);
-        return operation.execute(dynamoDbClient, extension);
+        return BatchGetResultPageIterable.create(operation.execute(dynamoDbClient, extension));
     }
 
     @Override
-    public SdkIterable<BatchGetResultPage> batchGetItem(Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
+    public BatchGetResultPageIterable batchGetItem(Consumer<BatchGetItemEnhancedRequest.Builder> requestConsumer) {
         BatchGetItemEnhancedRequest.Builder builder = BatchGetItemEnhancedRequest.builder();
         requestConsumer.accept(builder);
         return batchGetItem(builder.build());

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPage.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPage.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
  * Defines one result page with retrieved items in the result of a batchGetItem() operation, such as
  * {@link DynamoDbEnhancedClient#batchGetItem(BatchGetItemEnhancedRequest)}.
  * <p>
- * Use the {@link #getResultsForTable(MappedTableResource)} method once for each table present in the request
+ * Use the {@link #resultsForTable(MappedTableResource)} method once for each table present in the request
  * to retrieve items from that table in the page.
  */
 @SdkPublicApi
@@ -61,7 +61,7 @@ public final class BatchGetResultPage {
      * @param <T> the type of the table items
      * @return a list of items
      */
-    public <T> List<T> getResultsForTable(MappedTableResource<T> mappedTable) {
+    public <T> List<T> resultsForTable(MappedTableResource<T> mappedTable) {
         List<Map<String, AttributeValue>> results =
             batchGetItemResponse.responses()
                                 .getOrDefault(mappedTable.tableName(), emptyList());

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPageIterable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPageIterable.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.model;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.pagination.sync.PaginatedItemsIterable;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
+
+/**
+ * Defines the result of {@link DynamoDbEnhancedClient#batchGetItem} operation.
+ *
+ * <p>
+ * The result can be accessed either through iterable {@link BatchGetResultPage}s or flattened items
+ * across <b>all</b>  pages via {@link #resultsForTable}
+ *
+ * <p>
+ * Example:
+ * <p>
+ * 1) Iterating through pages
+ *
+ * <pre>
+ * {@code
+ * batchResults.forEach(page -> {
+ *     page.resultsForTable(firstItemTable).forEach(item -> System.out.println(item));
+ *     page.resultsForTable(secondItemTable).forEach(item -> System.out.println(item));
+ * });
+ * }
+ * </pre>
+ *
+ * 2) Iterating through items across all pages
+ *
+ * <pre>
+ * {@code
+ * results.resultsForTable(firstItemTable).forEach(item -> System.out.println(item));
+ * results.resultsForTable(secondItemTable).forEach(item -> System.out.println(item));
+ * }
+ * </pre>
+ */
+@SdkPublicApi
+public interface BatchGetResultPageIterable extends SdkIterable<BatchGetResultPage> {
+
+    static BatchGetResultPageIterable create(SdkIterable<BatchGetResultPage> pageIterable) {
+        return pageIterable::iterator;
+    }
+
+    /**
+     * Retrieve all items belonging to the supplied table across <b>all</b> pages.
+     *
+     * @param mappedTable the table to retrieve items for
+     * @param <T> the type of the table items
+     * @return iterable items
+     */
+    default <T> SdkIterable<T> resultsForTable(MappedTableResource<T> mappedTable) {
+        return PaginatedItemsIterable.<BatchGetResultPage, T>builder()
+            .pagesIterable(this)
+            .itemIteratorFunction(page -> page.resultsForTable(mappedTable).iterator())
+            .build();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPagePublisher.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/BatchGetResultPagePublisher.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.model;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.MappedTableResource;
+
+/**
+ * Defines the result of {@link DynamoDbEnhancedAsyncClient#batchGetItem} operation.
+ *
+ * <p>
+ * You can either subscribe to the {@link BatchGetResultPage}s or flattened items across <b>all</b> pages via
+ * {@link #resultsForTable(MappedTableResource)}.
+ *
+ * Example:
+ * <p>
+ * 1) Subscribing to {@link BatchGetResultPage}s
+ * <pre>
+ * {@code
+ * batchGetResultPagePublisher.subscribe(page -> {
+ *     page.resultsForTable(firstItemTable).forEach(item -> System.out.println(item));
+ *     page.resultsForTable(secondItemTable).forEach(item -> System.out.println(item));
+ * });
+ * }
+ * </pre>
+ *
+ * <p>
+ * 2) Subscribing to results across all pages.
+ * <pre>
+ * {@code
+ * batchGetResultPagePublisher.resultsForTable(firstItemTable).subscribe(item -> System.out.println(item));
+ * batchGetResultPagePublisher.resultsForTable(secondItemTable).subscribe(item -> System.out.println(item));
+ * }
+ * </pre>
+ */
+@SdkPublicApi
+public interface BatchGetResultPagePublisher extends SdkPublisher<BatchGetResultPage> {
+
+    /**
+     * Creates a flattened items publisher with the underlying page publisher.
+     */
+    static BatchGetResultPagePublisher create(SdkPublisher<BatchGetResultPage> publisher) {
+        return publisher::subscribe;
+    }
+
+    /**
+     * Returns a publisher that can be used to request a stream of results belonging to the supplied table across all pages.
+     *
+     * <p>
+     * This method is useful if you are interested in subscribing to the items in all response pages
+     * instead of the top level pages.
+     *
+     * @param mappedTable the table to retrieve items for
+     * @param <T> the type of the table items
+     * @return a {@link SdkPublisher}
+     */
+    default <T> SdkPublisher<T> resultsForTable(MappedTableResource<T> mappedTable) {
+        return this.flatMapIterable(p -> p.resultsForTable(mappedTable));
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BatchGetItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BatchGetItemTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
 
@@ -33,6 +34,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPage;
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchGetResultPageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.ReadBatch;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 
@@ -148,8 +150,90 @@ public class BatchGetItemTest extends LocalDynamoDbSyncTestBase {
     @Test
     public void getRecordsFromMultipleTables() {
         insertRecords();
+        SdkIterable<BatchGetResultPage> results = getBatchGetResultPagesForBothTables();
+        assertThat(results.stream().count(), is(1L));
 
-        SdkIterable<BatchGetResultPage> results = enhancedClient.batchGetItem(r -> r.readBatches(
+        results.iterator().forEachRemaining((page) -> {
+            List<Record1> table1Results = page.resultsForTable(mappedTable1);
+            assertThat(table1Results.size(), is(2));
+            assertThat(table1Results.get(0).id, is(0));
+            assertThat(table1Results.get(1).id, is(1));
+            assertThat(page.resultsForTable(mappedTable2).size(), is(2));
+        });
+    }
+
+    @Test
+    public void getRecordsFromMultipleTables_viaFlattenedItems() {
+        insertRecords();
+
+        BatchGetResultPageIterable results = getBatchGetResultPagesForBothTables();
+
+        SdkIterable<Record1> recordsList1 = results.resultsForTable(mappedTable1);
+        assertThat(recordsList1, containsInAnyOrder(RECORDS_1.toArray()));
+
+        SdkIterable<Record2> recordsList2 = results.resultsForTable(mappedTable2);
+        assertThat(recordsList2, containsInAnyOrder(RECORDS_2.toArray()));
+    }
+
+    @Test
+    public void notFoundRecordIgnored() {
+        insertRecords();
+
+        BatchGetItemEnhancedRequest batchGetItemEnhancedRequest = batchGetItemEnhancedRequestWithNotFoundRecord();
+
+        SdkIterable<BatchGetResultPage> results = enhancedClient.batchGetItem(batchGetItemEnhancedRequest);
+
+        assertThat(results.stream().count(), is(1L));
+
+        results.iterator().forEachRemaining((page) -> {
+            List<Record1> mappedTable1Results = page.resultsForTable(mappedTable1);
+            assertThat(mappedTable1Results.size(), is(1));
+            assertThat(mappedTable1Results.get(0).id, is(0));
+            assertThat(page.resultsForTable(mappedTable2).size(), is(2));
+        });
+    }
+
+    @Test
+    public void notFoundRecordIgnored_viaFlattenedItems() {
+        insertRecords();
+
+        BatchGetItemEnhancedRequest batchGetItemEnhancedRequest = batchGetItemEnhancedRequestWithNotFoundRecord();
+
+        BatchGetResultPageIterable pageIterable = enhancedClient.batchGetItem(batchGetItemEnhancedRequest);
+
+        assertThat(pageIterable.stream().count(), is(1L));
+
+        List<Record1> recordsList1 = pageIterable.resultsForTable(mappedTable1).stream().collect(Collectors.toList());
+        assertThat(recordsList1, is(RECORDS_1.subList(0, 1)));
+
+        SdkIterable<Record2> recordsList2 = pageIterable.resultsForTable(mappedTable2);
+        assertThat(recordsList2, containsInAnyOrder(RECORDS_2.toArray()));
+    }
+
+    private BatchGetItemEnhancedRequest batchGetItemEnhancedRequestWithNotFoundRecord() {
+        return BatchGetItemEnhancedRequest.builder()
+                                          .readBatches(
+                                              ReadBatch.builder(Record1.class)
+                                                       .mappedTableResource(mappedTable1)
+                                                       .addGetItem(r -> r.key(k -> k.partitionValue(0)))
+                                                       .build(),
+                                              ReadBatch.builder(Record2.class)
+                                                       .mappedTableResource(mappedTable2)
+                                                       .addGetItem(r -> r.key(k -> k.partitionValue(0)))
+                                                       .build(),
+                                              ReadBatch.builder(Record2.class)
+                                                       .mappedTableResource(mappedTable2)
+                                                       .addGetItem(r -> r.key(k -> k.partitionValue(1)))
+                                                       .build(),
+                                              ReadBatch.builder(Record1.class)
+                                                       .mappedTableResource(mappedTable1)
+                                                       .addGetItem(r -> r.key(k -> k.partitionValue(5)))
+                                                       .build())
+                                          .build();
+    }
+
+    private BatchGetResultPageIterable getBatchGetResultPagesForBothTables() {
+        return enhancedClient.batchGetItem(r -> r.readBatches(
             ReadBatch.builder(Record1.class)
                      .mappedTableResource(mappedTable1)
                      .addGetItem(i -> i.key(k -> k.partitionValue(0)))
@@ -166,53 +250,6 @@ public class BatchGetItemTest extends LocalDynamoDbSyncTestBase {
                      .mappedTableResource(mappedTable1)
                      .addGetItem(i -> i.key(k -> k.partitionValue(1)))
                      .build()));
-
-        assertThat(results.stream().count(), is(1L));
-
-        results.iterator().forEachRemaining((page) -> {
-            List<Record1> table1Results = page.getResultsForTable(mappedTable1);
-            assertThat(table1Results.size(), is(2));
-            assertThat(table1Results.get(0).id, is(0));
-            assertThat(table1Results.get(1).id, is(1));
-            assertThat(page.getResultsForTable(mappedTable2).size(), is(2));
-        });
-    }
-
-    @Test
-    public void notFoundRecordIgnored() {
-        insertRecords();
-
-        BatchGetItemEnhancedRequest batchGetItemEnhancedRequest =
-            BatchGetItemEnhancedRequest.builder()
-                                       .readBatches(
-                                           ReadBatch.builder(Record1.class)
-                                                    .mappedTableResource(mappedTable1)
-                                                    .addGetItem(r -> r.key(k -> k.partitionValue(0)))
-                                                    .build(),
-                                           ReadBatch.builder(Record2.class)
-                                                    .mappedTableResource(mappedTable2)
-                                                    .addGetItem(r -> r.key(k -> k.partitionValue(0)))
-                                                    .build(),
-                                           ReadBatch.builder(Record2.class)
-                                                    .mappedTableResource(mappedTable2)
-                                                    .addGetItem(r -> r.key(k -> k.partitionValue(1)))
-                                                    .build(),
-                                           ReadBatch.builder(Record1.class)
-                                                    .mappedTableResource(mappedTable1)
-                                                    .addGetItem(r -> r.key(k -> k.partitionValue(5)))
-                                                    .build())
-                                       .build();
-
-        SdkIterable<BatchGetResultPage> results = enhancedClient.batchGetItem(batchGetItemEnhancedRequest);
-
-        assertThat(results.stream().count(), is(1L));
-
-        results.iterator().forEachRemaining((page) -> {
-            List<Record1> mappedTable1Results = page.getResultsForTable(mappedTable1);
-            assertThat(mappedTable1Results.size(), is(1));
-            assertThat(mappedTable1Results.get(0).id, is(0));
-            assertThat(page.getResultsForTable(mappedTable2).size(), is(2));
-        });
     }
 }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/LocalDynamoDbAsyncTestBase.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/LocalDynamoDbAsyncTestBase.java
@@ -30,7 +30,7 @@ public class LocalDynamoDbAsyncTestBase extends LocalDynamoDbTestBase {
         return dynamoDbAsyncClient;
     }
 
-    protected static <T> List<T> drainPublisher(SdkPublisher<T> publisher, int expectedNumberOfResults) {
+    public static <T> List<T> drainPublisher(SdkPublisher<T> publisher, int expectedNumberOfResults) {
         BufferingSubscriber<T> subscriber = new BufferingSubscriber<>();
         publisher.subscribe(subscriber);
         subscriber.waitForCompletion(1000L);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/BatchGetItemOperationTest.java
@@ -288,9 +288,9 @@ public class BatchGetItemOperationTest {
 
         BatchGetResultPage resultsPage = operation.transformResponse(fakeResults, null);
 
-        List<FakeItem> fakeItemResultsPage = resultsPage.getResultsForTable(fakeItemMappedTable);
+        List<FakeItem> fakeItemResultsPage = resultsPage.resultsForTable(fakeItemMappedTable);
         List<FakeItemWithSort> fakeItemWithSortResultsPage =
-            resultsPage.getResultsForTable(fakeItemWithSortMappedTable);
+            resultsPage.resultsForTable(fakeItemWithSortMappedTable);
 
         assertThat(fakeItemResultsPage, containsInAnyOrder(FAKE_ITEMS.get(0), FAKE_ITEMS.get(1)));
         assertThat(fakeItemWithSortResultsPage, containsInAnyOrder(FAKESORT_ITEMS.get(0)));
@@ -323,9 +323,9 @@ public class BatchGetItemOperationTest {
 
         BatchGetResultPage resultsPage = operation.transformResponse(fakeResults, mockExtension);
 
-        List<FakeItem> fakeItemResultsPage = resultsPage.getResultsForTable(fakeItemMappedTable);
+        List<FakeItem> fakeItemResultsPage = resultsPage.resultsForTable(fakeItemMappedTable);
         List<FakeItemWithSort> fakeItemWithSortResultsPage =
-            resultsPage.getResultsForTable(fakeItemWithSortMappedTable);
+            resultsPage.resultsForTable(fakeItemWithSortMappedTable);
 
 
         assertThat(fakeItemResultsPage, containsInAnyOrder(FAKE_ITEMS.get(3), FAKE_ITEMS.get(4)));
@@ -339,7 +339,7 @@ public class BatchGetItemOperationTest {
 
         BatchGetResultPage resultsPage = operation.transformResponse(fakeResults, null);
 
-        assertThat(resultsPage.getResultsForTable(fakeItemMappedTable), is(emptyList()));
+        assertThat(resultsPage.resultsForTable(fakeItemMappedTable), is(emptyList()));
     }
 
     private static BatchGetItemEnhancedRequest emptyRequest() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- sync batchGetItem returns`BatchGetItemPageIterable` that allows customers to iterate through flattened results via `BatchGetItemIterable#resultsForTable`

- async batchGetItem returns `BatchGetItemPagePublisher` that allows customers to subscribe to flattened results via `BatchGetItemPagePublisher#resultsForTable`

- renamed `getResutlsForTable` -> `resultsForTable`

~~- add `unprocessedKeys` in `BatchGetItemPage` so that it's consistent with `Page`~~

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
