### PR TITLE
REST-JSON: Unmarshall URI members from body

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-bf4eb0a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-bf4eb0a.json
@@ -1,0 +1,5 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "For JSON protocols, when unmarshalling a response, if a member is declared to be located in the URI, the member is treated as being located in the payload instead."
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/MarshallerUtil.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/MarshallerUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocols.json.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.protocol.MarshallLocation;
+
+@SdkInternalApi
+public final class MarshallerUtil {
+    private MarshallerUtil() {
+    }
+
+    /**
+     * @return true if the location is in the URI, false otherwise.
+     */
+    public static boolean locationInUri(MarshallLocation location) {
+        switch (location) {
+            case PATH:
+            case QUERY_PARAM:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallerContext.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonUnmarshallerContext.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.protocols.json.internal.MarshallerUtil;
 
 /**
  * Dependencies needed by implementations of {@link JsonUnmarshaller}.
@@ -51,6 +52,11 @@ public final class JsonUnmarshallerContext {
      * @throws SdkClientException if no unmarshaller is found.
      */
     public JsonUnmarshaller<Object> getUnmarshaller(MarshallLocation location, MarshallingType<?> marshallingType) {
+        // A member being in the URI on a response is nonsensical; when a member is declared to be somewhere in the URI,
+        // it should be found in the payload on response
+        if (MarshallerUtil.locationInUri(location)) {
+            location = MarshallLocation.PAYLOAD;
+        }
         return unmarshallerRegistry.getUnmarshaller(location, marshallingType);
     }
 

--- a/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/runners/UnmarshallingTestRunner.java
+++ b/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/runners/UnmarshallingTestRunner.java
@@ -20,9 +20,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import java.lang.reflect.Method;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
@@ -31,6 +31,7 @@ import software.amazon.awssdk.protocol.asserts.unmarshalling.UnmarshallingTestCo
 import software.amazon.awssdk.protocol.model.GivenResponse;
 import software.amazon.awssdk.protocol.model.TestCase;
 import software.amazon.awssdk.protocol.reflect.ClientReflector;
+import software.amazon.awssdk.protocol.reflect.ShapeModelReflector;
 import software.amazon.awssdk.utils.IoUtils;
 
 /**
@@ -51,13 +52,14 @@ class UnmarshallingTestRunner {
     void runTest(TestCase testCase) throws Exception {
         resetWireMock(testCase.getGiven().getResponse());
         String operationName = testCase.getWhen().getOperationName();
+        ShapeModelReflector shapeModelReflector = createShapeModelReflector(testCase);
         if (!hasStreamingMember(operationName)) {
-            Object actualResult = clientReflector.invokeMethod(testCase, createRequestObject(operationName));
+            Object actualResult = clientReflector.invokeMethod(testCase, shapeModelReflector.createShapeObject());
             testCase.getThen().getUnmarshallingAssertion().assertMatches(createContext(operationName), actualResult);
         } else {
             CapturingResponseTransformer responseHandler = new CapturingResponseTransformer();
             Object actualResult = clientReflector
-                    .invokeStreamingMethod(testCase, createRequestObject(operationName), responseHandler);
+                    .invokeStreamingMethod(testCase, shapeModelReflector.createShapeObject(), responseHandler);
             testCase.getThen().getUnmarshallingAssertion()
                     .assertMatches(createContext(operationName, responseHandler.captured), actualResult);
         }
@@ -112,35 +114,11 @@ class UnmarshallingTestRunner {
         return responseBuilder;
     }
 
-    /**
-     * @return An empty request object to call the operation method with.
-     */
-    private Object createRequestObject(String operationName) throws Exception {
-        String requestClassName = getModelFqcn(getOperationRequestClassName(operationName));
-
-        Class<?> requestClass = Class.forName(requestClassName);
-
-        Method builderMethod = null;
-
-        try {
-            builderMethod = requestClass.getDeclaredMethod("builder");
-        } catch (NoSuchMethodException ignored) {
-            // Ignored
-        }
-
-        if (builderMethod != null) {
-            builderMethod.setAccessible(true);
-
-            Object builderInstance = builderMethod.invoke(null);
-
-            Method buildMethod = builderInstance.getClass().getDeclaredMethod("build");
-            buildMethod.setAccessible(true);
-
-            return buildMethod.invoke(builderInstance);
-        } else {
-            return requestClass.newInstance();
-        }
-
+    private ShapeModelReflector createShapeModelReflector(TestCase testCase) {
+        String operationName = testCase.getWhen().getOperationName();
+        String requestClassName = getOperationRequestClassName(operationName);
+        JsonNode input = testCase.getGiven().getInput();
+        return new ShapeModelReflector(model, requestClassName, input);
     }
 
     private UnmarshallingTestContext createContext(String operationName) {
@@ -152,14 +130,6 @@ class UnmarshallingTestRunner {
                 .withModel(model)
                 .withOperationName(operationName)
                 .withStreamedResponse(streamedResponse);
-    }
-
-    /**
-     * @param simpleClassName Class name to fully qualify.
-     * @return Fully qualified name of class in the client's model package.
-     */
-    private String getModelFqcn(String simpleClassName) {
-        return String.format("%s.%s", metadata.getFullModelPackageName(), simpleClassName);
     }
 
     /**

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-output.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-output.json
@@ -114,5 +114,27 @@
         "StatusCodeMember": 201
       }
     }
+  },
+  {
+    "description": "Members declared to be in the query parameters or path on response are unmarshalled from the payload",
+    "given": {
+      "input": {
+        "PathParam": "param"
+      },
+      "response": {
+        "status_code": 200,
+        "body": "{\"PathParam\": \"Found PathParam in the payload! Yay!\", \"QueryParamOne\":\"Found QueryParamOne in the payload! Yay!\"}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "MultiLocationOperation"
+    },
+    "then": {
+      "deserializedAs": {
+        "PathParam": "Found PathParam in the payload! Yay!",
+        "QueryParamOne": "Found QueryParamOne in the payload! Yay!"
+      }
+    }
   }
 ]

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -101,7 +101,8 @@
         "method":"GET",
         "requestUri":"/2016-03-11/membersInQueryParams?StaticQueryParam=foo"
       },
-      "input":{"shape":"MembersInQueryParamsInput"}
+      "input":{"shape":"MembersInQueryParamsInput"},
+      "output":{"shape":"MembersInQueryParamsInput"}
     },
     "MultiLocationOperation":{
       "name":"MultiLocationOperation",
@@ -109,7 +110,8 @@
         "method":"POST",
         "requestUri":"/2016-03-11/multiLocationOperation/{PathParam}"
       },
-      "input":{"shape":"MultiLocationOperationInput"}
+      "input":{"shape":"MultiLocationOperationInput"},
+      "output":{"shape":"MultiLocationOperationInput"}
     },
     "NestedContainers":{
       "name":"NestedContainers",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
When unmarshalling, shapes that have marshalling locations set for a URI
component such as path or query paramter, they are located in the payload on
responses.

## Motivation and Context
Bugfix.

## Testing
 - Added protocols tests.
 - Ran integ tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
