### PR TITLE
Fix event marshaller binding for input event streams.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-410cf46.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-410cf46.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "type": "bugfix", 
+    "description": "Fix marshaller binding for input event streams when member name and shape name are not equal."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -46,7 +46,6 @@ import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionJsonMars
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
-import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
@@ -273,7 +272,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                                             EventStreamTaggedUnionJsonMarshaller.class);
 
         List<String> eventNames = EventStreamUtils.getEventMembers(eventStreamShape)
-                                                  .map(MemberModel::getC2jName)
+                                                  .map(m -> m.getShape().getShapeName())
                                                   .collect(Collectors.toList());
 
         eventNames.forEach(event -> builder.add(".putMarshaller($T.class, new $T(protocolFactory))",

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -60,7 +60,6 @@ import software.amazon.awssdk.services.json.model.EventTwo;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InputEvent;
-import software.amazon.awssdk.services.json.model.InputEventOne;
 import software.amazon.awssdk.services.json.model.InputEventStream;
 import software.amazon.awssdk.services.json.model.InputEventStreamTwo;
 import software.amazon.awssdk.services.json.model.InputEventTwo;
@@ -86,7 +85,6 @@ import software.amazon.awssdk.services.json.transform.EventStreamOperationWithOn
 import software.amazon.awssdk.services.json.transform.EventStreamOperationWithOnlyOutputRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventMarshaller;
-import software.amazon.awssdk.services.json.transform.InputEventOneMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventTwoMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
@@ -343,7 +341,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
                     operationMetadata);
             EventStreamTaggedUnionJsonMarshaller eventMarshaller = EventStreamTaggedUnionJsonMarshaller.builder()
-                    .putMarshaller(InputEventOne.class, new InputEventOneMarshaller(protocolFactory))
+                    .putMarshaller(InputEvent.class, new InputEventMarshaller(protocolFactory))
                     .putMarshaller(InputEventTwo.class, new InputEventTwoMarshaller(protocolFactory)).build();
             SdkPublisher<InputEventStreamTwo> eventPublisher = SdkPublisher.adapt(requestStream);
             Publisher<ByteBuffer> adapted = eventPublisher.map(event -> eventMarshaller.marshall(event)).map(


### PR DESCRIPTION
This is another case of SDK code generation failing when the event's structure name and the structure member name are not identical.

## Description
This is similar to https://github.com/aws/aws-sdk-java-v2/pull/1821 which fixed the problem for output event streams.

## Motivation and Context
This fixes generation for services that do not align their structure member names and structure type names when modelling event streams.

## Testing
I modified the existing unit tests.  The previously generated client appears to be nonfunctional, as it references an `InputEventOne` class and an `InputEventOneMarshaller` class, but the [C2JModel](https://github.com/aws/aws-sdk-java-v2/blob/f6e3d9f6172368eafd7a0d2cfcd871d83e754372/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json#L445) only contains shapes `InputEvent` and `InputEventTwo`.

I also tested this offline on a model that broke generation without this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
