### PR TITLE
Support multiple metric publishers in both request and client configu…

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -32,7 +32,6 @@ import com.squareup.javapoet.TypeSpec;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
@@ -71,7 +70,7 @@ import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.FunctionalUtils;
 
 public final class AsyncClientClass extends AsyncClientInterface {
-    private static final String PUBLISHER_NAME = "metricPublisher";
+    private static final String PUBLISHERS_NAME = "metricPublishers";
     private static final String METRIC_COLLECTOR_NAME = "apiCallMetricCollector";
     private final IntermediateModel model;
     private final PoetExtensions poetExtensions;
@@ -240,13 +239,13 @@ public final class AsyncClientClass extends AsyncClientInterface {
                                  "() -> $N.exceptionOccurred(t))", paramName);
         }
 
-        builder.addStatement("$T<$T> $N = $T.resolvePublisher(clientConfiguration, $N.overrideConfiguration().orElse(null))",
-                             Optional.class,
+        builder.addStatement("$T<$T> $N = $T.resolvePublishers(clientConfiguration, $N.overrideConfiguration().orElse(null))",
+                             List.class,
                              MetricPublisher.class,
-                             PUBLISHER_NAME,
+                             PUBLISHERS_NAME,
                              MetricUtils.class,
                              opModel.getInput().getVariableName())
-               .addStatement("$N.ifPresent(p -> p.publish($N.collect()))", PUBLISHER_NAME, "apiCallMetricCollector")
+               .addStatement("$N.forEach(p -> p.publish($N.collect()))", PUBLISHERS_NAME, "apiCallMetricCollector")
                .addStatement("return $T.failedFuture(t)", CompletableFutureUtils.class)
                .endControlFlow();
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -28,7 +28,6 @@ import com.squareup.javapoet.TypeSpec.Builder;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -196,7 +195,7 @@ public class SyncClientClass implements ClassSpec {
         method.addStatement("$1T $2N = $1T.create($3S)",
                 MetricCollector.class, metricCollectorName, "ApiCall");
 
-        String publisherName = "metricPublisher";
+        String publisherListName = "metricPublishers";
 
         method.beginControlFlow("try")
                 .addStatement("$N.reportMetric($T.$L, $S)", metricCollectorName, CoreMetric.class, "SERVICE_ID",
@@ -206,13 +205,13 @@ public class SyncClientClass implements ClassSpec {
                 .addCode(protocolSpec.executionHandler(opModel))
                 .endControlFlow()
                 .beginControlFlow("finally")
-                .addStatement("$T<$T> $N = $T.resolvePublisher(clientConfiguration, $N)",
-                              Optional.class,
+                .addStatement("$T<$T> $N = $T.resolvePublishers(clientConfiguration, $N)",
+                              List.class,
                               MetricPublisher.class,
-                              publisherName,
+                              publisherListName,
                               MetricUtils.class,
                               opModel.getInput().getVariableName())
-                .addStatement("$N.ifPresent(p -> p.publish($N.collect()))", publisherName, metricCollectorName)
+                .addStatement("$N.forEach(p -> p.publish($N.collect()))", publisherListName, metricCollectorName)
                 .endControlFlow();
 
         methods.add(method.build());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
@@ -186,8 +186,8 @@ public interface ProtocolSpec {
     }
 
     default String publishMetrics() {
-        return "Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration, "
+        return "List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration, "
                + "requestOverrideConfig);\n"
-               + "metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));";
+               + "metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));";
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.json;
 import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
 import java.nio.ByteBuffer;
-import java.util.Optional;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -181,15 +181,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                             .withInput(aPostOperationRequest));
             AwsRequestOverrideConfiguration requestOverrideConfig = aPostOperationRequest.overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration, aPostOperationRequest
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration, aPostOperationRequest
                     .overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -242,15 +242,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = aPostOperationWithOutputRequest.overrideConfiguration()
                     .orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     aPostOperationWithOutputRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -333,17 +333,17 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                         future.completeExceptionally(e);
                     }
                 }
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                     () -> asyncResponseHandler.exceptionOccurred(t));
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     eventStreamOperationRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -403,15 +403,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = eventStreamOperationWithOnlyInputRequest
                     .overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     eventStreamOperationWithOnlyInputRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -490,17 +490,17 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                         future.completeExceptionally(e);
                     }
                 }
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                     () -> asyncResponseHandler.exceptionOccurred(t));
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     eventStreamOperationWithOnlyOutputRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -553,15 +553,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = getWithoutRequiredMembersRequest.overrideConfiguration()
                     .orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     getWithoutRequiredMembersRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -611,15 +611,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = paginatedOperationWithResultKeyRequest
                     .overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     paginatedOperationWithResultKeyRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -746,15 +746,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = paginatedOperationWithoutResultKeyRequest
                     .overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     paginatedOperationWithoutResultKeyRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -889,15 +889,15 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = streamingInputOperationRequest.overrideConfiguration()
                     .orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingInputOperationRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -969,17 +969,17 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                             () -> asyncResponseTransformer.exceptionOccurred(e));
                 }
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                     () -> asyncResponseTransformer.exceptionOccurred(t));
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingInputOutputOperationRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -1039,17 +1039,17 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                             () -> asyncResponseTransformer.exceptionOccurred(e));
                 }
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                     () -> asyncResponseTransformer.exceptionOccurred(t));
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingOutputOperationRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.endpointdiscoverytest;
 import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
 import java.net.URI;
