### PR TITLE
Refactoring and request future cancellation

### DIFF
--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestContext.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestContext.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+
+@SdkInternalApi
+public final class CrtRequestContext {
+    private final AsyncExecuteRequest request;
+    private final int readBufferSize;
+    private final HttpClientConnectionManager crtConnPool;
+
+    private CrtRequestContext(Builder builder) {
+        this.request = builder.request;
+        this.readBufferSize = builder.readBufferSize;
+        this.crtConnPool = builder.crtConnPool;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public AsyncExecuteRequest sdkRequest() {
+        return request;
+    }
+
+    public int readBufferSize() {
+        return readBufferSize;
+    }
+
+    public HttpClientConnectionManager crtConnPool() {
+        return crtConnPool;
+    }
+
+    public static class Builder {
+        private AsyncExecuteRequest request;
+        private int readBufferSize;
+        private HttpClientConnectionManager crtConnPool;
+
+        private Builder() {
+        }
+
+        public Builder request(AsyncExecuteRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder readBufferSize(int readBufferSize) {
+            this.readBufferSize = readBufferSize;
+            return this;
+        }
+
+        public Builder crtConnPool(HttpClientConnectionManager crtConnPool) {
+            this.crtConnPool = crtConnPool;
+            return this;
+        }
+
+        public CrtRequestContext build() {
+            return new CrtRequestContext(this);
+        }
+    }
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.http.Header;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
+
+@SdkInternalApi
+public final class CrtRequestExecutor {
+    private static final Logger log = Logger.loggerFor(CrtRequestExecutor.class);
+
+    public CompletableFuture<Void> execute(CrtRequestContext executionContext) {
+        CompletableFuture<Void> requestFuture = new CompletableFuture<>();
+
+        // When a Connection is ready from the Connection Pool, schedule the Request on the connection
+        CompletableFuture<HttpClientConnection> httpClientConnectionCompletableFuture =
+            executionContext.crtConnPool().acquireConnection();
+
+        httpClientConnectionCompletableFuture.whenComplete((crtConn, throwable) -> {
+            AsyncExecuteRequest asyncRequest = executionContext.sdkRequest();
+            // If we didn't get a connection for some reason, fail the request
+            if (throwable != null) {
+                handleFailure(new IOException("An exception occurred when acquiring connection", throwable),
+                              requestFuture,
+                              asyncRequest.responseHandler());
+                return;
+            }
+
+            AwsCrtAsyncHttpStreamAdapter crtToSdkAdapter =
+                new AwsCrtAsyncHttpStreamAdapter(crtConn, requestFuture, asyncRequest, executionContext.readBufferSize());
+            HttpRequest crtRequest = toCrtRequest(asyncRequest, crtToSdkAdapter);
+            // Submit the Request on this Connection
+            invokeSafely(() -> {
+                try {
+                    crtConn.makeRequest(crtRequest, crtToSdkAdapter).activate();
+                } catch (IllegalStateException | CrtRuntimeException e) {
+                    log.debug(() -> "An exception occurred when making the request", e);
+                    handleFailure(new IOException("An exception occurred when making the request", e),
+                                  requestFuture,
+                                  asyncRequest.responseHandler());
+
+                }
+            });
+        });
+
+        return requestFuture;
+    }
+
+    private void handleFailure(Throwable cause,
+                               CompletableFuture<Void> executeFuture,
+                               SdkAsyncHttpResponseHandler responseHandler) {
+        try {
+            responseHandler.onError(cause);
+        } catch (Exception e) {
+            log.error(() -> String.format("SdkAsyncHttpResponseHandler %s throw an exception in onError",
+                                          responseHandler.toString()), e);
+        }
+
+        executeFuture.completeExceptionally(cause);
+    }
+
+    private static HttpRequest toCrtRequest(AsyncExecuteRequest asyncRequest, AwsCrtAsyncHttpStreamAdapter crtToSdkAdapter) {
+        URI uri = asyncRequest.request().getUri();
+        SdkHttpRequest sdkRequest = asyncRequest.request();
+
+        String method = sdkRequest.method().name();
+        String encodedPath = sdkRequest.encodedPath();
+        if (encodedPath == null || encodedPath.length() == 0) {
+            encodedPath = "/";
+        }
+
+        String encodedQueryString = SdkHttpUtils.encodeAndFlattenQueryParameters(sdkRequest.rawQueryParameters())
+                                                .map(value -> "?" + value)
+                                                .orElse("");
+
+        HttpHeader[] crtHeaderArray = asArray(createHttpHeaderList(uri, asyncRequest));
+
+        return new HttpRequest(method, encodedPath + encodedQueryString, crtHeaderArray, crtToSdkAdapter);
+    }
+
+    private static HttpHeader[] asArray(List<HttpHeader> crtHeaderList) {
+        return crtHeaderList.toArray(new HttpHeader[0]);
+    }
+
+    private static List<HttpHeader> createHttpHeaderList(URI uri, AsyncExecuteRequest asyncRequest) {
+        SdkHttpRequest sdkRequest = asyncRequest.request();
+        // worst case we may add 3 more headers here
+        List<HttpHeader> crtHeaderList = new ArrayList<>(sdkRequest.headers().size() + 3);
+
+        // Set Host Header if needed
+        if (isNullOrEmpty(sdkRequest.headers().get(Header.HOST))) {
+            crtHeaderList.add(new HttpHeader(Header.HOST, uri.getHost()));
+        }
+
+        // Add Connection Keep Alive Header to reuse this Http Connection as long as possible
+        if (isNullOrEmpty(sdkRequest.headers().get(Header.CONNECTION))) {
+            crtHeaderList.add(new HttpHeader(Header.CONNECTION, Header.KEEP_ALIVE_VALUE));
+        }
+
+        // Set Content-Length if needed
+        Optional<Long> contentLength = asyncRequest.requestContentPublisher().contentLength();
+        if (isNullOrEmpty(sdkRequest.headers().get(Header.CONTENT_LENGTH)) && contentLength.isPresent()) {
+            crtHeaderList.add(new HttpHeader(Header.CONTENT_LENGTH, Long.toString(contentLength.get())));
+        }
+
+        // Add the rest of the Headers
+        sdkRequest.headers().forEach((key, value) -> {
+            value.stream().map(val -> new HttpHeader(key, val)).forEach(crtHeaderList::add);
+        });
+
+        return crtHeaderList;
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtHttpClientTestUtils.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtHttpClientTestUtils.java
@@ -61,7 +61,7 @@ public class CrtHttpClientTestUtils {
         };
     }
 
-    static SdkHttpFullRequest createRequest(URI endpoint) {
+    public static SdkHttpFullRequest createRequest(URI endpoint) {
         return createRequest(endpoint, "/", null, SdkHttpMethod.GET, emptyMap());
     }
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutorTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.HttpTestUtils.createProvider;
+import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.createRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CrtRequestExecutorTest {
+
+    private CrtRequestExecutor requestExecutor;
+    @Mock
+    private HttpClientConnectionManager connectionManager;
+    @Mock
+    private SdkAsyncHttpResponseHandler responseHandler;
+
+    @Mock
+    private HttpClientConnection httpClientConnection;
+
+    @Before
+    public void setup() {
+        requestExecutor = new CrtRequestExecutor();
+    }
+
+    @Test
+    public void execute_acquireConnectionThrowException_shouldInvokeOnError() {
+        RuntimeException exception = new RuntimeException("error");
+        CrtRequestContext context = CrtRequestContext.builder()
+                                                     .crtConnPool(connectionManager)
+                                                     .request(AsyncExecuteRequest.builder()
+                                                                                 .responseHandler(responseHandler)
+                                                                                 .build())
+                                                     .build();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.completeExceptionally(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasMessageContaining("An exception occurred when acquiring connection");
+        assertThat(actualException).hasCause(exception);
+        assertThat(executeFuture).hasFailedWithThrowableThat().hasCause(exception).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void execute_makeRequestThrowException_shouldInvokeOnError() {
+        CrtRuntimeException exception = new CrtRuntimeException("");
+        SdkHttpFullRequest request = createRequest(URI.create("http://localhost"));
+        CrtRequestContext context = CrtRequestContext.builder()
+                                                     .readBufferSize(2000)
+                                                     .crtConnPool(connectionManager)
+                                                     .request(AsyncExecuteRequest.builder()
+                                                                                 .request(request)
+                                                                                 .requestContentPublisher(createProvider(""))
+                                                                                 .responseHandler(responseHandler)
+                                                                                 .build())
+                                                     .build();
+        CompletableFuture<HttpClientConnection> completableFuture = new CompletableFuture<>();
+
+        Mockito.when(connectionManager.acquireConnection()).thenReturn(completableFuture);
+        completableFuture.complete(httpClientConnection);
+
+        Mockito.when(httpClientConnection.makeRequest(Mockito.any(HttpRequest.class), Mockito.any(AwsCrtAsyncHttpStreamAdapter.class)))
+               .thenThrow(exception);
+
+        CompletableFuture<Void> executeFuture = requestExecutor.execute(context);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        Mockito.verify(responseHandler).onError(argumentCaptor.capture());
+
+        Exception actualException = argumentCaptor.getValue();
+        assertThat(actualException).hasMessageContaining("An exception occurred when making the request");
+        assertThat(actualException).hasCause(exception);
+        assertThat(executeFuture).hasFailedWithThrowableThat().hasCause(exception).isInstanceOf(IOException.class);
+    }
+}

--- a/http-clients/aws-crt-client/src/test/resources/jetty-logging.properties
+++ b/http-clients/aws-crt-client/src/test/resources/jetty-logging.properties
@@ -1,0 +1,18 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+# Set up logging implementation
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+org.eclipse.jetty.LEVEL=OFF

--- a/test/http-client-tests/pom.xml
+++ b/test/http-client-tests/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>metrics-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/HttpTestUtils.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/HttpTestUtils.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.http;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static software.amazon.awssdk.utils.StringUtils.isBlank;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.reactivex.Flowable;
@@ -23,11 +25,19 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 
 public class HttpTestUtils {
     private HttpTestUtils() {
@@ -84,5 +94,44 @@ public class HttpTestUtils {
                 .build();
 
         return client.execute(req);
+    }
+
+    public static SdkHttpContentPublisher createProvider(String body) {
+        Stream<ByteBuffer> chunks = splitStringBySize(body).stream()
+                                                           .map(chunk -> ByteBuffer.wrap(chunk.getBytes(UTF_8)));
+        return new SdkHttpContentPublisher() {
+
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of(Long.valueOf(body.length()));
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> s) {
+                s.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(long n) {
+                        chunks.forEach(s::onNext);
+                        s.onComplete();
+                    }
+
+                    @Override
+                    public void cancel() {
+
+                    }
+                });
+            }
+        };
+    }
+
+    public static Collection<String> splitStringBySize(String str) {
+        if (isBlank(str)) {
+            return Collections.emptyList();
+        }
+        ArrayList<String> split = new ArrayList<>();
+        for (int i = 0; i <= str.length() / 1000; i++) {
+            split.add(str.substring(i * 1000, Math.min((i + 1) * 1000, str.length())));
+        }
+        return split;
     }
 }

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingNetworkTrafficListener.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingNetworkTrafficListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Simple implementation of {@link WiremockNetworkTrafficListener} to record all requests received as a string for later
+ * verification.
+ */
+public class RecordingNetworkTrafficListener implements WiremockNetworkTrafficListener {
+    private final StringBuilder requests = new StringBuilder();
+
+
+    @Override
+    public void opened(Socket socket) {
+
+    }
+
+    @Override
+    public void incoming(Socket socket, ByteBuffer byteBuffer) {
+        requests.append(StandardCharsets.UTF_8.decode(byteBuffer));
+    }
+
+    @Override
+    public void outgoing(Socket socket, ByteBuffer byteBuffer) {
+
+    }
+
+    @Override
+    public void closed(Socket socket) {
+
+    }
+
+    public void reset() {
+        requests.setLength(0);
+    }
+
+    public StringBuilder requests() {
+        return requests;
+    }
+}

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingResponseHandler.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingResponseHandler.java
@@ -34,7 +34,6 @@ public final class RecordingResponseHandler implements SdkAsyncHttpResponseHandl
 
     @Override
     public void onHeaders(SdkHttpResponse response) {
-        System.out.println("received response");
         responses.add(response);
     }
 

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingResponseHandler.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/RecordingResponseHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.async.SimpleSubscriber;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+public final class RecordingResponseHandler implements SdkAsyncHttpResponseHandler {
+
+    private final List<SdkHttpResponse> responses = new ArrayList<>();
+    private final StringBuilder bodyParts = new StringBuilder();
+    private final CompletableFuture<Void> completeFuture = new CompletableFuture<>();
+    private final MetricCollector collector = MetricCollector.create("test");
+
+    @Override
+    public void onHeaders(SdkHttpResponse response) {
+        System.out.println("received response");
+        responses.add(response);
+    }
+
+    @Override
+    public void onStream(Publisher<ByteBuffer> publisher) {
+        publisher.subscribe(new SimpleSubscriber(byteBuffer -> {
+            byte[] b = new byte[byteBuffer.remaining()];
+            byteBuffer.duplicate().get(b);
+            bodyParts.append(new String(b, StandardCharsets.UTF_8));
+        }) {
+
+            @Override
+            public void onError(Throwable t) {
+                completeFuture.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completeFuture.complete(null);
+            }
+        });
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        completeFuture.completeExceptionally(error);
+
+    }
+
+    public String fullResponseAsString() {
+        return bodyParts.toString();
+    }
+
+    public List<SdkHttpResponse> responses() {
+        return responses;
+    }
+
+    public StringBuilder bodyParts() {
+        return bodyParts;
+    }
+
+    public CompletableFuture<Void> completeFuture() {
+        return completeFuture;
+    }
+
+    public MetricCollector collector() {
+        return collector;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Refactoring - moving the request execution logic to a separate class 
- Invoke `responseHandler#onError` when the request future is cancelled

There are two commits, easier to review one by one

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Added test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
