### PR TITLE
Stricter implementation of ARN rules when parsing resource strings. R…

### DIFF
--- a/core/arns/src/main/java/software/amazon/awssdk/arns/ArnResource.java
+++ b/core/arns/src/main/java/software/amazon/awssdk/arns/ArnResource.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.arns;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -78,38 +77,64 @@ public final class ArnResource implements ToCopyableBuilder<ArnResource.Builder,
     /**
      * Parses a string containing either a resource, resource type and resource or
      * resource type, resource and qualifier into an {@link ArnResource}.
-     *
      * <p>
-     * Supports fields separated by either ":" or "/".
-     *
-     * <p>
-     * For legacy AWS Arns not following the resourceType:resource:qualifier pattern,
-     * the qualifier field will contain everything after the first two sections separated
-     * by either ":" or "/".
+     * Matches:
+     * <p><pre>
+     * resource-id
+     * resource-type:resource-id
+     * resource-type/resource-id
+     * resource-type:resource-id:qualifier
+     * resource-type/resource-id:qualifier
+     * </pre><p>
+     * resource-id can be a resource name or a resource path.
      *
      * @param resource - The resource string to parse.
      * @return {@link ArnResource}
      */
     public static ArnResource fromString(String resource) {
-        Character splitter = StringUtils.findFirstOccurrence(resource, ':', '/');
+        Integer resourceTypeBoundary = null;
+        Integer resourceIdBoundary = null;
 
-        if (splitter == null) {
+        for (int i = 0; i < resource.length(); ++i) {
+            char ch = resource.charAt(i);
+
+            if (ch == ':' || ch == '/') {
+                resourceTypeBoundary = i;
+                break;
+            }
+        }
+
+        if (resourceTypeBoundary != null) {
+            for (int i = resource.length() - 1; i > resourceTypeBoundary; --i) {
+                char ch = resource.charAt(i);
+
+                if (ch == ':') {
+                    resourceIdBoundary = i;
+                    break;
+                }
+            }
+        }
+
+        if (resourceTypeBoundary == null) {
+            // 'resource-id'
             return ArnResource.builder().resource(resource).build();
-        }
-
-        int resourceTypeColonIndex = resource.indexOf(splitter);
-
-        ArnResource.Builder builder = ArnResource.builder().resourceType(resource.substring(0, resourceTypeColonIndex));
-        int resourceColonIndex = resource.indexOf(splitter, resourceTypeColonIndex);
-        int qualifierColonIndex = resource.indexOf(splitter, resourceColonIndex + 1);
-        if (qualifierColonIndex < 0) {
-            builder.resource(resource.substring(resourceTypeColonIndex + 1));
+        } else if (resourceIdBoundary == null) {
+            // 'resource-type:resource-id'
+            String resourceType = resource.substring(0, resourceTypeBoundary);
+            String resourceId = resource.substring(resourceTypeBoundary + 1);
+            return ArnResource.builder().resourceType(resourceType).resource(resourceId).build();
         } else {
-            builder.resource(resource.substring(resourceTypeColonIndex + 1, qualifierColonIndex));
-            builder.qualifier(resource.substring(qualifierColonIndex + 1));
-        }
+            // 'resource-type:resource-id:qualifier'
+            String resourceType = resource.substring(0, resourceTypeBoundary);
+            String resourceId = resource.substring(resourceTypeBoundary + 1, resourceIdBoundary);
+            String qualifier = resource.substring(resourceIdBoundary + 1);
+            return ArnResource.builder()
+                              .resourceType(resourceType)
+                              .resource(resourceId)
+                              .qualifier(qualifier)
+                              .build();
 
-        return builder.build();
+        }
     }
 
     @Override

--- a/core/arns/src/test/java/software/amazon/awssdk/arns/ArnResourceTest.java
+++ b/core/arns/src/test/java/software/amazon/awssdk/arns/ArnResourceTest.java
@@ -15,11 +15,11 @@
 
 package software.amazon.awssdk.arns;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
