### PR TITLE
Added support for HTTP/2 metrics to Netty.

### DIFF
--- a/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/internal/DefaultMetricCollection.java
+++ b/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/internal/DefaultMetricCollection.java
@@ -15,15 +15,17 @@
 
 package software.amazon.awssdk.metrics.internal;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricRecord;
 import software.amazon.awssdk.metrics.SdkMetric;
+import software.amazon.awssdk.utils.ToString;
 
 @SdkInternalApi
 public final class DefaultMetricCollection implements MetricCollection {
@@ -52,7 +54,7 @@ public final class DefaultMetricCollection implements MetricCollection {
             List<MetricRecord<?>> metricRecords = metrics.get(metric);
             List<?> values = metricRecords.stream()
                     .map(MetricRecord::value)
-                    .collect(Collectors.toList());
+                    .collect(toList());
             return (List<T>) Collections.unmodifiableList(values);
         }
         return Collections.emptyList();
@@ -68,5 +70,14 @@ public final class DefaultMetricCollection implements MetricCollection {
         return metrics.values().stream()
                 .flatMap(List::stream)
                 .iterator();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("MetricCollection")
+                       .add("name", name)
+                       .add("metrics", metrics.values().stream().flatMap(List::stream).collect(toList()))
+                       .add("children", children)
+                       .build();
     }
 }

--- a/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/internal/DefaultMetricRecord.java
+++ b/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/internal/DefaultMetricRecord.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.metrics.internal;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.metrics.MetricRecord;
 import software.amazon.awssdk.metrics.SdkMetric;
