### PR TITLE
Ensure bean-style setter method names match getter method names for modeled structures.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-97280b7.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-97280b7.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Fixed bean-style setter names on serializable builders to match bean-style getter names."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -299,14 +299,20 @@ public class DefaultNamingStrategy implements NamingStrategy {
 
     @Override
     public String getBeanStyleGetterMethodName(String memberName, Shape parentShape, Shape c2jShape) {
-        String fluentGetterMethodName = getFluentGetterMethodName(memberName, parentShape, c2jShape);
+        String fluentGetterMethodName;
+        if (Utils.isOrContainsEnumShape(c2jShape, serviceModel.getShapes())) {
+            // Use the enum (modeled) name for bean-style getters
+            fluentGetterMethodName = getFluentEnumGetterMethodName(memberName, parentShape, c2jShape);
+        } else {
+            fluentGetterMethodName = getFluentGetterMethodName(memberName, parentShape, c2jShape);
+        }
         return String.format("get%s", Utils.capitalize(fluentGetterMethodName));
     }
 
     @Override
     public String getBeanStyleSetterMethodName(String memberName, Shape parentShape, Shape c2jShape) {
-        String fluentSetterMethodName = getFluentSetterMethodName(memberName, parentShape, c2jShape);
-        return String.format("set%s", Utils.capitalize(fluentSetterMethodName));
+        String beanStyleGetter = getBeanStyleGetterMethodName(memberName, parentShape, c2jShape);
+        return String.format("set%s", beanStyleGetter.substring("get".length()));
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -2042,7 +2042,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.simpleList = ListOfStringsCopier.copy(simpleList);
         }
 
-        public final Collection<String> getListOfEnumsAsStrings() {
+        public final Collection<String> getListOfEnums() {
             return listOfEnums;
         }
 
@@ -2072,7 +2072,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setListOfEnumsWithStrings(Collection<String> listOfEnums) {
+        public final void setListOfEnums(Collection<String> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
         }
 
@@ -2127,7 +2127,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.listOfStructs = ListOfSimpleStructsCopier.copyFromBuilder(listOfStructs);
         }
 
-        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToStringAsStrings() {
+        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToString() {
             return listOfMapOfEnumToString;
         }
 
@@ -2144,7 +2144,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setListOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
+        public final void setListOfMapOfEnumToString(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
         }
 
@@ -2191,7 +2191,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToSimpleStruct);
         }
 
-        public final Map<String, String> getMapOfEnumToEnumAsStrings() {
+        public final Map<String, String> getMapOfEnumToEnum() {
             return mapOfEnumToEnum;
         }
 
@@ -2207,11 +2207,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
+        public final void setMapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
         }
 
-        public final Map<String, String> getMapOfEnumToStringAsStrings() {
+        public final Map<String, String> getMapOfEnumToString() {
             return mapOfEnumToString;
         }
 
@@ -2227,11 +2227,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
+        public final void setMapOfEnumToString(Map<String, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
         }
 
-        public final Map<String, String> getMapOfStringToEnumAsStrings() {
+        public final Map<String, String> getMapOfStringToEnum() {
             return mapOfStringToEnum;
         }
 
@@ -2247,11 +2247,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
+        public final void setMapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
         }
 
-        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
+        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
                                                    : null;
         }
@@ -2268,11 +2268,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
+        public final void setMapOfEnumToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyFromBuilder(mapOfEnumToSimpleStruct);
         }
 
-        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnumsAsStrings() {
+        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnums() {
             return mapOfEnumToListOfEnums;
         }
 
@@ -2288,11 +2288,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
+        public final void setMapOfEnumToListOfEnums(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
         }
 
-        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnumAsStrings() {
+        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
             return mapOfEnumToMapOfStringToEnum;
         }
 
@@ -2308,7 +2308,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final void setMapOfEnumToMapOfStringToEnum(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
         }
 
@@ -2450,7 +2450,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
                                                                                          : null;
         }
 
