### PR TITLE
DDB Enhanced adding ChainConverterProvider

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/AttributeConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/AttributeConverterProvider.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.enhanced.dynamodb;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.enhanced.dynamodb.internal.DefaultAttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.ConverterProviderResolver;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -40,6 +40,6 @@ public interface AttributeConverterProvider {
      * standard Java type converters included.
      */
     static AttributeConverterProvider defaultProvider() {
-        return DefaultAttributeConverterProvider.create();
+        return ConverterProviderResolver.defaultConverterProvider();
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProvider.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.enhanced.dynamodb.internal;
+package software.amazon.awssdk.enhanced.dynamodb;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,11 +22,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import software.amazon.awssdk.annotations.Immutable;
-import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
-import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
-import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
-import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.PrimitiveConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverterProvider;
@@ -76,11 +73,15 @@ import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
 /**
+ * This class is the default attribute converter provider in the DDB Enhanced library. When instantiated
+ * using the constructor {@link #DefaultAttributeConverterProvider()} or the {@link #create()} method, it's loaded
+ * with the currently supported attribute converters in the library.
  * <p>
- * Given an input, this will identify a converter that can convert the specific Java type and invoke it. If a converter cannot
- * be found, it will invoke a "parent" converter, which would be expected to be able to convert the value (or throw an exception).
+ * Given an input, the method {@link #converterFor(EnhancedType)} will identify a converter that can convert the
+ * specific Java type and invoke it. If a converter cannot be found, it will invoke a "parent" converter,
+ * which would be expected to be able to convert the value (or throw an exception).
  */
-@SdkInternalApi
+@SdkPublicApi
 @ThreadSafe
 @Immutable
 public final class DefaultAttributeConverterProvider implements AttributeConverterProvider {
@@ -101,6 +102,21 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
             }
         }
     }
