### PR TITLE
Update javadoc for AwsBasicCredentials

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-795fee6.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-795fee6.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Update javadoc annotation for AwsBasicCredentials"
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.java
@@ -49,7 +49,7 @@ public final class AwsBasicCredentials implements AwsCredentials {
     private final String secretAccessKey;
 
     /**
-     * Constructs a new credentials object, with the specified AWS access key, AWS secret key and AWS session token.
+     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
      *
      * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.
@@ -69,7 +69,7 @@ public final class AwsBasicCredentials implements AwsCredentials {
     }
 
     /**
-     * Constructs a new credentials object, with the specified AWS access key, AWS secret key and AWS session token.
+     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
      *
      * @param accessKeyId The AWS access key, used to identify the user interacting with AWS.
      * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with AWS.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
[This page](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/AwsBasicCredentials.html) in the v2 javadocs mentions "AWS session token" in annotations but AwsBasicCredentials doesn't seem to support this (i.e. it only accepts two parameters, accessKeyId and secretAccessKey):

Removed the two mentions of the session token.

## Motivation and Context
Incorrect information/confusing. V209538068

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
