### PR TITLE
Remove LimitExceededException as throttling error

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-fbcd9ee.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-fbcd9ee.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Remove the `LimitExceededException` as a throttling error as it seems many services don't treat it as a throttling error."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsErrorCode.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsErrorCode.java
@@ -44,7 +44,6 @@ public final class AwsErrorCode {
         throttlingErrorCodes.add("BandwidthLimitExceeded");
         throttlingErrorCodes.add("RequestThrottled");
         throttlingErrorCodes.add("RequestThrottledException");
-        throttlingErrorCodes.add("LimitExceededException");
         throttlingErrorCodes.add("EC2ThrottledException");
         THROTTLING_ERROR_CODES = unmodifiableSet(throttlingErrorCodes);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
