### PR TITLE
Fixed the endTime not modified bug to pass sonar cloud tests.

### DIFF
--- a/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/meter/DefaultTimer.java
+++ b/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/meter/DefaultTimer.java
@@ -51,7 +51,7 @@ public final class DefaultTimer implements Timer {
             throw new IllegalArgumentException("Duration cannot be negative");
         }
 
-        this.endTime.plusNanos(TimeUnit.NANOSECONDS.convert(duration, timeUnit));
+        this.endTime = this.endTime.plusNanos(TimeUnit.NANOSECONDS.convert(duration, timeUnit));
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the bug of endTime not modified by plusNanos() by reassigning the modified result to itself;
Added corresponding test to test if the change works;
Modified the stub of mockClock.instant() to make it pass all the tests.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The reason why stubbing mockClock.instant() is moved ahead of creating timer is that while creating the timer there are two calls of mockClock.instant(). In original version, these two calls were ignored so the startTime and endTime were null and the new added test will fail to this. After changing the position of the stubbing and adding two more values to the stub, all the tests are able to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