-        public final String getEnumTypeAsString() {
+        public final String getEnumType() {
             return enumType;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -2035,7 +2035,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.simpleList = ListOfStringsCopier.copy(simpleList);
         }
 
-        public final Collection<String> getListOfEnumsAsStrings() {
+        public final Collection<String> getListOfEnums() {
             return listOfEnums;
         }
 
@@ -2065,7 +2065,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setListOfEnumsWithStrings(Collection<String> listOfEnums) {
+        public final void setListOfEnums(Collection<String> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
         }
 
@@ -2120,7 +2120,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.listOfStructs = ListOfSimpleStructsCopier.copyFromBuilder(listOfStructs);
         }
 
-        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToStringAsStrings() {
+        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToString() {
             return listOfMapOfEnumToString;
         }
 
@@ -2137,7 +2137,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setListOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
+        public final void setListOfMapOfEnumToString(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
         }
 
@@ -2184,7 +2184,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToSimpleStruct);
         }
 
-        public final Map<String, String> getMapOfEnumToEnumAsStrings() {
+        public final Map<String, String> getMapOfEnumToEnum() {
             return mapOfEnumToEnum;
         }
 
@@ -2200,11 +2200,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
+        public final void setMapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
         }
 
-        public final Map<String, String> getMapOfEnumToStringAsStrings() {
+        public final Map<String, String> getMapOfEnumToString() {
             return mapOfEnumToString;
         }
 
@@ -2220,11 +2220,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
+        public final void setMapOfEnumToString(Map<String, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
         }
 
-        public final Map<String, String> getMapOfStringToEnumAsStrings() {
+        public final Map<String, String> getMapOfStringToEnum() {
             return mapOfStringToEnum;
         }
 
@@ -2240,11 +2240,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
+        public final void setMapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
         }
 
-        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
+        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
                                                    : null;
         }
@@ -2261,11 +2261,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
+        public final void setMapOfEnumToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyFromBuilder(mapOfEnumToSimpleStruct);
         }
 
-        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnumsAsStrings() {
+        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnums() {
             return mapOfEnumToListOfEnums;
         }
 
@@ -2281,11 +2281,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
+        public final void setMapOfEnumToListOfEnums(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
         }
 
-        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnumAsStrings() {
+        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
             return mapOfEnumToMapOfStringToEnum;
         }
 
@@ -2301,7 +2301,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final void setMapOfEnumToMapOfStringToEnum(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
         }
 
@@ -2443,7 +2443,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
                                                                                          : null;
         }
 
-        public final String getEnumTypeAsString() {
+        public final String getEnumType() {
             return enumType;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesrequest.java
@@ -2040,7 +2040,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.simpleList = ListOfStringsCopier.copy(simpleList);
         }
 
-        public final Collection<String> getListOfEnumsAsStrings() {
+        public final Collection<String> getListOfEnums() {
             return listOfEnums;
         }
 
@@ -2070,7 +2070,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setListOfEnumsWithStrings(Collection<String> listOfEnums) {
+        public final void setListOfEnums(Collection<String> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
         }
 
@@ -2125,7 +2125,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.listOfStructs = ListOfSimpleStructsCopier.copyFromBuilder(listOfStructs);
         }
 
-        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToStringAsStrings() {
+        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToString() {
             return listOfMapOfEnumToString;
         }
 
@@ -2142,7 +2142,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setListOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
+        public final void setListOfMapOfEnumToString(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
         }
 
@@ -2189,7 +2189,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToSimpleStruct);
         }
 
-        public final Map<String, String> getMapOfEnumToEnumAsStrings() {
+        public final Map<String, String> getMapOfEnumToEnum() {
             return mapOfEnumToEnum;
         }
 
@@ -2205,11 +2205,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
+        public final void setMapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
         }
 
-        public final Map<String, String> getMapOfEnumToStringAsStrings() {
+        public final Map<String, String> getMapOfEnumToString() {
             return mapOfEnumToString;
         }
 
@@ -2225,11 +2225,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
+        public final void setMapOfEnumToString(Map<String, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
         }
 
-        public final Map<String, String> getMapOfStringToEnumAsStrings() {
+        public final Map<String, String> getMapOfStringToEnum() {
             return mapOfStringToEnum;
         }
 
@@ -2245,11 +2245,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
+        public final void setMapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
         }
 
-        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
+        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
                                                    : null;
         }
@@ -2266,11 +2266,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
+        public final void setMapOfEnumToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyFromBuilder(mapOfEnumToSimpleStruct);
         }
 