+
 import org.junit.Test;
 
 public class ArnResourceTest {
@@ -55,6 +55,120 @@ public class ArnResourceTest {
         assertThat(arnResource.qualifier()).isEqualTo(Optional.of("1"));
         assertThat(arnResource.resourceType()).isEqualTo(Optional.of("foobar"));
         assertThat(arnResource.resource()).isEqualTo("bucket:foobar:1");
+    }
+
+    @Test
+    public void fromString_slashForm_pathNoQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint/test/object/unit-01/finance/*");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test/object/unit-01/finance/*");
+        assertThat(arnResource.qualifier()).isEmpty();
+    }
+
+    @Test
+    public void fromString_slashForm_pathWithQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint/test/object/unit-01/finance/file1:123");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test/object/unit-01/finance/file1");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of("123"));
+    }
+
+    @Test
+    public void fromString_slashForm_pathEmptyQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint/test/object/unit-01/finance/*:");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test/object/unit-01/finance/*");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of(""));
+    }
+
+    @Test
+    public void fromString_colonForm_pathNoQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint:test/object/unit-01/finance/*");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test/object/unit-01/finance/*");
+        assertThat(arnResource.qualifier()).isEmpty();
+    }
+
+    @Test
+    public void fromString_colonForm_pathWithQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint:test/object/unit-01/finance/file1:123");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test/object/unit-01/finance/file1");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of("123"));
+    }
+
+    @Test
+    public void fromString_colonForm_pathEmptyQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint:test/object/unit-01/finance/file1:");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test/object/unit-01/finance/file1");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of(""));
+    }
+
+    @Test
+    public void fromString_slashForm_typeAndNameNoQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint/test");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test");
+        assertThat(arnResource.qualifier()).isEmpty();
+    }
+
+    @Test
+    public void fromString_slashForm_typeAndNameWithQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint/test:123");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of("123"));
+    }
+
+    @Test
+    public void fromString_slashForm_typeAndNameEmptyQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint/test:");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of(""));
+    }
+
+    @Test
+    public void fromString_colonForm_typeAndNameNoQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint:test");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test");
+        assertThat(arnResource.qualifier()).isEmpty();
+    }
+
+    @Test
+    public void fromString_colonForm_typeAndNameWithQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint:test:123");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of("123"));
+    }
+
+    @Test
+    public void fromString_colonForm_typeAndNameEmptyQualifier() {
+        ArnResource arnResource = ArnResource.fromString("accesspoint:test:");
+        assertThat(arnResource.resourceType()).isEqualTo(Optional.of("accesspoint"));
+        assertThat(arnResource.resource()).isEqualTo("test");
+        assertThat(arnResource.qualifier()).isEqualTo(Optional.of(""));
+    }
+
+    @Test
+    public void fromString_nameOnly() {
+        ArnResource arnResource = ArnResource.fromString("bob");
+        assertThat(arnResource.resourceType()).isEmpty();
+        assertThat(arnResource.resource()).isEqualTo("bob");
+        assertThat(arnResource.qualifier()).isEmpty();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromString_colonForm_typeWithNoId() {
+        ArnResource.fromString("bob:");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromString_slashForm_typeWithNoId() {
+        ArnResource.fromString("bob/");
     }
 
     @Test

--- a/core/arns/src/test/java/software/amazon/awssdk/arns/ArnTest.java
+++ b/core/arns/src/test/java/software/amazon/awssdk/arns/ArnTest.java
@@ -105,12 +105,12 @@ public class ArnTest {
 
     @Test
     public void arnWithResourceTypeAndResourceAndQualifier_SlashSplitter_ParsesCorrectly() {
-        String arnString = "arn:aws:s3:us-east-1:12345678910:bucket/foobar/1";
+        String arnString = "arn:aws:s3:us-east-1:12345678910:bucket/foobar:1";
         Arn arn = Arn.fromString(arnString);
         assertThat(arn.partition()).isEqualTo("aws");
         assertThat(arn.service()).isEqualTo("s3");
         assertThat(arn.region()).isEqualTo(Optional.of("us-east-1"));
-        assertThat(arn.resourceAsString()).isEqualTo("bucket/foobar/1");
+        assertThat(arn.resourceAsString()).isEqualTo("bucket/foobar:1");
         verifyArnResource(arn.resource());
         assertThat(arn.resource().qualifier().get()).isEqualTo("1");
     }


### PR DESCRIPTION
…equired to support paths properly in S3 operations that take ARNs

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