+
+    /**
+     * Returns an attribute converter provider with all default converters set.
+     */
+    public DefaultAttributeConverterProvider() {
+        this(getDefaultBuilder());
+    }
+
+    /**
+     * Returns an attribute converter provider with all default converters set.
+     */
+    public static DefaultAttributeConverterProvider create() {
+        return getDefaultBuilder().build();
+    }
+
 
     /**
      * Equivalent to {@code builder(EnhancedType.of(Object.class))}.
@@ -179,7 +195,7 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
         return (AttributeConverter<T>) SetAttributeConverter.setConverter(innerConverter);
     }
 
-    public static DefaultAttributeConverterProvider create() {
+    private static Builder getDefaultBuilder() {
         return DefaultAttributeConverterProvider.builder()
                                                 .addConverter(AtomicBooleanAttributeConverter.create())
                                                 .addConverter(AtomicIntegerAttributeConverter.create())
@@ -217,8 +233,7 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
                                                 .addConverter(UuidAttributeConverter.create())
                                                 .addConverter(ZonedDateTimeAsStringAttributeConverter.create())
                                                 .addConverter(ZoneIdAttributeConverter.create())
-                                                .addConverter(ZoneOffsetAttributeConverter.create())
-                                                .build();
+                                                .addConverter(ZoneOffsetAttributeConverter.create());
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ChainConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ChainConverterProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+
+/**
+ * A {@link AttributeConverterProvider} that allows multiple providers to be chained in a specified order
+ * to act as a single composite provider. When searching for an attribute converter for a type,
+ * the providers will be called in forward/ascending order, attempting to find a converter from the
+ * first provider, then the second, and so on, until a match is found or the operation fails.
+ */
+@SdkInternalApi
+public final class ChainConverterProvider implements AttributeConverterProvider {
+    private final List<AttributeConverterProvider> providerChain;
+
+    private ChainConverterProvider(List<AttributeConverterProvider> providers) {
+        this.providerChain = new ArrayList<>(providers);
+    }
+
+    /**
+     * Construct a new instance of {@link ChainConverterProvider}.
+     * @param providers A list of {@link AttributeConverterProvider} to chain together.
+     * @return A constructed {@link ChainConverterProvider} object.
+     */
+    public static ChainConverterProvider create(AttributeConverterProvider... providers) {
+        return new ChainConverterProvider(Arrays.asList(providers));
+    }
+
+    /**
+     * Construct a new instance of {@link ChainConverterProvider}.
+     * @param providers A list of {@link AttributeConverterProvider} to chain together.
+     * @return A constructed {@link ChainConverterProvider} object.
+     */
+    public static ChainConverterProvider create(List<AttributeConverterProvider> providers) {
+        return new ChainConverterProvider(providers);
+    }
+
+    public List<AttributeConverterProvider> chainedProviders() {
+        return Collections.unmodifiableList(this.providerChain);
+    }
+
+    @Override
+    public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+        return this.providerChain.stream()
+                .filter(provider -> provider.converterFor(enhancedType) != null)
+                .map(p -> p.converterFor(enhancedType))
+                .findFirst().orElse(null);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterProviderResolver.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterProviderResolver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import java.util.List;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DefaultAttributeConverterProvider;
+
+/**
+ * Static module to assist with the initialization of attribute converter providers for a StaticTableSchema.
+ */
+@SdkInternalApi
+public final class ConverterProviderResolver {
+
+    private static final AttributeConverterProvider DEFAULT_ATTRIBUTE_CONVERTER =
+        DefaultAttributeConverterProvider.create();
+
+    private ConverterProviderResolver() {
+    }
+
+    /**
+     * Static provider for the default attribute converters that are bundled with the DynamoDB Enhanced Client.
+     * This provider will be used by default unless overridden in the static table schema builder or using bean
+     * annotations.
+     */
+    public static AttributeConverterProvider defaultConverterProvider() {
+        return DEFAULT_ATTRIBUTE_CONVERTER;
+    }
+
+    /**
+     * Resolves a list of attribute converter providers into a single provider. If the list is a singleton,
+     * it will just return that provider, otherwise it will combine them into a
+     * {@link ChainConverterProvider} using the order provided in the list.
+     *
+     * @param providers A list of providers to be combined in strict order
+     * @return A single provider that combines all the supplied providers or null if no providers were supplied
+     */
+    public static AttributeConverterProvider resolveProviders(List<AttributeConverterProvider> providers) {
+        if (providers == null || providers.isEmpty()) {
+            return null;
+        }
+
+        if (providers.size() == 1) {
+            return providers.get(0);
+        }
+
+        return ChainConverterProvider.create(providers);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbBean.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/annotations/DynamoDbBean.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Target;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DefaultAttributeConverterProvider;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
 
 /**
@@ -29,15 +30,30 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
  * a {@link BeanTableSchema} must have this annotation. If a class is used as a document within another DynamoDbBean,
  * it will also require this annotation.
  * <p>
+ * <b>Attribute Converter Providers</b><br>
  * Using {@link AttributeConverterProvider}s is optional and, if used, the supplied provider supersedes the default
- * converter provided by the table schema. The converter must provide {@link AttributeConverter}s for all types used
- * in the schema. The table schema default AttributeConverterProvider provides standard converters for most primitive
- * and common Java types. Use custom AttributeConverterProviders when you have specific needs for type conversion
- * that the defaults do not cover.
+ * converter provided by the table schema.
+ * <p>
+ * Note:
+ * <ul>
+ *     <li>The converter(s) must provide {@link AttributeConverter}s for all types used in the schema. </li>
+ *     <li>The table schema DefaultAttributeConverterProvider provides standard converters for most primitive
+ *     and common Java types. Use custom AttributeConverterProviders when you have specific needs for type conversion
+ *     that the defaults do not cover.</li>
+ *     <li>If you provide a list of attribute converter providers, you can add DefaultAttributeConverterProvider
+ *     to the end of the list to fall back on the defaults.</li>
+ *     <li>Providing an empty list {} will cause no providers to get loaded.</li>
+ * </ul>
+ *
+ * Example using attribute converter providers with one custom provider and the default provider:
+ * {@code
+ * (converterProviders = {CustomAttributeConverter.class, DefaultAttributeConverterProvider.class});
+ * }
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @SdkPublicApi
 public @interface DynamoDbBean {
-    Class<? extends AttributeConverterProvider>[] converterProviders() default {};
+    Class<? extends AttributeConverterProvider>[] converterProviders()
+            default { DefaultAttributeConverterProvider.class };
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ChainConverterProviderTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ChainConverterProviderTest.java
@@ -1,0 +1,75 @@
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChainConverterProviderTest {
+
+    @Mock
+    private AttributeConverterProvider mockConverterProvider1;
+
+    @Mock
+    private AttributeConverterProvider mockConverterProvider2;
+
+    @Mock
+    private AttributeConverter mockAttributeConverter1;
+
+    @Mock
+    private AttributeConverter mockAttributeConverter2;
+
+    @Test
+    public void checkSingleProviderChain() {
+        ChainConverterProvider chain = ChainConverterProvider.create(mockConverterProvider1);
+        List providerQueue = chain.chainedProviders();
+        assertThat(providerQueue.size()).isEqualTo(1);
+        assertThat(providerQueue.get(0)).isEqualTo(mockConverterProvider1);
+    }
+
+    @Test
+    public void checkMultipleProviderChain() {
+        ChainConverterProvider chain = ChainConverterProvider.create(mockConverterProvider1, mockConverterProvider2);
+        List providerQueue = chain.chainedProviders();
+        assertThat(providerQueue.size()).isEqualTo(2);
+        assertThat(providerQueue.get(0)).isEqualTo(mockConverterProvider1);
+        assertThat(providerQueue.get(1)).isEqualTo(mockConverterProvider2);
+    }
+
+    @Test
+    public void resolveSingleProviderChain() {
+        when(mockConverterProvider1.converterFor(any())).thenReturn(mockAttributeConverter1);
+        ChainConverterProvider chain = ChainConverterProvider.create(mockConverterProvider1);
+        assertThat(chain.converterFor(EnhancedType.of(String.class))).isSameAs(mockAttributeConverter1);
+    }
+
+    @Test
+    public void resolveMultipleProviderChain_noMatch() {
+        ChainConverterProvider chain = ChainConverterProvider.create(mockConverterProvider1, mockConverterProvider2);
+        assertThat(chain.converterFor(EnhancedType.of(String.class))).isNull();
+    }
+
+    @Test
+    public void resolveMultipleProviderChain_matchSecond() {
+        when(mockConverterProvider2.converterFor(any())).thenReturn(mockAttributeConverter2);
+        ChainConverterProvider chain = ChainConverterProvider.create(mockConverterProvider1, mockConverterProvider2);
+        assertThat(chain.converterFor(EnhancedType.of(String.class))).isSameAs(mockAttributeConverter2);
+    }
+
+    @Test
+    public void resolveMultipleProviderChain_matchFirst() {
+        when(mockConverterProvider1.converterFor(any())).thenReturn(mockAttributeConverter1);
+        ChainConverterProvider chain = ChainConverterProvider.create(mockConverterProvider1, mockConverterProvider2);
+        assertThat(chain.converterFor(EnhancedType.of(String.class))).isSameAs(mockAttributeConverter1);
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterProviderResolverTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterProviderResolverTest.java
@@ -1,0 +1,55 @@
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DefaultAttributeConverterProvider;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConverterProviderResolverTest {
+
+    @Mock
+    private AttributeConverterProvider mockConverterProvider1;
+
+    @Mock
+    private AttributeConverterProvider mockConverterProvider2;
+
+    @Test
+    public void resolveProviders_null() {
+        assertThat(ConverterProviderResolver.resolveProviders(null)).isNull();
+    }
+
+    @Test
+    public void resolveProviders_empty() {
+        assertThat(ConverterProviderResolver.resolveProviders(emptyList())).isNull();
+    }
+
+    @Test
+    public void resolveProviders_singleton() {
+        assertThat(ConverterProviderResolver.resolveProviders(singletonList(mockConverterProvider1)))
+            .isSameAs(mockConverterProvider1);
+    }
+
+    @Test
+    public void resolveProviders_multiple() {
+        AttributeConverterProvider result = ConverterProviderResolver.resolveProviders(
+            Arrays.asList(mockConverterProvider1, mockConverterProvider2));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(ChainConverterProvider.class);
+    }
+
+    @Test
+    public void defaultProvider_returnsInstance() {
+        AttributeConverterProvider defaultProvider = ConverterProviderResolver.defaultConverterProvider();
+        assertThat(defaultProvider).isNotNull();
+        assertThat(defaultProvider).isInstanceOf(DefaultAttributeConverterProvider.class);
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchemaTest.java
@@ -44,9 +44,9 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.AbstractBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.AttributeConverterBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.AttributeConverterNoConstructorBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.CommonTypesBean;
-import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.ConverterBean;
-import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.ConverterNoConstructorBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.DocumentBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.EmptyConverterProvidersInvalidBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.EmptyConverterProvidersValidBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.EnumBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.ExtendedBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.FlattenedBean;
@@ -54,6 +54,8 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.IgnoredAttribut
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.InvalidBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.ListBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.MapBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.MultipleConverterProvidersBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.NoConstructorConverterProvidersBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.ParameterizedAbstractBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.ParameterizedDocumentBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.PrimitiveTypesBean;
@@ -62,6 +64,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SecondaryIndexB
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SetBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SetterAnnotatedBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SimpleBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SingleConverterProvidersBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans.SortKeyBean;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -866,29 +869,10 @@ public class BeanTableSchemaTest {
     }
 
     @Test
-    public void usesCustomAttributeConverterProvider() {
-        BeanTableSchema<ConverterBean> beanTableSchema = BeanTableSchema.create(ConverterBean.class);
-
-        ConverterBean converterBean = new ConverterBean();
-        converterBean.setId("id-value");
-        converterBean.setIntegerAttribute(123);
-
-        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(converterBean, false);
-
-        assertThat(itemMap.size(), is(2));
-        assertThat(itemMap, hasEntry("id", stringValue("id-value-custom")));
-        assertThat(itemMap, hasEntry("integerAttribute", numberValue(133)));
-
-        ConverterBean reverse = beanTableSchema.mapToItem(itemMap);
-        assertThat(reverse.getId(), is(equalTo("id-value-custom")));
-        assertThat(reverse.getIntegerAttribute(), is(equalTo(133)));
-    }
-
-    @Test
-    public void converterProviderWithoutConstructor_throwsIllegalArgumentException() {
+    public void attributeConverterWithoutConstructor_throwsIllegalArgumentException() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("default constructor");
-        BeanTableSchema.create(ConverterNoConstructorBean.class);
+        BeanTableSchema.create(AttributeConverterNoConstructorBean.class);
     }
 
     @Test
@@ -915,9 +899,74 @@ public class BeanTableSchemaTest {
     }
 
     @Test
-    public void attributeConverterWithoutConstructor_throwsIllegalArgumentException() {
+    public void converterProviderWithoutConstructor_throwsIllegalArgumentException() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("default constructor");
-        BeanTableSchema.create(AttributeConverterNoConstructorBean.class);
+        BeanTableSchema.create(NoConstructorConverterProvidersBean.class);
+    }
+
+    @Test
+    public void usesCustomAttributeConverterProvider() {
+        BeanTableSchema<SingleConverterProvidersBean> beanTableSchema = BeanTableSchema.create(SingleConverterProvidersBean.class);
+
+        SingleConverterProvidersBean converterBean = new SingleConverterProvidersBean();
+        converterBean.setId("id-value");
+        converterBean.setIntegerAttribute(123);
+
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(converterBean, false);
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("id-value-custom")));
+        assertThat(itemMap, hasEntry("integerAttribute", numberValue(133)));
+
+        SingleConverterProvidersBean reverse = beanTableSchema.mapToItem(itemMap);
+        assertThat(reverse.getId(), is(equalTo("id-value-custom")));
+        assertThat(reverse.getIntegerAttribute(), is(equalTo(133)));
+    }
+
+    @Test
+    public void usesCustomAttributeConverterProviders() {
+        BeanTableSchema<MultipleConverterProvidersBean> beanTableSchema =
+                BeanTableSchema.create(MultipleConverterProvidersBean.class);
+
+        MultipleConverterProvidersBean converterBean = new MultipleConverterProvidersBean();
+        converterBean.setId("id-value");
+        converterBean.setIntegerAttribute(123);
+
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(converterBean, false);
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("id-value-custom")));
+        assertThat(itemMap, hasEntry("integerAttribute", numberValue(133)));
+
+        MultipleConverterProvidersBean reverse = beanTableSchema.mapToItem(itemMap);
+        assertThat(reverse.getId(), is(equalTo("id-value-custom")));
+        assertThat(reverse.getIntegerAttribute(), is(equalTo(133)));
+    }
+
+    @Test
+    public void emptyConverterProviderList_fails_whenAttributeConvertersAreMissing() {
+        exception.expect(NullPointerException.class);
+        BeanTableSchema.create(EmptyConverterProvidersInvalidBean.class);
+    }
+
+    @Test
+    public void emptyConverterProviderList_correct_whenAttributeConvertersAreSupplied() {
+        BeanTableSchema<EmptyConverterProvidersValidBean> beanTableSchema =
+                BeanTableSchema.create(EmptyConverterProvidersValidBean.class);
+
+        EmptyConverterProvidersValidBean converterBean = new EmptyConverterProvidersValidBean();
+        converterBean.setId("id-value");
+        converterBean.setIntegerAttribute(123);
+
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(converterBean, false);
+
+        assertThat(itemMap.size(), is(2));
+        assertThat(itemMap, hasEntry("id", stringValue("id-value-custom")));
+        assertThat(itemMap, hasEntry("integerAttribute", numberValue(133)));
+
+        EmptyConverterProvidersValidBean reverse = beanTableSchema.mapToItem(itemMap);
+        assertThat(reverse.getId(), is(equalTo("id-value-custom")));
+        assertThat(reverse.getIntegerAttribute(), is(equalTo(133)));
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/EmptyConverterProvidersInvalidBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/EmptyConverterProvidersInvalidBean.java
@@ -25,11 +25,13 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConve
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-@DynamoDbBean
-public class AttributeConverterBean {
+@DynamoDbBean(converterProviders = {})
+public class EmptyConverterProvidersInvalidBean {
     private String id;
+    private Integer integerAttribute;
 
     @DynamoDbPartitionKey
+    @DynamoDbConvertedBy(CustomStringAttributeConverter.class)
     public String getId() {
         return this.id;
     }
@@ -37,17 +39,6 @@ public class AttributeConverterBean {
         this.id = id;
     }
 
-    private AttributeItem attributeItem;
-
-    @DynamoDbConvertedBy(CustomAttributeConverter.class)
-    public AttributeItem getAttributeItem() {
-        return attributeItem;
-    }
-    public void setAttributeItem(AttributeItem attributeItem) {
-        this.attributeItem = attributeItem;
-    }
-
-    private Integer integerAttribute;
     public Integer getIntegerAttribute() {
         return integerAttribute;
     }
@@ -59,35 +50,35 @@ public class AttributeConverterBean {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        AttributeConverterBean that = (AttributeConverterBean) o;
+        EmptyConverterProvidersInvalidBean that = (EmptyConverterProvidersInvalidBean) o;
         return Objects.equals(id, that.id) &&
-                Objects.equals(integerAttribute, that.integerAttribute) &&
-                Objects.equals(attributeItem, that.attributeItem);
+            Objects.equals(integerAttribute, that.integerAttribute);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, integerAttribute, attributeItem);
+        return Objects.hash(id, integerAttribute);
     }
 
-    public static class CustomAttributeConverter implements AttributeConverter<AttributeItem> {
+    public static class CustomStringAttributeConverter implements AttributeConverter<String> {
+        final static String DEFAULT_SUFFIX = "-custom";
 
-        public CustomAttributeConverter() {
+        public CustomStringAttributeConverter() {
         }
 
         @Override
-        public AttributeValue transformFrom(AttributeItem input) {
-            return EnhancedAttributeValue.fromString(input.getInnerValue()).toAttributeValue();
+        public AttributeValue transformFrom(String input) {
+            return EnhancedAttributeValue.fromString(input + DEFAULT_SUFFIX).toAttributeValue();
         }
 
         @Override
-        public AttributeItem transformTo(AttributeValue input) {
-            return new AttributeItem(input.s());
+        public String transformTo(AttributeValue input) {
+            return input.s();
         }
 
         @Override
-        public EnhancedType<AttributeItem> type() {
-            return EnhancedType.of(AttributeItem.class);
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
         }
 
         @Override
@@ -96,35 +87,4 @@ public class AttributeConverterBean {
         }
     }
 
-    public static class AttributeItem {
-        private String innerValue;
-
-        public AttributeItem() {
-        }
-
-        AttributeItem(String value) {
-            innerValue = value;
-        }
-
-        public String getInnerValue() {
-            return innerValue;
-        }
-
-        public void setInnerValue(String innerValue) {
-            this.innerValue = innerValue;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            AttributeItem that = (AttributeItem) o;
-            return Objects.equals(innerValue, that.innerValue);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(innerValue);
-        }
-    }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/MultipleConverterProvidersBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/MultipleConverterProvidersBean.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
+
+import java.util.Map;
+import java.util.Objects;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.IntegerStringConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@DynamoDbBean(converterProviders = {
+        MultipleConverterProvidersBean.FirstAttributeConverterProvider.class,
+        MultipleConverterProvidersBean.SecondAttributeConverterProvider.class})
+public class MultipleConverterProvidersBean {
+    private String id;
+    private Integer integerAttribute;
+
+    @DynamoDbPartitionKey
+    public String getId() {
+        return this.id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getIntegerAttribute() {
+        return integerAttribute;
+    }
+    public void setIntegerAttribute(Integer integerAttribute) {
+        this.integerAttribute = integerAttribute;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MultipleConverterProvidersBean that = (MultipleConverterProvidersBean) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(integerAttribute, that.integerAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, integerAttribute);
+    }
+
+    public static class FirstAttributeConverterProvider implements AttributeConverterProvider {
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            return null;
+        }
+    }
+
+    public static class SecondAttributeConverterProvider implements AttributeConverterProvider {
+
+        private final Map<EnhancedType<?>, AttributeConverter<?>> converterCache = ImmutableMap.of(
+                EnhancedType.of(String.class), new CustomStringAttributeConverter(),
+                EnhancedType.of(Integer.class), new CustomIntegerAttributeConverter()
+        );
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            return (AttributeConverter<T>) converterCache.get(enhancedType);
+        }
+    }
+
+    private static class CustomStringAttributeConverter implements AttributeConverter<String> {
+
+        final static String DEFAULT_SUFFIX = "-custom";
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return EnhancedAttributeValue.fromString(input + DEFAULT_SUFFIX).toAttributeValue();
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            return input.s();
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    private static class CustomIntegerAttributeConverter implements AttributeConverter<Integer> {
+
+        final static Integer DEFAULT_INCREMENT = 10;
+
+        @Override
+        public AttributeValue transformFrom(Integer input) {
+            return EnhancedAttributeValue.fromNumber(IntegerStringConverter.create().toString(input + DEFAULT_INCREMENT))
+                                         .toAttributeValue();
+        }
+
+        @Override
+        public Integer transformTo(AttributeValue input) {
+            return Integer.valueOf(input.n());
+        }
+
+        @Override
+        public EnhancedType<Integer> type() {
+            return EnhancedType.of(Integer.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.N;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/NoConstructorConverterProvidersBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/NoConstructorConverterProvidersBean.java
@@ -20,8 +20,8 @@ import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 
-@DynamoDbBean(converterProviders = ConverterNoConstructorBean.CustomAttributeConverterProvider.class)
-public class ConverterNoConstructorBean extends AbstractBean {
+@DynamoDbBean(converterProviders = NoConstructorConverterProvidersBean.CustomAttributeConverterProvider.class)
+public class NoConstructorConverterProvidersBean extends AbstractBean {
 
     public static class CustomAttributeConverterProvider implements AttributeConverterProvider {
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/SingleConverterProvidersBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/SingleConverterProvidersBean.java
@@ -28,8 +28,8 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.ImmutableMap;
 
-@DynamoDbBean(converterProviders = ConverterBean.CustomAttributeConverterProvider.class)
-public class ConverterBean {
+@DynamoDbBean(converterProviders = SingleConverterProvidersBean.CustomAttributeConverterProvider.class)
+public class SingleConverterProvidersBean {
     private String id;
     private Integer integerAttribute;
 
@@ -52,7 +52,7 @@ public class ConverterBean {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ConverterBean that = (ConverterBean) o;
+        SingleConverterProvidersBean that = (SingleConverterProvidersBean) o;
         return Objects.equals(id, that.id) &&
             Objects.equals(integerAttribute, that.integerAttribute);
     }


### PR DESCRIPTION
## Description
- Adds a 'chained' `AttributeConverterProvider` that can hold any number of user-supplied AttributeConverterProviders and will match converters using strict precedence, first-come-first-served. 
- It's also possible to supply an empty list to completely override the default AttributeConverterProvider provided by the library, in which case the user must add an `AttributeConverter` for each attribute in the schema
- Both features available for `StaticTableSchema` and for `DynamoDbBeans` (`BeanTableSchema`). 

For reference: [Issue 35](https://github.com/aws/aws-sdk-java-v2/issues/35)

Note: README updated separately in [PR 1731](https://github.com/aws/aws-sdk-java-v2/pull/1731).

## Motivation and Context
* Consistent behavior over both bean and static table schema
* User-friendly syntax for bean

## Testing
Unit tested

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

