### PR TITLE
#986 Fixing codegen's unit- and integration tests on Windows systems

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-75385bc.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-75385bc.json
@@ -1,0 +1,5 @@
+{
+    "description": "Code Generator test failures on Windows systems were fixed.", 
+    "type": "bugfix", 
+    "category": "AWS SDK for Java v2"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ checklist below:
 * [ ] If the change is related to an existing Bug Report or Feature Request,
   the issue number is referenced
 * [ ] A short description of the change added to
-  [CHANGELOG.md](./CHANGELOG.md). Adding a new entry can be accomplished by
+  [CHANGELOG.md](./CHANGELOG.md). Adding a new entry must be accomplished by
   running the `scripts/new-change` script and following the instructions.
   Commit the new file created by the script in `.changes/next-release` with
   your changes.

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/TestStringUtils.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/TestStringUtils.java
@@ -1,0 +1,28 @@
+package software.amazon.awssdk.codegen;
+
+import software.amazon.awssdk.codegen.internal.Constant;
+
+/**
+ * Various convenience methods for strings manipulation required in Code Generator tests.
+ */
+public final class TestStringUtils {
+
+    /**
+     * Not intended to be constructed directly.
+     */
+    private TestStringUtils() {
+    }
+
+    /**
+     * Replaces all the newline (line feed/LF) characters ('&#x5c;u000A' or '\n') with the platform-dependent line separator char
+     * (e.g. "&#x5c;u000D&#x5c;u000A" or "\r\n" on Windows systems).
+     *
+     * @param str string, containing '\n' chars to be replaced
+     * @return original string with '\n' chars replaced with platform-dependent line separator chars
+     * @see Constant#LF
+     */
+    public static String toPlatformLfs(String str) {
+        return str.replaceAll("\n", Constant.LF);
+    }
+
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/emitters/PoetGeneratorTaskIntegrationTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/emitters/PoetGeneratorTaskIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.CombinableMatcher.both;
+import static software.amazon.awssdk.codegen.TestStringUtils.toPlatformLfs;
 import static software.amazon.awssdk.utils.FunctionalUtils.safeConsumer;
 
 import com.squareup.javapoet.ClassName;
@@ -43,7 +44,7 @@ public final class PoetGeneratorTaskIntegrationTest {
     public void canGenerateJavaClass() throws Exception {
         String randomBaseDirectory = Files.createTempDirectory(getClass().getSimpleName()).toString();
         tempDirectories.add(randomBaseDirectory);
-        String fileHeader = "/*\n * this is the file header\n */";
+        String fileHeader = toPlatformLfs("/*\n * this is the file header\n */");
         ClassSpec classSpec = dummyClass();
 
         PoetGeneratorTask sut = new PoetGeneratorTask(randomBaseDirectory, fileHeader, classSpec);

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/model/intermediate/DocumentationBuilderTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/model/intermediate/DocumentationBuilderTest.java
@@ -17,36 +17,36 @@ package software.amazon.awssdk.codegen.model.intermediate;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.codegen.TestStringUtils.toPlatformLfs;
 
 import org.junit.Test;
 import software.amazon.awssdk.codegen.docs.DocumentationBuilder;
-
 
 public class DocumentationBuilderTest {
 
     @Test
     public void javadocFormattedCorrectly() {
         String docs = new DocumentationBuilder()
-                .description("Some service docs")
-                .param("paramOne", "param one docs")
-                .param("paramTwo", "param two docs")
-                .returns("This returns something")
-                .syncThrows("FooException", "Thrown when foo happens")
-                .syncThrows("BarException", "Thrown when bar happens")
-                .tag("sample", "FooService.FooOperation")
-                .see("this thing")
-                .see("this other thing")
-                .build();
-        assertThat(docs).isEqualTo("Some service docs\n" +
-                                   "\n" +
-                                   "@param paramOne param one docs\n" +
-                                   "@param paramTwo param two docs\n" +
-                                   "@return This returns something\n" +
-                                   "@throws FooException Thrown when foo happens\n" +
-                                   "@throws BarException Thrown when bar happens\n" +
-                                   "@sample FooService.FooOperation\n" +
-                                   "@see this thing\n" +
-                                   "@see this other thing\n");
+            .description("Some service docs")
+            .param("paramOne", "param one docs")
+            .param("paramTwo", "param two docs")
+            .returns("This returns something")
+            .syncThrows("FooException", "Thrown when foo happens")
+            .syncThrows("BarException", "Thrown when bar happens")
+            .tag("sample", "FooService.FooOperation")
+            .see("this thing")
+            .see("this other thing")
+            .build();
+        assertThat(docs).isEqualTo(toPlatformLfs("Some service docs\n" +
+                                                 "\n" +
+                                                 "@param paramOne param one docs\n" +
+                                                 "@param paramTwo param two docs\n" +
+                                                 "@return This returns something\n" +
+                                                 "@throws FooException Thrown when foo happens\n" +
+                                                 "@throws BarException Thrown when bar happens\n" +
+                                                 "@sample FooService.FooOperation\n" +
+                                                 "@see this thing\n" +
+                                                 "@see this other thing\n"));
     }
 
     /**
@@ -57,55 +57,55 @@ public class DocumentationBuilderTest {
     @Test
     public void asyncReturns_FormatsExceptionsInUnorderedList() {
         String docs = new DocumentationBuilder()
-                .description("Some service docs")
-                .param("paramOne", "param one docs")
-                .returns("CompletableFuture of success")
-                .asyncThrows("FooException", "Foo docs")
-                .asyncThrows("BarException", "Bar docs")
-                .build();
-        assertThat(docs).isEqualTo("Some service docs\n" +
-                                   "\n" +
-                                   "@param paramOne param one docs\n" +
-                                   "@return CompletableFuture of success<br/>\n" +
-                                   "The CompletableFuture returned by this method can be completed exceptionally with the following exceptions.\n" +
-                                   "<ul>\n" +
-                                   "<li>FooException Foo docs</li>\n" +
-                                   "<li>BarException Bar docs</li>\n" +
-                                   "</ul>\n");
+            .description("Some service docs")
+            .param("paramOne", "param one docs")
+            .returns("CompletableFuture of success")
+            .asyncThrows("FooException", "Foo docs")
+            .asyncThrows("BarException", "Bar docs")
+            .build();
+        assertThat(docs).isEqualTo(toPlatformLfs("Some service docs\n" +
+                                                 "\n" +
+                                                 "@param paramOne param one docs\n" +
+                                                 "@return CompletableFuture of success<br/>\n" +
+                                                 "The CompletableFuture returned by this method can be completed exceptionally with the following exceptions.\n" +
+                                                 "<ul>\n" +
+                                                 "<li>FooException Foo docs</li>\n" +
+                                                 "<li>BarException Bar docs</li>\n" +
+                                                 "</ul>\n"));
 
     }
 
     @Test
     public void asyncReturnsWithoutDocsForSuccessReturn_FormatsExceptionsInUnorderedList() {
         String docs = new DocumentationBuilder()
-                .description("Some service docs")
-                .param("paramOne", "param one docs")
-                .asyncThrows("FooException", "Foo docs")
-                .asyncThrows("BarException", "Bar docs")
-                .build();
-        assertThat(docs).isEqualTo("Some service docs\n" +
-                                   "\n" +
-                                   "@param paramOne param one docs\n" +
-                                   "@return A CompletableFuture indicating when result will be completed.<br/>\n" +
-                                   "The CompletableFuture returned by this method can be completed exceptionally with the following exceptions.\n" +
-                                   "<ul>\n" +
-                                   "<li>FooException Foo docs</li>\n" +
-                                   "<li>BarException Bar docs</li>\n" +
-                                   "</ul>\n");
+            .description("Some service docs")
+            .param("paramOne", "param one docs")
+            .asyncThrows("FooException", "Foo docs")
+            .asyncThrows("BarException", "Bar docs")
+            .build();
+        assertThat(docs).isEqualTo(toPlatformLfs("Some service docs\n" +
+                                                 "\n" +
+                                                 "@param paramOne param one docs\n" +
+                                                 "@return A CompletableFuture indicating when result will be completed.<br/>\n" +
+                                                 "The CompletableFuture returned by this method can be completed exceptionally with the following exceptions.\n" +
+                                                 "<ul>\n" +
+                                                 "<li>FooException Foo docs</li>\n" +
+                                                 "<li>BarException Bar docs</li>\n" +
+                                                 "</ul>\n"));
     }
 
     @Test
     public void missingValuesAreNotPresent() {
         String docs = new DocumentationBuilder()
-                .description("Some service docs")
-                .build();
-        assertThat(docs).isEqualTo("Some service docs\n\n");
+            .description("Some service docs")
+            .build();
+        assertThat(docs).isEqualTo(toPlatformLfs("Some service docs\n\n"));
     }
 
     @Test
     public void allValuesMissing_ProducesEmptyDocString() {
         String docs = new DocumentationBuilder()
-                .build();
+            .build();
         assertThat(docs).isEqualTo("");
     }
 


### PR DESCRIPTION
## Description
Adding convenience method that allows to replace '\n' characters with the platform-dependent ones and applying it to affected test data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Partial fix for #986. Namely for the issue [described in this comment](https://github.com/aws/aws-sdk-java-v2/issues/986#issuecomment-452976266).

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-run `software.amazon.awssdk.codegen.model.intermediate.DocumentationBuilderTest` and `software.amazon.awssdk.codegen.emitters.PoetGeneratorTaskIntegrationTest`, which were failing previously.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license