### PR TITLE
Updated DynamoDBEnhancedClient to support '0' and '1' as valid boolean values

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-532841e.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-532841e.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "description": "Support converting \"0\" and \"1\" numbers read from DynamoDB to Boolean and AtomicBoolean."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicBooleanAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/AtomicBooleanAttributeConverter.java
@@ -22,8 +22,6 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
-import software.amazon.awssdk.enhanced.dynamodb.internal.converter.TypeConvertingVisitor;
-import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.AtomicBooleanStringConverter;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -43,8 +41,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 @ThreadSafe
 @Immutable
 public final class AtomicBooleanAttributeConverter implements AttributeConverter<AtomicBoolean> {
-    private static final Visitor VISITOR = new Visitor();
-    private static final AtomicBooleanStringConverter STRING_CONVERTER = AtomicBooleanStringConverter.create();
+    private static final BooleanAttributeConverter BOOLEAN_CONVERTER = BooleanAttributeConverter.create();
 
     private AtomicBooleanAttributeConverter() {
     }
@@ -70,26 +67,6 @@ public final class AtomicBooleanAttributeConverter implements AttributeConverter
 
     @Override
     public AtomicBoolean transformTo(AttributeValue input) {
-        if (input.bool() != null) {
-            return EnhancedAttributeValue.fromBoolean(input.bool()).convert(VISITOR);
-        }
-
-        return EnhancedAttributeValue.fromAttributeValue(input).convert(VISITOR);
-    }
-
-    private static final class Visitor extends TypeConvertingVisitor<AtomicBoolean> {
-        private Visitor() {
-            super(AtomicBoolean.class, AtomicBooleanAttributeConverter.class);
-        }
-
-        @Override
-        public AtomicBoolean convertString(String value) {
-            return STRING_CONVERTER.fromString(value);
-        }
-
-        @Override
-        public AtomicBoolean convertBoolean(Boolean value) {
-            return new AtomicBoolean(value);
-        }
+        return new AtomicBoolean(BOOLEAN_CONVERTER.transformTo(input));
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BooleanAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/BooleanAttributeConverter.java
@@ -93,6 +93,15 @@ public final class BooleanAttributeConverter implements AttributeConverter<Boole
         }
 
         @Override
+        public Boolean convertNumber(String value) {
+            switch (value) {
+                case "0": return false;
+                case "1": return true;
+                default: throw new IllegalArgumentException("Number could not be converted to boolean: " + value);
+            }
+        }
+
+        @Override
         public Boolean convertBoolean(Boolean value) {
             return value;
         }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/BooleanAttributeConvertersTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/attribute/BooleanAttributeConvertersTest.java
@@ -40,6 +40,8 @@ public class BooleanAttributeConvertersTest {
         assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("0").toAttributeValue()));
         assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("1").toAttributeValue()));
         assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("").toAttributeValue()));
+        assertThat(transformTo(converter, EnhancedAttributeValue.fromNumber("1").toAttributeValue())).isTrue();
+        assertThat(transformTo(converter, EnhancedAttributeValue.fromNumber("0").toAttributeValue())).isFalse();
         assertThat(transformTo(converter, EnhancedAttributeValue.fromString("true").toAttributeValue())).isTrue();
         assertThat(transformTo(converter, EnhancedAttributeValue.fromString("false").toAttributeValue())).isFalse();
         assertThat(transformTo(converter, EnhancedAttributeValue.fromBoolean(true).toAttributeValue())).isTrue();
@@ -58,6 +60,8 @@ public class BooleanAttributeConvertersTest {
         assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("0").toAttributeValue()));
         assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("1").toAttributeValue()));
         assertFails(() -> transformTo(converter, EnhancedAttributeValue.fromString("").toAttributeValue()));
+        assertThat(transformTo(converter, EnhancedAttributeValue.fromNumber("1").toAttributeValue())).isTrue();
+        assertThat(transformTo(converter, EnhancedAttributeValue.fromNumber("0").toAttributeValue())).isFalse();
         assertThat(transformTo(converter, EnhancedAttributeValue.fromString("true").toAttributeValue())).isTrue();
         assertThat(transformTo(converter, EnhancedAttributeValue.fromString("false").toAttributeValue())).isFalse();
         assertThat(transformTo(converter, EnhancedAttributeValue.fromBoolean(true).toAttributeValue())).isTrue();


### PR DESCRIPTION
The 1.11.x DynamoDB mapper persisted booleans as 0s and 1s (in the 'number' type). For backwards-compatibility, we should be able to read these values. The values will be converted to boolean types if they are written back to DynamoDB.

Fixes #1912 