+import software.amazon.awssdk.utils.ToString;
 
 @SdkInternalApi
 public final class DefaultMetricRecord<T> implements MetricRecord<T> {
@@ -37,5 +38,13 @@ public final class DefaultMetricRecord<T> implements MetricRecord<T> {
     @Override
     public T value() {
         return value;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("MetricRecord")
+                       .add("metric", metric.name())
+                       .add("value", value)
+                       .build();
     }
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/Http2Metric.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/Http2Metric.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.metrics.MetricCategory;
+import software.amazon.awssdk.metrics.SdkMetric;
+
+/**
+ * Metrics collected by HTTP clients for HTTP/2 operations. See {@link HttpMetric} for metrics that are available on both HTTP/1
+ * and HTTP/2 operations.
+ */
+@SdkPublicApi
+public final class Http2Metric {
+    /**
+     * The local HTTP/2 window size in bytes for the stream that this request was executed on.
+     *
+     * <p>See https://http2.github.io/http2-spec/#FlowControl for more information on HTTP/2 window sizes.
+     */
+    public static final SdkMetric<Integer> LOCAL_STREAM_WINDOW_SIZE_IN_BYTES = metric("LocalStreamWindowSize", Integer.class);
+
+    /**
+     * The remote HTTP/2 window size in bytes for the stream that this request was executed on.
+     *
+     * <p>See https://http2.github.io/http2-spec/#FlowControl for more information on HTTP/2 window sizes.
+     */
+    public static final SdkMetric<Integer> REMOTE_STREAM_WINDOW_SIZE_IN_BYTES = metric("RemoteStreamWindowSize", Integer.class);
+
+    private Http2Metric() {
+    }
+
+    private static <T> SdkMetric<T> metric(String name, Class<T> clzz) {
+        return SdkMetric.create(name, clzz, MetricCategory.DEFAULT, MetricCategory.HTTP_CLIENT);
+    }
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
@@ -20,7 +20,8 @@ import software.amazon.awssdk.metrics.MetricCategory;
 import software.amazon.awssdk.metrics.SdkMetric;
 
 /**
- * Metrics collected by HTTP clients.
+ * Metrics collected by HTTP clients for HTTP/1 and HTTP/2 operations. See {@link Http2Metric} for metrics that are only available
+ * on HTTP/2 operations.
  */
 @SdkPublicApi
 public final class HttpMetric {
@@ -30,24 +31,64 @@ public final class HttpMetric {
     public static final SdkMetric<String> HTTP_CLIENT_NAME = metric("HttpClientName", String.class);
 
     /**
-     * The maximum number of connections that will be pooled by the HTTP client.
+     * The maximum number of concurrent requests that is supported by the HTTP client.
+     *
+     * <p>For HTTP/1 operations, this is equal to the maximum number of TCP connections that can be be pooled by the HTTP client.
+     * For HTTP/2 operations, this is equal to the maximum number of streams that can be pooled by the HTTP client.
+     *
+     * <p>Note: Depending on the HTTP client, this is either a value for all endpoints served by the HTTP client, or a value
+     * that applies only to the specific endpoint/host used in the request. For 'apache-http-client', this value is
+     * for the entire HTTP client. For 'netty-nio-client', this value is per-endpoint. In all cases, this value is scoped to an
+     * individual HTTP client instance, and does not include concurrency that may be available in other HTTP clients running
+     * within the same JVM.
      */
-    public static final SdkMetric<Integer> MAX_CONNECTIONS = metric("MaxConnections", Integer.class);
+    public static final SdkMetric<Integer> MAX_CONCURRENCY = metric("MaxConcurrency", Integer.class);
 
     /**
-     * The number of idle connections in the connection pool that are ready to serve a request.
+     * The number of additional concurrent requests that can be supported by the HTTP client without needing to establish
+     * additional connections to the target server.
+     *
+     * <p>For HTTP/1 operations, this is equal to the number of TCP connections that have been established with the service,
+     * but are currently idle/unused. For HTTP/2 operations, this is equal to the number of streams that are currently
+     * idle/unused.
+     *
+     * <p>Note: Depending on the HTTP client, this is either a value for all endpoints served by the HTTP client, or a value
+     * that applies only to the specific endpoint/host used in the request. For 'apache-http-client', this value is
+     * for the entire HTTP client. For 'netty-nio-client', this value is per-endpoint. In all cases, this value is scoped to an
+     * individual HTTP client instance, and does not include concurrency that may be available in other HTTP clients running
+     * within the same JVM.
      */
-    public static final SdkMetric<Integer> AVAILABLE_CONNECTIONS = metric("AvailableConnections", Integer.class);
+    public static final SdkMetric<Integer> AVAILABLE_CONCURRENCY = metric("AvailableConcurrency", Integer.class);
 
     /**
-     * The number of connections from the connection pool that are busy serving requests.
+     * The number of requests that are currently being executed by the HTTP client.
+     *
+     * <p>For HTTP/1 operations, this is equal to the number of TCP connections currently in active communication with the service
+     * (excluding idle connections). For HTTP/2 operations, this is equal to the number of HTTP streams currently in active
+     * communication with the service (excluding idle stream capacity).
+     *
+     * <p>Note: Depending on the HTTP client, this is either a value for all endpoints served by the HTTP client, or a value
+     * that applies only to the specific endpoint/host used in the request. For 'apache-http-client', this value is
+     * for the entire HTTP client. For 'netty-nio-client', this value is per-endpoint. In all cases, this value is scoped to an
+     * individual HTTP client instance, and does not include concurrency that may be available in other HTTP clients running
+     * within the same JVM.
      */
-    public static final SdkMetric<Integer> LEASED_CONNECTIONS = metric("LeasedConnections", Integer.class);
+    public static final SdkMetric<Integer> LEASED_CONCURRENCY = metric("LeasedConcurrency", Integer.class);
 
     /**
-     * The number of requests awaiting a free connection from the pool.
+     * The number of requests that are awaiting concurrency to be made available from the HTTP client.
+     *
+     * <p>For HTTP/1 operations, this is equal to the number of requests currently blocked, waiting for a TCP connection to be
+     * established or returned from the connection pool. For HTTP/2 operations, this is equal to the number of requests currently
+     * blocked, waiting for a new stream (and possibly a new HTTP/2 connection) from the connection pool.
+     *
+     * <p>Note: Depending on the HTTP client, this is either a value for all endpoints served by the HTTP client, or a value
+     * that applies only to the specific endpoint/host used in the request. For 'apache-http-client', this value is
+     * for the entire HTTP client. For 'netty-nio-client', this value is per-endpoint. In all cases, this value is scoped to an
+     * individual HTTP client instance, and does not include concurrency that may be available in other HTTP clients running
+     * within the same JVM.
      */
-    public static final SdkMetric<Integer> PENDING_CONNECTION_ACQUIRES = metric("PendingConnectionAcquires", Integer.class);
+    public static final SdkMetric<Integer> PENDING_CONCURRENCY_ACQUIRES = metric("PendingConcurrencyAcquires", Integer.class);
 
     private HttpMetric() {
     }

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -18,11 +18,11 @@ package software.amazon.awssdk.http.apache;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
-import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONNECTIONS;
+import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONCURRENCY;
 import static software.amazon.awssdk.http.HttpMetric.HTTP_CLIENT_NAME;
-import static software.amazon.awssdk.http.HttpMetric.LEASED_CONNECTIONS;
-import static software.amazon.awssdk.http.HttpMetric.MAX_CONNECTIONS;
-import static software.amazon.awssdk.http.HttpMetric.PENDING_CONNECTION_ACQUIRES;
+import static software.amazon.awssdk.http.HttpMetric.LEASED_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.MAX_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.PENDING_CONCURRENCY_ACQUIRES;
 import static software.amazon.awssdk.utils.NumericUtils.saturatedCast;
 
 import java.io.IOException;
@@ -300,10 +300,10 @@ public final class ApacheHttpClient implements SdkHttpClient {
         if (cm instanceof PoolingHttpClientConnectionManager) {
             PoolingHttpClientConnectionManager poolingCm = (PoolingHttpClientConnectionManager) cm;
             PoolStats totalStats = poolingCm.getTotalStats();
-            metricCollector.reportMetric(MAX_CONNECTIONS, totalStats.getMax());
-            metricCollector.reportMetric(AVAILABLE_CONNECTIONS, totalStats.getAvailable());
-            metricCollector.reportMetric(LEASED_CONNECTIONS, totalStats.getLeased());
-            metricCollector.reportMetric(PENDING_CONNECTION_ACQUIRES, totalStats.getPending());
+            metricCollector.reportMetric(MAX_CONCURRENCY, totalStats.getMax());
+            metricCollector.reportMetric(AVAILABLE_CONCURRENCY, totalStats.getAvailable());
+            metricCollector.reportMetric(LEASED_CONCURRENCY, totalStats.getLeased());
+            metricCollector.reportMetric(PENDING_CONCURRENCY_ACQUIRES, totalStats.getPending());
         }
     }
 

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/MetricReportingTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/MetricReportingTest.java
@@ -19,11 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONNECTIONS;
+import static software.amazon.awssdk.http.HttpMetric.AVAILABLE_CONCURRENCY;
 import static software.amazon.awssdk.http.HttpMetric.HTTP_CLIENT_NAME;
-import static software.amazon.awssdk.http.HttpMetric.LEASED_CONNECTIONS;
-import static software.amazon.awssdk.http.HttpMetric.MAX_CONNECTIONS;
-import static software.amazon.awssdk.http.HttpMetric.PENDING_CONNECTION_ACQUIRES;
+import static software.amazon.awssdk.http.HttpMetric.LEASED_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.MAX_CONCURRENCY;
+import static software.amazon.awssdk.http.HttpMetric.PENDING_CONCURRENCY_ACQUIRES;
 import java.io.IOException;
 import java.time.Duration;
 import org.apache.http.HttpVersion;
@@ -77,10 +77,10 @@ public class MetricReportingTest {
         MetricCollection collected = collector.collect();
 
         assertThat(collected.metricValues(HTTP_CLIENT_NAME)).containsExactly("Apache");
-        assertThat(collected.metricValues(LEASED_CONNECTIONS)).containsExactly(1);
-        assertThat(collected.metricValues(PENDING_CONNECTION_ACQUIRES)).containsExactly(2);
-        assertThat(collected.metricValues(AVAILABLE_CONNECTIONS)).containsExactly(3);
-        assertThat(collected.metricValues(MAX_CONNECTIONS)).containsExactly(4);
+        assertThat(collected.metricValues(LEASED_CONCURRENCY)).containsExactly(1);
+        assertThat(collected.metricValues(PENDING_CONCURRENCY_ACQUIRES)).containsExactly(2);
+        assertThat(collected.metricValues(AVAILABLE_CONCURRENCY)).containsExactly(3);
+        assertThat(collected.metricValues(MAX_CONCURRENCY)).containsExactly(4);
     }
 
     @Test
@@ -95,10 +95,10 @@ public class MetricReportingTest {
         MetricCollection collected = collector.collect();
 
         assertThat(collected.metricValues(HTTP_CLIENT_NAME)).containsExactly("Apache");
-        assertThat(collected.metricValues(LEASED_CONNECTIONS)).isEmpty();
-        assertThat(collected.metricValues(PENDING_CONNECTION_ACQUIRES)).isEmpty();
-        assertThat(collected.metricValues(AVAILABLE_CONNECTIONS)).isEmpty();
-        assertThat(collected.metricValues(MAX_CONNECTIONS)).isEmpty();
+        assertThat(collected.metricValues(LEASED_CONCURRENCY)).isEmpty();
+        assertThat(collected.metricValues(PENDING_CONCURRENCY_ACQUIRES)).isEmpty();
+        assertThat(collected.metricValues(AVAILABLE_CONCURRENCY)).isEmpty();
+        assertThat(collected.metricValues(MAX_CONCURRENCY)).isEmpty();
     }
 
     private ApacheHttpClient newClient() {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.http.nio.netty.internal;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2FrameStream;
 import io.netty.util.AttributeKey;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
@@ -60,6 +61,13 @@ public final class ChannelAttributeKey {
      */
     public static final AttributeKey<Long> MAX_CONCURRENT_STREAMS = AttributeKey.newInstance(
         "aws.http.nio.netty.async.maxConcurrentStreams");
+
+    /**
+     * The {@link Http2FrameStream} associated with this stream channel. This is added to stream channels when they are created,
+     * before they are fully initialized.
+     */
+    public static final AttributeKey<Http2FrameStream> HTTP2_FRAME_STREAM = AttributeKey.newInstance(
+        "aws.http.nio.netty.async.http2FrameStream");
 
     /**
      * {@link AttributeKey} to keep track of whether we should close the connection after this request

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionCountingChannelPool.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionCountingChannelPool.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static software.amazon.awssdk.http.nio.netty.internal.utils.NettyUtils.doInEventLoop;
+
+import io.netty.channel.Channel;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * A channel pool implementation that tracks the number of "idle" channels in an underlying channel pool.
+ *
+ * <p>Specifically, this pool counts the number of channels acquired and then released from/to the underlying channel pool. It
+ * will monitor for the underlying channels to be closed, and will remove them from the "idle" count.
+ */
+@SdkInternalApi
+public class IdleConnectionCountingChannelPool implements SdkChannelPool {
+    private static final Logger log = Logger.loggerFor(IdleConnectionCountingChannelPool.class);
+
+    /**
+     * The idle channel state for a specific channel. This should only be accessed from the {@link #executor}.
+     */
+    private static final AttributeKey<ChannelIdleState> CHANNEL_STATE =
+        AttributeKey.newInstance("IdleConnectionCountingChannelPool.CHANNEL_STATE");
+
+    /**
+     * The executor in which all updates to {@link #idleConnections} is performed.
+     */
+    private final EventExecutor executor;
+
+    /**
+     * The delegate pool to which all acquire and release calls are delegated.
+     */
+    private final ChannelPool delegatePool;
+
+    /**
+     * The number of idle connections in the underlying channel pool. This value is only valid if accessed from the
+     * {@link #executor}.
+     */
+    private int idleConnections = 0;
+
+    public IdleConnectionCountingChannelPool(EventExecutor executor, ChannelPool delegatePool) {
+        this.executor = executor;
+        this.delegatePool = delegatePool;
+    }
+
+    @Override
+    public Future<Channel> acquire() {
+        return acquire(executor.newPromise());
+    }
+
+    @Override
+    public Future<Channel> acquire(Promise<Channel> promise) {
+        Future<Channel> acquirePromise = delegatePool.acquire(executor.newPromise());
+        acquirePromise.addListener(f -> {
+            Throwable failure = acquirePromise.cause();
+            if (failure != null) {
+                promise.setFailure(failure);
+            } else {
+                Channel channel = acquirePromise.getNow();
+                channelAcquired(channel);
+                promise.setSuccess(channel);
+            }
+        });
+
+        return promise;
+    }
+
+    @Override
+    public Future<Void> release(Channel channel) {
+        channelReleased(channel);
+        return delegatePool.release(channel);
+    }
+
+    @Override
+    public Future<Void> release(Channel channel, Promise<Void> promise) {
+        channelReleased(channel);
+        return delegatePool.release(channel, promise);
+    }
+
+    @Override
+    public void close() {
+        delegatePool.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> collectChannelPoolMetrics(MetricCollector metrics) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        doInEventLoop(executor, () -> {
+            metrics.reportMetric(HttpMetric.AVAILABLE_CONCURRENCY, idleConnections);
+            result.complete(null);
+        });
+        return result;
+    }
+
+    /**
+     * Add a listener to the provided channel that will update the idle channel count when the channel is closed.
+     */
+    private void addUpdateIdleCountOnCloseListener(Channel channel) {
+        channel.closeFuture().addListener(f -> channelClosed(channel));
+    }
+
+    /**
+     * Invoked when a channel is acquired, marking it non-idle until it's closed or released.
+     */
+    private void channelAcquired(Channel channel) {
+        doInEventLoop(executor, () -> {
+            ChannelIdleState channelIdleState = getChannelIdleState(channel);
+
+            if (channelIdleState == null) {
+                addUpdateIdleCountOnCloseListener(channel);
+                setChannelIdleState(channel, ChannelIdleState.NOT_IDLE);
+            } else {
+                switch (channelIdleState) {
+                    case IDLE:
+                        decrementIdleConnections();
+                        setChannelIdleState(channel, ChannelIdleState.NOT_IDLE);
+                        break;
+                    case CLOSED:
+                        break;
+                    case NOT_IDLE:
+                    default:
+                        log.warn(() -> "Failed to update idle connection count metric on acquire, because the channel (" +
+                                       channel + ") was in an unexpected state: " + channelIdleState);
+                }
+            }
+        });
+    }
+
+    /**
+     * Invoked when a channel is released, marking it idle until it's acquired.
+     */
+    private void channelReleased(Channel channel) {
+        doInEventLoop(executor, () -> {
+            ChannelIdleState channelIdleState = getChannelIdleState(channel);
+
+            if (channelIdleState == null) {
+                log.warn(() -> "Failed to update idle connection count metric on release, because the channel (" + channel +
+                               ") was in an unexpected state: null");
+            } else {
+                switch (channelIdleState) {
+                    case NOT_IDLE:
+                        incrementIdleConnections();
+                        setChannelIdleState(channel, ChannelIdleState.IDLE);
+                        break;
+                    case CLOSED:
+                        break;
+                    case IDLE:
+                    default:
+                        log.warn(() -> "Failed to update idle connection count metric on release, because the channel (" +
+                                       channel + ") was in an unexpected state: " + channelIdleState);
+                }
+            }
+        });
+    }
+
+    /**
+     * Invoked when a channel is closed, ensure it is marked as non-idle.
+     */
+    private void channelClosed(Channel channel) {
+        doInEventLoop(executor, () -> {
+            ChannelIdleState channelIdleState = getChannelIdleState(channel);
+            setChannelIdleState(channel, ChannelIdleState.CLOSED);
+
+            if (channelIdleState != null) {
+                switch (channelIdleState) {
+                    case IDLE:
+                        decrementIdleConnections();
+                        break;
+                    case NOT_IDLE:
+                        break;
+                    default:
+                        log.warn(() -> "Failed to update idle connection count metric on close, because the channel (" + channel +
+                                       ") was in an unexpected state: " + channelIdleState);
+                }
+            }
+        });
+    }
+
+    private ChannelIdleState getChannelIdleState(Channel channel) {
+        return channel.attr(CHANNEL_STATE).get();
+    }
+
+    private void setChannelIdleState(Channel channel, ChannelIdleState newState) {
+        channel.attr(CHANNEL_STATE).set(newState);
+    }
+
+    /**
+     * Decrement the idle connection count. This must be invoked from the {@link #executor}.
+     */
+    private void decrementIdleConnections() {
+        --idleConnections;
+        log.trace(() -> "Idle connection count decremented, now " + idleConnections);
+    }
+
+    /**
+     * Increment the idle connection count. This must be invoked from the {@link #executor}.
+     */
+    private void incrementIdleConnections() {
+        ++idleConnections;
+        log.trace(() -> "Idle connection count incremented, now " + idleConnections);
+    }
+
+    /**
+     * The idle state of a channel.
+     */
+    private enum ChannelIdleState {
+        IDLE,
+        NOT_IDLE,
+        CLOSED
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestMetrics.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestMetrics.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2Stream;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.Http2Metric;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+
+/**
+ * Utilities for collecting and publishing request-level metrics.
+ */
+@SdkInternalApi
+public class NettyRequestMetrics {
+    private NettyRequestMetrics() {
+    }
+
+    /**
+     * Determine whether metrics are enabled, based on the provided metric collector.
+     */
+    public static boolean metricsAreEnabled(MetricCollector metricCollector) {
+        return metricCollector != null && !(metricCollector instanceof NoOpMetricCollector);
+    }
+
+    /**
+     * Publish stream metrics for the provided stream channel to the provided collector. This should only be invoked after
+     * the stream has been initialized. If the stream is not initialized when this is invoked, an exception will be thrown.
+     */
+    public static void publishHttp2StreamMetrics(MetricCollector metricCollector, Channel channel) {
+        if (!metricsAreEnabled(metricCollector)) {
+            return;
+        }
+
+        getHttp2Connection(channel).ifPresent(http2Connection -> {
+            writeHttp2RequestMetrics(metricCollector, channel, http2Connection);
+        });
+    }
+
+    private static Optional<Http2Connection> getHttp2Connection(Channel channel) {
+        Channel parentChannel = channel.parent();
+        if (parentChannel == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(parentChannel.attr(ChannelAttributeKey.HTTP2_CONNECTION).get());
+    }
+
+    private static void writeHttp2RequestMetrics(MetricCollector metricCollector,
+                                                 Channel channel,
+                                                 Http2Connection http2Connection) {
+        int streamId = channel.attr(ChannelAttributeKey.HTTP2_FRAME_STREAM).get().id();
+
+        Http2Stream stream = http2Connection.stream(streamId);
+        metricCollector.reportMetric(Http2Metric.LOCAL_STREAM_WINDOW_SIZE_IN_BYTES,
+                                     http2Connection.local().flowController().windowSize(stream));
+        metricCollector.reportMetric(Http2Metric.REMOTE_STREAM_WINDOW_SIZE_IN_BYTES,
+                                     http2Connection.remote().flowController().windowSize(stream));
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/Http2MetricsTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/Http2MetricsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2Frame;
+import io.netty.handler.codec.http2.Http2FrameCodec;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.codec.http2.Http2StreamFrame;
+import io.netty.util.ReferenceCountUtil;
+import java.net.URI;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import software.amazon.awssdk.http.Http2Metric;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+public class Http2MetricsTest {
+    private static final int SERVER_MAX_CONCURRENT_STREAMS = 2;
+    private static final int SERVER_INITIAL_WINDOW_SIZE = 65535 * 2;
+
+    private static final TestHttp2Server SERVER = new TestHttp2Server();
+
+    @BeforeClass
+    public static void setup() throws InterruptedException {
+        SERVER.start();
+    }
+
+    @AfterClass
+    public static void teardown() throws InterruptedException {
+        SERVER.stop();
+    }
+
+    @Test
+    public void maxClientStreamsLowerThanServerMaxStreamsReportClientMaxStreams() {
+        try (SdkAsyncHttpClient client = NettyNioAsyncHttpClient.builder()
+                                                                .protocol(Protocol.HTTP2)
+                                                                .maxConcurrency(10)
+                                                                .http2Configuration(c -> c.maxStreams(1L)
+                                                                                          .initialWindowSize(65535 * 3))
+                                                                .build()) {
+            MetricCollector metricCollector = MetricCollector.create("test");
+            client.execute(createExecuteRequest(metricCollector)).join();
+            MetricCollection metrics = metricCollector.collect();
+
+            assertThat(metrics.metricValues(HttpMetric.HTTP_CLIENT_NAME)).containsExactly("NettyNio");
+            assertThat(metrics.metricValues(HttpMetric.MAX_CONCURRENCY)).containsExactly(10);
+            assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
+            assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
+            assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY)).containsExactly(0);
+            assertThat(metrics.metricValues(Http2Metric.LOCAL_STREAM_WINDOW_SIZE_IN_BYTES)).containsExactly(65535 * 3);
+            assertThat(metrics.metricValues(Http2Metric.REMOTE_STREAM_WINDOW_SIZE_IN_BYTES)).containsExactly(SERVER_INITIAL_WINDOW_SIZE);
+        }
+    }
+
+    @Test
+    public void maxClientStreamsHigherThanServerMaxStreamsReportServerMaxStreams() {
+        try (SdkAsyncHttpClient client = NettyNioAsyncHttpClient.builder()
+                                                                .protocol(Protocol.HTTP2)
+                                                                .maxConcurrency(10)
+                                                                .http2Configuration(c -> c.maxStreams(3L)
+                                                                                          .initialWindowSize(65535 * 3))
+                                                                .build()) {
+            MetricCollector metricCollector = MetricCollector.create("test");
+            client.execute(createExecuteRequest(metricCollector)).join();
+            MetricCollection metrics = metricCollector.collect();
+
+            assertThat(metrics.metricValues(HttpMetric.HTTP_CLIENT_NAME)).containsExactly("NettyNio");
+            assertThat(metrics.metricValues(HttpMetric.MAX_CONCURRENCY)).containsExactly(10);
+            assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
+            assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
+            assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0)).isIn(0, 2, 3);
+            assertThat(metrics.metricValues(Http2Metric.LOCAL_STREAM_WINDOW_SIZE_IN_BYTES)).containsExactly(65535 * 3);
+            assertThat(metrics.metricValues(Http2Metric.REMOTE_STREAM_WINDOW_SIZE_IN_BYTES)).containsExactly(SERVER_INITIAL_WINDOW_SIZE);
+        }
+    }
+
+    private AsyncExecuteRequest createExecuteRequest(MetricCollector metricCollector)  {
+        URI uri = URI.create("http://localhost:" + SERVER.port());
+        SdkHttpRequest request = createRequest(uri);
+        return AsyncExecuteRequest.builder()
+                                  .request(request)
+                                  .requestContentPublisher(new EmptyPublisher())
+                                  .responseHandler(new RecordingResponseHandler())
+                                  .metricCollector(metricCollector)
+                                  .build();
+    }
+
+    private SdkHttpFullRequest createRequest(URI uri) {
+        return SdkHttpFullRequest.builder()
+                                 .uri(uri)
+                                 .method(SdkHttpMethod.GET)
+                                 .encodedPath("/")
+                                 .putHeader("Host", uri.getHost())
+                                 .putHeader("Content-Length", "0")
+                                 .build();
+    }
+
+    private static final class TestHttp2Server extends ChannelInitializer<SocketChannel> {
+        private ServerBootstrap bootstrap;
+        private ServerSocketChannel channel;
+
+        private TestHttp2Server() {
+        }
+
+        public void start() throws InterruptedException {
+            bootstrap = new ServerBootstrap()
+                .channel(NioServerSocketChannel.class)
+                .group(new NioEventLoopGroup())
+                .childHandler(this)
+                .localAddress(0)
+                .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+            channel = ((ServerSocketChannel) bootstrap.bind().await().channel());
+        }
+
+        public int port() {
+            return channel.localAddress().getPort();
+        }
+
+        public void stop() throws InterruptedException {
+            channel.close().await();
+        }
+
+        @Override
+        protected void initChannel(SocketChannel ch) {
+            Http2FrameCodec codec = Http2FrameCodecBuilder.forServer()
+                                                          .initialSettings(new Http2Settings()
+                                                                               .maxConcurrentStreams(SERVER_MAX_CONCURRENT_STREAMS)
+                                                                               .initialWindowSize(SERVER_INITIAL_WINDOW_SIZE))
+                                                          .build();
+            ch.pipeline().addLast(codec);
+            ch.pipeline().addLast(new SuccessfulHandler());
+        }
+    }
+
+    private static class SuccessfulHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            if (!(msg instanceof Http2Frame)) {
+                ctx.fireChannelRead(msg);
+                return;
+            }
+            ReferenceCountUtil.release(msg);
+
+            boolean isEnd = isEndFrame(msg);
+            if (isEnd) {
+                ctx.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers().status("204"), true)
+                                      .stream(((Http2StreamFrame) msg).stream()));
+            }
+        }
+
+        private boolean isEndFrame(Object msg) {
+            if (msg instanceof Http2HeadersFrame) {
+                return ((Http2HeadersFrame) msg).isEndStream();
+            }
+
+            if (msg instanceof Http2DataFrame) {
+                return ((Http2DataFrame) msg).isEndStream();
+            }
+
+            return false;
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -703,10 +703,10 @@ public class NettyNioAsyncHttpClientWireMockTest {
 
             MetricCollection metrics = handler.collector.collect();
             assertThat(metrics.metricValues(HttpMetric.HTTP_CLIENT_NAME)).containsExactly("NettyNio");
-            assertThat(metrics.metricValues(HttpMetric.MAX_CONNECTIONS)).containsExactly(1);
-            assertThat(metrics.metricValues(HttpMetric.PENDING_CONNECTION_ACQUIRES)).allSatisfy(a -> assertThat(a).isBetween(0, 9));
-            assertThat(metrics.metricValues(HttpMetric.LEASED_CONNECTIONS)).allSatisfy(a -> assertThat(a).isBetween(0, 1));
-            assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONNECTIONS)).allSatisfy(a -> assertThat(a).isBetween(0, 1));
+            assertThat(metrics.metricValues(HttpMetric.MAX_CONCURRENCY)).containsExactly(1);
+            assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES)).allSatisfy(a -> assertThat(a).isBetween(0, 9));
+            assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY)).allSatisfy(a -> assertThat(a).isBetween(0, 1));
+            assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY)).allSatisfy(a -> assertThat(a).isBetween(0, 1));
         }
 
         customClient.close();
