### PR TITLE
Add create method for Apache and Netty HttpClient

### DIFF
--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -133,6 +133,15 @@ public final class ApacheHttpClient implements SdkHttpClient {
         return new DefaultBuilder();
     }
 
+    /**
+     * Create a {@link ApacheHttpClient} with the default properties
+     *
+     * @return an {@link ApacheHttpClient}
+     */
+    public static SdkHttpClient create() {
+        return new DefaultBuilder().build();
+    }
+
     private ConnectionManagerAwareHttpClient createClient(ApacheHttpClient.DefaultBuilder configuration,
                                                           AttributeMap standardOptions) {
         ApacheConnectionManagerFactory cmFactory = new ApacheConnectionManagerFactory();

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientDefaultWireMockTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheHttpClientDefaultWireMockTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache;
+
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpClientDefaultTestSuite;
+
+public class ApacheHttpClientDefaultWireMockTest extends SdkHttpClientDefaultTestSuite {
+
+    @Override
+    protected SdkHttpClient createSdkHttpClient() {
+        return ApacheHttpClient.create();
+    }
+
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -126,6 +126,15 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         return new DefaultBuilder();
     }
 
+    /**
+     * Create a {@link NettyNioAsyncHttpClient} with the default properties
+     *
+     * @return an {@link NettyNioAsyncHttpClient}
+     */
+    public static SdkAsyncHttpClient create() {
+        return new DefaultBuilder().build();
+    }
+
     private RequestContext createRequestContext(AsyncExecuteRequest request) {
         SdkChannelPool pool = pools.get(poolKey(request.request()));
         return new RequestContext(pool, sdkEventLoopGroup.eventLoopGroup(), request, configuration);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientDefaultWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientDefaultWireMockTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.reverse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Condition;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+import software.amazon.awssdk.utils.AttributeMap;
+
+public class NettyNioAsyncHttpClientDefaultWireMockTest {
+
+    private final RecordingNetworkTrafficListener wiremockTrafficListener = new RecordingNetworkTrafficListener();
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig()
+                                                          .dynamicPort()
+                                                          .dynamicHttpsPort()
+                                                          .networkTrafficListener(wiremockTrafficListener));
+
+    private static SdkAsyncHttpClient client = NettyNioAsyncHttpClient.create();
+
+    @Before
+    public void methodSetup() {
+        wiremockTrafficListener.reset();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        client.close();
+    }
+
+    @Test
+    public void defaultThreadFactoryUsesHelpfulName() throws Exception {
+        // Make a request to ensure a thread is primed
+        makeSimpleRequest(client);
+
+        String expectedPattern = "aws-java-sdk-NettyEventLoop-\\d+-\\d+";
+        assertThat(Thread.getAllStackTraces().keySet())
+            .areAtLeast(1, new Condition<>(t -> t.getName().matches(expectedPattern),
+                                           "Matches default thread pattern: `%s`", expectedPattern));
+    }
+
+    /**
+     * Make a simple async request and wait for it to fiish.
+     *
+     * @param client Client to make request with.
+     */
+    private void makeSimpleRequest(SdkAsyncHttpClient client) throws Exception {
+        String body = randomAlphabetic(10);
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withBody(body)));
+        SdkHttpRequest request = createRequest(uri);
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder().request(request).requestContentPublisher(createProvider("")).responseHandler(recorder).build());
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void canMakeBasicRequestOverHttp() throws Exception {
+        String smallBody = randomAlphabetic(10);
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+
+        assertCanReceiveBasicRequest(uri, smallBody);
+    }
+
+    @Test
+    public void canHandleLargerPayloadsOverHttp() throws Exception {
+        String largishBody = randomAlphabetic(25000);
+
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+
+        assertCanReceiveBasicRequest(uri, largishBody);
+    }
+
+    @Test
+    public void canSendContentAndGetThatContentBack() throws Exception {
+        String body = randomAlphabetic(50);
+        stubFor(any(urlEqualTo("/echo?reversed=true"))
+                    .withRequestBody(equalTo(body))
+                    .willReturn(aResponse().withBody(reverse(body))));
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+
+        SdkHttpRequest request = createRequest(uri, "/echo", body, SdkHttpMethod.POST, singletonMap("reversed", "true"));
+
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder().request(request).requestContentPublisher(createProvider(body)).responseHandler(recorder).build());
+
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+
+        verify(1, postRequestedFor(urlEqualTo("/echo?reversed=true")));
+
+        assertThat(recorder.fullResponseAsString()).isEqualTo(reverse(body));
+    }
+
+    @Test
+    public void requestContentOnlyEqualToContentLengthHeaderFromProvider() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        final String content = randomAlphabetic(32);
+        final String streamContent = content + reverse(content);
+        stubFor(any(urlEqualTo("/echo?reversed=true"))
+                    .withRequestBody(equalTo(content))
+                    .willReturn(aResponse().withBody(reverse(content))));
+        URI uri = URI.create("http://localhost:" + mockServer.port());
+
+        SdkHttpFullRequest request = createRequest(uri, "/echo", streamContent, SdkHttpMethod.POST, singletonMap("reversed", "true"));
+        request = request.toBuilder().putHeader("Content-Length", Integer.toString(content.length())).build();
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+
+        client.execute(AsyncExecuteRequest.builder().request(request).requestContentPublisher(createProvider(streamContent)).responseHandler(recorder).build());
+
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+
+        // HTTP servers will stop processing the request as soon as it reads
+        // bytes equal to 'Content-Length' so we need to inspect the raw
+        // traffic to ensure that there wasn't anything after that.
+        assertThat(wiremockTrafficListener.requests().toString()).endsWith(content);
+    }
+
+
+    private void assertCanReceiveBasicRequest(URI uri, String body) throws Exception {
+        stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withHeader("Some-Header", "With Value").withBody(body)));
+
+        SdkHttpRequest request = createRequest(uri);
+
+        RecordingResponseHandler recorder = new RecordingResponseHandler();
+        client.execute(AsyncExecuteRequest.builder().request(request).requestContentPublisher(createProvider("")).responseHandler(recorder).build());
+
+        recorder.completeFuture.get(5, TimeUnit.SECONDS);
+
+        assertThat(recorder.responses).hasOnlyOneElementSatisfying(
+            headerResponse -> {
+                assertThat(headerResponse.headers()).containsKey("Some-Header");
+                assertThat(headerResponse.statusCode()).isEqualTo(200);
+            });
+
+        assertThat(recorder.fullResponseAsString()).isEqualTo(body);
+        verify(1, getRequestedFor(urlMatching("/")));
+    }
+
+    private SdkHttpContentPublisher createProvider(String body) {
+        Stream<ByteBuffer> chunks = splitStringBySize(body).stream()
+                                                           .map(chunk -> ByteBuffer.wrap(chunk.getBytes(UTF_8)));
+        return new SdkHttpContentPublisher() {
+
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of(Long.valueOf(body.length()));
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                s.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(long n) {
+                        chunks.forEach(s::onNext);
+                        s.onComplete();
+                    }
+
+                    @Override
+                    public void cancel() {
+
+                    }
+                });
+            }
+        };
+    }
+
+    private SdkHttpFullRequest createRequest(URI uri) {
+        return createRequest(uri, "/", null, SdkHttpMethod.GET, emptyMap());
+    }
+
+    private SdkHttpFullRequest createRequest(URI uri,
+                                             String resourcePath,
+                                             String body,
+                                             SdkHttpMethod method,
+                                             Map<String, String> params) {
+        String contentLength = body == null ? null : String.valueOf(body.getBytes(UTF_8).length);
+        return SdkHttpFullRequest.builder()
+                                 .uri(uri)
+                                 .method(method)
+                                 .encodedPath(resourcePath)
+                                 .applyMutation(b -> params.forEach(b::putRawQueryParameter))
+                                 .applyMutation(b -> {
+                                     b.putHeader("Host", uri.getHost());
+                                     if (contentLength != null) {
+                                         b.putHeader("Content-Length", contentLength);
+                                     }
+                                 }).build();
+    }
+
+    private static Collection<String> splitStringBySize(String str) {
+        if (isBlank(str)) {
+            return Collections.emptyList();
+        }
+        ArrayList<String> split = new ArrayList<>();
+        for (int i = 0; i <= str.length() / 1000; i++) {
+            split.add(str.substring(i * 1000, Math.min((i + 1) * 1000, str.length())));
+        }
+        return split;
+    }
+    
+}

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientDefaultWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientDefaultWireMockTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.urlconnection;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.After;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpClientDefaultTestSuite;
+
+public class UrlConnectionHttpClientDefaultWireMockTest extends SdkHttpClientDefaultTestSuite {
+
+    @Override
+    protected SdkHttpClient createSdkHttpClient() {
+        return UrlConnectionHttpClient.create();
+    }
+
+    @After
+    public void reset() {
+        HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+    }
+}

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientDefaultTestSuite.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import javax.net.ssl.SSLHandshakeException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * A set of tests validating that the functionality implemented by a {@link SdkHttpClient}.
+ *
+ * This is used by an HTTP plugin implementation by extending this class and implementing the abstract methods to provide this
+ * suite with a testable HTTP client implementation.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public abstract class SdkHttpClientDefaultTestSuite {
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+
+    @Test
+    public void supportsResponseCode200() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_OK);
+    }
+
+    @Test
+    public void supportsResponseCode200Head() throws Exception {
+        // HEAD is special due to closing of the connection immediately and streams are null
+        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN, SdkHttpMethod.HEAD);
+    }
+
+    @Test
+    public void supportsResponseCode202() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_ACCEPTED);
+    }
+
+    @Test
+    public void supportsResponseCode403() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN);
+    }
+
+    @Test
+    public void supportsResponseCode403Head() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_FORBIDDEN, SdkHttpMethod.HEAD);
+    }
+
+    @Test
+    public void supportsResponseCode301() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_MOVED_PERM);
+    }
+
+    @Test
+    public void supportsResponseCode302() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_MOVED_TEMP);
+    }
+
+    @Test
+    public void supportsResponseCode500() throws Exception {
+        testForResponseCode(HttpURLConnection.HTTP_INTERNAL_ERROR);
+    }
+
+    @Test
+    public void validatesHttpsCertificateIssuer() throws Exception {
+        SdkHttpClient client = createSdkHttpClient();
+
+        SdkHttpFullRequest request = mockSdkRequest("https://localhost:" + mockServer.httpsPort(), SdkHttpMethod.POST);
+
+        assertThatThrownBy(client.prepareRequest(HttpExecuteRequest.builder().request(request).build())::call)
+            .isInstanceOf(SSLHandshakeException.class);
+    }
+
+    private void testForResponseCode(int returnCode) throws Exception {
+        testForResponseCode(returnCode, SdkHttpMethod.POST);
+    }
+
+    private void testForResponseCode(int returnCode, SdkHttpMethod method) throws Exception {
+        SdkHttpClient client = createSdkHttpClient();
+
+        stubForMockRequest(returnCode);
+
+        SdkHttpFullRequest req = mockSdkRequest("http://localhost:" + mockServer.port(), method);
+        HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                          .request(req)
+                                                                          .contentStreamProvider(req.contentStreamProvider()
+                                                                                                    .orElse(null))
+                                                                          .build())
+                                        .call();
+
+        validateResponse(rsp, returnCode, method);
+    }
+
+    protected void testForResponseCodeUsingHttps(SdkHttpClient client, int returnCode) throws Exception {
+        SdkHttpMethod sdkHttpMethod = SdkHttpMethod.POST;
+        stubForMockRequest(returnCode);
+
+        SdkHttpFullRequest req = mockSdkRequest("https://localhost:" + mockServer.httpsPort(), sdkHttpMethod);
+        HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                          .request(req)
+                                                                          .contentStreamProvider(req.contentStreamProvider()
+                                                                                                    .orElse(null))
+                                                                          .build())
+                                        .call();
+
+        validateResponse(rsp, returnCode, sdkHttpMethod);
+    }
+
+    private void stubForMockRequest(int returnCode) {
+        ResponseDefinitionBuilder responseBuilder = aResponse().withStatus(returnCode)
+                                                               .withHeader("Some-Header", "With Value")
+                                                               .withBody("hello");
+
+        if (returnCode >= 300 && returnCode <= 399) {
+            responseBuilder.withHeader("Location", "Some New Location");
+        }
+
+        mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(responseBuilder));
+    }
+
+    private void validateResponse(HttpExecuteResponse response, int returnCode, SdkHttpMethod method) throws IOException {
+        RequestMethod requestMethod = RequestMethod.fromString(method.name());
+
+        RequestPatternBuilder patternBuilder = RequestPatternBuilder.newRequestPattern(requestMethod, urlMatching("/"))
+                                                                    .withHeader("Host", containing("localhost"))
+                                                                    .withHeader("User-Agent", equalTo("hello-world!"));
+
+        if (method == SdkHttpMethod.HEAD) {
+            patternBuilder.withRequestBody(equalTo(""));
+        } else {
+            patternBuilder.withRequestBody(equalTo("Body"));
+        }
+
+        mockServer.verify(1, patternBuilder);
+
+        if (method == SdkHttpMethod.HEAD) {
+            assertThat(response.responseBody()).isEmpty();
+        } else {
+            assertThat(IoUtils.toUtf8String(response.responseBody().orElse(null))).isEqualTo("hello");
+        }
+
+        assertThat(response.httpResponse().firstMatchingHeader("Some-Header")).contains("With Value");
+        assertThat(response.httpResponse().statusCode()).isEqualTo(returnCode);
+        mockServer.resetMappings();
+    }
+
+    private SdkHttpFullRequest mockSdkRequest(String uriString, SdkHttpMethod method) {
+        URI uri = URI.create(uriString);
+        SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder()
+                                                                      .uri(uri)
+                                                                      .method(method)
+                                                                      .putHeader("Host", uri.getHost())
+                                                                      .putHeader("User-Agent", "hello-world!");
+        if (method != SdkHttpMethod.HEAD) {
+            requestBuilder.contentStreamProvider(() -> new ByteArrayInputStream("Body".getBytes(StandardCharsets.UTF_8)));
+        }
+
+        return requestBuilder.build();
+    }
+
+    /**
+     * Implemented by a child class to create an HTTP client to validate, without any extra options.
+     */
+    protected abstract SdkHttpClient createSdkHttpClient();
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add create method for Apache and Netty HttpClient.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