-import java.util.Optional;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,15 +116,15 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
                             .withMetricCollector(apiCallMetricCollector).withInput(describeEndpointsRequest));
             AwsRequestOverrideConfiguration requestOverrideConfig = describeEndpointsRequest.overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     describeEndpointsRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -181,15 +181,15 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
             AwsRequestOverrideConfiguration requestOverrideConfig = testDiscoveryIdentifiersRequiredRequest
                     .overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     testDiscoveryIdentifiersRequiredRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -245,15 +245,15 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
             AwsRequestOverrideConfiguration requestOverrideConfig = testDiscoveryOptionalRequest.overrideConfiguration().orElse(
                     null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     testDiscoveryOptionalRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -309,15 +309,15 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
             AwsRequestOverrideConfiguration requestOverrideConfig = testDiscoveryRequiredRequest.overrideConfiguration().orElse(
                     null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     testDiscoveryRequiredRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
@@ -1,7 +1,7 @@
 package software.amazon.awssdk.services.endpointdiscoverytest;
 
 import java.net.URI;
-import java.util.Optional;
+import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
@@ -104,9 +104,9 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
                     .withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new DescribeEndpointsRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     describeEndpointsRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -156,9 +156,9 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
                             .withInput(testDiscoveryIdentifiersRequiredRequest).withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new TestDiscoveryIdentifiersRequiredRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     testDiscoveryIdentifiersRequiredRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -206,9 +206,9 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
                     .withInput(testDiscoveryOptionalRequest).withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new TestDiscoveryOptionalRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     testDiscoveryOptionalRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -256,9 +256,9 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
                     .withInput(testDiscoveryRequiredRequest).withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new TestDiscoveryRequiredRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     testDiscoveryRequiredRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -1,6 +1,6 @@
 package software.amazon.awssdk.services.json;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -129,8 +129,8 @@ final class DefaultJsonClient implements JsonClient {
                     .withInput(aPostOperationRequest).withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration, aPostOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration, aPostOperationRequest);
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -178,9 +178,9 @@ final class DefaultJsonClient implements JsonClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     aPostOperationWithOutputRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -228,9 +228,9 @@ final class DefaultJsonClient implements JsonClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     getWithoutRequiredMembersRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -274,9 +274,9 @@ final class DefaultJsonClient implements JsonClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     paginatedOperationWithResultKeyRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -398,9 +398,9 @@ final class DefaultJsonClient implements JsonClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     paginatedOperationWithoutResultKeyRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -539,9 +539,9 @@ final class DefaultJsonClient implements JsonClient {
                                             .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
                                             .requestBody(requestBody).build()));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingInputOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -614,9 +614,9 @@ final class DefaultJsonClient implements JsonClient {
                                                     new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
                                             .requestBody(requestBody).transferEncoding(true).build()), responseTransformer);
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingInputOutputOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -667,9 +667,9 @@ final class DefaultJsonClient implements JsonClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingOutputOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -2,7 +2,7 @@ package software.amazon.awssdk.services.query;
 
 import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,15 +113,15 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                             .withInput(aPostOperationRequest));
             AwsRequestOverrideConfiguration requestOverrideConfig = aPostOperationRequest.overrideConfiguration().orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