-        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnumsAsStrings() {
+        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnums() {
             return mapOfEnumToListOfEnums;
         }
 
@@ -2286,11 +2286,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
+        public final void setMapOfEnumToListOfEnums(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
         }
 
-        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnumAsStrings() {
+        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
             return mapOfEnumToMapOfStringToEnum;
         }
 
@@ -2306,7 +2306,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setMapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final void setMapOfEnumToMapOfStringToEnum(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
         }
 
@@ -2448,7 +2448,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
                                                                                          : null;
         }
 
-        public final String getEnumTypeAsString() {
+        public final String getEnumType() {
             return enumType;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nonautoconstructcontainers/alltypesresponse.java
@@ -2033,7 +2033,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.simpleList = ListOfStringsCopier.copy(simpleList);
         }
 
-        public final Collection<String> getListOfEnumsAsStrings() {
+        public final Collection<String> getListOfEnums() {
             return listOfEnums;
         }
 
@@ -2063,7 +2063,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setListOfEnumsWithStrings(Collection<String> listOfEnums) {
+        public final void setListOfEnums(Collection<String> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
         }
 
@@ -2118,7 +2118,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.listOfStructs = ListOfSimpleStructsCopier.copyFromBuilder(listOfStructs);
         }
 
-        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToStringAsStrings() {
+        public final Collection<? extends Map<String, String>> getListOfMapOfEnumToString() {
             return listOfMapOfEnumToString;
         }
 
@@ -2135,7 +2135,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setListOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
+        public final void setListOfMapOfEnumToString(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
         }
 
@@ -2182,7 +2182,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copyFromBuilder(mapOfStringToSimpleStruct);
         }
 
-        public final Map<String, String> getMapOfEnumToEnumAsStrings() {
+        public final Map<String, String> getMapOfEnumToEnum() {
             return mapOfEnumToEnum;
         }
 
@@ -2198,11 +2198,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
+        public final void setMapOfEnumToEnum(Map<String, String> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
         }
 
-        public final Map<String, String> getMapOfEnumToStringAsStrings() {
+        public final Map<String, String> getMapOfEnumToString() {
             return mapOfEnumToString;
         }
 
@@ -2218,11 +2218,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
+        public final void setMapOfEnumToString(Map<String, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
         }
 
-        public final Map<String, String> getMapOfStringToEnumAsStrings() {
+        public final Map<String, String> getMapOfStringToEnum() {
             return mapOfStringToEnum;
         }
 
@@ -2238,11 +2238,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
+        public final void setMapOfStringToEnum(Map<String, String> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
         }
 
-        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStructAsStrings() {
+        public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
             return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
                                                    : null;
         }
@@ -2259,11 +2259,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
+        public final void setMapOfEnumToSimpleStruct(Map<String, SimpleStruct.BuilderImpl> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyFromBuilder(mapOfEnumToSimpleStruct);
         }
 
-        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnumsAsStrings() {
+        public final Map<String, ? extends Collection<String>> getMapOfEnumToListOfEnums() {
             return mapOfEnumToListOfEnums;
         }
 
@@ -2279,11 +2279,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
+        public final void setMapOfEnumToListOfEnums(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
         }
 
-        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnumAsStrings() {
+        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
             return mapOfEnumToMapOfStringToEnum;
         }
 
@@ -2299,7 +2299,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setMapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final void setMapOfEnumToMapOfStringToEnum(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
         }
 
@@ -2441,7 +2441,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
                                                                                          : null;
         }
 
-        public final String getEnumTypeAsString() {
+        public final String getEnumType() {
             return enumType;
         }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/ModelSerializationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/ModelSerializationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+import java.time.Instant;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.BaseType;
+import software.amazon.awssdk.services.protocolrestjson.model.RecursiveStructType;
+import software.amazon.awssdk.services.protocolrestjson.model.SimpleStruct;
+import software.amazon.awssdk.services.protocolrestjson.model.StructWithNestedBlobType;
+import software.amazon.awssdk.services.protocolrestjson.model.StructWithTimestamp;
+import software.amazon.awssdk.services.protocolrestjson.model.SubTypeOne;
+
+/**
+ * Verify that modeled objects can be marshalled using Jackson.
+ */
+public class ModelSerializationTest {
+    @Test
+    public void jacksonSerializationWorksForEmptyRequestObjects() throws IOException {
+        validateJacksonSerialization(AllTypesRequest.builder().build());
+    }
+
+    @Test
+    public void jacksonSerializationWorksForPopulatedRequestModels() throws IOException {
+        SdkBytes blob = SdkBytes.fromUtf8String("foo");
+
+        SimpleStruct simpleStruct = SimpleStruct.builder().stringMember("foo").build();
+        StructWithTimestamp structWithTimestamp = StructWithTimestamp.builder().nestedTimestamp(Instant.EPOCH).build();
+        StructWithNestedBlobType structWithNestedBlob = StructWithNestedBlobType.builder().nestedBlob(blob).build();
+        RecursiveStructType recursiveStruct = RecursiveStructType.builder()
+                                                                 .recursiveStruct(RecursiveStructType.builder().build())
+                                                                 .build();
+        BaseType baseType = BaseType.builder().baseMember("foo").build();
+        SubTypeOne subtypeOne = SubTypeOne.builder().subTypeOneMember("foo").build();
+
+        validateJacksonSerialization(AllTypesRequest.builder()
+                                                    .stringMember("foo")
+                                                    .integerMember(5)
+                                                    .booleanMember(true)
+                                                    .floatMember(5F)
+                                                    .doubleMember(5D)
+                                                    .longMember(5L)
+                                                    .simpleList("foo", "bar")
+                                                    .listOfMaps(singletonList(singletonMap("foo", "bar")))
+                                                    .listOfStructs(simpleStruct)
+                                                    .mapOfStringToIntegerList(singletonMap("foo", singletonList(5)))
+                                                    .mapOfStringToStruct(singletonMap("foo", simpleStruct))
+                                                    .timestampMember(Instant.EPOCH)
+                                                    .structWithNestedTimestampMember(structWithTimestamp)
+                                                    .blobArg(blob)
+                                                    .structWithNestedBlob(structWithNestedBlob)
+                                                    .blobMap(singletonMap("foo", blob))
+                                                    .listOfBlobs(blob, blob)
+                                                    .recursiveStruct(recursiveStruct)
+                                                    .polymorphicTypeWithSubTypes(baseType)
+                                                    .polymorphicTypeWithoutSubTypes(subtypeOne)
+                                                    .enumMember("foo")
+                                                    .listOfEnumsWithStrings("foo", "bar")
+                                                    .mapOfEnumToEnumWithStrings(singletonMap("foo", "bar"))
+                                                    .build());
+    }
+
+    private void validateJacksonSerialization(AllTypesRequest original) throws IOException {
+        SimpleModule instantModule = new SimpleModule();
+        instantModule.addSerializer(Instant.class, new InstantSerializer());
+        instantModule.addDeserializer(Instant.class, new InstantDeserializer());
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(instantModule);
+
+        String serialized = mapper.writeValueAsString(original.toBuilder());
+        AllTypesRequest deserialized = mapper.readValue(serialized, AllTypesRequest.serializableBuilderClass()).build();
+        assertThat(deserialized).isEqualTo(original);
+
+    }
+
+    private class InstantSerializer extends JsonSerializer<Instant> {
+        @Override
+        public void serialize(Instant t, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+                throws IOException {
+            jsonGenerator.writeString(t.toString());
+        }
+    }
+
+    private class InstantDeserializer extends JsonDeserializer<Instant> {
+        @Override
+        public Instant deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+            return Instant.parse(jsonParser.getText());
+        }
+    }
+}


### PR DESCRIPTION
To follow the bean standard, the setter names should match the getter names, which isn't the case. This caused issues when marshalling request/response objects containing enums. This change ensures the bean setter always matches the bean getter.