### PR TITLE
Add SourceRegion to CopyDBClusterSnapshot and CreateDBCluster operations.

### DIFF
--- a/.changes/next-release/feature-AmazonRDS-fb062ac.json
+++ b/.changes/next-release/feature-AmazonRDS-fb062ac.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "Amazon RDS",
+    "description": "Add SourceRegion to CopyDBClusterSnapshot and CreateDBCluster operations. As with CopyDBSnapshot and CreateDBInstanceReadReplica, specifying this field will automatically populate the PresignedURL field with a valid value."
+}

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/CopyDbClusterSnapshotPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/CopyDbClusterSnapshotPresignInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.rds.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.services.rds.model.CopyDbClusterSnapshotRequest;
+import software.amazon.awssdk.services.rds.transform.CopyDbClusterSnapshotRequestMarshaller;
+
+/**
+ * Handler for pre-signing {@link CopyDbClusterSnapshotRequest}.
+ */
+@SdkInternalApi
+public final class CopyDbClusterSnapshotPresignInterceptor extends RdsPresignInterceptor<CopyDbClusterSnapshotRequest> {
+
+    public static final CopyDbClusterSnapshotRequestMarshaller MARSHALLER =
+        new CopyDbClusterSnapshotRequestMarshaller(PROTOCOL_FACTORY);
+
+    public CopyDbClusterSnapshotPresignInterceptor() {
+        super(CopyDbClusterSnapshotRequest.class);
+    }
+
+    @Override
+    protected PresignableRequest adaptRequest(final CopyDbClusterSnapshotRequest originalRequest) {
+        return new PresignableRequest() {
+            @Override
+            public String getSourceRegion() {
+                return originalRequest.sourceRegion();
+            }
+
+            @Override
+            public SdkHttpFullRequest marshall() {
+                return MARSHALLER.marshall(originalRequest);
+            }
+        };
+    }
+}

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/CreateDbClusterPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/CreateDbClusterPresignInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.rds.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
+import software.amazon.awssdk.services.rds.transform.CreateDbClusterRequestMarshaller;
+
+/**
+ * Handler for pre-signing {@link CreateDbClusterRequest}.
+ */
+@SdkInternalApi
+public final class CreateDbClusterPresignInterceptor extends RdsPresignInterceptor<CreateDbClusterRequest> {
+
+    public static final CreateDbClusterRequestMarshaller MARSHALLER =
+        new CreateDbClusterRequestMarshaller(PROTOCOL_FACTORY);
+
+    public CreateDbClusterPresignInterceptor() {
+        super(CreateDbClusterRequest.class);
+    }
+
+    @Override
+    protected PresignableRequest adaptRequest(final CreateDbClusterRequest originalRequest) {
+        return new PresignableRequest() {
+            @Override
+            public String getSourceRegion() {
+                return originalRequest.sourceRegion();
+            }
+
+            @Override
+            public SdkHttpFullRequest marshall() {
+                return MARSHALLER.marshall(originalRequest);
+            }
+        };
+    }
+}

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
@@ -21,9 +21,9 @@ import java.net.URI;
 import java.time.Clock;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
-import software.amazon.awssdk.awscore.util.AwsHostNameUtils;
 import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -103,16 +103,10 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
             return request;
         }
 
-        String destinationRegion =
-                AwsHostNameUtils.parseSigningRegion(request.host(), SERVICE_NAME)
-                                .orElseThrow(() -> new IllegalArgumentException("Could not determine region for " +
-                                                                                request.host()))
-                                .id();
+        String destinationRegion = executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION).id();
 
         URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME);
-        SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall()
-                                                                         .toBuilder()
-                                                                         .uri(endpoint);
+        SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
                 marshalledRequest.method(SdkHttpMethod.GET)

--- a/services/rds/src/main/resources/codegen-resources/customization.config
+++ b/services/rds/src/main/resources/codegen-resources/customization.config
@@ -6,7 +6,7 @@
                     // This is for enabling automatic request presigning only; it should not be marshalled
                     "SourceRegion" : {
                         "shape" : "String",
-                        "documentation" : "The region where the source snapshot is located."
+                        "documentation" : "If PreSignedUrl is not specified, this is the region where the source snapshot is located. A PreSignedUrl will be generated automatically by the SDK."
                     }
                 }
             ]
@@ -17,12 +17,33 @@
                     // This is for enabling automatic request presigning only; it should not be marshalled
                     "SourceRegion" : {
                         "shape" : "String",
-                        "documentation" : "The region where the source instance is located."
+                        "documentation" : "If PreSignedUrl is not specified, this is the region where the source snapshot is located. A PreSignedUrl will be generated automatically by the SDK."
+                    }
+                }
+            ]
+        },
+        "CopyDBClusterSnapshotMessage" : {
+            "inject" : [
+                {
+                    // This is for enabling automatic request presigning only; it should not be marshalled
+                    "SourceRegion" : {
+                        "shape" : "String",
+                        "documentation" : "If PreSignedUrl is not specified, this is the region where the source snapshot is located. A PreSignedUrl will be generated automatically by the SDK."
+                    }
+                }
+            ]
+        },
+        "CreateDBClusterMessage" : {
+            "inject" : [
+                {
+                    // This is for enabling automatic request presigning only; it should not be marshalled
+                    "SourceRegion" : {
+                        "shape" : "String",
+                        "documentation" : "If PreSignedUrl is not specified, this is the region where the source snapshot is located. A PreSignedUrl will be generated automatically by the SDK."
                     }
                 }
             ]
         }