-                        requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                List<MetricPublisher> metricPublishers = MetricUtils
+                    .resolvePublishers(clientConfiguration, requestOverrideConfig);
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration, aPostOperationRequest
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration, aPostOperationRequest
                     .overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -171,15 +171,15 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = aPostOperationWithOutputRequest.overrideConfiguration()
                     .orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     aPostOperationWithOutputRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -233,15 +233,15 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
             AwsRequestOverrideConfiguration requestOverrideConfig = streamingInputOperationRequest.overrideConfiguration()
                     .orElse(null);
             executeFuture.whenComplete((r, e) -> {
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingInputOperationRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }
@@ -298,17 +298,17 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                     runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                             () -> asyncResponseTransformer.exceptionOccurred(e));
                 }
-                Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+                List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                         requestOverrideConfig);
-                metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             return executeFuture;
         } catch (Throwable t) {
             runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
                     () -> asyncResponseTransformer.exceptionOccurred(t));
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingOutputOperationRequest.overrideConfiguration().orElse(null));
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             return CompletableFutureUtils.failedFuture(t);
         }
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -1,6 +1,6 @@
 package software.amazon.awssdk.services.query;
 
-import java.util.Optional;
+import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
@@ -100,8 +100,8 @@ final class DefaultQueryClient implements QueryClient {
                     .withInput(aPostOperationRequest).withMetricCollector(apiCallMetricCollector)
                     .withMarshaller(new APostOperationRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration, aPostOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration, aPostOperationRequest);
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -146,9 +146,9 @@ final class DefaultQueryClient implements QueryClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory)));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     aPostOperationWithOutputRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -205,9 +205,9 @@ final class DefaultQueryClient implements QueryClient {
                                             .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
                                             .requestBody(requestBody).build()));
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingInputOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 
@@ -255,9 +255,9 @@ final class DefaultQueryClient implements QueryClient {
                             .withMetricCollector(apiCallMetricCollector)
                             .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory)), responseTransformer);
         } finally {
-            Optional<MetricPublisher> metricPublisher = MetricUtils.resolvePublisher(clientConfiguration,
+            List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfiguration,
                     streamingOutputOperationRequest);
-            metricPublisher.ifPresent(p -> p.publish(apiCallMetricCollector.collect()));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
@@ -45,7 +45,7 @@ public abstract class RequestOverrideConfiguration {
     private final Duration apiCallTimeout;
     private final Duration apiCallAttemptTimeout;
     private final Signer signer;
-    private final MetricPublisher metricPublisher;
+    private final List<MetricPublisher> metricPublishers;
 
     protected RequestOverrideConfiguration(Builder<?> builder) {
         this.headers = CollectionUtils.deepUnmodifiableMap(builder.headers(), () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
@@ -54,7 +54,7 @@ public abstract class RequestOverrideConfiguration {
         this.apiCallTimeout = Validate.isPositiveOrNull(builder.apiCallTimeout(), "apiCallTimeout");
         this.apiCallAttemptTimeout = Validate.isPositiveOrNull(builder.apiCallAttemptTimeout(), "apiCallAttemptTimeout");
         this.signer = builder.signer();
-        this.metricPublisher = builder.metricPublisher();
+        this.metricPublishers = builder.metricPublishers();
     }
 
     /**
@@ -134,8 +134,8 @@ public abstract class RequestOverrideConfiguration {
      * Return the metric publisher for publishing the metrics collected for this request. This publisher supersedes the
      * metric publisher set on the client.
      */
-    public Optional<MetricPublisher> metricPublisher() {
-        return Optional.ofNullable(metricPublisher);
+    public List<MetricPublisher> metricPublishers() {
+        return metricPublishers;
     }
 
     @Override
@@ -153,7 +153,7 @@ public abstract class RequestOverrideConfiguration {
                Objects.equals(apiCallTimeout, that.apiCallTimeout) &&
                Objects.equals(apiCallAttemptTimeout, that.apiCallAttemptTimeout) &&
                Objects.equals(signer, that.signer) &&
-               Objects.equals(metricPublisher, that.metricPublisher);
+               Objects.equals(metricPublishers, that.metricPublishers);
     }
 
     @Override
@@ -165,7 +165,7 @@ public abstract class RequestOverrideConfiguration {
         hashCode = 31 * hashCode + Objects.hashCode(apiCallTimeout);
         hashCode = 31 * hashCode + Objects.hashCode(apiCallAttemptTimeout);
         hashCode = 31 * hashCode + Objects.hashCode(signer);
-        hashCode = 31 * hashCode + Objects.hashCode(metricPublisher);
+        hashCode = 31 * hashCode + Objects.hashCode(metricPublishers);
         return hashCode;
     }
 
@@ -353,15 +353,20 @@ public abstract class RequestOverrideConfiguration {
         Signer signer();
 
         /**
-         * Sets the metric publisher for publishing the metrics collected for this request. This publisher supersedes
-         * the metric publisher set on the client.
+         * Sets the metric publishers for publishing the metrics collected for this request. This list of publishers supersedes
+         * the metric publishers set on the client.
          *
-         * @param metricPublisher The metric publisher for this request.
+         * @param metricPublishers The list of metric publishers for this request.
          * @return This object for method chaining.
          */
-        B metricPublisher(MetricPublisher metricPublisher);
+        B metricPublishers(List<MetricPublisher> metricPublishers);
 
-        MetricPublisher metricPublisher();
+        List<MetricPublisher> metricPublishers();
+
+        /**
+         * Adds a new metric publisher for this request.
+         */
+        B addMetricPublisher(MetricPublisher metricPublisher);
 
         /**
          * Create a new {@code SdkRequestOverrideConfiguration} with the properties set on this builder.
@@ -378,7 +383,7 @@ public abstract class RequestOverrideConfiguration {
         private Duration apiCallTimeout;
         private Duration apiCallAttemptTimeout;
         private Signer signer;
-        private MetricPublisher metricPublisher;
+        private List<MetricPublisher> metricPublishers = new ArrayList<>();
 
         protected BuilderImpl() {
         }
@@ -497,18 +502,19 @@ public abstract class RequestOverrideConfiguration {
         }
 
         @Override
-        public B metricPublisher(MetricPublisher metricPublisher) {
-            this.metricPublisher = metricPublisher;
+        public B metricPublishers(List<MetricPublisher> metricPublishers) {
+            this.metricPublishers = metricPublishers;
             return (B) this;
         }
 
-        public void setMetricPublisher(MetricPublisher metricPublisher) {
-            metricPublisher(metricPublisher);
+        public B addMetricPublisher(MetricPublisher metricPublisher) {
+            metricPublishers.add(metricPublisher);
+            return (B) this;
         }
 
         @Override
-        public MetricPublisher metricPublisher() {
-            return metricPublisher;
+        public List<MetricPublisher> metricPublishers() {
+            return metricPublishers;
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -28,7 +28,7 @@ import static software.amazon.awssdk.core.client.config.SdkClientOption.API_CALL
 import static software.amazon.awssdk.core.client.config.SdkClientOption.ASYNC_HTTP_CLIENT;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.EXECUTION_INTERCEPTORS;
-import static software.amazon.awssdk.core.client.config.SdkClientOption.METRIC_PUBLISHER;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.METRIC_PUBLISHERS;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_FILE;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.PROFILE_NAME;
 import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_POLICY;
@@ -366,7 +366,7 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
                                    overrideConfig.advancedOption(DISABLE_HOST_PREFIX_INJECTION).orElse(null));
         clientConfiguration.option(PROFILE_FILE, overrideConfig.defaultProfileFile().orElse(null));
         clientConfiguration.option(PROFILE_NAME, overrideConfig.defaultProfileName().orElse(null));
-        clientConfiguration.option(METRIC_PUBLISHER, overrideConfig.metricPublisher().orElse(null));
+        clientConfiguration.option(METRIC_PUBLISHERS, overrideConfig.metricPublishers());
         return thisBuilder();
     }
 
@@ -394,8 +394,8 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
         return thisBuilder();
     }
 
-    public final B metricPublisher(MetricPublisher metricPublisher) {
-        clientConfiguration.option(METRIC_PUBLISHER, metricPublisher);
+    public final B metricPublishers(List<MetricPublisher> metricPublishers) {
+        clientConfiguration.option(METRIC_PUBLISHERS, metricPublishers);
         return thisBuilder();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -56,7 +56,7 @@ public final class ClientOverrideConfiguration
     private final Duration apiCallTimeout;
     private final ProfileFile defaultProfileFile;
     private final String defaultProfileName;
-    private final MetricPublisher metricPublisher;
+    private final List<MetricPublisher> metricPublishers;
 
     /**
      * Initialize this configuration. Private to require use of {@link #builder()}.
@@ -70,7 +70,7 @@ public final class ClientOverrideConfiguration
         this.apiCallAttemptTimeout = Validate.isPositiveOrNull(builder.apiCallAttemptTimeout(), "apiCallAttemptTimeout");
         this.defaultProfileFile = builder.defaultProfileFile();
         this.defaultProfileName = builder.defaultProfileName();
-        this.metricPublisher = builder.metricPublisher();
+        this.metricPublishers = builder.metricPublishers();
     }
 
     @Override
@@ -188,12 +188,12 @@ public final class ClientOverrideConfiguration
     }
 
     /**
-     * The metric publisher to use to publisher metrics collected for this client.
+     * The list of metric publishers to use to publish metrics collected for this client.
      *
      * @return The metric publisher.
      */
-    public Optional<MetricPublisher> metricPublisher() {
-        return Optional.ofNullable(metricPublisher);
+    public List<MetricPublisher> metricPublishers() {
+        return metricPublishers;
     }
 
     @Override
@@ -422,14 +422,21 @@ public final class ClientOverrideConfiguration
         String defaultProfileName();
 
         /**
-         * Set the metric publisher to use for publishing metrics collected fo this client.
+         * Set the metric publishers to use for publishing metrics collected for this client.
          *
-         * @param metricPublisher The metric publisher to use.
+         * @param metricPublishers The list of metric publishers to use.
          * @return This object for method chaining.
          */
-        Builder metricPublisher(MetricPublisher metricPublisher);
+        Builder metricPublishers(List<MetricPublisher> metricPublishers);
 
-        MetricPublisher metricPublisher();
+        /**
+         * Add a new metric publisher to the metric publishers list.
+         * @param metricPublisher Newly added metric publisher.
+         * @return This object for method chaining.
+         */
+        Builder addMetricPublisher(MetricPublisher metricPublisher);
+
+        List<MetricPublisher> metricPublishers();
     }
 
     /**
@@ -444,7 +451,7 @@ public final class ClientOverrideConfiguration
         private Duration apiCallAttemptTimeout;
         private ProfileFile defaultProfileFile;
         private String defaultProfileName;
-        private MetricPublisher metricPublisher;
+        private List<MetricPublisher> metricPublishers = new ArrayList<>();
 
         @Override
         public Builder headers(Map<String, List<String>> headers) {
@@ -587,14 +594,20 @@ public final class ClientOverrideConfiguration
         }
 
         @Override
-        public Builder metricPublisher(MetricPublisher metricPublisher) {
-            this.metricPublisher = metricPublisher;
+        public Builder metricPublishers(List<MetricPublisher> metricPublishers) {
+            this.metricPublishers = metricPublishers;
             return this;
         }
 
         @Override
-        public MetricPublisher metricPublisher() {
-            return metricPublisher;
+        public Builder addMetricPublisher(MetricPublisher metricPublisher) {
+            this.metricPublishers.add(metricPublisher);
+            return this;
+        }
+
+        @Override
+        public List<MetricPublisher> metricPublishers() {
+            return metricPublishers;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -130,7 +130,9 @@ public final class SdkClientOption<T> extends ClientOption<T> {
      */
     public static final SdkClientOption<String> PROFILE_NAME = new SdkClientOption<>(String.class);
 
-    public static final SdkClientOption<MetricPublisher> METRIC_PUBLISHER = new SdkClientOption<>(MetricPublisher.class);
+
+    public static final SdkClientOption<List<MetricPublisher>> METRIC_PUBLISHERS =
+        new SdkClientOption<>(new UnsafeValueType(List.class));
 
     private SdkClientOption(Class<T> valueClass) {
         super(valueClass);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/MetricsConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/MetricsConfigurationTest.java
@@ -1,0 +1,95 @@
+package software.amazon.awssdk.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.METRIC_PUBLISHERS;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.internal.util.MetricUtils;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+public class MetricsConfigurationTest {
+
+    @Test
+    public void onlyConfigRequestMetricPublisher_returnRequestPublisher() {
+        MetricPublisher metricPublisher1 = mock(MetricPublisher.class);
+        MetricPublisher metricPublisher2 = mock(MetricPublisher.class);
+        List<MetricPublisher> expectedPublishers = Arrays.asList(metricPublisher1, metricPublisher2);
+        SdkRequest sdkRequest = mock(SdkRequest.class);
+        Optional requestConfig = Optional.of(SdkRequestOverrideConfiguration.builder()
+                                                                            .addMetricPublisher(metricPublisher1)
+                                                                            .addMetricPublisher(metricPublisher2)
+                                                                            .build());
+        when(sdkRequest.overrideConfiguration()).thenReturn(requestConfig);
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder().build();
+        List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfig, sdkRequest);
+        assertEquals(expectedPublishers, metricPublishers);
+    }
+
+    @Test
+    public void onlyConfigRequestOverrideMetricPublisher_returnRequestPublisher() {
+        MetricPublisher metricPublisher1 = mock(MetricPublisher.class);
+        MetricPublisher metricPublisher2 = mock(MetricPublisher.class);
+        List<MetricPublisher> expectedPublishers = Arrays.asList(metricPublisher1, metricPublisher2);
+        RequestOverrideConfiguration requestConfig = SdkRequestOverrideConfiguration.builder()
+                                                                                    .addMetricPublisher(metricPublisher1)
+                                                                                    .addMetricPublisher(metricPublisher2)
+                                                                                    .build();
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder().build();
+        List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfig, requestConfig);
+        assertEquals(expectedPublishers, metricPublishers);
+    }
+
+    @Test
+    public void onlyConfigClientMetricPublisher_returnClientPublisher() {
+        MetricPublisher metricPublisher1 = mock(MetricPublisher.class);
+        MetricPublisher metricPublisher2 = mock(MetricPublisher.class);
+        List<MetricPublisher> expectedPublishers = Arrays.asList(metricPublisher1, metricPublisher2);
+        RequestOverrideConfiguration requestConfig = SdkRequestOverrideConfiguration.builder().build();
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                                                                    .option(METRIC_PUBLISHERS,
+                                                                            Arrays.asList(metricPublisher1, metricPublisher2))
+                                                                    .build();
+        List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfig, requestConfig);
+        assertEquals(expectedPublishers, metricPublishers);
+    }
+
+    @Test
+    public void clientOverrideConfigurationMetricPublisher_returnClientPublisher() {
+        MetricPublisher metricPublisher1 = mock(MetricPublisher.class);
+        MetricPublisher metricPublisher2 = mock(MetricPublisher.class);
+        List<MetricPublisher> expectedPublishers = Arrays.asList(metricPublisher1, metricPublisher2);
+        ClientOverrideConfiguration clientConfig = ClientOverrideConfiguration.builder()
+                                                                              .addMetricPublisher(metricPublisher1)
+                                                                              .addMetricPublisher(metricPublisher2)
+                                                                              .build();
+        List<MetricPublisher> metricPublishers = clientConfig.metricPublishers();
+        assertEquals(expectedPublishers, metricPublishers);
+    }
+
+
+    @Test
+    public void configBothRequestAndClientMetricPublisher_returnRequestPublisher() {
+        MetricPublisher metricPublisher1 = mock(MetricPublisher.class);
+        MetricPublisher metricPublisher2 = mock(MetricPublisher.class);
+        MetricPublisher metricPublisher3 = mock(MetricPublisher.class);
+        List<MetricPublisher> expectedPublishers = Collections.singletonList(metricPublisher3);
+        SdkClientConfiguration clientConfig = SdkClientConfiguration.builder()
+                                                                    .option(METRIC_PUBLISHERS,
+                                                                            Arrays.asList(metricPublisher1, metricPublisher2))
+                                                                    .build();
+        RequestOverrideConfiguration requestConfig = SdkRequestOverrideConfiguration.builder()
+                                                                                    .addMetricPublisher(metricPublisher3)
+                                                                                    .build();
+        List<MetricPublisher> metricPublishers = MetricUtils.resolvePublishers(clientConfig, requestConfig);
+        assertEquals(expectedPublishers, metricPublishers);
+    }
+
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/MetricUtilsTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/util/MetricUtilsTest.java
@@ -18,11 +18,12 @@ package software.amazon.awssdk.core.internal.util;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static software.amazon.awssdk.core.client.config.SdkClientOption.METRIC_PUBLISHER;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.METRIC_PUBLISHERS;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,7 +31,6 @@ import org.junit.rules.ExpectedException;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkRequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
@@ -124,21 +124,29 @@ public class MetricUtilsTest {
 
     @Test
     public void resolvePublisher_requestConfigNull_ShouldUseSdkClientConfig() {
-        MetricPublisher metricPublisher = mock(MetricPublisher.class);
+        List metricPublishers = mock(List.class);
 
-        SdkClientConfiguration config = SdkClientConfiguration.builder().option(METRIC_PUBLISHER, metricPublisher).build();
+        SdkClientConfiguration config = SdkClientConfiguration.builder().option(METRIC_PUBLISHERS, metricPublishers).build();
         RequestOverrideConfiguration requestOverrideConfiguration = null;
-        Optional<MetricPublisher> result = MetricUtils.resolvePublisher(config, requestOverrideConfiguration);
-        Assertions.assertThat(result).isEqualTo(Optional.of(metricPublisher));
+        List<MetricPublisher> result = MetricUtils.resolvePublishers(config, requestOverrideConfiguration);
+        Assertions.assertThat(result).isEqualTo(metricPublishers);
     }
 
     @Test
     public void resolvePublisher_requestConfigNotNull_shouldTakePrecedence() {
-        MetricPublisher metricPublisher = mock(MetricPublisher.class);
+        List metricPublishers = mock(List.class);
 
-        SdkClientConfiguration config = SdkClientConfiguration.builder().option(METRIC_PUBLISHER, mock(MetricPublisher.class)).build();
-        RequestOverrideConfiguration requestOverrideConfiguration = SdkRequestOverrideConfiguration.builder().metricPublisher(metricPublisher).build();
-        Optional<MetricPublisher> result = MetricUtils.resolvePublisher(config, requestOverrideConfiguration);
-        Assertions.assertThat(result).isEqualTo(Optional.of(metricPublisher));
+        SdkClientConfiguration config = SdkClientConfiguration.builder().option(METRIC_PUBLISHERS, metricPublishers).build();
+        RequestOverrideConfiguration requestOverrideConfiguration = SdkRequestOverrideConfiguration.builder().metricPublishers(metricPublishers).build();
+        List<MetricPublisher> result = MetricUtils.resolvePublishers(config, requestOverrideConfiguration);
+        Assertions.assertThat(result).isEqualTo(metricPublishers);
+    }
+
+    @Test
+    public void resolvePublisher_bothConfigNull_ShouldReturnEmptyList() {
+        SdkClientConfiguration config = null;
+        RequestOverrideConfiguration requestOverrideConfiguration = null;
+        List<MetricPublisher> result = MetricUtils.resolvePublishers(config, requestOverrideConfiguration);
+        Assertions.assertThat(result).isEqualTo(new ArrayList());
     }
 }


### PR DESCRIPTION
Added support for multiple metric publishers configuration in both request and client;
Migrated ```Optional<MetricPublisher>``` into ```List<MetricPublisher> and changed related resolve function;
Added multiple tests to see if the precedence between request and client configuration works;
Changed codegen module to adjust the way metric publishers are used;
Changed test files of codegen tests.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
