### PR TITLE
Fix StaticAttribute#toBuilder() to include 'attributeConverter'

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttribute.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttribute.java
@@ -146,7 +146,8 @@ public final class StaticAttribute<T, R> {
         return new Builder<T, R>(this.type).name(this.name)
                                            .getter(this.getter)
                                            .setter(this.setter)
-                                           .tags(this.tags);
+                                           .tags(this.tags)
+                                           .attributeConverter(this.attributeConverter);
     }
 
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttributeTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticAttributeTest.java
@@ -90,6 +90,7 @@ public class StaticAttributeTest {
                                                                          .getter(TEST_GETTER)
                                                                          .setter(TEST_SETTER)
                                                                          .tags(mockTag)
+                                                                         .attributeConverter(attributeConverter)
                                                                          .build();
 
         assertThat(staticAttribute.name()).isEqualTo("test-attribute");
@@ -97,6 +98,7 @@ public class StaticAttributeTest {
         assertThat(staticAttribute.setter()).isSameAs(TEST_SETTER);
         assertThat(staticAttribute.tags()).containsExactly(mockTag);
         assertThat(staticAttribute.type()).isEqualTo(EnhancedType.of(String.class));
+        assertThat(staticAttribute.attributeConverter()).isSameAs(attributeConverter);
     }
 
     @Test
@@ -151,6 +153,7 @@ public class StaticAttributeTest {
                                                                          .getter(TEST_GETTER)
                                                                          .setter(TEST_SETTER)
                                                                          .tags(mockTag, mockTag2)
+                                                                         .attributeConverter(attributeConverter)
                                                                          .build();
 
         StaticAttribute<Object, String> clonedAttribute = staticAttribute.toBuilder().build();
@@ -160,6 +163,7 @@ public class StaticAttributeTest {
         assertThat(clonedAttribute.setter()).isSameAs(TEST_SETTER);
         assertThat(clonedAttribute.tags()).containsExactly(mockTag, mockTag2);
         assertThat(clonedAttribute.type()).isEqualTo(EnhancedType.of(String.class));
+        assertThat(clonedAttribute.attributeConverter()).isSameAs(attributeConverter);
     }
 
     @Test


### PR DESCRIPTION
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
