### PR TITLE
Fixed wrong Mimetype result for null fileName and deleted wrongly pasted javadocs

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/Mimetype.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/Mimetype.java
@@ -116,10 +116,6 @@ public final class Mimetype {
      * to find the corresponding mime type. If the file has no extension, or the extension is not
      * available in the listing contained in this class, the default mimetype
      * <code>application/octet-stream</code> is returned.
-     * <p>
-     * A file extension is one or more characters that occur after the last period (.) in the file's name.
-     * If a file has no extension,
-     * Guesses the mimetype of file data based on the file's extension.
      *
      * @param path the file whose extension may match a known mimetype.
      * @return the file's mimetype based on its extension, or a default value of
@@ -132,7 +128,7 @@ public final class Mimetype {
         if (file != null) {
             return getMimetype(file.toString());
         }
-        return null;
+        return MIMETYPE_OCTET_STREAM;
     }
 
     /**
@@ -140,10 +136,6 @@ public final class Mimetype {
      * to find the corresponding mime type. If the file has no extension, or the extension is not
      * available in the listing contained in this class, the default mimetype
      * <code>application/octet-stream</code> is returned.
-     * <p>
-     * A file extension is one or more characters that occur after the last period (.) in the file's name.
-     * If a file has no extension,
-     * Guesses the mimetype of file data based on the file's extension.
      *
      * @param file the file whose extension may match a known mimetype.
      * @return the file's mimetype based on its extension, or a default value of
@@ -159,10 +151,6 @@ public final class Mimetype {
      * no extension, or the extension is not available in the listing contained
      * in this class, the default mimetype <code>application/octet-stream</code>
      * is returned.
-     * <p>
-     * A file extension is one or more characters that occur after the last
-     * period (.) in the file's name. If a file has no extension, Guesses the
-     * mimetype of file data based on the file's extension.
      *
      * @param fileName The name of the file whose extension may match a known
      * mimetype.

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/MimetypeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/MimetypeTest.java
@@ -16,7 +16,10 @@
 package software.amazon.awssdk.core.internal.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -47,5 +50,12 @@ public class MimetypeTest {
     @Test
     public void noExtensions_defaulttoBeStream() throws Exception {
         assertThat(mimetype.getMimetype("test")).isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
+    }
+
+    @Test
+    public void pathWithoutFileName_defaulttoBeStream() throws Exception {
+        Path mockPath = mock(Path.class);
+        when(mockPath.getFileName()).thenReturn(null);
+        assertThat(mimetype.getMimetype(mockPath)).isEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed wrong Mimetype result for null fileName to keep consistency with our API contract;
Deleted wrongly pasted javadocs;

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
#1811 
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There is no newly added unit test for this change because it's impossible to set the fileName as null here in the path.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
