### PR TITLE
Check the x-amz-content-range header for GetObject responses when the Content-Range header is not returned by the service.

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-74e484e.json
+++ b/.changes/next-release/bugfix-AmazonS3-74e484e.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "Amazon S3",
+    "description": "Check the `x-amz-content-range` header for `GetObject` responses when the `Content-Range` header is not returned by the service. Fixes [#1209](https://github.com/aws/aws-sdk-java-v2/issues/1209)."
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
@@ -74,7 +74,6 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
         }
     }
 
-
     @Test
     public void toInputStream_loadFromProperties() throws IOException {
         s3.putObject(b -> b.bucket(BUCKET).key(PROPERTY_KEY), RequestBody.fromString("test: test"));
@@ -115,6 +114,13 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
             });
             assertThat(result).isEqualTo("result");
         }
+    }
+
+    @Test
+    public void contentRangeIsReturnedForRangeRequests() {
+        ResponseInputStream<GetObjectResponse> stream = s3.getObject(getObjectRequest.copy(r -> r.range("bytes=0-1")));
+        stream.abort();
+        assertThat(stream.response().contentRange()).isEqualTo("bytes 0-1/10000");
     }
 
     private S3Client createClientWithInterceptor(ExecutionInterceptor interceptor) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/GetObjectInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/GetObjectInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.handlers;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+/**
+ * Interceptor for {@link GetObjectRequest} messages.
+ */
+@SdkInternalApi
+public class GetObjectInterceptor implements ExecutionInterceptor {
+    @Override
+    public SdkResponse modifyResponse(Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
+        SdkResponse response = context.response();
+        if (!(response instanceof GetObjectResponse)) {
+            return response;
+        }
+
+        return fixContentRange(response, context.httpResponse());
+    }
+
+    /**
+     * S3 currently returns content-range in two possible headers: Content-Range or x-amz-content-range based on the x-amz-te
+     * in the request. This will check the x-amz-content-range if the modeled header (Content-Range) wasn't populated.
+     */
+    private SdkResponse fixContentRange(SdkResponse sdkResponse, SdkHttpResponse httpResponse) {
+        // Use the modeled content range header, if the service returned it.
+        GetObjectResponse getObjectResponse = (GetObjectResponse) sdkResponse;
+        if (getObjectResponse.contentRange() != null) {
+            return getObjectResponse;
+        }
+
+        // If the service didn't use the modeled content range header, check the x-amz-content-range header.
+        Optional<String> xAmzContentRange = httpResponse.firstMatchingHeader("x-amz-content-range");
+        if (!xAmzContentRange.isPresent()) {
+            return getObjectResponse;
+        }
+
+        return getObjectResponse.copy(r -> r.contentRange(xAmzContentRange.get()));
+    }
+}

--- a/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
+++ b/services/s3/src/main/resources/software/amazon/awssdk/services/s3/execution.interceptors
@@ -11,3 +11,4 @@ software.amazon.awssdk.services.s3.internal.handlers.AsyncChecksumValidationInte
 software.amazon.awssdk.services.s3.internal.handlers.SyncChecksumValidationInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.EnableTrailingChecksumInterceptor
 software.amazon.awssdk.services.s3.internal.handlers.ExceptionTranslationInterceptor
+software.amazon.awssdk.services.s3.internal.handlers.GetObjectInterceptor


### PR DESCRIPTION
We're still investigating this issue (S3 behaving inconsistently) internally, but this issue has lingered for long enough. No reason for people to suffer while we try to sort out the laundry. 

Fixes #1209.