### PR TITLE
Expose the extendedRequestId from SdkServiceException

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-00d47cf.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-00d47cf.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "feature", 
+    "description": "Expose the `extendedRequestId` from `SdkServiceException`, so it can be provided to support to investigate issues."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -65,7 +65,8 @@ public class AwsServiceException extends SdkServiceException {
             return awsErrorDetails().errorMessage() +
                     " (Service: " + awsErrorDetails().serviceName() +
                     ", Status Code: " + statusCode() +
-                    ", Request ID: " + requestId() + ")";
+                    ", Request ID: " + requestId() +
+                    ", Extended Request ID: " + extendedRequestId() + ")";
         }
 
         return super.getMessage();
@@ -165,6 +166,9 @@ public class AwsServiceException extends SdkServiceException {
         Builder requestId(String requestId);
 
         @Override
+        Builder extendedRequestId(String extendedRequestId);
+
+        @Override
         Builder statusCode(int statusCode);
 
         @Override
@@ -229,6 +233,12 @@ public class AwsServiceException extends SdkServiceException {
         @Override
         public Builder requestId(String requestId) {
             this.requestId = requestId;
+            return this;
+        }
+
+        @Override
+        public Builder extendedRequestId(String extendedRequestId) {
+            this.extendedRequestId = extendedRequestId;
             return this;
         }
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/AwsJsonProtocolErrorUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/AwsJsonProtocolErrorUnmarshaller.java
@@ -85,6 +85,7 @@ public final class AwsJsonProtocolErrorUnmarshaller implements HttpResponseHandl
         exception.message(errorMessage);
         exception.statusCode(statusCode(response, modeledExceptionMetadata));
         exception.requestId(getRequestIdFromHeaders(response.headers()));
+        exception.extendedRequestId(getExtendedRequestIdFromHeaders(response.headers()));
         return exception.build();
     }
 
@@ -134,6 +135,10 @@ public final class AwsJsonProtocolErrorUnmarshaller implements HttpResponseHandl
 
     private String getRequestIdFromHeaders(Map<String, List<String>> headers) {
         return SdkHttpUtils.firstMatchingHeader(headers, X_AMZN_REQUEST_ID_HEADER).orElse(null);
+    }
+
+    private String getExtendedRequestIdFromHeaders(Map<String, List<String>> headers) {
+        return SdkHttpUtils.firstMatchingHeader(headers, X_AMZ_ID_2_HEADER).orElse(null);
     }
 
     public static Builder builder() {

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonResponseHandler.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonResponseHandler.java
@@ -74,6 +74,9 @@ public final class JsonResponseHandler<T extends SdkPojo> implements HttpRespons
                                                         response.firstMatchingHeader(X_AMZN_REQUEST_ID_HEADER)
                                                                 .orElse("not available"));
 
+        SdkStandardLogger.REQUEST_ID_LOGGER.debug(() -> X_AMZ_ID_2_HEADER + " : " +
+                                                        response.firstMatchingHeader(X_AMZ_ID_2_HEADER)
+                                                                .orElse("not available"));
 
         try {
             T result = unmarshaller.unmarshall(pojoSupplier.apply(response), response);

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/AwsXmlErrorUnmarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/AwsXmlErrorUnmarshaller.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.protocols.query.unmarshall.XmlErrorUnmarshaller;
 @SdkInternalApi
 public final class AwsXmlErrorUnmarshaller {
     private static final String X_AMZN_REQUEST_ID_HEADER = "x-amzn-RequestId";
+    private static final String X_AMZ_ID_2_HEADER = "x-amz-id-2";
 
     private final List<ExceptionMetadata> exceptions;
     private final Supplier<SdkPojo> defaultExceptionSupplier;
@@ -90,6 +91,7 @@ public final class AwsXmlErrorUnmarshaller {
                            .build();
 
         builder.requestId(getRequestId(response, documentRoot))
+               .extendedRequestId(getExtendedRequestId(response))
                .statusCode(response.statusCode())
                .clockSkew(getClockSkew(executionAttributes))
                .awsErrorDetails(awsErrorDetails);
@@ -174,6 +176,16 @@ public final class AwsXmlErrorUnmarshaller {
         return requestId != null ?
                requestId.textContent() :
                response.firstMatchingHeader(X_AMZN_REQUEST_ID_HEADER).orElse(null);
+    }
+
+    /**
+     * Extracts the extended request ID from the response headers.
+     *
+     * @param response The HTTP response object.
+     * @return Extended Request ID string or null if not present.
+     */
+    private String getExtendedRequestId(SdkHttpFullResponse response) {
+        return response.firstMatchingHeader(X_AMZ_ID_2_HEADER).orElse(null);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -41,11 +41,13 @@ import software.amazon.awssdk.http.HttpStatusCode;
 public class SdkServiceException extends SdkException implements SdkPojo {
 
     private final String requestId;
+    private final String extendedRequestId;
     private final int statusCode;
 
     protected SdkServiceException(Builder b) {
         super(b);
         this.requestId = b.requestId();
+        this.extendedRequestId = b.extendedRequestId();
         this.statusCode = b.statusCode();
     }
 
@@ -55,6 +57,14 @@ public class SdkServiceException extends SdkException implements SdkPojo {
      */
     public String requestId() {
         return requestId;
+    }
+
+    /**
+     * The extendedRequestId that was returned by the called service.
+     * @return String ctontaining the extendedRequestId
+     */
+    public String extendedRequestId() {
+        return extendedRequestId;
     }
 
     /**
@@ -128,6 +138,21 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         String requestId();
 
         /**
+         * Specifies the extendedRequestId returned by the called service.
+         *
+         * @param extendedRequestId A string that identifies the request made to a service.
+         * @return This object for method chaining.
+         */
+        Builder extendedRequestId(String extendedRequestId);
+
+        /**
+         * The extendedRequestId returned by the called service.
+         *
+         * @return String containing the extendedRequestId
+         */
+        String extendedRequestId();
+
+        /**
          * Specifies the status code returned by the service.
          *
          * @param statusCode an int containing the status code returned by the service.
@@ -153,6 +178,7 @@ public class SdkServiceException extends SdkException implements SdkPojo {
     protected static class BuilderImpl extends SdkException.BuilderImpl implements Builder {
 
         protected String requestId;
+        protected String extendedRequestId;
         protected int statusCode;
 
         protected BuilderImpl() {
@@ -161,6 +187,7 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         protected BuilderImpl(SdkServiceException ex) {
             super(ex);
             this.requestId = ex.requestId();
+            this.extendedRequestId = ex.extendedRequestId();
             this.statusCode = ex.statusCode();
         }
 
@@ -183,6 +210,12 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         }
 
         @Override
+        public Builder extendedRequestId(String extendedRequestId) {
+            this.extendedRequestId = extendedRequestId;
+            return this;
+        }
+
+        @Override
         public String requestId() {
             return requestId;
         }
@@ -193,6 +226,19 @@ public class SdkServiceException extends SdkException implements SdkPojo {
 
         public void setRequestId(String requestId) {
             this.requestId = requestId;
+        }
+
+        @Override
+        public String extendedRequestId() {
+            return extendedRequestId;
+        }
+
+        public String getExtendedRequestId() {
+            return extendedRequestId;
+        }
+
+        public void setExtendedRequestId(String extendedRequestId) {
+            this.extendedRequestId = extendedRequestId;
         }
 
         @Override

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/AwsJsonExceptionTest.java
@@ -126,6 +126,29 @@ public class AwsJsonExceptionTest {
             assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolJsonRpc");
             assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
             assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isNull();
+            assertThat(e.statusCode()).isEqualTo(404);
+        }
+    }
+
+    @Test
+    public void modeledException_HasExceptionMetadataIncludingExtendedRequestIdSet() {
+        stubFor(post(urlEqualTo(PATH)).willReturn(
+            aResponse()
+                .withStatus(404)
+                .withHeader("x-amzn-RequestId", "1234")
+                .withHeader("x-amz-id-2", "5678")
+                .withBody("{\"__type\": \"EmptyModeledException\", \"Message\": \"This is the service message\"}")));
+        try {
+            client.allTypes();
+        } catch (EmptyModeledException e) {
+            AwsErrorDetails awsErrorDetails = e.awsErrorDetails();
+            assertThat(awsErrorDetails.errorCode()).isEqualTo("EmptyModeledException");
+            assertThat(awsErrorDetails.errorMessage()).isEqualTo("This is the service message");
+            assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolJsonRpc");
+            assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
+            assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isEqualTo("5678");
             assertThat(e.statusCode()).isEqualTo(404);
         }
     }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/QueryExceptionTests.java
@@ -231,6 +231,7 @@ public class QueryExceptionTests {
             assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolQuery");
             assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
             assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isNull();
             assertThat(e.statusCode()).isEqualTo(404);
         }
     }
@@ -252,6 +253,7 @@ public class QueryExceptionTests {
             client.allTypes();
         } catch (EmptyModeledException e) {
             assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isNull();
         }
     }
 
@@ -265,6 +267,22 @@ public class QueryExceptionTests {
             client.allTypes();
         } catch (ProtocolQueryException e) {
             assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isNull();
+        }
+    }
+
+    @Test
+    public void requestIdAndExtendedRequestIdInHeader_IsSetOnException() {
+        stubFor(post(urlEqualTo(PATH)).willReturn(
+            aResponse()
+                .withStatus(404)
+                .withHeader("x-amzn-RequestId", "1234")
+                .withHeader("x-amz-id-2", "5678")));
+        try {
+            client.allTypes();
+        } catch (ProtocolQueryException e) {
+            assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isEqualTo("5678");
         }
     }
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestJsonExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestJsonExceptionTests.java
@@ -158,6 +158,29 @@ public class RestJsonExceptionTests {
             assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolRestJson");
             assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
             assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isNull();
+            assertThat(e.statusCode()).isEqualTo(404);
+        }
+    }
+
+    @Test
+    public void modeledException_HasExceptionMetadataIncludingExtendedRequestIdSet() {
+        stubFor(post(urlEqualTo(ALL_TYPES_PATH)).willReturn(
+            aResponse()
+                .withStatus(404)
+                .withHeader("x-amzn-RequestId", "1234")
+                .withHeader("x-amz-id-2", "5678")
+                .withBody("{\"__type\": \"EmptyModeledException\", \"Message\": \"This is the service message\"}")));
+        try {
+            client.allTypes();
+        } catch (EmptyModeledException e) {
+            AwsErrorDetails awsErrorDetails = e.awsErrorDetails();
+            assertThat(awsErrorDetails.errorCode()).isEqualTo("EmptyModeledException");
+            assertThat(awsErrorDetails.errorMessage()).isEqualTo("This is the service message");
+            assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolRestJson");
+            assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
+            assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isEqualTo("5678");
             assertThat(e.statusCode()).isEqualTo(404);
         }
     }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestXmlExceptionTests.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/exception/RestXmlExceptionTests.java
@@ -155,6 +155,35 @@ public class RestXmlExceptionTests {
             assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolRestXml");
             assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
             assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isNull();
+            assertThat(e.statusCode()).isEqualTo(404);
+        }
+    }
+
+    @Test
+    public void modeledException_HasExceptionMetadataIncludingExtendedRequestIdSet() {
+        String xml = "<ErrorResponse>"
+                     + "   <Error>"
+                     + "      <Code>EmptyModeledException</Code>"
+                     + "      <Message>This is the service message</Message>"
+                     + "   </Error>"
+                     + "   <RequestId>1234</RequestId>"
+                     + "</ErrorResponse>";
+        stubFor(post(urlEqualTo(ALL_TYPES_PATH)).willReturn(
+            aResponse()
+                .withStatus(404)
+                .withHeader("x-amz-id-2", "5678")
+                .withBody(xml)));
+        try {
+            client.allTypes();
+        } catch (EmptyModeledException e) {
+            AwsErrorDetails awsErrorDetails = e.awsErrorDetails();
+            assertThat(awsErrorDetails.errorCode()).isEqualTo("EmptyModeledException");
+            assertThat(awsErrorDetails.errorMessage()).isEqualTo("This is the service message");
+            assertThat(awsErrorDetails.serviceName()).isEqualTo("ProtocolRestXml");
+            assertThat(awsErrorDetails.sdkHttpResponse()).isNotNull();
+            assertThat(e.requestId()).isEqualTo("1234");
+            assertThat(e.extendedRequestId()).isEqualTo("5678");
             assertThat(e.statusCode()).isEqualTo(404);
         }
     }


### PR DESCRIPTION
## Description
Adds a new `extendedRequestId` property to the `SdkServiceException` class and includes it in the contents of AwsServiceException messages.

## Motivation and Context
Currently the only way to access this information from the exception is via the headers supplied by the `SdkHttpResponse` in the exception's `errorDetails`.  However when the AWS client is automatically retrying and causing my Lambda function to timeout due to the added time it takes to retry, I have no way to access this information.  AWS support requires this information in order to deep dive issues for some services such as S3.

## Testing
Ran mvn clean install and the build succeeded.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
