### PR TITLE
[Draft] Use default shared EventLoopGroup across all clients if not provided

### DIFF
--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientCallingPatternIntegrationTest.java
@@ -99,10 +99,8 @@ public class AwsCrtClientCallingPatternIntegrationTest {
     private boolean testWithNewClient(int eventLoopSize, int numberOfRequests) {
 
         try (EventLoopGroup eventLoopGroup = new EventLoopGroup(eventLoopSize);
-             HostResolver hostResolver = new HostResolver(eventLoopGroup);
              SdkAsyncHttpClient newAwsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
-                .eventLoopGroup(eventLoopGroup)
-                .hostResolver(hostResolver)
+                .eventLoopGroup(SdkEventLoopGroup.create(eventLoopGroup))
                 .build()) {
             try (KmsAsyncClient newAsyncKMSClient = KmsAsyncClient.builder()
                     .region(REGION)
@@ -163,11 +161,9 @@ public class AwsCrtClientCallingPatternIntegrationTest {
                     .build();
 
             EventLoopGroup eventLoopGroup = new EventLoopGroup(eventLoopSize);
-            HostResolver hostResolver = new HostResolver(eventLoopGroup);
 
             SdkAsyncHttpClient awsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
-                    .eventLoopGroup(eventLoopGroup)
-                    .hostResolver(hostResolver)
+                    .eventLoopGroup(SdkEventLoopGroup.create(eventLoopGroup))
                     .buildWithDefaults(attributes);
 
             KmsAsyncClient sharedAsyncKMSClient = KmsAsyncClient.builder()
@@ -203,7 +199,6 @@ public class AwsCrtClientCallingPatternIntegrationTest {
             awsCrtHttpClient.close();
             Assert.assertFalse(failed.get());
 
-            hostResolver.close();
             eventLoopGroup.close();
 
             CrtResource.waitForNoResources();

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientKmsIntegrationTest.java
@@ -34,8 +34,6 @@ public class AwsCrtClientKmsIntegrationTest {
     private static String KEY_ALIAS = "alias/aws-sdk-java-v2-integ-test";
     private static Region REGION = Region.US_EAST_1;
     private static List<SdkAsyncHttpClient> awsCrtHttpClients = new ArrayList<>();
-    private static EventLoopGroup eventLoopGroup;
-    private static HostResolver hostResolver;
 
     @Before
     public void setup() {
@@ -47,14 +45,7 @@ public class AwsCrtClientKmsIntegrationTest {
                 continue;
             }
 
-            int numThreads = 1;
-            eventLoopGroup = new EventLoopGroup(numThreads);
-            hostResolver = new HostResolver(eventLoopGroup);
-
-            SdkAsyncHttpClient awsCrtHttpClient = AwsCrtAsyncHttpClient.builder()
-                    .eventLoopGroup(eventLoopGroup)
-                    .hostResolver(hostResolver)
-                    .build();
+            SdkAsyncHttpClient awsCrtHttpClient = AwsCrtAsyncHttpClient.create();
 
             awsCrtHttpClients.add(awsCrtHttpClient);
         }
@@ -63,8 +54,6 @@ public class AwsCrtClientKmsIntegrationTest {
 
     @After
     public void tearDown() {
-        hostResolver.close();
-        eventLoopGroup.close();
         CrtResource.waitForNoResources();
     }
 

--- a/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
+++ b/http-clients/aws-crt-client/src/it/java/software/amazon/awssdk/http/crt/AwsCrtClientS3IntegrationTest.java
@@ -52,8 +52,6 @@ public class AwsCrtClientS3IntegrationTest {
 
     private static Region REGION = Region.US_EAST_1;
 
-    private static EventLoopGroup eventLoopGroup;
-    private static HostResolver hostResolver;
     private static SdkAsyncHttpClient crtClient;
 
     private static S3AsyncClient s3;
@@ -62,13 +60,7 @@ public class AwsCrtClientS3IntegrationTest {
     public void setup() {
         CrtResource.waitForNoResources();
 
-        int numThreads = 4;
-        eventLoopGroup = new EventLoopGroup(numThreads);
-        hostResolver = new HostResolver(eventLoopGroup);
-
         crtClient = AwsCrtAsyncHttpClient.builder()
-                .eventLoopGroup(eventLoopGroup)
-                .hostResolver(hostResolver)
                 .build();
 
         s3 = S3AsyncClient.builder()
@@ -82,8 +74,6 @@ public class AwsCrtClientS3IntegrationTest {
     public void tearDown() {
         s3.close();
         crtClient.close();
-        hostResolver.close();
-        eventLoopGroup.close();
         CrtResource.waitForNoResources();
     }
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/SdkEventLoopGroup.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/SdkEventLoopGroup.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Provides {@link EventLoopGroup} for {@link AwsCrtAsyncHttpClient}.
+ * <p>
+ * There are three ways to create a new instance.
+ *
+ * <ul>
+ * <li>using {@link #builder()} to provide custom configuration of {@link EventLoopGroup}.
+ * This is the preferred configuration method when you just want to customize the {@link EventLoopGroup}</li>
+ *
+ * <li>Using {@link #create(EventLoopGroup)} to provide a custom {@link EventLoopGroup}
+ * </ul>
+ *
+ * <p>
+ * When configuring the {@link EventLoopGroup} of {@link AwsCrtAsyncHttpClient}, if {@link Builder} is
+ * passed to {@link AwsCrtAsyncHttpClient.Builder#eventLoopGroupBuilder},
+ * the {@link EventLoopGroup} is managed by the SDK and will be shutdown when the HTTP client is closed. Otherwise,
+ * if an instance of {@link SdkEventLoopGroup} is passed to {@link AwsCrtAsyncHttpClient.Builder#eventLoopGroup},
+ * the {@link EventLoopGroup} <b>MUST</b> be closed by the caller when it is ready to be disposed. The SDK will not
+ * close the {@link EventLoopGroup} when the HTTP client is closed. See {@link EventLoopGroup#close()} ()} to
+ * properly close the event loop group.
+ *
+ * @see AwsCrtAsyncHttpClient.Builder#eventLoopGroupBuilder(Builder)
+ * @see AwsCrtAsyncHttpClient.Builder#eventLoopGroup(SdkEventLoopGroup)
+ */
+@SdkPublicApi
+public final class SdkEventLoopGroup {
+
+    private final EventLoopGroup eventLoopGroup;
+
+    SdkEventLoopGroup(EventLoopGroup eventLoopGroup) {
+        Validate.paramNotNull(eventLoopGroup, "eventLoopGroup");
+        this.eventLoopGroup = eventLoopGroup;
+    }
+
+    /**
+     * Create an instance of {@link SdkEventLoopGroup} from the builder
+     */
+    private SdkEventLoopGroup(DefaultBuilder builder) {
+        Validate.isPositiveOrNull(builder.numberOfThreads, "numOfThreads");
+        this.eventLoopGroup = resolveEventLoopGroup(builder);
+    }
+
+    /**
+     * @return the {@link EventLoopGroup} to be used with Netty Http client.
+     */
+    public EventLoopGroup eventLoopGroup() {
+        return eventLoopGroup;
+    }
+
+    /**
+     * Creates a new instance of SdkEventLoopGroup with {@link EventLoopGroup}
+     * to be used with {@link AwsCrtAsyncHttpClient}.
+     *
+     * @param eventLoopGroup the EventLoopGroup to be used
+     * @return a new instance of SdkEventLoopGroup
+     */
+    public static SdkEventLoopGroup create(EventLoopGroup eventLoopGroup) {
+        return new SdkEventLoopGroup(eventLoopGroup);
+    }
+
+    public static Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    private EventLoopGroup resolveEventLoopGroup(DefaultBuilder builder) {
+        int numThreads = builder.numberOfThreads != null ? builder.numberOfThreads : Runtime.getRuntime().availableProcessors();
+        return new EventLoopGroup(numThreads);
+    }
+
+    /**
+     * A builder for {@link SdkEventLoopGroup}.
+     *
+     * <p>All implementations of this interface are mutable and not thread safe.
+     */
+    public interface Builder {
+
+        /**
+         * Number of threads to use for the {@link EventLoopGroup}.
+         *
+         * @param numberOfThreads Number of threads to use.
+         * @return This builder for method chaining.
+         */
+        Builder numberOfThreads(Integer numberOfThreads);
+
+        SdkEventLoopGroup build();
+    }
+
+    public static final class DefaultBuilder implements Builder {
+
+        private Integer numberOfThreads;
+
+        private DefaultBuilder() {
+        }
+
+        @Override
+        public Builder numberOfThreads(Integer numberOfThreads) {
+            this.numberOfThreads = numberOfThreads;
+            return this;
+        }
+
+        @Override
+        public SdkEventLoopGroup build() {
+            return new SdkEventLoopGroup(this);
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/SharedResourcesManager.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/SharedResourcesManager.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
+import software.amazon.awssdk.http.crt.SdkEventLoopGroup;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Provides access and manages shared {@link SharedCrtResources}s. Uses reference counting to keep track of how many HTTP
+ * clients are using the shared resources and will automatically close it when that count reaches zero. The resources
+ * are lazily initialized for the first time.
+ */
+@SdkInternalApi
+public final class SharedResourcesManager {
+    private static final Logger log = Logger.loggerFor(SharedResourcesManager.class);
+
+    /**
+     * Reference count of clients using the shared event loop group and host resolver
+     */
+    private static int referenceCount = 0;
+
+    /**
+     * Lazily initialized shared crt resources
+     */
+    private static SharedCrtResources sharedCrtResource;
+
+    private SharedResourcesManager() {
+    }
+
+    public static synchronized SharedCrtResources sharedCrtResource() {
+        if (sharedCrtResource == null) {
+            EventLoopGroup sharedSdkEventLoopGroup = SdkEventLoopGroup.builder().build().eventLoopGroup();
+            HostResolver sharedHostResolver = new HostResolver(sharedSdkEventLoopGroup);
+            ReferenceCountingCrtResource referenceCountingCrtResource = new ReferenceCountingCrtResource();
+
+            sharedCrtResource = new SharedCrtResources(sharedHostResolver, sharedSdkEventLoopGroup, referenceCountingCrtResource);
+        }
+        referenceCount++;
+
+        return sharedCrtResource;
+    }
+
+    /**
+     * Crt resource that prevents shutdown and decrements the reference count when a client is closed
+     */
+    private static final class ReferenceCountingCrtResource extends CrtResource {
+
+        @Override
+        public void close() {
+            decrementReference();
+        }
+
+        /**
+         * Decrement the reference count and close the Crt resrouces if necessary.
+         */
+        private static synchronized void decrementReference() {
+            referenceCount--;
+            if (referenceCount == 0) {
+                log.debug(() -> "Reference count is 0, closing the shared eventLoopGroup and hostResolver");
+                sharedCrtResource.eventLoopGroup.close();
+                sharedCrtResource.hostResolver.close();
+                sharedCrtResource = null;
+            }
+        }
+
+        @Override
+        protected void releaseNativeHandle() {
+            // no op
+        }
+
+        @Override
+        protected boolean canReleaseReferencesImmediately() {
+            return false;
+        }
+    }
+
+    /**
+     * A wrapper class for the shared crt resources
+     */
+    public static final class SharedCrtResources {
+        private final HostResolver hostResolver;
+        private final EventLoopGroup eventLoopGroup;
+        private final ReferenceCountingCrtResource referenceCountingCrtResource;
+
+        public SharedCrtResources(HostResolver hostResolver, EventLoopGroup eventLoopGroup,
+                                  ReferenceCountingCrtResource referenceCountingCrtResource) {
+            this.hostResolver = hostResolver;
+            this.eventLoopGroup = eventLoopGroup;
+            this.referenceCountingCrtResource = referenceCountingCrtResource;
+        }
+
+
+        public HostResolver hostResolver() {
+            return hostResolver;
+        }
+
+        public EventLoopGroup eventLoopGroup() {
+            return eventLoopGroup;
+        }
+
+        public ReferenceCountingCrtResource referenceCountingCrtResource() {
+            return referenceCountingCrtResource;
+        }
+    }
+
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientWireMockTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.http.HttpTestUtils.createProvider;
+import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createRequest;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.http.RecordingNetworkTrafficListener;
+import software.amazon.awssdk.http.RecordingResponseHandler;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.utils.Logger;
+
+public class AwsCrtAsyncHttpClientWireMockTest {
+    private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpClientWireMockTest.class);
+    private final RecordingNetworkTrafficListener wiremockTrafficListener = new RecordingNetworkTrafficListener();
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+                                                          .dynamicPort()
+                                                          .dynamicHttpsPort()
+                                                          .networkTrafficListener(wiremockTrafficListener));
+
+    @BeforeClass
+    public static void setup() {
+        System.setProperty("aws.crt.debugnative", "true");
+    }
+
+    @Before
+    public void methodSetup() {
+        wiremockTrafficListener.reset();
+    }
+
+    @After
+    public void tearDown() {
+        // Verify there is no resource leak.
+        CrtResource.waitForNoResources();
+    }
+
+    @Test
+    public void closeClient_reuse_throwException() throws Exception {
+        SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.create();
+
+        client.close();
+        assertThatThrownBy(() -> makeSimpleRequest(client)).hasMessageContaining("is closed");
+    }
+
+    @Test
+    public void sharedEventLoopGroup_closeOneClient_shouldNotAffectOtherClients() throws Exception {
+        try (SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.create()) {
+            makeSimpleRequest(client);
+        }
+
+        CrtResource.collectNativeResources(s -> log.error(() -> s));
+
+        try (SdkAsyncHttpClient anotherClient = AwsCrtAsyncHttpClient.create()) {
+            makeSimpleRequest(anotherClient);
+        }
+    }
+
+    @Test
+    public void sharedEventLoopGroup() throws Exception {
+        SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.create();
+        SdkAsyncHttpClient anotherClient = AwsCrtAsyncHttpClient.create();
+
+        makeSimpleRequest(client);
+        makeSimpleRequest(anotherClient);
+        client.close();
+        anotherClient.close();
+    }
+
+    @Test
+    public void customizedEventLoopGroup_closeClient_shouldNotCloseUnderlyingEventLoop() throws Exception {
+
+        SdkEventLoopGroup sdkEventLoopGroup = SdkEventLoopGroup.create(new EventLoopGroup(2));
+        CompletableFuture<Void> shutdownCompleteFuture = sdkEventLoopGroup.eventLoopGroup().getShutdownCompleteFuture();
+        try (SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.builder().eventLoopGroup(sdkEventLoopGroup)
+                                                                                                .build()) {
+            makeSimpleRequest(client);
+        }
+        assertThat(shutdownCompleteFuture).isNotDone();
+
+        try (SdkAsyncHttpClient anotherClient = AwsCrtAsyncHttpClient.builder()
+                                                                     .eventLoopGroup(sdkEventLoopGroup)
+                                                                     .build()) {
+            makeSimpleRequest(anotherClient);
+        }
+
+        assertThat(shutdownCompleteFuture).isNotDone();
+        sdkEventLoopGroup.eventLoopGroup().close();
+
+        shutdownCompleteFuture.get(5, TimeUnit.SECONDS);
+        assertThat(shutdownCompleteFuture).isDone();
+    }
+
+    @Test
+    public void customizedEventLoopGroupBuilder_closeClient_shouldCloseUnderlyingEventLoop() throws Exception {
+
+        SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.builder()
+                                                         .eventLoopGroupBuilder(SdkEventLoopGroup.builder().numberOfThreads(3))
+                                                         .build();
+        makeSimpleRequest(client);
+        client.close();
+    }
+
+    /**
+     * Make a simple async request and wait for it to finish.
+     *
+     * @param client Client to make request with.
+     */
+    private void makeSimpleRequest(SdkAsyncHttpClient client) throws Exception {
+        String body = randomAlphabetic(10);
+        URI uri = URI.create("http://127.0.0.1:" + mockServer.port());
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body)));
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder().request(request).requestContentPublisher(createProvider("")).responseHandler(recorder).build());
+        recorder.completeFuture().get(5, TimeUnit.SECONDS);
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientSpiVerificationTest.java
@@ -74,12 +74,8 @@ public class AwsCrtHttpClientSpiVerificationTest {
         CrtResource.waitForNoResources();
 
         int numThreads = Runtime.getRuntime().availableProcessors();
-        eventLoopGroup = new EventLoopGroup(numThreads);
-        hostResolver = new HostResolver(eventLoopGroup);
 
         client = AwsCrtAsyncHttpClient.builder()
-                                      .eventLoopGroup(eventLoopGroup)
-                                      .hostResolver(hostResolver)
                                       .connectionHealthChecksConfiguration(b -> b.minThroughputInBytesPerSecond(4068L)
                                                                                  .allowableThroughputFailureInterval(Duration.ofSeconds(3)))
                                       .build();
@@ -88,8 +84,6 @@ public class AwsCrtHttpClientSpiVerificationTest {
     @After
     public void tearDown() {
         client.close();
-        hostResolver.close();
-        eventLoopGroup.close();
         CrtResource.waitForNoResources();
     }
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/H1ServerBehaviorTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/H1ServerBehaviorTest.java
@@ -17,8 +17,6 @@ package software.amazon.awssdk.http.crt;
 
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 
-import software.amazon.awssdk.crt.io.EventLoopGroup;
-import software.amazon.awssdk.crt.io.HostResolver;
 import software.amazon.awssdk.http.SdkAsyncHttpClientH1TestSuite;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -30,15 +28,8 @@ public class H1ServerBehaviorTest extends SdkAsyncHttpClientH1TestSuite {
 
     @Override
     protected SdkAsyncHttpClient setupClient() {
-        int numThreads = Runtime.getRuntime().availableProcessors();
-        try (EventLoopGroup eventLoopGroup = new EventLoopGroup(numThreads);
-             HostResolver hostResolver = new HostResolver(eventLoopGroup)) {
-
-            return AwsCrtAsyncHttpClient.builder()
-                                        .eventLoopGroup(eventLoopGroup)
-                                        .hostResolver(hostResolver)
-                                        .buildWithDefaults(AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, true).build());
-        }
+        return AwsCrtAsyncHttpClient.builder()
+                                    .buildWithDefaults(AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, true).build());
     }
 
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/ProxyWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/ProxyWireMockTest.java
@@ -48,9 +48,6 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 public class ProxyWireMockTest {
     private SdkAsyncHttpClient client;
 
-    private EventLoopGroup eventLoopGroup;
-    private HostResolver hostResolver;
-
     private ProxyConfiguration proxyCfg;
 
     private WireMockServer mockProxy = new WireMockServer(new WireMockConfiguration()
@@ -76,13 +73,7 @@ public class ProxyWireMockTest {
                 .build();
 
 
-        int numThreads = Runtime.getRuntime().availableProcessors();
-        eventLoopGroup = new EventLoopGroup(numThreads);
-        hostResolver = new HostResolver(eventLoopGroup);
-
         client = AwsCrtAsyncHttpClient.builder()
-                .eventLoopGroup(eventLoopGroup)
-                .hostResolver(hostResolver)
                 .proxyConfiguration(proxyCfg)
                 .build();
     }
@@ -92,8 +83,6 @@ public class ProxyWireMockTest {
         mockServer.stop();
         mockProxy.stop();
         client.close();
-        eventLoopGroup.close();
-        hostResolver.close();
         CrtResource.waitForNoResources();
     }
 

--- a/test/http-client-tests/pom.xml
+++ b/test/http-client-tests/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>metrics-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingNetworkTrafficListener.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingNetworkTrafficListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Simple implementation of {@link WiremockNetworkTrafficListener} to record all requests received as a string for later
+ * verification.
+ */
+public class RecordingNetworkTrafficListener implements WiremockNetworkTrafficListener {
+    private final StringBuilder requests = new StringBuilder();
+
+
+    @Override
+    public void opened(Socket socket) {
+
+    }
+
+    @Override
+    public void incoming(Socket socket, ByteBuffer byteBuffer) {
+        requests.append(StandardCharsets.UTF_8.decode(byteBuffer));
+    }
+
+    @Override
+    public void outgoing(Socket socket, ByteBuffer byteBuffer) {
+
+    }
+
+    @Override
+    public void closed(Socket socket) {
+
+    }
+
+    public void reset() {
+        requests.setLength(0);
+    }
+
+    public StringBuilder requests() {
+        return requests;
+    }
+}

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingResponseHandler.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingResponseHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+public final class RecordingResponseHandler implements SdkAsyncHttpResponseHandler {
+
+    private final List<SdkHttpResponse> responses = new ArrayList<>();
+    private final StringBuilder bodyParts = new StringBuilder();
+    private final CompletableFuture<Void> completeFuture = new CompletableFuture<>();
+    private final MetricCollector collector = MetricCollector.create("test");
+
+    @Override
+    public void onHeaders(SdkHttpResponse response) {
+        responses.add(response);
+    }
+
+    @Override
+    public void onStream(Publisher<ByteBuffer> publisher) {
+        publisher.subscribe(new SimpleSubscriber(byteBuffer -> {
+            byte[] b = new byte[byteBuffer.remaining()];
+            byteBuffer.duplicate().get(b);
+            bodyParts.append(new String(b, StandardCharsets.UTF_8));
+        }) {
+
+            @Override
+            public void onError(Throwable t) {
+                completeFuture.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completeFuture.complete(null);
+            }
+        });
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        completeFuture.completeExceptionally(error);
+
+    }
+
+    public String fullResponseAsString() {
+        return bodyParts.toString();
+    }
+
+    public List<SdkHttpResponse> responses() {
+        return responses;
+    }
+
+    public StringBuilder bodyParts() {
+        return bodyParts;
+    }
+
+    public CompletableFuture<Void> completeFuture() {
+        return completeFuture;
+    }
+
+    public MetricCollector collector() {
+        return collector;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Use a default shared EventLoopGroup if a customized eventloop group is not provided
- create `SdkEventLoopGroup` to allow customers to either provide a EventLoopGroup (not managed by the SDK) or just customize the thread number (managed by the SDK)

This is just a draft PR. I still need to add more tests.

Different ways to configure the client:

1.  default: uses the shared event loop group, it will only be closed once all clients are closed 
```java
AwsCrtAsyncHttpClient.create()
```

2. configuring eventLooGroupBuilder: eventLoopGroup will be closed once the client is closed.

```java
AwsCrtAsyncHttpClient.builder()
                         .eventLoopGroupBuilder(b -> b.numberOfThreads(1))
                         .build()
```

3. configuring eventLoopGroup:  eventLoopGroup will not be closed once the client is closed.
```java
AwsCrtAsyncHttpClient.builder()
                         .eventLoopGroup(SdkEventLoopGroup.create(new EventLoopGroup(2)))
                         .build()
```



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Added wire mock tests to verify the resources are cleaned up

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