@@ -725,13 +725,10 @@ public class NettyNioAsyncHttpClientWireMockTest {
         Thread.sleep(5_000);
         MetricCollection metrics = handler.collector.collect();
         assertThat(metrics.metricValues(HttpMetric.HTTP_CLIENT_NAME)).containsExactly("NettyNio");
-        assertThat(metrics.metricValues(HttpMetric.MAX_CONNECTIONS)).containsExactly(10);
-        assertThat(metrics.metricValues(HttpMetric.PENDING_CONNECTION_ACQUIRES)).hasSize(1)
-                                                                                .allSatisfy(a -> assertThat(a).isBetween(0, 1));
-        assertThat(metrics.metricValues(HttpMetric.LEASED_CONNECTIONS)).hasSize(1)
-                                                                       .allSatisfy(a -> assertThat(a).isBetween(0, 1));
-        assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONNECTIONS)).hasSize(1)
-                                                                          .allSatisfy(a -> assertThat(a).isBetween(9, 10));
+        assertThat(metrics.metricValues(HttpMetric.MAX_CONCURRENCY)).containsExactly(10);
+        assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
+        assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
+        assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0)).isBetween(0, 1);
 
         customClient.close();
     }
@@ -753,10 +750,10 @@ public class NettyNioAsyncHttpClientWireMockTest {
 
         MetricCollection metrics = handler.collector.collect();
         assertThat(metrics.metricValues(HttpMetric.HTTP_CLIENT_NAME)).containsExactly("NettyNio");
-        assertThat(metrics.metricValues(HttpMetric.MAX_CONNECTIONS)).containsExactly(10);
-        assertThat(metrics.metricValues(HttpMetric.PENDING_CONNECTION_ACQUIRES)).containsExactly(0);
-        assertThat(metrics.metricValues(HttpMetric.LEASED_CONNECTIONS)).containsExactly(0);
-        assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONNECTIONS)).containsExactly(10);
+        assertThat(metrics.metricValues(HttpMetric.MAX_CONCURRENCY)).containsExactly(10);
+        assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES)).containsExactly(0);
+        assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY)).containsExactly(0);
+        assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0)).isBetween(0, 1);
     }
 
     private void verifyChannelRelease(Channel channel) throws InterruptedException {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionCountingChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/IdleConnectionCountingChannelPoolTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+public class IdleConnectionCountingChannelPoolTest {
+    private EventLoopGroup eventLoopGroup;
+    private ChannelPool delegatePool;
+    private IdleConnectionCountingChannelPool idleCountingPool;
+
+    @Before
+    public void setup() {
+        delegatePool = mock(ChannelPool.class);
+        eventLoopGroup = new NioEventLoopGroup(4);
+        idleCountingPool = new IdleConnectionCountingChannelPool(eventLoopGroup.next(), delegatePool);
+    }
+
+    @After
+    public void teardown() {
+        eventLoopGroup.shutdownGracefully();
+    }
+
+    @Test(timeout = 5_000)
+    public void acquiresAndReleasesOfNewChannelsIncreaseCount() throws InterruptedException {
+        stubDelegatePoolAcquires(createSuccessfulAcquire(), createSuccessfulAcquire());
+        stubDelegatePoolReleasesForSuccess();
+
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        Channel firstChannel = idleCountingPool.acquire().await().getNow();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        Channel secondChannel = idleCountingPool.acquire().await().getNow();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        idleCountingPool.release(firstChannel).await();
+        assertThat(getIdleConnectionCount()).isEqualTo(1);
+
+        idleCountingPool.release(secondChannel).await();
+        assertThat(getIdleConnectionCount()).isEqualTo(2);
+    }
+
+    @Test(timeout = 5_000)
+    public void channelsClosedInTheDelegatePoolAreNotCounted() throws InterruptedException {
+        stubDelegatePoolAcquires(createSuccessfulAcquire());
+        stubDelegatePoolReleasesForSuccess();
+
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        Channel channel = idleCountingPool.acquire().await().getNow();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        idleCountingPool.release(channel).await();
+        assertThat(getIdleConnectionCount()).isEqualTo(1);
+
+        channel.close().await();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+    }
+
+    @Test(timeout = 5_000)
+    public void channelsClosedWhenCheckedOutAreNotCounted() throws InterruptedException {
+        stubDelegatePoolAcquires(createSuccessfulAcquire());
+        stubDelegatePoolReleasesForSuccess();
+
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        Channel channel = idleCountingPool.acquire().await().getNow();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        channel.close().await();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        idleCountingPool.release(channel).await();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void checkingOutAnIdleChannelIsCountedCorrectly() throws InterruptedException {
+        Future<Channel> successfulAcquire = createSuccessfulAcquire();
+        stubDelegatePoolAcquires(successfulAcquire, successfulAcquire);
+        stubDelegatePoolReleasesForSuccess();
+
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        Channel channel1 = idleCountingPool.acquire().await().getNow();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+
+        idleCountingPool.release(channel1).await();
+        assertThat(getIdleConnectionCount()).isEqualTo(1);
+
+        Channel channel2 = idleCountingPool.acquire().await().getNow();
+        assertThat(getIdleConnectionCount()).isEqualTo(0);
+        assertThat(channel1).isEqualTo(channel2);
+    }
+
+    @Test
+    public void stochastic_rapidAcquireReleaseIsCalculatedCorrectly() throws InterruptedException {
+        Future<Channel> successfulAcquire = createSuccessfulAcquire();
+        Channel expectedChannel = successfulAcquire.getNow();
+        stubDelegatePoolAcquires(successfulAcquire);
+        stubDelegatePoolReleasesForSuccess();
+
+        for (int i = 0; i < 1000; ++i) {
+            Channel channel = idleCountingPool.acquire().await().getNow();
+            assertThat(channel).isEqualTo(expectedChannel);
+            assertThat(getIdleConnectionCount()).isEqualTo(0);
+            idleCountingPool.release(channel).await();
+            assertThat(getIdleConnectionCount()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void stochastic_rapidAcquireReleaseCloseIsCalculatedCorrectly() throws InterruptedException {
+        stubDelegatePoolAcquiresForSuccess();
+        stubDelegatePoolReleasesForSuccess();
+
+        for (int i = 0; i < 1000; ++i) {
+            Channel channel = idleCountingPool.acquire().await().getNow();
+            assertThat(getIdleConnectionCount()).isEqualTo(0);
+            idleCountingPool.release(channel).await();
+            assertThat(getIdleConnectionCount()).isEqualTo(1);
+            channel.close().await();
+            assertThat(getIdleConnectionCount()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void stochastic_rapidAcquireCloseReleaseIsCalculatedCorrectly() throws InterruptedException {
+        stubDelegatePoolAcquiresForSuccess();
+        stubDelegatePoolReleasesForSuccess();
+
+        for (int i = 0; i < 1000; ++i) {
+            Channel channel = idleCountingPool.acquire().await().getNow();
+            assertThat(getIdleConnectionCount()).isEqualTo(0);
+            channel.close().await();
+            assertThat(getIdleConnectionCount()).isEqualTo(0);
+            idleCountingPool.release(channel).await();
+            assertThat(getIdleConnectionCount()).isEqualTo(0);
+        }
+    }
+
+    private int getIdleConnectionCount() {
+        MetricCollector metricCollector = MetricCollector.create("test");
+        idleCountingPool.collectChannelPoolMetrics(metricCollector).join();
+        return metricCollector.collect().metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0);
+    }
+
+    @SafeVarargs
+    private final void stubDelegatePoolAcquires(Future<Channel> result, Future<Channel>... extraResults) {
+        Mockito.when(delegatePool.acquire(any())).thenReturn(result, extraResults);
+    }
+
+    private void stubDelegatePoolAcquiresForSuccess() {
+        Mockito.when(delegatePool.acquire(any())).thenAnswer(a -> createSuccessfulAcquire());
+    }
+
+    private void stubDelegatePoolReleasesForSuccess() {
+        Mockito.when(delegatePool.release(any())).thenAnswer((Answer<Future<Channel>>) invocation -> {
+            Channel channel = invocation.getArgumentAt(0, Channel.class);
+            Promise<Channel> result = channel.eventLoop().newPromise();
+            return result.setSuccess(channel);
+        });
+    }
+
+    private Future<Channel> createSuccessfulAcquire() {
+        try {
+            EventLoop eventLoop = this.eventLoopGroup.next();
+
+            Promise<Channel> channelPromise = eventLoop.newPromise();
+            MockChannel channel = new MockChannel();
+            eventLoop.register(channel);
+            channelPromise.setSuccess(channel);
+
+            return channelPromise;
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/HttpOrHttp2ChannelPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/http2/HttpOrHttp2ChannelPoolTest.java
@@ -262,19 +262,9 @@ public class HttpOrHttp2ChannelPoolTest {
         metricsFuture.join();
         MetricCollection metrics = metricCollector.collect();
 
-        assertThat(metrics.metricValues(HttpMetric.PENDING_CONNECTION_ACQUIRES).get(0)).isEqualTo(0);
-        assertThat(metrics.metricValues(HttpMetric.MAX_CONNECTIONS).get(0)).isEqualTo(4);
-
-        // We get a snapshot at some point during or after the acquire, so we have to check the during and after case
-        // separately.
-        Integer availableConnections = metrics.metricValues(HttpMetric.AVAILABLE_CONNECTIONS).get(0);
-        Integer leasedConnections = metrics.metricValues(HttpMetric.LEASED_CONNECTIONS).get(0);
-
-        assertThat(availableConnections).isBetween(3, 4);
-        if (availableConnections == 3) {
-            assertThat(leasedConnections).isEqualTo(1);
-        } else {
-            assertThat(leasedConnections).isEqualTo(0);
-        }
+        assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isEqualTo(0);
+        assertThat(metrics.metricValues(HttpMetric.MAX_CONCURRENCY).get(0)).isEqualTo(4);
+        assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0)).isBetween(0, 1);
+        assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
     }
 }


### PR DESCRIPTION
Updated existing HTTP metrics to specify that they are "concurrency", not "connections". For HTTP/2, we can't calculate the maximum number of connections, and concurrency is more useful to customers anyway.

Fixed the AVAILABLE_CONCURRENCY in Netty to actually be the number of established but idle concurrency, not the difference between max concurrency and leased concurrency.