### PR TITLE
Enable endpoint discovery by default for services that support it

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-534a8f5.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-534a8f5.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "description": "Endpoint discovery is now enabled by default for services that support it (as of writing only Amazon DynamoDB). A new method 'endpointDiscoveryEnabled' has been added to client builders that support endpoint discovery allowing a true or false value to be set. 'enableEndpointDiscovery' has been deprecated on the client builders as it is now superseded by 'endpointDiscoveryEnabled'."
+}

--- a/archetypes/archetype-lambda/pom.xml
+++ b/archetypes/archetype-lambda/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>archetypes</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>archetype-lambda</artifactId>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>archetypes</artifactId>

--- a/aws-sdk-java/pom.xml
+++ b/aws-sdk-java/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>aws-sdk-java</artifactId>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>bom</artifactId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>bundle</artifactId>
     <packaging>jar</packaging>

--- a/codegen-lite-maven-plugin/pom.xml
+++ b/codegen-lite-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>codegen-lite-maven-plugin</artifactId>

--- a/codegen-lite/pom.xml
+++ b/codegen-lite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codegen-lite</artifactId>
     <name>AWS Java SDK :: Code Generator Lite</name>

--- a/codegen-maven-plugin/pom.xml
+++ b/codegen-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>codegen-maven-plugin</artifactId>

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codegen</artifactId>
     <name>AWS Java SDK :: Code Generator</name>

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -54,10 +54,22 @@ public class AsyncClientBuilderClass implements ClassSpec {
                          .addJavadoc("Internal implementation of {@link $T}.", builderInterfaceName);
 
         if (model.getEndpointOperation().isPresent()) {
-            builder.addMethod(enableEndpointDiscovery());
+            builder.addMethod(endpointDiscoveryEnabled())
+                   .addMethod(enableEndpointDiscovery());
         }
 
         return builder.addMethod(buildClientMethod()).build();
+    }
+
+    private MethodSpec endpointDiscoveryEnabled() {
+        return MethodSpec.methodBuilder("endpointDiscoveryEnabled")
+                         .addAnnotation(Override.class)
+                         .addModifiers(Modifier.PUBLIC)
+                         .returns(builderClassName)
+                         .addParameter(boolean.class, "endpointDiscoveryEnabled")
+                         .addStatement("this.endpointDiscoveryEnabled = endpointDiscoveryEnabled")
+                         .addStatement("return this")
+                         .build();
     }
 
     private MethodSpec enableEndpointDiscovery() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -53,6 +53,9 @@ import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.StringUtils;
 
 public class BaseClientBuilderClass implements ClassSpec {
+    // This only applies to services that support endpoint discovery
+    private static final String ENDPOINT_DISCOVERY_ENABLED_BY_DEFAULT = "true";
+
     private final IntermediateModel model;
     private final ClassName builderInterfaceName;
     private final ClassName builderClassName;
@@ -81,7 +84,7 @@ public class BaseClientBuilderClass implements ClassSpec {
         if (model.getEndpointOperation().isPresent()) {
             builder.addField(FieldSpec.builder(boolean.class, "endpointDiscoveryEnabled")
                                       .addModifiers(PROTECTED)
-                                      .initializer("false")
+                                      .initializer(ENDPOINT_DISCOVERY_ENABLED_BY_DEFAULT)
                                       .build());
         }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
@@ -51,6 +51,7 @@ public class BaseClientBuilderInterface implements ClassSpec {
 
         if (model.getEndpointOperation().isPresent()) {
             builder.addMethod(enableEndpointDiscovery());
+            builder.addMethod(endpointDiscovery());
         }
 
         if (model.getCustomizationConfig().getServiceSpecificClientConfigClass() != null) {
@@ -72,6 +73,16 @@ public class BaseClientBuilderInterface implements ClassSpec {
         return MethodSpec.methodBuilder("enableEndpointDiscovery")
                          .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                          .returns(TypeVariableName.get("B"))
+                         .addAnnotation(Deprecated.class)
+                         .addJavadoc("@deprecated Use {@link #endpointDiscoveryEnabled($T)} instead.", boolean.class)
+                         .build();
+    }
+
+    private MethodSpec endpointDiscovery() {
+        return MethodSpec.methodBuilder("endpointDiscoveryEnabled")
+                         .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                         .returns(TypeVariableName.get("B"))
+                         .addParameter(boolean.class, "endpointDiscovery")
                          .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
@@ -54,10 +54,22 @@ public class SyncClientBuilderClass implements ClassSpec {
                          .addJavadoc("Internal implementation of {@link $T}.", builderInterfaceName);
 
         if (model.getEndpointOperation().isPresent()) {
-            builder.addMethod(enableEndpointDiscovery());
+            builder.addMethod(endpointDiscoveryEnabled())
+                   .addMethod(enableEndpointDiscovery());
         }
 
         return builder.addMethod(buildClientMethod()).build();
+    }
+
+    private MethodSpec endpointDiscoveryEnabled() {
+        return MethodSpec.methodBuilder("endpointDiscoveryEnabled")
+                         .addAnnotation(Override.class)
+                         .addModifiers(Modifier.PUBLIC)
+                         .returns(builderClassName)
+                         .addParameter(boolean.class, "endpointDiscoveryEnabled")
+                         .addStatement("this.endpointDiscoveryEnabled = endpointDiscoveryEnabled")
+                         .addStatement("return this")
+                         .build();
     }
 
     private MethodSpec enableEndpointDiscovery() {

--- a/core/annotations/pom.xml
+++ b/core/annotations/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/arns/pom.xml
+++ b/core/arns/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/auth/pom.xml
+++ b/core/auth/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>auth</artifactId>

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aws-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/core/profiles/pom.xml
+++ b/core/profiles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>profiles</artifactId>

--- a/core/protocols/aws-cbor-protocol/pom.xml
+++ b/core/protocols/aws-cbor-protocol/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>protocols</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/protocols/aws-ion-protocol/pom.xml
+++ b/core/protocols/aws-ion-protocol/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>protocols</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/protocols/aws-json-protocol/pom.xml
+++ b/core/protocols/aws-json-protocol/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>protocols</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/protocols/aws-query-protocol/pom.xml
+++ b/core/protocols/aws-query-protocol/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>protocols</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/protocols/aws-xml-protocol/pom.xml
+++ b/core/protocols/aws-xml-protocol/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>protocols</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/protocols/pom.xml
+++ b/core/protocols/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/protocols/protocol-core/pom.xml
+++ b/core/protocols/protocol-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>protocols</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/regions/pom.xml
+++ b/core/regions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>regions</artifactId>

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>core</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sdk-core</artifactId>
     <name>AWS Java SDK :: SDK Core</name>

--- a/http-client-spi/pom.xml
+++ b/http-client-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>http-client-spi</artifactId>
     <name>AWS Java SDK :: HTTP Client Interface</name>

--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apache-client</artifactId>

--- a/http-clients/netty-nio-client/pom.xml
+++ b/http-clients/netty-nio-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-clients/pom.xml
+++ b/http-clients/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/http-clients/url-connection-client/pom.xml
+++ b/http-clients/url-connection-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>http-clients</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.awssdk</groupId>
     <artifactId>aws-sdk-java-pom</artifactId>
-    <version>2.13.18-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>AWS Java SDK :: Parent</name>
     <description>The Amazon Web Services SDK for Java provides Java APIs

--- a/release-scripts/pom.xml
+++ b/release-scripts/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>release-scripts</artifactId>

--- a/services-custom/dynamodb-enhanced/pom.xml
+++ b/services-custom/dynamodb-enhanced/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services-custom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>dynamodb-enhanced</artifactId>
     <version>${awsjavasdk.version}</version>

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/InstantAsStringAttributeConvertersTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/InstantAsStringAttributeConvertersTest.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.Ins
 
 public class InstantAsStringAttributeConvertersTest {
 
-    private static InstantAsStringAttributeConverter converter = InstantAsStringAttributeConverter.create();
+    private static final InstantAsStringAttributeConverter CONVERTER = InstantAsStringAttributeConverter.create();
 
     @Test
     public void InstantAsStringAttributeConverterMinTest() {
@@ -57,62 +57,62 @@ public class InstantAsStringAttributeConvertersTest {
 
     @Test
     public void InstantAsStringAttributeConverterExceedLowerBoundTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("-1000000001-12-31T23:59:59.999999999Z")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("-1000000001-12-31T23:59:59.999999999Z")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterInvalidFormatTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("X")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("X")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterExceedHigherBoundTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("+1000000001-01-01T00:00:00Z")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("+1000000001-01-01T00:00:00Z")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterNotAcceptLocalDateTimeTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("1988-05-21T00:12:00.000000001")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("1988-05-21T00:12:00.000000001")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterNotAcceptOffsetTimeTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("1988-05-21T00:12:00+01:00")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("1988-05-21T00:12:00+01:00")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterNotAcceptZonedTimeTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("1988-05-21T00:12:00+01:00[Europe/Paris]")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("1988-05-21T00:12:00+01:00[Europe/Paris]")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterNotAcceptLocalDateTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("1988-05-21")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("1988-05-21")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterNotAcceptLocalTimeTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("00:12:00.000000001")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("00:12:00.000000001")
                                                                        .toAttributeValue()));
     }
 
     @Test
     public void InstantAsStringAttributeConverterNotAcceptMonthDayTest() {
-        assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("05-21")
+        assertFails(() -> transformTo(CONVERTER, EnhancedAttributeValue.fromString("05-21")
                                                                        .toAttributeValue()));
     }
 
     private void verifyTransform(Instant objectToTransform, String attributeValueString) {
-        assertThat(transformFrom(converter, objectToTransform))
+        assertThat(transformFrom(CONVERTER, objectToTransform))
             .isEqualTo(EnhancedAttributeValue.fromString(attributeValueString).toAttributeValue());
-        assertThat(transformTo(converter, EnhancedAttributeValue.fromString(attributeValueString).toAttributeValue()))
+        assertThat(transformTo(CONVERTER, EnhancedAttributeValue.fromString(attributeValueString).toAttributeValue()))
             .isEqualTo(objectToTransform);
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/AsyncBatchGetItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/AsyncBatchGetItemTest.java
@@ -55,6 +55,7 @@ public class AsyncBatchGetItemTest {
                                .region(Region.US_WEST_2)
                                .credentialsProvider(() -> AwsBasicCredentials.create("foo", "bar"))
                                .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                               .endpointDiscoveryEnabled(false)
                                .build();
         enhancedClient = DynamoDbEnhancedAsyncClient.builder()
                                                     .dynamoDbClient(dynamoDbClient)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/BatchGetItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mocktests/BatchGetItemTest.java
@@ -56,6 +56,7 @@ public class BatchGetItemTest {
                           .region(Region.US_WEST_2)
                           .credentialsProvider(() -> AwsBasicCredentials.create("foo", "bar"))
                           .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                          .endpointDiscoveryEnabled(false)
                           .build();
         enhancedClient = DynamoDbEnhancedClient.builder()
                                                .dynamoDbClient(dynamoDbClient)

--- a/services-custom/pom.xml
+++ b/services-custom/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>services-custom</artifactId>
     <name>AWS Java SDK :: Custom Services</name>

--- a/services/accessanalyzer/pom.xml
+++ b/services/accessanalyzer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>accessanalyzer</artifactId>
     <name>AWS Java SDK :: Services :: AccessAnalyzer</name>

--- a/services/acm/pom.xml
+++ b/services/acm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>acm</artifactId>
     <name>AWS Java SDK :: Services :: AWS Certificate Manager</name>

--- a/services/acmpca/pom.xml
+++ b/services/acmpca/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>acmpca</artifactId>
     <name>AWS Java SDK :: Services :: ACM PCA</name>

--- a/services/alexaforbusiness/pom.xml
+++ b/services/alexaforbusiness/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alexaforbusiness</artifactId>

--- a/services/amplify/pom.xml
+++ b/services/amplify/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>amplify</artifactId>
     <name>AWS Java SDK :: Services :: Amplify</name>

--- a/services/apigateway/pom.xml
+++ b/services/apigateway/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>apigateway</artifactId>
     <name>AWS Java SDK :: Services :: Amazon API Gateway</name>

--- a/services/apigatewaymanagementapi/pom.xml
+++ b/services/apigatewaymanagementapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>apigatewaymanagementapi</artifactId>
     <name>AWS Java SDK :: Services :: ApiGatewayManagementApi</name>

--- a/services/apigatewayv2/pom.xml
+++ b/services/apigatewayv2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>apigatewayv2</artifactId>
     <name>AWS Java SDK :: Services :: ApiGatewayV2</name>

--- a/services/appconfig/pom.xml
+++ b/services/appconfig/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>appconfig</artifactId>
     <name>AWS Java SDK :: Services :: AppConfig</name>

--- a/services/applicationautoscaling/pom.xml
+++ b/services/applicationautoscaling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>applicationautoscaling</artifactId>
     <name>AWS Java SDK :: Services :: AWS Application Auto Scaling</name>

--- a/services/applicationdiscovery/pom.xml
+++ b/services/applicationdiscovery/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>applicationdiscovery</artifactId>
     <name>AWS Java SDK :: Services :: AWS Application Discovery Service</name>

--- a/services/applicationinsights/pom.xml
+++ b/services/applicationinsights/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>applicationinsights</artifactId>
     <name>AWS Java SDK :: Services :: Application Insights</name>

--- a/services/appmesh/pom.xml
+++ b/services/appmesh/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>appmesh</artifactId>
     <name>AWS Java SDK :: Services :: App Mesh</name>

--- a/services/appstream/pom.xml
+++ b/services/appstream/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>appstream</artifactId>
     <name>AWS Java SDK :: Services :: Amazon AppStream</name>

--- a/services/appsync/pom.xml
+++ b/services/appsync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>appsync</artifactId>

--- a/services/athena/pom.xml
+++ b/services/athena/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>athena</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Athena</name>

--- a/services/autoscaling/pom.xml
+++ b/services/autoscaling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>autoscaling</artifactId>
     <name>AWS Java SDK :: Services :: Auto Scaling</name>

--- a/services/autoscalingplans/pom.xml
+++ b/services/autoscalingplans/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>autoscalingplans</artifactId>
     <name>AWS Java SDK :: Services :: Auto Scaling Plans</name>

--- a/services/backup/pom.xml
+++ b/services/backup/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>backup</artifactId>
     <name>AWS Java SDK :: Services :: Backup</name>

--- a/services/batch/pom.xml
+++ b/services/batch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>batch</artifactId>
     <name>AWS Java SDK :: Services :: AWS Batch</name>

--- a/services/budgets/pom.xml
+++ b/services/budgets/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>budgets</artifactId>
     <name>AWS Java SDK :: Services :: AWS Budgets</name>

--- a/services/chime/pom.xml
+++ b/services/chime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>chime</artifactId>
     <name>AWS Java SDK :: Services :: Chime</name>

--- a/services/cloud9/pom.xml
+++ b/services/cloud9/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cloud9</artifactId>

--- a/services/clouddirectory/pom.xml
+++ b/services/clouddirectory/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>clouddirectory</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudDirectory</name>

--- a/services/cloudformation/pom.xml
+++ b/services/cloudformation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudformation</artifactId>
     <name>AWS Java SDK :: Services :: AWS CloudFormation</name>

--- a/services/cloudfront/pom.xml
+++ b/services/cloudfront/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudfront</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudFront</name>

--- a/services/cloudhsm/pom.xml
+++ b/services/cloudhsm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudhsm</artifactId>
     <name>AWS Java SDK :: Services :: AWS CloudHSM</name>

--- a/services/cloudhsmv2/pom.xml
+++ b/services/cloudhsmv2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cloudhsmv2</artifactId>

--- a/services/cloudsearch/pom.xml
+++ b/services/cloudsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudsearch</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudSearch</name>

--- a/services/cloudsearchdomain/pom.xml
+++ b/services/cloudsearchdomain/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudsearchdomain</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudSearch Domain</name>

--- a/services/cloudtrail/pom.xml
+++ b/services/cloudtrail/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudtrail</artifactId>
     <name>AWS Java SDK :: Services :: AWS CloudTrail</name>

--- a/services/cloudwatch/pom.xml
+++ b/services/cloudwatch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudwatch</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudWatch</name>

--- a/services/cloudwatchevents/pom.xml
+++ b/services/cloudwatchevents/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudwatchevents</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudWatch Events</name>

--- a/services/cloudwatchlogs/pom.xml
+++ b/services/cloudwatchlogs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cloudwatchlogs</artifactId>
     <name>AWS Java SDK :: Services :: Amazon CloudWatch Logs</name>

--- a/services/codebuild/pom.xml
+++ b/services/codebuild/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codebuild</artifactId>
     <name>AWS Java SDK :: Services :: AWS Code Build</name>

--- a/services/codecommit/pom.xml
+++ b/services/codecommit/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codecommit</artifactId>
     <name>AWS Java SDK :: Services :: AWS CodeCommit</name>

--- a/services/codedeploy/pom.xml
+++ b/services/codedeploy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codedeploy</artifactId>
     <name>AWS Java SDK :: Services :: AWS CodeDeploy</name>

--- a/services/codeguruprofiler/pom.xml
+++ b/services/codeguruprofiler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codeguruprofiler</artifactId>
     <name>AWS Java SDK :: Services :: CodeGuruProfiler</name>

--- a/services/codegurureviewer/pom.xml
+++ b/services/codegurureviewer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codegurureviewer</artifactId>
     <name>AWS Java SDK :: Services :: CodeGuru Reviewer</name>

--- a/services/codepipeline/pom.xml
+++ b/services/codepipeline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codepipeline</artifactId>
     <name>AWS Java SDK :: Services :: AWS CodePipeline</name>

--- a/services/codestar/pom.xml
+++ b/services/codestar/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codestar</artifactId>
     <name>AWS Java SDK :: Services :: AWS CodeStar</name>

--- a/services/codestarconnections/pom.xml
+++ b/services/codestarconnections/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codestarconnections</artifactId>
     <name>AWS Java SDK :: Services :: CodeStar connections</name>

--- a/services/codestarnotifications/pom.xml
+++ b/services/codestarnotifications/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>codestarnotifications</artifactId>
     <name>AWS Java SDK :: Services :: Codestar Notifications</name>

--- a/services/cognitoidentity/pom.xml
+++ b/services/cognitoidentity/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cognitoidentity</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Cognito Identity</name>

--- a/services/cognitoidentityprovider/pom.xml
+++ b/services/cognitoidentityprovider/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cognitoidentityprovider</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Cognito Identity Provider Service</name>

--- a/services/cognitosync/pom.xml
+++ b/services/cognitosync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>cognitosync</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Cognito Sync</name>

--- a/services/comprehend/pom.xml
+++ b/services/comprehend/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>comprehend</artifactId>

--- a/services/comprehendmedical/pom.xml
+++ b/services/comprehendmedical/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>comprehendmedical</artifactId>
     <name>AWS Java SDK :: Services :: ComprehendMedical</name>

--- a/services/computeoptimizer/pom.xml
+++ b/services/computeoptimizer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>computeoptimizer</artifactId>
     <name>AWS Java SDK :: Services :: Compute Optimizer</name>

--- a/services/config/pom.xml
+++ b/services/config/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>config</artifactId>
     <name>AWS Java SDK :: Services :: AWS Config</name>

--- a/services/connect/pom.xml
+++ b/services/connect/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>connect</artifactId>
     <name>AWS Java SDK :: Services :: Connect</name>

--- a/services/connectparticipant/pom.xml
+++ b/services/connectparticipant/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>connectparticipant</artifactId>
     <name>AWS Java SDK :: Services :: ConnectParticipant</name>

--- a/services/costandusagereport/pom.xml
+++ b/services/costandusagereport/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>costandusagereport</artifactId>
     <name>AWS Java SDK :: Services :: AWS Cost and Usage Report</name>

--- a/services/costexplorer/pom.xml
+++ b/services/costexplorer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>costexplorer</artifactId>

--- a/services/databasemigration/pom.xml
+++ b/services/databasemigration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>databasemigration</artifactId>
     <name>AWS Java SDK :: Services :: AWS Database Migration Service</name>

--- a/services/dataexchange/pom.xml
+++ b/services/dataexchange/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>dataexchange</artifactId>
     <name>AWS Java SDK :: Services :: DataExchange</name>

--- a/services/datapipeline/pom.xml
+++ b/services/datapipeline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>datapipeline</artifactId>
     <name>AWS Java SDK :: Services :: AWS Data Pipeline</name>

--- a/services/datasync/pom.xml
+++ b/services/datasync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>datasync</artifactId>
     <name>AWS Java SDK :: Services :: DataSync</name>

--- a/services/dax/pom.xml
+++ b/services/dax/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>dax</artifactId>
     <name>AWS Java SDK :: Services :: Amazon DynamoDB Accelerator (DAX)</name>

--- a/services/detective/pom.xml
+++ b/services/detective/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>detective</artifactId>
     <name>AWS Java SDK :: Services :: Detective</name>

--- a/services/devicefarm/pom.xml
+++ b/services/devicefarm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>devicefarm</artifactId>
     <name>AWS Java SDK :: Services :: AWS Device Farm</name>

--- a/services/directconnect/pom.xml
+++ b/services/directconnect/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>directconnect</artifactId>
     <name>AWS Java SDK :: Services :: AWS Direct Connect</name>

--- a/services/directory/pom.xml
+++ b/services/directory/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>directory</artifactId>
     <name>AWS Java SDK :: Services :: AWS Directory Service</name>

--- a/services/dlm/pom.xml
+++ b/services/dlm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>dlm</artifactId>
     <name>AWS Java SDK :: Services :: DLM</name>

--- a/services/docdb/pom.xml
+++ b/services/docdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>docdb</artifactId>
     <name>AWS Java SDK :: Services :: DocDB</name>

--- a/services/dynamodb/pom.xml
+++ b/services/dynamodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>dynamodb</artifactId>
     <name>AWS Java SDK :: Services :: Amazon DynamoDB</name>

--- a/services/ebs/pom.xml
+++ b/services/ebs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ebs</artifactId>
     <name>AWS Java SDK :: Services :: EBS</name>

--- a/services/ec2/pom.xml
+++ b/services/ec2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ec2</artifactId>
     <name>AWS Java SDK :: Services :: Amazon EC2</name>

--- a/services/ec2instanceconnect/pom.xml
+++ b/services/ec2instanceconnect/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ec2instanceconnect</artifactId>
     <name>AWS Java SDK :: Services :: EC2 Instance Connect</name>

--- a/services/ecr/pom.xml
+++ b/services/ecr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ecr</artifactId>
     <name>AWS Java SDK :: Services :: Amazon EC2 Container Registry</name>

--- a/services/ecs/pom.xml
+++ b/services/ecs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ecs</artifactId>
     <name>AWS Java SDK :: Services :: Amazon EC2 Container Service</name>

--- a/services/efs/pom.xml
+++ b/services/efs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>efs</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Elastic File System</name>

--- a/services/eks/pom.xml
+++ b/services/eks/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>eks</artifactId>
     <name>AWS Java SDK :: Services :: EKS</name>

--- a/services/elasticache/pom.xml
+++ b/services/elasticache/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticache</artifactId>
     <name>AWS Java SDK :: Services :: Amazon ElastiCache</name>

--- a/services/elasticbeanstalk/pom.xml
+++ b/services/elasticbeanstalk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticbeanstalk</artifactId>
     <name>AWS Java SDK :: Services :: AWS Elastic Beanstalk</name>

--- a/services/elasticinference/pom.xml
+++ b/services/elasticinference/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticinference</artifactId>
     <name>AWS Java SDK :: Services :: Elastic Inference</name>

--- a/services/elasticloadbalancing/pom.xml
+++ b/services/elasticloadbalancing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticloadbalancing</artifactId>
     <name>AWS Java SDK :: Services :: Elastic Load Balancing</name>

--- a/services/elasticloadbalancingv2/pom.xml
+++ b/services/elasticloadbalancingv2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticloadbalancingv2</artifactId>
     <name>AWS Java SDK :: Services :: Elastic Load Balancing V2</name>

--- a/services/elasticsearch/pom.xml
+++ b/services/elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticsearch</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Elasticsearch Service</name>

--- a/services/elastictranscoder/pom.xml
+++ b/services/elastictranscoder/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>elastictranscoder</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Elastic Transcoder</name>

--- a/services/emr/pom.xml
+++ b/services/emr/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>emr</artifactId>
     <name>AWS Java SDK :: Services :: Amazon EMR</name>

--- a/services/eventbridge/pom.xml
+++ b/services/eventbridge/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>eventbridge</artifactId>
     <name>AWS Java SDK :: Services :: EventBridge</name>

--- a/services/firehose/pom.xml
+++ b/services/firehose/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>firehose</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Kinesis Firehose</name>

--- a/services/fms/pom.xml
+++ b/services/fms/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>fms</artifactId>
     <name>AWS Java SDK :: Services :: FMS</name>

--- a/services/forecast/pom.xml
+++ b/services/forecast/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>forecast</artifactId>
     <name>AWS Java SDK :: Services :: Forecast</name>

--- a/services/forecastquery/pom.xml
+++ b/services/forecastquery/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>forecastquery</artifactId>
     <name>AWS Java SDK :: Services :: Forecastquery</name>

--- a/services/frauddetector/pom.xml
+++ b/services/frauddetector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>frauddetector</artifactId>
     <name>AWS Java SDK :: Services :: FraudDetector</name>

--- a/services/fsx/pom.xml
+++ b/services/fsx/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>fsx</artifactId>
     <name>AWS Java SDK :: Services :: FSx</name>

--- a/services/gamelift/pom.xml
+++ b/services/gamelift/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>gamelift</artifactId>
     <name>AWS Java SDK :: Services :: AWS GameLift</name>

--- a/services/glacier/pom.xml
+++ b/services/glacier/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>glacier</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Glacier</name>

--- a/services/globalaccelerator/pom.xml
+++ b/services/globalaccelerator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>globalaccelerator</artifactId>
     <name>AWS Java SDK :: Services :: Global Accelerator</name>

--- a/services/glue/pom.xml
+++ b/services/glue/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>glue</artifactId>

--- a/services/greengrass/pom.xml
+++ b/services/greengrass/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>greengrass</artifactId>
     <name>AWS Java SDK :: Services :: AWS Greengrass</name>

--- a/services/groundstation/pom.xml
+++ b/services/groundstation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>groundstation</artifactId>
     <name>AWS Java SDK :: Services :: GroundStation</name>

--- a/services/guardduty/pom.xml
+++ b/services/guardduty/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>guardduty</artifactId>

--- a/services/health/pom.xml
+++ b/services/health/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>health</artifactId>
     <name>AWS Java SDK :: Services :: AWS Health APIs and Notifications</name>

--- a/services/iam/pom.xml
+++ b/services/iam/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iam</artifactId>
     <name>AWS Java SDK :: Services :: AWS IAM</name>

--- a/services/imagebuilder/pom.xml
+++ b/services/imagebuilder/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>imagebuilder</artifactId>
     <name>AWS Java SDK :: Services :: Imagebuilder</name>

--- a/services/inspector/pom.xml
+++ b/services/inspector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>inspector</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Inspector Service</name>

--- a/services/iot/pom.xml
+++ b/services/iot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iot</artifactId>
     <name>AWS Java SDK :: Services :: AWS IoT</name>

--- a/services/iot1clickdevices/pom.xml
+++ b/services/iot1clickdevices/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iot1clickdevices</artifactId>
     <name>AWS Java SDK :: Services :: IoT 1Click Devices Service</name>

--- a/services/iot1clickprojects/pom.xml
+++ b/services/iot1clickprojects/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iot1clickprojects</artifactId>
     <name>AWS Java SDK :: Services :: IoT 1Click Projects</name>

--- a/services/iotanalytics/pom.xml
+++ b/services/iotanalytics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotanalytics</artifactId>
     <name>AWS Java SDK :: Services :: IoTAnalytics</name>

--- a/services/iotdataplane/pom.xml
+++ b/services/iotdataplane/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotdataplane</artifactId>
     <name>AWS Java SDK :: Services :: AWS IoT Data Plane</name>

--- a/services/iotevents/pom.xml
+++ b/services/iotevents/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotevents</artifactId>
     <name>AWS Java SDK :: Services :: IoT Events</name>

--- a/services/ioteventsdata/pom.xml
+++ b/services/ioteventsdata/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ioteventsdata</artifactId>
     <name>AWS Java SDK :: Services :: IoT Events Data</name>

--- a/services/iotjobsdataplane/pom.xml
+++ b/services/iotjobsdataplane/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotjobsdataplane</artifactId>
     <name>AWS Java SDK :: Services :: IoT Jobs Data Plane</name>

--- a/services/iotsecuretunneling/pom.xml
+++ b/services/iotsecuretunneling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotsecuretunneling</artifactId>
     <name>AWS Java SDK :: Services :: IoTSecureTunneling</name>

--- a/services/iotsitewise/pom.xml
+++ b/services/iotsitewise/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotsitewise</artifactId>
     <name>AWS Java SDK :: Services :: Io T Site Wise</name>

--- a/services/iotthingsgraph/pom.xml
+++ b/services/iotthingsgraph/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>iotthingsgraph</artifactId>
     <name>AWS Java SDK :: Services :: IoTThingsGraph</name>

--- a/services/kafka/pom.xml
+++ b/services/kafka/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kafka</artifactId>
     <name>AWS Java SDK :: Services :: Kafka</name>

--- a/services/kendra/pom.xml
+++ b/services/kendra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kendra</artifactId>
     <name>AWS Java SDK :: Services :: Kendra</name>

--- a/services/kinesis/pom.xml
+++ b/services/kinesis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kinesis</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Kinesis</name>

--- a/services/kinesisanalytics/pom.xml
+++ b/services/kinesisanalytics/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kinesisanalytics</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Kinesis Analytics</name>

--- a/services/kinesisanalyticsv2/pom.xml
+++ b/services/kinesisanalyticsv2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kinesisanalyticsv2</artifactId>
     <name>AWS Java SDK :: Services :: Kinesis Analytics V2</name>

--- a/services/kinesisvideo/pom.xml
+++ b/services/kinesisvideo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kinesisvideo</artifactId>

--- a/services/kinesisvideoarchivedmedia/pom.xml
+++ b/services/kinesisvideoarchivedmedia/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kinesisvideoarchivedmedia</artifactId>
     <name>AWS Java SDK :: Services :: Kinesis Video Archived Media</name>

--- a/services/kinesisvideomedia/pom.xml
+++ b/services/kinesisvideomedia/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kinesisvideomedia</artifactId>
     <name>AWS Java SDK :: Services :: Kinesis Video Media</name>

--- a/services/kinesisvideosignaling/pom.xml
+++ b/services/kinesisvideosignaling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kinesisvideosignaling</artifactId>
     <name>AWS Java SDK :: Services :: Kinesis Video Signaling</name>

--- a/services/kms/pom.xml
+++ b/services/kms/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>kms</artifactId>
     <name>AWS Java SDK :: Services :: AWS KMS</name>

--- a/services/lakeformation/pom.xml
+++ b/services/lakeformation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>lakeformation</artifactId>
     <name>AWS Java SDK :: Services :: LakeFormation</name>

--- a/services/lambda/pom.xml
+++ b/services/lambda/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>lambda</artifactId>
     <name>AWS Java SDK :: Services :: AWS Lambda</name>

--- a/services/lexmodelbuilding/pom.xml
+++ b/services/lexmodelbuilding/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>lexmodelbuilding</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Lex Model Building</name>

--- a/services/lexruntime/pom.xml
+++ b/services/lexruntime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>lexruntime</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Lex Runtime</name>

--- a/services/licensemanager/pom.xml
+++ b/services/licensemanager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>licensemanager</artifactId>
     <name>AWS Java SDK :: Services :: License Manager</name>

--- a/services/lightsail/pom.xml
+++ b/services/lightsail/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>lightsail</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Lightsail</name>

--- a/services/machinelearning/pom.xml
+++ b/services/machinelearning/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>machinelearning</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Machine Learning</name>

--- a/services/macie/pom.xml
+++ b/services/macie/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>macie</artifactId>
     <name>AWS Java SDK :: Services :: Macie</name>

--- a/services/macie2/pom.xml
+++ b/services/macie2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>macie2</artifactId>
     <name>AWS Java SDK :: Services :: Macie2</name>

--- a/services/managedblockchain/pom.xml
+++ b/services/managedblockchain/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>managedblockchain</artifactId>
     <name>AWS Java SDK :: Services :: ManagedBlockchain</name>

--- a/services/marketplacecatalog/pom.xml
+++ b/services/marketplacecatalog/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>marketplacecatalog</artifactId>
     <name>AWS Java SDK :: Services :: Marketplace Catalog</name>

--- a/services/marketplacecommerceanalytics/pom.xml
+++ b/services/marketplacecommerceanalytics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>marketplacecommerceanalytics</artifactId>
     <name>AWS Java SDK :: Services :: AWS Marketplace Commerce Analytics</name>

--- a/services/marketplaceentitlement/pom.xml
+++ b/services/marketplaceentitlement/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>marketplaceentitlement</artifactId>
     <name>AWS Java SDK :: Services :: AWS Marketplace Entitlement</name>

--- a/services/marketplacemetering/pom.xml
+++ b/services/marketplacemetering/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>marketplacemetering</artifactId>
     <name>AWS Java SDK :: Services :: AWS Marketplace Metering Service</name>

--- a/services/mediaconnect/pom.xml
+++ b/services/mediaconnect/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>mediaconnect</artifactId>
     <name>AWS Java SDK :: Services :: MediaConnect</name>

--- a/services/mediaconvert/pom.xml
+++ b/services/mediaconvert/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mediaconvert</artifactId>

--- a/services/medialive/pom.xml
+++ b/services/medialive/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>medialive</artifactId>

--- a/services/mediapackage/pom.xml
+++ b/services/mediapackage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mediapackage</artifactId>

--- a/services/mediapackagevod/pom.xml
+++ b/services/mediapackagevod/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>mediapackagevod</artifactId>
     <name>AWS Java SDK :: Services :: MediaPackage Vod</name>

--- a/services/mediastore/pom.xml
+++ b/services/mediastore/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mediastore</artifactId>

--- a/services/mediastoredata/pom.xml
+++ b/services/mediastoredata/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mediastoredata</artifactId>

--- a/services/mediatailor/pom.xml
+++ b/services/mediatailor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>mediatailor</artifactId>
     <name>AWS Java SDK :: Services :: MediaTailor</name>

--- a/services/migrationhub/pom.xml
+++ b/services/migrationhub/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>migrationhub</artifactId>

--- a/services/migrationhubconfig/pom.xml
+++ b/services/migrationhubconfig/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>migrationhubconfig</artifactId>
     <name>AWS Java SDK :: Services :: MigrationHub Config</name>

--- a/services/mobile/pom.xml
+++ b/services/mobile/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mobile</artifactId>

--- a/services/mq/pom.xml
+++ b/services/mq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mq</artifactId>

--- a/services/mturk/pom.xml
+++ b/services/mturk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>mturk</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Mechanical Turk Requester</name>

--- a/services/neptune/pom.xml
+++ b/services/neptune/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>neptune</artifactId>
     <name>AWS Java SDK :: Services :: Neptune</name>

--- a/services/networkmanager/pom.xml
+++ b/services/networkmanager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>networkmanager</artifactId>
     <name>AWS Java SDK :: Services :: NetworkManager</name>

--- a/services/opsworks/pom.xml
+++ b/services/opsworks/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>opsworks</artifactId>
     <name>AWS Java SDK :: Services :: AWS OpsWorks</name>

--- a/services/opsworkscm/pom.xml
+++ b/services/opsworkscm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>opsworkscm</artifactId>
     <name>AWS Java SDK :: Services :: AWS OpsWorks for Chef Automate</name>

--- a/services/organizations/pom.xml
+++ b/services/organizations/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>organizations</artifactId>
     <name>AWS Java SDK :: Services :: AWS Organizations</name>

--- a/services/outposts/pom.xml
+++ b/services/outposts/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>outposts</artifactId>
     <name>AWS Java SDK :: Services :: Outposts</name>

--- a/services/personalize/pom.xml
+++ b/services/personalize/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>personalize</artifactId>
     <name>AWS Java SDK :: Services :: Personalize</name>

--- a/services/personalizeevents/pom.xml
+++ b/services/personalizeevents/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>personalizeevents</artifactId>
     <name>AWS Java SDK :: Services :: Personalize Events</name>

--- a/services/personalizeruntime/pom.xml
+++ b/services/personalizeruntime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>personalizeruntime</artifactId>
     <name>AWS Java SDK :: Services :: Personalize Runtime</name>

--- a/services/pi/pom.xml
+++ b/services/pi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>pi</artifactId>
     <name>AWS Java SDK :: Services :: PI</name>

--- a/services/pinpoint/pom.xml
+++ b/services/pinpoint/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>pinpoint</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Pinpoint</name>

--- a/services/pinpointemail/pom.xml
+++ b/services/pinpointemail/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>pinpointemail</artifactId>
     <name>AWS Java SDK :: Services :: Pinpoint Email</name>

--- a/services/pinpointsmsvoice/pom.xml
+++ b/services/pinpointsmsvoice/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>pinpointsmsvoice</artifactId>
     <name>AWS Java SDK :: Services :: Pinpoint SMS Voice</name>

--- a/services/polly/pom.xml
+++ b/services/polly/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>polly</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Polly</name>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>services</artifactId>
     <name>AWS Java SDK :: Services</name>

--- a/services/pricing/pom.xml
+++ b/services/pricing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pricing</artifactId>

--- a/services/qldb/pom.xml
+++ b/services/qldb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>qldb</artifactId>
     <name>AWS Java SDK :: Services :: QLDB</name>

--- a/services/qldbsession/pom.xml
+++ b/services/qldbsession/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>qldbsession</artifactId>
     <name>AWS Java SDK :: Services :: QLDB Session</name>

--- a/services/quicksight/pom.xml
+++ b/services/quicksight/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>quicksight</artifactId>
     <name>AWS Java SDK :: Services :: QuickSight</name>

--- a/services/ram/pom.xml
+++ b/services/ram/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ram</artifactId>
     <name>AWS Java SDK :: Services :: RAM</name>

--- a/services/rds/pom.xml
+++ b/services/rds/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>rds</artifactId>
     <name>AWS Java SDK :: Services :: Amazon RDS</name>

--- a/services/rdsdata/pom.xml
+++ b/services/rdsdata/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>rdsdata</artifactId>
     <name>AWS Java SDK :: Services :: RDS Data</name>

--- a/services/redshift/pom.xml
+++ b/services/redshift/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>redshift</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Redshift</name>

--- a/services/rekognition/pom.xml
+++ b/services/rekognition/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>rekognition</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Rekognition</name>

--- a/services/resourcegroups/pom.xml
+++ b/services/resourcegroups/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>resourcegroups</artifactId>

--- a/services/resourcegroupstaggingapi/pom.xml
+++ b/services/resourcegroupstaggingapi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>resourcegroupstaggingapi</artifactId>
     <name>AWS Java SDK :: Services :: AWS Resource Groups Tagging API</name>

--- a/services/robomaker/pom.xml
+++ b/services/robomaker/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>robomaker</artifactId>
     <name>AWS Java SDK :: Services :: RoboMaker</name>

--- a/services/route53/pom.xml
+++ b/services/route53/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>route53</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Route53</name>

--- a/services/route53domains/pom.xml
+++ b/services/route53domains/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>route53domains</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Route53 Domains</name>

--- a/services/route53resolver/pom.xml
+++ b/services/route53resolver/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>route53resolver</artifactId>
     <name>AWS Java SDK :: Services :: Route53Resolver</name>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>s3</artifactId>
     <name>AWS Java SDK :: Services :: Amazon S3</name>

--- a/services/s3control/pom.xml
+++ b/services/s3control/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>s3control</artifactId>
     <name>AWS Java SDK :: Services :: Amazon S3 Control</name>

--- a/services/sagemaker/pom.xml
+++ b/services/sagemaker/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>sagemaker</artifactId>

--- a/services/sagemakera2iruntime/pom.xml
+++ b/services/sagemakera2iruntime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sagemakera2iruntime</artifactId>
     <name>AWS Java SDK :: Services :: SageMaker A2I Runtime</name>

--- a/services/sagemakerruntime/pom.xml
+++ b/services/sagemakerruntime/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sagemakerruntime</artifactId>
     <name>AWS Java SDK :: Services :: SageMaker Runtime</name>

--- a/services/savingsplans/pom.xml
+++ b/services/savingsplans/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>savingsplans</artifactId>
     <name>AWS Java SDK :: Services :: Savingsplans</name>

--- a/services/schemas/pom.xml
+++ b/services/schemas/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>schemas</artifactId>
     <name>AWS Java SDK :: Services :: Schemas</name>

--- a/services/secretsmanager/pom.xml
+++ b/services/secretsmanager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>secretsmanager</artifactId>
     <name>AWS Java SDK :: Services :: AWS Secrets Manager</name>

--- a/services/securityhub/pom.xml
+++ b/services/securityhub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>securityhub</artifactId>
     <name>AWS Java SDK :: Services :: SecurityHub</name>

--- a/services/serverlessapplicationrepository/pom.xml
+++ b/services/serverlessapplicationrepository/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>serverlessapplicationrepository</artifactId>

--- a/services/servicecatalog/pom.xml
+++ b/services/servicecatalog/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>servicecatalog</artifactId>
     <name>AWS Java SDK :: Services :: AWS Service Catalog</name>

--- a/services/servicediscovery/pom.xml
+++ b/services/servicediscovery/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>servicediscovery</artifactId>

--- a/services/servicequotas/pom.xml
+++ b/services/servicequotas/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>servicequotas</artifactId>
     <name>AWS Java SDK :: Services :: Service Quotas</name>

--- a/services/ses/pom.xml
+++ b/services/ses/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ses</artifactId>
     <name>AWS Java SDK :: Services :: Amazon SES</name>

--- a/services/sesv2/pom.xml
+++ b/services/sesv2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sesv2</artifactId>
     <name>AWS Java SDK :: Services :: SESv2</name>

--- a/services/sfn/pom.xml
+++ b/services/sfn/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sfn</artifactId>
     <name>AWS Java SDK :: Services :: AWS Step Functions</name>

--- a/services/shield/pom.xml
+++ b/services/shield/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>shield</artifactId>
     <name>AWS Java SDK :: Services :: AWS Shield</name>

--- a/services/signer/pom.xml
+++ b/services/signer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>signer</artifactId>
     <name>AWS Java SDK :: Services :: Signer</name>

--- a/services/sms/pom.xml
+++ b/services/sms/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sms</artifactId>
     <name>AWS Java SDK :: Services :: AWS Server Migration</name>

--- a/services/snowball/pom.xml
+++ b/services/snowball/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>snowball</artifactId>
     <name>AWS Java SDK :: Services :: Amazon Snowball</name>

--- a/services/sns/pom.xml
+++ b/services/sns/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sns</artifactId>
     <name>AWS Java SDK :: Services :: Amazon SNS</name>

--- a/services/sqs/pom.xml
+++ b/services/sqs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sqs</artifactId>
     <name>AWS Java SDK :: Services :: Amazon SQS</name>

--- a/services/ssm/pom.xml
+++ b/services/ssm/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ssm</artifactId>
     <name>AWS Java SDK :: Services :: AWS Simple Systems Management (SSM)</name>

--- a/services/sso/pom.xml
+++ b/services/sso/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sso</artifactId>
     <name>AWS Java SDK :: Services :: SSO</name>

--- a/services/ssooidc/pom.xml
+++ b/services/ssooidc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>ssooidc</artifactId>
     <name>AWS Java SDK :: Services :: SSO OIDC</name>

--- a/services/storagegateway/pom.xml
+++ b/services/storagegateway/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>storagegateway</artifactId>
     <name>AWS Java SDK :: Services :: AWS Storage Gateway</name>

--- a/services/sts/pom.xml
+++ b/services/sts/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>sts</artifactId>
     <name>AWS Java SDK :: Services :: AWS STS</name>

--- a/services/support/pom.xml
+++ b/services/support/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>support</artifactId>
     <name>AWS Java SDK :: Services :: AWS Support</name>

--- a/services/swf/pom.xml
+++ b/services/swf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>swf</artifactId>
     <name>AWS Java SDK :: Services :: Amazon SWF</name>

--- a/services/synthetics/pom.xml
+++ b/services/synthetics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>synthetics</artifactId>
     <name>AWS Java SDK :: Services :: Synthetics</name>

--- a/services/textract/pom.xml
+++ b/services/textract/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>textract</artifactId>
     <name>AWS Java SDK :: Services :: Textract</name>

--- a/services/transcribe/pom.xml
+++ b/services/transcribe/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>transcribe</artifactId>
     <name>AWS Java SDK :: Services :: Transcribe</name>

--- a/services/transcribestreaming/pom.xml
+++ b/services/transcribestreaming/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>transcribestreaming</artifactId>
     <name>AWS Java SDK :: Services :: AWS Transcribe Streaming</name>

--- a/services/transfer/pom.xml
+++ b/services/transfer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>transfer</artifactId>
     <name>AWS Java SDK :: Services :: Transfer</name>

--- a/services/translate/pom.xml
+++ b/services/translate/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>translate</artifactId>

--- a/services/waf/pom.xml
+++ b/services/waf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>waf</artifactId>
     <name>AWS Java SDK :: Services :: AWS WAF</name>

--- a/services/wafv2/pom.xml
+++ b/services/wafv2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>wafv2</artifactId>
     <name>AWS Java SDK :: Services :: WAFV2</name>

--- a/services/workdocs/pom.xml
+++ b/services/workdocs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>workdocs</artifactId>
     <name>AWS Java SDK :: Services :: Amazon WorkDocs</name>

--- a/services/worklink/pom.xml
+++ b/services/worklink/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>worklink</artifactId>
     <name>AWS Java SDK :: Services :: WorkLink</name>

--- a/services/workmail/pom.xml
+++ b/services/workmail/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>services</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>workmail</artifactId>

--- a/services/workmailmessageflow/pom.xml
+++ b/services/workmailmessageflow/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>workmailmessageflow</artifactId>
     <name>AWS Java SDK :: Services :: WorkMailMessageFlow</name>

--- a/services/workspaces/pom.xml
+++ b/services/workspaces/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>workspaces</artifactId>
     <name>AWS Java SDK :: Services :: Amazon WorkSpaces</name>

--- a/services/xray/pom.xml
+++ b/services/xray/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>services</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <artifactId>xray</artifactId>
     <name>AWS Java SDK :: Services :: AWS X-Ray</name>

--- a/test/codegen-generated-classes-test/pom.xml
+++ b/test/codegen-generated-classes-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test/http-client-tests/pom.xml
+++ b/test/http-client-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>http-client-tests</artifactId>

--- a/test/module-path-tests/pom.xml
+++ b/test/module-path-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test/protocol-tests-core/pom.xml
+++ b/test/protocol-tests-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/coldstart/V2DefaultClientCreationBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/coldstart/V2DefaultClientCreationBenchmark.java
@@ -57,6 +57,7 @@ public class V2DefaultClientCreationBenchmark implements SdkClientCreationBenchm
     @Benchmark
     public void createClient(Blackhole blackhole) throws Exception {
         client = DynamoDbClient.builder()
+                               .endpointDiscoveryEnabled(false)
                                .httpClient(ApacheHttpClient.builder().build()).build();
         blackhole.consume(client);
     }

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/coldstart/V2OptimizedClientCreationBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/coldstart/V2OptimizedClientCreationBenchmark.java
@@ -66,6 +66,7 @@ public class V2OptimizedClientCreationBenchmark implements SdkClientCreationBenc
                                             AwsBasicCredentials.create("test", "test")))
                                         .httpClient(ApacheHttpClient.builder().build())
                                         .overrideConfiguration(ClientOverrideConfiguration.builder().build())
+                                        .endpointDiscoveryEnabled(false)
                                         .build();
 
         blackhole.consume(client);

--- a/test/service-test-utils/pom.xml
+++ b/test/service-test-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>service-test-utils</artifactId>

--- a/test/stability-tests/pom.xml
+++ b/test/stability-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test/test-utils/pom.xml
+++ b/test/test-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-sdk-java-pom</artifactId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>test-utils</artifactId>

--- a/test/tests-coverage-reporting/pom.xml
+++ b/test/tests-coverage-reporting/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>aws-sdk-java-pom</artifactId>
         <groupId>software.amazon.awssdk</groupId>
-        <version>2.13.18-SNAPSHOT</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Description
Endpoint discovery allows the SDK to discover an endpoint based on the resource being accessed. This change makes this feature opt-out instead of opt-in for clients of services that support endpoint discovery. An additional call to the endpoint discovery service will be made when an endpoint needs to be discovered, that value is then cached and re-used.

## Motivation and Context
There may be services launched in the future that only support endpoint discovery instead of traditional static endpoints. We believe endpoint discovery will provide a better experience for customers, and therefore we want to give them that better experience out of the box without expecting them to know to enable it. Any customers that do not wish to use endpoint discovery may opt-out by setting 'endpointDiscoveryEnabled(false)' on the client builder.

## Testing
Ran all unit/functional and mock integration tests. Verified through manual integration testing that endpoint discovery calls were being made.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [X] My change requires a change to the Javadoc documentation
- [X] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
