### PR TITLE
Make STSCredentialsProvider prefetch and stale times configurable

### DIFF
--- a/.changes/next-release/feature-AmazonSTS-289d9e7.json
+++ b/.changes/next-release/feature-AmazonSTS-289d9e7.json
@@ -1,0 +1,5 @@
+{
+    "category": "Amazon STS", 
+    "type": "feature", 
+    "description": "Make the STSCredentialsProvider stale and prefetch times configurable so clients can control when session credentials are refreshed"
+}

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -41,19 +41,43 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
 
     @Test
     public void cachingDoesNotApplyToExpiredSession() {
-        callClientWithCredentialsProvider(Instant.now().minus(Duration.ofSeconds(5)), 2);
+        callClientWithCredentialsProvider(Instant.now().minus(Duration.ofSeconds(5)), 2, false);
+        callClient(verify(stsClient, times(2)), Mockito.any());
+    }
+
+    @Test
+    public void cachingDoesNotApplyToExpiredSession_OverridePrefetchAndStaleTimes() {
+        callClientWithCredentialsProvider(Instant.now().minus(Duration.ofSeconds(5)), 2, true);
         callClient(verify(stsClient, times(2)), Mockito.any());
     }
 
     @Test
     public void cachingAppliesToNonExpiredSession() {
-        callClientWithCredentialsProvider(Instant.now().plus(Duration.ofHours(5)), 2);
+        callClientWithCredentialsProvider(Instant.now().plus(Duration.ofHours(5)), 2, false);
+        callClient(verify(stsClient, times(1)), Mockito.any());
+    }
+
+    @Test
+    public void cachingAppliesToNonExpiredSession_OverridePrefetchAndStaleTimes() {
+        callClientWithCredentialsProvider(Instant.now().plus(Duration.ofHours(5)), 2, true);
         callClient(verify(stsClient, times(1)), Mockito.any());
     }
 
     @Test
     public void distantExpiringCredentialsUpdatedInBackground() throws InterruptedException {
-        callClientWithCredentialsProvider(Instant.now().plusSeconds(90), 2);
+        callClientWithCredentialsProvider(Instant.now().plusSeconds(90), 2, false);
+
+        Instant endCheckTime = Instant.now().plus(Duration.ofSeconds(5));
+        while (Mockito.mockingDetails(stsClient).getInvocations().size() < 2 && endCheckTime.isAfter(Instant.now())) {
+            Thread.sleep(100);
+        }
+
+        callClient(verify(stsClient, times(2)), Mockito.any());
+    }
+
+    @Test
+    public void distantExpiringCredentialsUpdatedInBackground_OverridePrefetchAndStaleTimes() throws InterruptedException {
+        callClientWithCredentialsProvider(Instant.now().plusSeconds(90), 2, true);
 
         Instant endCheckTime = Instant.now().plus(Duration.ofSeconds(5));
         while (Mockito.mockingDetails(stsClient).getInvocations().size() < 2 && endCheckTime.isAfter(Instant.now())) {
@@ -72,14 +96,32 @@ public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
 
     protected abstract ResponseT callClient(StsClient client, RequestT request);
 
-    public void callClientWithCredentialsProvider(Instant credentialsExpirationDate, int numTimesInvokeCredentialsProvider) {
+    public void callClientWithCredentialsProvider(Instant credentialsExpirationDate, int numTimesInvokeCredentialsProvider, boolean overrideStaleAndPrefetchTimes) {
         Credentials credentials = Credentials.builder().accessKeyId("a").secretAccessKey("b").sessionToken("c").expiration(credentialsExpirationDate).build();
         RequestT request = getRequest();
         ResponseT response = getResponse(credentials);
 
         when(callClient(stsClient, request)).thenReturn(response);
 
-        try (StsCredentialsProvider credentialsProvider = createCredentialsProviderBuilder(request).stsClient(stsClient).build()) {
+        StsCredentialsProvider.BaseBuilder<?, ? extends StsCredentialsProvider> credentialsProviderBuilder = createCredentialsProviderBuilder(request);
+
+        if(overrideStaleAndPrefetchTimes) {
+            //do the same values as we would do without overriding the stale and prefetch times
+            credentialsProviderBuilder.staleTime(Duration.ofMinutes(2));
+            credentialsProviderBuilder.prefetchTime(Duration.ofMinutes(4));
+        }
+
+        try (StsCredentialsProvider credentialsProvider = credentialsProviderBuilder.stsClient(stsClient).build()) {
+            if(overrideStaleAndPrefetchTimes) {
+                //validate that we actually stored the override values in the build provider
+                assertThat(credentialsProvider.staleTime()).as("stale time").isEqualTo(Duration.ofMinutes(2));
+                assertThat(credentialsProvider.prefetchTime()).as("prefetch time").isEqualTo(Duration.ofMinutes(4));
+            } else {
+                //validate that the default values are used
+                assertThat(credentialsProvider.staleTime()).as("stale time").isEqualTo(Duration.ofMinutes(1));
+                assertThat(credentialsProvider.prefetchTime()).as("prefetch time").isEqualTo(Duration.ofMinutes(5));
+            }
+
             for (int i = 0; i < numTimesInvokeCredentialsProvider; ++i) {
                 AwsSessionCredentials providedCredentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
                 assertThat(providedCredentials.accessKeyId()).isEqualTo("a");


### PR DESCRIPTION
## Description
Allow clients to specify the time (relative to expiration) for when to refresh STS session tokens.


## Motivation and Context
The default STSCredentialsProvider's strategy for refreshing STS sessions is to wait until the session is almost stale and to refresh it either 5 minutes (prefetch) or 1 minute (stale) before it expires. This works great for most use cases. However, it doesn't work well for pre-signed S3 urls. For example, let's say I want to pre-sign an s3 URL that will be good for 90 minutes AND I'm signing the URL with an assumed STS role's credentials. The URL's effective expiration is the min(url expiration, sts session expiration). In other words, if you have STS session credentials that last for 60 minutes, and you want to hand out a URL that will last for 30 minutes, any URLs signed with said session credentials from minutes 31 to 60 will not actually be valid for the full 30 minutes.

The solution is to allow the client to specify the stale and prefetch times of the to use when determining when a session is ready for prefetch and when it's stale. I expose these values as Java Function objects because I intend to reference runtime changeable configuration properties to compute the stale and prefetch times (e.g. prefetch = actual - ${url_length} - ${prefetch_relative_to_url_expiration})

## Testing
I modified the StsCredentialsProviderTestBase. For each current test case I replicated it and specified stale and prefetch time functions that provide the same values they did before.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [Not quite] Local run of `mvn install` succeeds
I've seen several failures for classes that are not related to anything I've touched. Re-running the tests in intellij succeeds
For example: aws-sdk-java-v2/test/codegen-generated-classes-test/target/surefire-reports

- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
