### PR TITLE
DynamoDbStreaming: Fix for CRC of compressed responses

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBStreamingClient-1095bd2.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBStreamingClient-1095bd2.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Streaming Client",
+    "description": "Fix for CRC not working correctly for compressed responses"
+}

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
@@ -1,4 +1,5 @@
 {
+    "calculateCrc32FromCompressedData": true,
     "sdkModeledExceptionBaseClassName": "DynamoDbException",
 
     // exclude these shapes that are already present in the dynamodb client


### PR DESCRIPTION
## Description
Enable CRC to work correctly with gzipped http responses in the DynamoDBStreaming client. This had already been enabled in the DynamoDB client.

## Motivation and Context
A customer was not able to successfully read compressed responses received using the DynamoDBStreaming client.

## Testing
Had client test this fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [X] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
