### PR TITLE
Update archetype-lambda 

### DIFF
--- a/.changes/next-release/feature-AWSMavenLambdaArchetype-6cb01fa.json
+++ b/.changes/next-release/feature-AWSMavenLambdaArchetype-6cb01fa.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Maven Lambda Archetype", 
+    "type": "feature", 
+    "description": "Updated the `archetype-lambda` to generate SDK client that uses region from environment variable."
+}

--- a/archetypes/archetype-lambda/README.md
+++ b/archetypes/archetype-lambda/README.md
@@ -14,7 +14,7 @@ You can use `mvn archetype:generate` to generate a project using this archetype.
 mvn archetype:generate \
   -DarchetypeGroupId=software.amazon.awssdk \
   -DarchetypeArtifactId=archetype-lambda \
-  -DarchetypeVersion=2.x\
+  -DarchetypeVersion=2.x
 ```
 
 - Batch mode
@@ -23,12 +23,11 @@ mvn archetype:generate \
 mvn archetype:generate \
     -DarchetypeGroupId=software.amazon.awssdk \
     -DarchetypeArtifactId=archetype-lambda \
-    -DarchetypeVersion=2.x\
+    -DarchetypeVersion=2.x \
     -DgroupId=com.test \
     -DartifactId=sample-project \
     -Dservice=s3  \
-    -Dregion=us-west-2 \
-    -DinteractiveMode=false \
+    -DinteractiveMode=false
 ```
 
 ### Parameters
@@ -36,9 +35,9 @@ mvn archetype:generate \
 Parameter Name | Default Value | Description
 ---|---|---
 `service` (required) | n/a | Specifies the service client to be used in the lambda function, eg: s3, dynamodb. You can find available services [here][java-sdk-v2-services].
-`region` (required) | n/a | Specifies the region to be set for the SDK client in the application
 `groupId`(required) | n/a | Specifies the group ID of the project
 `artifactId`(required) | n/a | Specifies the artifact ID of the project
+`region` | n/a | Specifies the region to be set for the SDK client in the application
 `httpClient` | url-connection-client | Specifies the http client to be used by the SDK client. Available options are `url-connection-client` (sync), `apache-client` (sync), `netty-nio-client` (async). See [http clients][sdk-http-clients]
 `handlerClassName` | `"App"`| Specifies the class name of the handler, which will be used as the lambda function name. It should be camel case.
 `javaSdkVersion` | Same version as the archetype version | Specifies the version of the AWS Java SDK 2.x to be used

--- a/archetypes/archetype-lambda/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/archetype-lambda/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -39,6 +39,7 @@
       <validationRegex>(url-connection-client|apache-client|netty-nio-client)</validationRegex>
     </requiredProperty>
     <requiredProperty key="region">
+     <defaultValue>null</defaultValue>
      <validationRegex>^\w+-(\w+-)+\d+$</validationRegex>
     </requiredProperty>
     <!-- Required to pass the netty-open-ssl-version property from parent pom to velocity-->

--- a/archetypes/archetype-lambda/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/archetype-lambda/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>${javaSdkVersion}</aws.java.sdk.version>
@@ -93,6 +93,15 @@
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>${artifactId}</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!-- Suppress module-info.class warning-->
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>

--- a/archetypes/archetype-lambda/src/main/resources/archetype-resources/src/main/java/DependencyFactory.java
+++ b/archetypes/archetype-lambda/src/main/resources/archetype-resources/src/main/java/DependencyFactory.java
@@ -3,6 +3,9 @@
 package ${package};
 
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+#if ($region == 'null')
+import software.amazon.awssdk.core.SdkSystemSetting;
+#end
 import software.amazon.awssdk.http.${httpClientPackageName};
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.${servicePackage}.${serviceClientClassName};
@@ -20,7 +23,11 @@ public class DependencyFactory {
     public static ${serviceClientClassName} ${serviceClientVariable}Client() {
         return ${serviceClientClassName}.builder()
                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+#if ($region == 'null')
+                       .region(Region.of(System.getenv(SdkSystemSetting.AWS_REGION.environmentVariable())))
+#else
                        .region(Region.${regionEnum})
+#end
                        .httpClientBuilder(${httpClientClassName}.builder())
                        .build();
     }

--- a/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/archetype.properties
+++ b/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/archetype.properties
@@ -5,6 +5,6 @@ package=software.amazonaws.test
 service=dynamodb
 httpClient=apache-client
 handlerClassName=MyApacheFunction
-region=ap-southeast-1
+region=null
 javaSdkVersion=2.11.0
 nettyOpenSslVersion=2.0.29.Final

--- a/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/reference/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
@@ -80,6 +80,15 @@
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>test-apache-artifact</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!-- Suppress module-info.class warning-->
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>

--- a/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/reference/src/main/java/software/amazonaws/test/DependencyFactory.java
+++ b/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/reference/src/main/java/software/amazonaws/test/DependencyFactory.java
@@ -2,6 +2,7 @@
 package software.amazonaws.test;
 
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -19,7 +20,7 @@ public class DependencyFactory {
     public static DynamoDbClient dynamoDbClient() {
         return DynamoDbClient.builder()
                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                       .region(Region.AP_SOUTHEAST_1)
+                       .region(Region.of(System.getenv(SdkSystemSetting.AWS_REGION.environmentVariable())))
                        .httpClientBuilder(ApacheHttpClient.builder())
                        .build();
     }

--- a/archetypes/archetype-lambda/src/test/resources/projects/dynamodbstreamsclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/dynamodbstreamsclient/reference/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
@@ -80,6 +80,15 @@
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>test-dynamodbstreams-artifact</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!-- Suppress module-info.class warning-->
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>

--- a/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/reference/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
@@ -88,6 +88,15 @@
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>test-netty-artifact</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!-- Suppress module-info.class warning-->
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>

--- a/archetypes/archetype-lambda/src/test/resources/projects/urlhttpclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/urlhttpclient/reference/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
@@ -80,6 +80,15 @@
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>test-url-connection-client-artifact</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!-- Suppress module-info.class warning-->
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>

--- a/archetypes/archetype-lambda/src/test/resources/projects/wafregionalclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/wafregionalclient/reference/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
@@ -80,6 +80,15 @@
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <finalName>test-wafregional-artifact</finalName>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <!-- Suppress module-info.class warning-->
+                                <exclude>module-info.class</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
- Update the sdk client to use region from environment variable
- Fix module-info.class warning when compiling the generated project
- Fix README

```java
    public static DynamoDbClient dynamoDbClient() {
        return DynamoDbClient.builder()
                       .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                       .region(Region.of(System.getenv(SdkSystemSetting.AWS_REGION.environmentVariable())))
                       .httpClientBuilder(ApacheHttpClient.builder())
                       .build();
    }
```
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
