### PR TITLE
Allow event structures to be used as operation outputs outside of streaming contexts.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-eb912cc.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-eb912cc.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Allow event structures to be used as operation outputs outside of streaming contexts."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/IntermediateModelBuilder.java
@@ -168,8 +168,7 @@ public class IntermediateModelBuilder {
         for (Map.Entry<String, ShapeModel> entry : model.getShapes().entrySet()) {
             if (entry.getValue().getMembers() != null) {
                 for (MemberModel member : entry.getValue().getMembers()) {
-                    member.setShape(
-                        Utils.findShapeModelByC2jNameIfExists(model, member.getC2jShape()));
+                    member.setShape(Utils.findMemberShapeModelByC2jNameIfExists(model, member.getC2jShape()));
                 }
             }
         }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
@@ -84,7 +84,9 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
     }
 
     private String getMemberNameFromEventStream() {
-        ShapeModel eventStream = EventStreamUtils.getBaseEventStreamShape(intermediateModel, shapeModel);
+        ShapeModel eventStream = EventStreamUtils.getBaseEventStreamShape(intermediateModel, shapeModel)
+            .orElseThrow(() -> new IllegalStateException("Could not find associated event stream spec for "
+                                                         + shapeModel.getC2jName()));
         return eventStream.getMembers().stream()
                           .filter(memberModel -> memberModel.getShape().equals(shapeModel))
                           .findAny()

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonrequest.java
@@ -1,0 +1,120 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+@Generated("software.amazon.awssdk:codegen")
+public final class GetRandomPersonRequest extends SharedEventStreamRequest implements
+                                                                           ToCopyableBuilder<GetRandomPersonRequest.Builder, GetRandomPersonRequest> {
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList());
+
+    private GetRandomPersonRequest(BuilderImpl builder) {
+        super(builder);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof GetRandomPersonRequest)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("GetRandomPersonRequest").build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    public interface Builder extends SharedEventStreamRequest.Builder, SdkPojo, CopyableBuilder<Builder, GetRandomPersonRequest> {
+        @Override
+        Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration);
+
+        @Override
+        Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer);
+    }
+
+    static final class BuilderImpl extends SharedEventStreamRequest.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(GetRandomPersonRequest model) {
+            super(model);
+        }
+
+        @Override
+        public Builder overrideConfiguration(AwsRequestOverrideConfiguration overrideConfiguration) {
+            super.overrideConfiguration(overrideConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder overrideConfiguration(Consumer<AwsRequestOverrideConfiguration.Builder> builderConsumer) {
+            super.overrideConfiguration(builderConsumer);
+            return this;
+        }
+
+        @Override
+        public GetRandomPersonRequest build() {
+            return new GetRandomPersonRequest(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
@@ -1,0 +1,212 @@
+package software.amazon.awssdk.services.sharedeventstream.model;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.protocol.MarshallingType;
+import software.amazon.awssdk.core.traits.LocationTrait;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ */
+@Generated("software.amazon.awssdk:codegen")
+public final class GetRandomPersonResponse extends SharedEventStreamResponse implements
+                                                                             ToCopyableBuilder<GetRandomPersonResponse.Builder, GetRandomPersonResponse> {
+    private static final SdkField<String> NAME_FIELD = SdkField.<String> builder(MarshallingType.STRING)
+        .getter(getter(GetRandomPersonResponse::name)).setter(setter(Builder::name))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Name").build()).build();
+
+    private static final SdkField<Instant> BIRTHDAY_FIELD = SdkField.<Instant> builder(MarshallingType.INSTANT)
+        .getter(getter(GetRandomPersonResponse::birthday)).setter(setter(Builder::birthday))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("Birthday").build()).build();
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(NAME_FIELD, BIRTHDAY_FIELD));
+
+    private final String name;
+
+    private final Instant birthday;
+
+    private GetRandomPersonResponse(BuilderImpl builder) {
+        super(builder);
+        this.name = builder.name;
+        this.birthday = builder.birthday;
+    }
+
+    /**
+     * Returns the value of the Name property for this object.
+     *
+     * @return The value of the Name property for this object.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the value of the Birthday property for this object.
+     *
+     * @return The value of the Birthday property for this object.
+     */
+    public Instant birthday() {
+        return birthday;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public static Class<? extends Builder> serializableBuilderClass() {
+        return BuilderImpl.class;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        hashCode = 31 * hashCode + super.hashCode();
+        hashCode = 31 * hashCode + Objects.hashCode(name());
+        hashCode = 31 * hashCode + Objects.hashCode(birthday());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && equalsBySdkFields(obj);
+    }
+
+    @Override
+    public boolean equalsBySdkFields(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof GetRandomPersonResponse)) {
+            return false;
+        }
+        GetRandomPersonResponse other = (GetRandomPersonResponse) obj;
+        return Objects.equals(name(), other.name()) && Objects.equals(birthday(), other.birthday());
+    }
+
+    /**
+     * Returns a string representation of this object. This is useful for testing and debugging. Sensitive data will be
+     * redacted from this string using a placeholder value.
+     */
+    @Override
+    public String toString() {
+        return ToString.builder("GetRandomPersonResponse").add("Name", name()).add("Birthday", birthday()).build();
+    }
+
+    public <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
+        switch (fieldName) {
+            case "Name":
+                return Optional.ofNullable(clazz.cast(name()));
+            case "Birthday":
+                return Optional.ofNullable(clazz.cast(birthday()));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<SdkField<?>> sdkFields() {
+        return SDK_FIELDS;
+    }
+
+    private static <T> Function<Object, T> getter(Function<GetRandomPersonResponse, T> g) {
+        return obj -> g.apply((GetRandomPersonResponse) obj);
+    }
+
+    private static <T> BiConsumer<Object, T> setter(BiConsumer<Builder, T> s) {
+        return (obj, val) -> s.accept((Builder) obj, val);
+    }
+
+    public interface Builder extends SharedEventStreamResponse.Builder, SdkPojo,
+                                     CopyableBuilder<Builder, GetRandomPersonResponse> {
+        /**
+         * Sets the value of the Name property for this object.
+         *
+         * @param name
+         *        The new value for the Name property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder name(String name);
+
+        /**
+         * Sets the value of the Birthday property for this object.
+         *
+         * @param birthday
+         *        The new value for the Birthday property for this object.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        Builder birthday(Instant birthday);
+    }
+
+    static final class BuilderImpl extends SharedEventStreamResponse.BuilderImpl implements Builder {
+        private String name;
+
+        private Instant birthday;
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(GetRandomPersonResponse model) {
+            super(model);
+            name(model.name);
+            birthday(model.birthday);
+        }
+
+        public final String getName() {
+            return name;
+        }
+
+        @Override
+        public final Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public final void setName(String name) {
+            this.name = name;
+        }
+
+        public final Instant getBirthday() {
+            return birthday;
+        }
+
+        @Override
+        public final Builder birthday(Instant birthday) {
+            this.birthday = birthday;
+            return this;
+        }
+
+        public final void setBirthday(Instant birthday) {
+            this.birthday = birthday;
+        }
+
+        @Override
+        public GetRandomPersonResponse build() {
+            return new GetRandomPersonResponse(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/service-2.json
@@ -32,6 +32,16 @@
       "output": {
         "shape": "PeopleOutput"
       }
+    },
+    "GetRandomPerson" : {
+      "name" : "GetRandomPerson",
+      "http": {
+        "method": "GET",
+        "requestUri": "/randomPerson"
+      },
+      "output": {
+        "shape": "Person"
+      }
     }
   },
   "shapes": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Event is just a marker that a structure can be used as an event; it does not limit its use outside of stream contexts.

## Motivation and Context
Without this change, it is harder to add event streams to existing services and reuse existing structures defined for non-streaming operations.

## Testing
I added unit tests, and ran this generator against a service that uses an event structure as an output for a non-streaming API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
