### PR TITLE
Support event streams that are shared between two operations.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-66d1f62.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-66d1f62.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Support event streams that are shared between two operations."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
@@ -15,7 +15,9 @@
 
 package software.amazon.awssdk.codegen.poet.eventstream;
 
+import java.util.Collection;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
@@ -116,16 +118,21 @@ public class EventStreamUtils {
     }
 
     /**
-     * Returns the first operation that contains the given event stream shape. The event stream can be in operation
+     * Returns the all operations that contain the given event stream shape. The event stream can be in operation
      * request or response shape.
      */
-    public static OperationModel findOperationWithEventStream(IntermediateModel model, ShapeModel eventStreamShape) {
-        return model.getOperations().values()
+    public static Collection<OperationModel> findOperationsWithEventStream(IntermediateModel model, ShapeModel eventStreamShape) {
+        Collection<OperationModel> operations = model.getOperations().values()
                     .stream()
                     .filter(op -> operationContainsEventStream(op, eventStreamShape))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException(String.format(
-                        "%s is an event shape but has no corresponding operation in the model", eventStreamShape.getC2jName())));
+                    .collect(Collectors.toList());
+
+        if (operations.isEmpty()) {
+            throw new IllegalStateException(String.format(
+                "%s is an event shape but has no corresponding operation in the model", eventStreamShape.getC2jName()));
+        }
+
+        return operations;
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
@@ -28,6 +28,7 @@ import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -84,46 +85,40 @@ public class AwsServiceModel implements ClassSpec {
     @Override
     public TypeSpec poetSpec() {
         if (shapeModel.isEventStream()) {
-            OperationModel opModel = EventStreamUtils.findOperationWithEventStream(intermediateModel,
-                                                                                   shapeModel);
-            String apiName = poetExtensions.getApiName(opModel);
+            Collection<OperationModel> opModels = EventStreamUtils.findOperationsWithEventStream(intermediateModel,
+                                                                                                 shapeModel);
+
+            Collection<OperationModel> outputOperations = findOutputEventStreamOperations(opModels, shapeModel);
+
             ClassName modelClass = poetExtensions.getModelClassFromShape(shapeModel);
 
-            if (EventStreamUtils.doesShapeContainsEventStream(opModel.getOutputShape(), shapeModel)) {
-                ClassName responseHandlerClass = poetExtensions.eventStreamResponseHandlerType(opModel);
-                return PoetUtils.createInterfaceBuilder(modelClass)
-                                .addAnnotation(SdkPublicApi.class)
-                                .addSuperinterface(ClassName.get(SdkPojo.class))
-                                .addJavadoc("Base interface for all event types of the $L API.", apiName)
-                                .addField(FieldSpec.builder(modelClass, "UNKNOWN")
-                                                   .addModifiers(PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                                                   .initializer(CodeBlock.builder()
-                                                                         .add("new $T() {\n"
-                                                                              + "        @Override\n"
-                                                                              + "        public $T<$T<?>> sdkFields() {\n"
-                                                                              + "            return $T.emptyList();\n"
-                                                                              + "        }\n"
-                                                                              + "        @Override\n"
-                                                                              + "        public void accept($T.Visitor visitor) {"
-                                                                              + "            \nvisitor.visitDefault(this);\n"
-                                                                              + "        }\n"
-                                                                              + "    };\n",
-                                                                              modelClass, List.class, SdkField.class,
-                                                                              Collections.class, responseHandlerClass
-                                                                         )
-                                                                         .build())
-                                                   .addJavadoc("Special type of {@link $T} for unknown types of events that this "
-                                                               + "version of the SDK does not know about", modelClass)
-                                                   .build())
-                                .addMethod(acceptMethodSpec(modelClass, responseHandlerClass)
-                                               .addModifiers(Modifier.ABSTRACT)
-                                               .build())
-                                .build();
+            if (!outputOperations.isEmpty()) {
+                CodeBlock unknownInitializer = buildUnknownEventStreamInitializer(outputOperations,
+                                                                                  modelClass);
 
-            } else if (EventStreamUtils.doesShapeContainsEventStream(opModel.getInputShape(), shapeModel)) {
+                TypeSpec.Builder builder =
+                    PoetUtils.createInterfaceBuilder(modelClass)
+                              .addAnnotation(SdkPublicApi.class)
+                              .addSuperinterface(ClassName.get(SdkPojo.class))
+                              .addJavadoc("Base interface for all event types in $L.", shapeModel.getShapeName())
+                              .addField(FieldSpec.builder(modelClass, "UNKNOWN")
+                                       .addModifiers(PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                                       .initializer(unknownInitializer)
+                                       .addJavadoc("Special type of {@link $T} for unknown types of events that this "
+                                                   + "version of the SDK does not know about", modelClass)
+                                       .build());
+
+                for (OperationModel opModel : outputOperations) {
+                    ClassName responseHandlerClass = poetExtensions.eventStreamResponseHandlerType(opModel);
+                    builder.addMethod(acceptMethodSpec(modelClass, responseHandlerClass)
+                                          .addModifiers(Modifier.ABSTRACT)
+                                          .build());
+                }
+                return builder.build();
+            } else if (hasInputStreamOperations(opModels, shapeModel)) {
                 return PoetUtils.createInterfaceBuilder(modelClass)
                                 .addAnnotation(SdkPublicApi.class)
-                                .addJavadoc("Base interface for all event types of the $L API.", apiName)
+                                .addJavadoc("Base interface for all event types in $L.", shapeModel.getShapeName())
                                 .build();
             }
 
@@ -160,21 +155,25 @@ public class AwsServiceModel implements ClassSpec {
             if (this.shapeModel.isEvent()) {
                 ShapeModel eventStream = EventStreamUtils.getBaseEventStreamShape(intermediateModel, shapeModel);
                 ClassName eventStreamClassName = poetExtensions.getModelClassFromShape(eventStream);
-                OperationModel opModel = EventStreamUtils.findOperationWithEventStream(intermediateModel,
+                Collection<OperationModel> opModels = EventStreamUtils.findOperationsWithEventStream(intermediateModel,
                                                                                        eventStream);
 
-                if (EventStreamUtils.doesShapeContainsEventStream(opModel.getOutputShape(), eventStream)) {
-                    ClassName modelClass = poetExtensions.getModelClass(shapeModel.getShapeName());
-                    ClassName responseHandlerClass = poetExtensions.eventStreamResponseHandlerType(opModel);
-                    specBuilder.addSuperinterface(eventStreamClassName);
-                    specBuilder.addMethod(acceptMethodSpec(modelClass, responseHandlerClass)
-                                              .addAnnotation(Override.class)
-                                              .addCode(CodeBlock.builder()
-                                                                .addStatement("visitor.visit(this)")
-                                                                .build())
-                                              .build());
+                Collection<OperationModel> outputOperations = findOutputEventStreamOperations(opModels, eventStream);
 
-                } else if (EventStreamUtils.doesShapeContainsEventStream(opModel.getInputShape(), eventStream)) {
+                if (!outputOperations.isEmpty()) {
+                    ClassName modelClass = poetExtensions.getModelClass(shapeModel.getShapeName());
+                    specBuilder.addSuperinterface(eventStreamClassName);
+                    for (OperationModel opModel : outputOperations) {
+                        ClassName responseHandlerClass = poetExtensions.eventStreamResponseHandlerType(opModel);
+                        specBuilder.addMethod(acceptMethodSpec(modelClass, responseHandlerClass)
+                                                  .addAnnotation(Override.class)
+                                                  .addCode(CodeBlock.builder()
+                                                                    .addStatement("visitor.visit(this)")
+                                                                    .build())
+                                                  .build());
+                    }
+
+                } else if (hasInputStreamOperations(opModels, eventStream)) {
                     specBuilder.addSuperinterface(eventStreamClassName);
                 } else {
                     throw new IllegalArgumentException(shapeModel.getC2jName() + " event shape is not a member in any "
@@ -188,6 +187,44 @@ public class AwsServiceModel implements ClassSpec {
 
             return specBuilder.build();
         }
+    }
+
+    private boolean hasInputStreamOperations(Collection<OperationModel> opModels, ShapeModel eventStream) {
+        return opModels.stream()
+                       .anyMatch(op -> EventStreamUtils.doesShapeContainsEventStream(op.getInputShape(), eventStream));
+    }
+
+    private List<OperationModel> findOutputEventStreamOperations(Collection<OperationModel> opModels,
+                                                                 ShapeModel eventStream) {
+        return opModels
+            .stream()
+            .filter(opModel -> EventStreamUtils.doesShapeContainsEventStream(opModel.getOutputShape(), eventStream))
+            .collect(Collectors.toList());
+    }
+
+    private CodeBlock buildUnknownEventStreamInitializer(Collection<OperationModel> outputOperations,
+                                                         ClassName eventStreamModelClass) {
+        CodeBlock.Builder builder = CodeBlock.builder()
+                                             .add("new $T() {\n"
+                                                  + "        @Override\n"
+                                                  + "        public $T<$T<?>> sdkFields() {\n"
+                                                  + "            return $T.emptyList();\n"
+                                                  + "        }\n",
+                                                  eventStreamModelClass, List.class, SdkField.class,
+                                                  Collections.class
+                                             );
+
+        for (OperationModel opModel : outputOperations) {
+            ClassName responseHandlerClass = poetExtensions.eventStreamResponseHandlerType(opModel);
+            builder.add("        @Override\n"
+                      + "        public void accept($T.Visitor visitor) {"
+                      + "            \nvisitor.visitDefault(this);\n"
+                      + "        }\n", responseHandlerClass);
+        }
+
+        builder.add("    }\n");
+
+        return builder.build();
     }
 
     private MethodSpec sdkFieldsMethod() {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/SharedStreamAwsModelSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/model/SharedStreamAwsModelSpecTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.model;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Locale;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.codegen.C2jModels;
+import software.amazon.awssdk.codegen.IntermediateModelBuilder;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
+
+@RunWith(Parameterized.class)
+public class SharedStreamAwsModelSpecTest {
+    private static IntermediateModel intermediateModel;
+
+    private final ShapeModel shapeModel;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        invokeSafely(SharedStreamAwsModelSpecTest::setUp);
+        return intermediateModel.getShapes().values().stream().map(shape -> new Object[] { shape }).collect(toList());
+    }
+
+    public SharedStreamAwsModelSpecTest(ShapeModel shapeModel) {
+        this.shapeModel = shapeModel;
+    }
+
+    @Test
+    public void basicGeneration() throws Exception {
+        assertThat(new AwsServiceModel(intermediateModel, shapeModel), generatesTo(referenceFileForShape()));
+    }
+
+    private String referenceFileForShape() {
+        return "sharedstream/" + shapeModel.getShapeName().toLowerCase(Locale.ENGLISH) + ".java";
+    }
+
+    private static void setUp() throws IOException {
+        File serviceModelFile = new File(SharedStreamAwsModelSpecTest.class.getResource("sharedstream/service-2.json").getFile());
+        ServiceModel serviceModel = ModelLoaderUtils.loadModel(ServiceModel.class, serviceModelFile);
+
+        intermediateModel = new IntermediateModelBuilder(
+            C2jModels.builder()
+                     .serviceModel(serviceModel)
+                     .customizationConfig(CustomizationConfig.create())
+                     .build())
+            .build();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventstream.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 
 /**
- * Base interface for all event types of the EventStreamOperation API.
+ * Base interface for all event types in EventStream.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkPublicApi
@@ -26,7 +26,7 @@ public interface EventStream extends SdkPojo {
         public void accept(EventStreamOperationResponseHandler.Visitor visitor) {
             visitor.visitDefault(this);
         }
-    };;
+    };
 
     /**
      * Calls the appropriate visit method depending on the subtype of {@link EventStream}.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstream.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
- * Base interface for all event types of the EventStreamOperation API.
+ * Base interface for all event types in InputEventStream.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkPublicApi

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstreamtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventstreamtwo.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
- * Base interface for all event types of the EventStreamOperationWithOnlyInput API.
+ * Base interface for all event types in InputEventStreamTwo.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkPublicApi

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/eventstream.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/eventstream.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+
+/**
+ * Base interface for all event types in EventStream.
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+public interface EventStream extends SdkPojo {
+    /**
+     * Special type of {@link EventStream} for unknown types of events that this version of the SDK does not know about
+     */
+    EventStream UNKNOWN = new EventStream() {
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void accept(StreamBirthsResponseHandler.Visitor visitor) {
+            visitor.visitDefault(this);
+        }
+
+        @Override
+        public void accept(StreamDeathsResponseHandler.Visitor visitor) {
+            visitor.visitDefault(this);
+        }
+    };
+
+    /**
+     * Calls the appropriate visit method depending on the subtype of {@link EventStream}.
+     *
+     * @param visitor Visitor to invoke.
+     */
+    void accept(StreamBirthsResponseHandler.Visitor visitor);
+
+    /**
+     * Calls the appropriate visit method depending on the subtype of {@link EventStream}.
+     *
+     * @param visitor Visitor to invoke.
+     */
+    void accept(StreamDeathsResponseHandler.Visitor visitor);
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.Builder, Person>, EventStream {
+    private static final SdkField<String> NAME_FIELD = SdkField.<String>builder(MarshallingType.STRING)
+        .getter(getter(Person::name))
+        .setter(setter(Builder::name))
+        .traits(LocationTrait.builder()
+                             .location(MarshallLocation.PAYLOAD)
+                             .locationName("Name")
+                             .build()).build();
+
+    private static final SdkField<Instant> BIRTHDAY_FIELD = SdkField.<Instant>builder(MarshallingType.INSTANT)
+        .getter(getter(Person::birthday))
+        .setter(setter(Builder::birthday))
+        .traits(LocationTrait.builder()
+                             .location(MarshallLocation.PAYLOAD)
+                             .locationName("Birthday")
+                             .build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(NAME_FIELD, BIRTHDAY_FIELD));
+
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+
+    private final Instant birthday;
+
+    private Person(BuilderImpl builder) {
+        this.name = builder.name;
+        this.birthday = builder.birthday;
+    }
+
+    /**
+     * Returns the value of the Name property for this object.
+     *
+     * @return The value of the Name property for this object.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the value of the Birthday property for this object.
+     *
+     * @return The value of the Birthday property for this object.
+     */
+    public Instant birthday() {
+        return birthday;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + Objects.hashCode(name());
+        hashCode = 31 * hashCode + Objects.hashCode(birthday());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Person)) {
+            return false;
+        }
+        Person other = (Person) obj;
+        return Objects.equals(name(), other.name()) && Objects.equals(birthday(), other.birthday());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("Person").add("Name", name()).add("Birthday", birthday()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Name":
+                return Optional.ofNullable(clazz.cast(name()));
+            case "Birthday":
+                return Optional.ofNullable(clazz.cast(birthday()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<Person, T> g) {
+        return obj -> g.apply((Person) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    /**
+     * Calls the appropriate visit method depending on the subtype of {@link Person}.
+     *
+     * @param visitor Visitor to invoke.
+     */
+    @Override
+    public void accept(StreamBirthsResponseHandler.Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    /**
+     * Calls the appropriate visit method depending on the subtype of {@link Person}.
+     *
+     * @param visitor Visitor to invoke.
+     */
+    @Override
+    public void accept(StreamDeathsResponseHandler.Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    public interface Builder extends SdkPojo, CopyableBuilder<Builder, Person> {
+        /**
+         * Sets the value of the Name property for this object.
+         *
+         * @param name The new value for the Name property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder name(String name);
+
+        /**
+         * Sets the value of the Birthday property for this object.
+         *
+         * @param birthday The new value for the Birthday property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder birthday(Instant birthday);
+    }
+
+    static final class BuilderImpl implements Builder {
+        private String name;
+
+        private Instant birthday;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(Person model) {
+            name(model.name);
+            birthday(model.birthday);
+        }
+
+        public final String getName() {
+            return name;
+        }
+
+        @Override
+        public final Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public final void setName(String name) {
+            this.name = name;
+        }
+
+        public final Instant getBirthday() {
+            return birthday;
+        }
+
+        @Override
+        public final Builder birthday(Instant birthday) {
+            this.birthday = birthday;
+            return this;
+        }
+
+        public final void setBirthday(Instant birthday) {
+            this.birthday = birthday;
+        }
+
+        @Override
+        public Person build() {
+            return new Person(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/service-2.json
@@ -1,0 +1,75 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2010-05-08",
+    "endpointPrefix": "shared-event-stream-service",
+    "globalEndpoint": "shared-event-stream.amazonaws.com",
+    "protocol": "rest-json",
+    "serviceAbbreviation": "Shared Event Stream Service",
+    "serviceFullName": "Service that shares event streams",
+    "serviceId":"Shared Event Stream Service",
+    "signatureVersion": "v4",
+    "uid": "shared-event-stream-service-2010-05-08",
+    "xmlNamespace": "https://shared-event-stream-service.amazonaws.com/doc/2010-05-08/"
+  },
+  "operations": {
+    "StreamBirths" : {
+      "name": "StreamBirths",
+      "http": {
+        "method": "GET",
+        "requestUri": "/births"
+      },
+      "output": {
+        "shape": "PeopleOutput"
+      }
+    },
+    "StreamDeaths" : {
+      "name": "StreamDeaths",
+      "http": {
+        "method": "GET",
+        "requestUri": "/deaths"
+      },
+      "output": {
+        "shape": "PeopleOutput"
+      }
+    }
+  },
+  "shapes": {
+    "dateType": {
+      "type": "timestamp"
+    },
+    "String": {
+      "type": "string"
+    },
+    "PeopleOutput": {
+      "type": "structure",
+      "members": {
+        "EventStream": {
+          "shape": "EventStream"
+        }
+      }
+    },
+    "EventStream": {
+      "type": "structure",
+      "members": {
+        "Person": {
+          "shape": "Person"
+        }
+      },
+      "eventstream": true
+    },
+    "Person": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "shape": "String"
+        },
+        "Birthday": {
+          "shape": "dateType"
+        }
+      },
+      "event": true
+    }
+  },
+  "documentation": "A service that streams births and deaths"
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsrequest.java
@@ -1,0 +1,120 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamBirthsRequest extends SharedEventStreamRequest implements ToCopyableBuilder<StreamBirthsRequest.Builder, StreamBirthsRequest> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList());
+
+    private StreamBirthsRequest(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamBirthsRequest)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("StreamBirthsRequest").build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo, CopyableBuilder<Builder, StreamBirthsRequest> {
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(
+            Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends SharedEventStreamRequest.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamBirthsRequest model) {
+            super(model);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(
+            Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public StreamBirthsRequest build() {
+            return new StreamBirthsRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streambirthsresponse.java
@@ -1,0 +1,101 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamBirthsResponse extends SharedEventStreamResponse implements ToCopyableBuilder<StreamBirthsResponse.Builder, StreamBirthsResponse> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList());
+
+    private StreamBirthsResponse(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamBirthsResponse)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("StreamBirthsResponse").build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo, CopyableBuilder<Builder, StreamBirthsResponse> {
+    }
+
+    static final class BuilderImpl extends SharedEventStreamResponse.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamBirthsResponse model) {
+            super(model);
+        }
+
+        @Override
+        public StreamBirthsResponse build() {
+            return new StreamBirthsResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsrequest.java
@@ -1,0 +1,120 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamDeathsRequest extends SharedEventStreamRequest implements ToCopyableBuilder<StreamDeathsRequest.Builder, StreamDeathsRequest> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList());
+
+    private StreamDeathsRequest(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamDeathsRequest)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("StreamDeathsRequest").build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo, CopyableBuilder<Builder, StreamDeathsRequest> {
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(
+            Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends SharedEventStreamRequest.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamDeathsRequest model) {
+            super(model);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(
+            Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public StreamDeathsRequest build() {
+            return new StreamDeathsRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/streamdeathsresponse.java
@@ -1,0 +1,101 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class StreamDeathsResponse extends SharedEventStreamResponse implements ToCopyableBuilder<StreamDeathsResponse.Builder, StreamDeathsResponse> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList());
+
+    private StreamDeathsResponse(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof StreamDeathsResponse)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("StreamDeathsResponse").build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo, CopyableBuilder<Builder, StreamDeathsResponse> {
+    }
+
+    static final class BuilderImpl extends SharedEventStreamResponse.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(StreamDeathsResponse model) {
+            super(model);
+        }
+
+        @Override
+        public StreamDeathsResponse build() {
+            return new StreamDeathsResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Event streams do not have to be 1:1 with operations, but the generation of event stream model types selects the first operation linked with an event stream when generating.  This change adds support for all associated operations to event stream interfaces and event types.

## Motivation and Context
This brings event stream client generation closer to the models allowed by the event stream specification.

## Testing
I added a generation test for a model that shares an event stream between two operations, and performed an end-to-end test offline with a test service that reuses event stream structures.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
