### PR TITLE
Fix generation for services that contain operations with the same name as the service

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-5ba8894.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-5ba8894.json
@@ -1,0 +1,5 @@
+{
+  "category": "AWS SDK for Java v2",
+  "type": "bugfix",
+  "description": "Fix generation for services that contain operations with the same name as the service."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddEmptyInputShape.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddEmptyInputShape.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.codegen;
 
-import static software.amazon.awssdk.codegen.internal.Constant.REQUEST_CLASS_SUFFIX;
 import static software.amazon.awssdk.codegen.internal.Utils.createInputShapeMarshaller;
 import static software.amazon.awssdk.codegen.internal.Utils.unCapitalize;
 
@@ -62,7 +61,7 @@ final class AddEmptyInputShape implements IntermediateModelShapeProcessor {
 
             Input input = operation.getInput();
             if (input == null) {
-                String inputShape = operationName + REQUEST_CLASS_SUFFIX;
+                String inputShape = namingStrategy.getRequestClassName(operationName);
                 OperationModel operationModel = javaOperationMap.get(operationName);
 
                 operationModel.setInput(new VariableModel(unCapitalize(inputShape), inputShape));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddEmptyOutputShape.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddEmptyOutputShape.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.codegen;
 
-import static software.amazon.awssdk.codegen.internal.Constant.RESPONSE_CLASS_SUFFIX;
-
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -58,7 +56,7 @@ public class AddEmptyOutputShape implements IntermediateModelShapeProcessor {
 
             Output output = operation.getOutput();
             if (output == null) {
-                String outputShape = operationName + RESPONSE_CLASS_SUFFIX;
+                String outputShape = namingStrategy.getResponseClassName(operationName);
                 OperationModel operationModel = currentOperations.get(operationName);
 
                 operationModel.setReturnType(new ReturnTypeModel(outputShape));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java
@@ -50,6 +50,8 @@ public class DefaultNamingStrategy implements NamingStrategy {
 
     private static Logger log = Logger.loggerFor(DefaultNamingStrategy.class);
 
+    private static final String COLLISION_DISAMBIGUATION_PREFIX = "Default";
+
     private static final Set<String> RESERVED_KEYWORDS;
 
     private static final Set<String> RESERVED_EXCEPTION_METHOD_NAMES;
@@ -191,23 +193,39 @@ public class DefaultNamingStrategy implements NamingStrategy {
 
     @Override
     public String getExceptionName(String errorShapeName) {
+        String baseName;
         if (errorShapeName.endsWith(FAULT_CLASS_SUFFIX)) {
-            return pascalCase(errorShapeName.substring(0, errorShapeName.length() - FAULT_CLASS_SUFFIX.length())) +
+            baseName = pascalCase(errorShapeName.substring(0, errorShapeName.length() - FAULT_CLASS_SUFFIX.length())) +
                               EXCEPTION_CLASS_SUFFIX;
         } else if (errorShapeName.endsWith(EXCEPTION_CLASS_SUFFIX)) {
-            return pascalCase(errorShapeName);
+            baseName = pascalCase(errorShapeName);
+        } else {
+            baseName = pascalCase(errorShapeName) + EXCEPTION_CLASS_SUFFIX;
         }
-        return pascalCase(errorShapeName) + EXCEPTION_CLASS_SUFFIX;
+        if (baseName.equals(getServiceName() + EXCEPTION_CLASS_SUFFIX)) {
+            return COLLISION_DISAMBIGUATION_PREFIX + baseName;
+        }
+        return baseName;
     }
 
     @Override
     public String getRequestClassName(String operationName) {
-        return pascalCase(operationName) + REQUEST_CLASS_SUFFIX;
+        String baseName = pascalCase(operationName) + REQUEST_CLASS_SUFFIX;
+        if (!operationName.equals(getServiceName())) {
+            return baseName;
+        }
+
+        return COLLISION_DISAMBIGUATION_PREFIX + baseName;
     }
 
     @Override
     public String getResponseClassName(String operationName) {
-        return pascalCase(operationName) + RESPONSE_CLASS_SUFFIX;
+        String baseName = pascalCase(operationName) + RESPONSE_CLASS_SUFFIX;
+        if (!operationName.equals(getServiceName())) {
+            return baseName;
+        }
+
+        return COLLISION_DISAMBIGUATION_PREFIX + baseName;
     }
 
     @Override

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/IntermediateModelBuilderTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/IntermediateModelBuilderTest.java
@@ -15,16 +15,34 @@
 
 package software.amazon.awssdk.codegen;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import org.junit.Test;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
 
 public class IntermediateModelBuilderTest {
+
+    @Test
+    public void testServiceAndShapeNameCollisions() throws Exception {
+        final File modelFile = new File(IntermediateModelBuilderTest.class
+                                            .getResource("poet/client/c2j/collision/service-2.json").getFile());
+        IntermediateModel testModel = new IntermediateModelBuilder(
+            C2jModels.builder()
+                     .serviceModel(ModelLoaderUtils.loadModel(ServiceModel.class, modelFile))
+                     .customizationConfig(CustomizationConfig.create())
+                     .build())
+            .build();
+
+        assertThat(testModel.getShapes().values())
+            .extracting(ShapeModel::getShapeName)
+            .containsExactlyInAnyOrder("DefaultCollisionException", "DefaultCollisionRequest", "DefaultCollisionResponse");
+    }
 
     @Test
     public void sharedOutputShapesLinkCorrectlyToOperationOutputs() {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategyTest.java
@@ -250,6 +250,8 @@ public class DefaultNamingStrategyTest {
 
     @Test
     public void modelNameShouldHavePascalCase() {
+        when(serviceModel.getMetadata()).thenReturn(serviceMetadata);
+        when(serviceMetadata.getServiceId()).thenReturn("UnitTestService");
         assertThat(strat.getRequestClassName("CAPSTest")).isEqualTo("CapsTestRequest");
         assertThat(strat.getExceptionName("CAPSTest")).isEqualTo("CapsTestException");
         assertThat(strat.getResponseClassName("CAPSTest")).isEqualTo("CapsTestResponse");

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/collision/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/collision/service-2.json
@@ -1,0 +1,52 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2010-05-08",
+    "endpointPrefix": "collision-service",
+    "globalEndpoint": "collision-service.amazonaws.com",
+    "protocol": "rest-json",
+    "serviceAbbreviation": "Collision Service",
+    "serviceFullName": "A really bizarrely modelled service",
+    "serviceId":"CollisionService",
+    "signatureVersion": "v4",
+    "uid": "collision-service-2010-05-08",
+    "xmlNamespace": "https://collision-service.amazonaws.com/doc/2010-05-08/"
+  },
+  "operations": {
+    "Collision": {
+      "name": "Collision",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "Collision"
+      },
+      "errors": [
+        {
+          "shape": "CollisionFault"
+        }
+      ],
+      "documentation": "<p>A very strange operation></p>"
+    }
+  },
+  "shapes": {
+    "Collision": {
+      "type": "structure",
+      "required": [],
+      "members": {}
+    },
+    "CollisionFault" : {
+      "type": "structure",
+      "members": {},
+      "documentation": "<p>A fault</p>",
+      "error": {
+        "code": "Collision",
+        "httpStatusCode": 400,
+        "senderFault": true
+      },
+      "exception": true
+    }
+  },
+  "documentation": "Why would anyone do this?"
+}


### PR DESCRIPTION
## Description
If a 'FooService' contains an operation named 'Foo', the generator will attempt to generate a 'FooRequest' that extends an abstract 'FooRequest'.  This adds 'Default' to the concrete class names only in cases where there is an operation with a clashing name.

## Motivation and Context
Some simpler microservices do not adhere to the standard naming guidelines.  This allows clients to be generated for them.

## Testing
This should only impact models for which non-compiling code would be generated today.  This was tested with a simple unit test, and out-of-band against a similar service model end-to-end.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