-
     },
     "blacklistedSimpleMethods" : ["failoverDBCluster"],
     "deprecatedShapes" : [

--- a/services/rds/src/main/resources/software/amazon/awssdk/services/rds/execution.interceptors
+++ b/services/rds/src/main/resources/software/amazon/awssdk/services/rds/execution.interceptors
@@ -1,2 +1,4 @@
+software.amazon.awssdk.services.rds.internal.CopyDbClusterSnapshotPresignInterceptor
 software.amazon.awssdk.services.rds.internal.CopyDbSnapshotPresignInterceptor
+software.amazon.awssdk.services.rds.internal.CreateDbClusterPresignInterceptor
 software.amazon.awssdk.services.rds.internal.CreateDbInstanceReadReplicaPresignInterceptor

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
@@ -40,8 +40,6 @@ import software.amazon.awssdk.core.interceptor.InterceptorContext;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.rds.internal.CopyDbSnapshotPresignInterceptor;
-import software.amazon.awssdk.services.rds.internal.RdsPresignInterceptor;
 import software.amazon.awssdk.services.rds.model.CopyDbSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.RdsRequest;
 import software.amazon.awssdk.services.rds.transform.CopyDbSnapshotRequestMarshaller;
@@ -163,7 +161,8 @@ public class PresignRequestHandlerTest {
     }
 
     private ExecutionAttributes executionAttributes() {
-        return new ExecutionAttributes().putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, CREDENTIALS);
+        return new ExecutionAttributes().putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, CREDENTIALS)
+                                        .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION);
     }
 
     private CopyDbSnapshotRequest makeTestRequest() {

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestWireMockTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestWireMockTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.rds.internal;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import java.net.URI;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsClient;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PresignRequestWireMockTest {
+    @ClassRule
+    public static final WireMockRule WIRE_MOCK = new WireMockRule(0);
+
+    public static RdsClient client;
+
+    @BeforeClass
+    public static void setup() {
+        client = RdsClient.builder()
+                          .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                          .region(Region.US_EAST_1)
+                          .endpointOverride(URI.create("http://localhost:" + WIRE_MOCK.port()))
+                          .build();
+    }
+
+    @Before
+    public void reset() {
+        WIRE_MOCK.resetAll();
+    }
+
+    @Test
+    public void copyDbClusterSnapshotWithSourceRegionSendsPresignedUrl() {
+        verifyMethodCallSendsPresignedUrl(() -> client.copyDBClusterSnapshot(r -> r.sourceRegion("us-west-2")),
+                                          "CopyDBClusterSnapshot");
+    }
+
+    @Test
+    public void copyDBSnapshotWithSourceRegionSendsPresignedUrl() {
+        verifyMethodCallSendsPresignedUrl(() -> client.copyDBSnapshot(r -> r.sourceRegion("us-west-2")),
+                                          "CopyDBSnapshot");
+    }
+
+    @Test
+    public void createDbClusterWithSourceRegionSendsPresignedUrl() {
+        verifyMethodCallSendsPresignedUrl(() -> client.createDBCluster(r -> r.sourceRegion("us-west-2")),
+                                          "CreateDBCluster");
+    }
+
+    @Test
+    public void createDBInstanceReadReplicaWithSourceRegionSendsPresignedUrl() {
+        verifyMethodCallSendsPresignedUrl(() -> client.createDBInstanceReadReplica(r -> r.sourceRegion("us-west-2")),
+                                          "CreateDBInstanceReadReplica");
+    }
+
+    public void verifyMethodCallSendsPresignedUrl(Runnable methodCall, String actionName) {
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody("<body/>")));
+
+        methodCall.run();
+
+        List<LoggedRequest> requests = findAll(anyRequestedFor(anyUrl()));
+
+        assertThat(requests).isNotEmpty();
+
+        LoggedRequest lastRequest = requests.get(0);
+        String lastRequestBody = new String(lastRequest.getBody(), UTF_8);
+        assertThat(lastRequestBody).contains("PreSignedUrl=https%3A%2F%2Frds.us-west-2.amazonaws.com%3FAction%3D" + actionName
+                                             + "%26Version%3D2014-10-31%26DestinationRegion%3Dus-east-1%26");
+    }
+}

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptorIntegrationTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptorIntegrationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.rds.internal;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.testutils.Waiter;
+import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
+
+public class RdsPresignInterceptorIntegrationTest extends AwsIntegrationTestBase {
+    private static final RdsClient US_WEST_2_CLIENT = RdsClient.builder()
+                                                               .region(Region.US_WEST_2)
+                                                               .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                                               .build();
+
+    @Test
+    public void createDbClusterReplicaPresigningWorks() {
+        US_WEST_2_CLIENT.createDBCluster(r -> r.dbClusterIdentifier("database-2-replica")
+                                               .sourceRegion("us-east-1")
+                                               .engine("aurora")
+                                               .storageEncrypted(true)
+                                               .kmsKeyId("aws/rds")
+                                               .replicationSourceIdentifier("arn:aws:rds:us-east-1:295513896279:cluster:database-2"));
+
+        US_WEST_2_CLIENT.deleteDBCluster(r -> r.dbClusterIdentifier("database-2-replica")
+                                               .skipFinalSnapshot(true));
+    }
+}


### PR DESCRIPTION
 As with CopyDBSnapshot and CreateDBInstanceReadReplica, specifying this field will automatically populate the PresignedURL field with a valid value.