### PR TITLE
Add JMESPath parsing logic to the code generator, preparing for evaluation of JMESPath expressions for waiter acceptors.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Jackson.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/Jackson.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.stree.JacksonJrsTreeCodec;
+import com.fasterxml.jackson.jr.stree.JrsValue;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -47,6 +48,10 @@ public final class Jackson {
     }
 
     private Jackson() {
+    }
+
+    public static JrsValue readJrsValue(String input) throws IOException {
+        return MAPPER.beanFrom(JrsValue.class, input);
     }
 
     public static <T> T load(Class<T> clazz, File file) throws IOException {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/AndExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/AndExpression.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * An and expression will evaluate to either the left expression or the right expression. If the expression on the left hand side
+ * is a truth-like value, then the value on the right hand side is returned. Otherwise the result of the expression on the left
+ * hand side is returned.
+ *
+ * Examples:
+ * <ul>
+ * <li>True && False</li>
+ * <li>Number && EmptyList</li>
+ * <li>a == `1` && b == `2`</li>
+ * </ul>
+ *
+ * https://jmespath.org/specification.html#and-expressions
+ */
+public class AndExpression {
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+
+    public AndExpression(Expression leftExpression, Expression rightExpression) {
+        this.leftExpression = leftExpression;
+        this.rightExpression = rightExpression;
+    }
+
+    public Expression leftExpression() {
+        return leftExpression;
+    }
+
+    public Expression rightExpression() {
+        return rightExpression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifier.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifier.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A bracket specifier within an {@link IndexExpression}. Either:
+ * <ul>
+ *     <li>With content, as in [1], [*] or [1:2:3]: {@link BracketSpecifierWithContents}</li>
+ *     <li>Without content, as in []: {@link BracketSpecifierWithContents}</li>
+ *     <li>With question-mark content, as in [?foo]: {@link BracketSpecifierWithQuestionMark}</li>
+ * </ul>
+ */
+public class BracketSpecifier {
+    private BracketSpecifierWithContents bracketSpecifierWithContents;
+    private BracketSpecifierWithoutContents bracketSpecifierWithoutContents;
+    private BracketSpecifierWithQuestionMark bracketSpecifierWithQuestionMark;
+
+    public static BracketSpecifier withContents(BracketSpecifierWithContents bracketSpecifierWithContents) {
+        Validate.notNull(bracketSpecifierWithContents, "bracketSpecifierWithContents");
+        BracketSpecifier result = new BracketSpecifier();
+        result.bracketSpecifierWithContents = bracketSpecifierWithContents;
+        return result;
+    }
+
+    public static BracketSpecifier withNumberContents(int numberContents) {
+        return withContents(BracketSpecifierWithContents.number(numberContents));
+    }
+
+    public static BracketSpecifier withSliceExpressionContents(SliceExpression sliceExpression) {
+        return withContents(BracketSpecifierWithContents.sliceExpression(sliceExpression));
+    }
+
+    public static BracketSpecifier withWildcardExpressionContents(WildcardExpression wildcardExpression) {
+        return withContents(BracketSpecifierWithContents.wildcardExpression(wildcardExpression));
+    }
+
+    public static BracketSpecifier withoutContents() {
+        BracketSpecifier result = new BracketSpecifier();
+        result.bracketSpecifierWithoutContents = new BracketSpecifierWithoutContents();
+        return result;
+    }
+
+    public static BracketSpecifier withQuestionMark(BracketSpecifierWithQuestionMark bracketSpecifierWithQuestionMark) {
+        Validate.notNull(bracketSpecifierWithQuestionMark, "bracketSpecifierWithQuestionMark");
+        BracketSpecifier result = new BracketSpecifier();
+        result.bracketSpecifierWithQuestionMark = bracketSpecifierWithQuestionMark;
+        return result;
+    }
+
+    public boolean isBracketSpecifierWithContents() {
+        return bracketSpecifierWithContents != null;
+    }
+
+    public boolean isBracketSpecifierWithoutContents() {
+        return bracketSpecifierWithoutContents != null;
+    }
+
+    public boolean isBracketSpecifierWithQuestionMark() {
+        return bracketSpecifierWithQuestionMark != null;
+    }
+
+    public BracketSpecifierWithContents asBracketSpecifierWithContents() {
+        Validate.validState(isBracketSpecifierWithContents(), "Not a BracketSpecifierWithContents");
+        return bracketSpecifierWithContents;
+    }
+
+    public BracketSpecifierWithoutContents asBracketSpecifierWithoutContents() {
+        Validate.validState(isBracketSpecifierWithoutContents(), "Not a BracketSpecifierWithoutContents");
+        return bracketSpecifierWithoutContents;
+    }
+
+    public BracketSpecifierWithQuestionMark asBracketSpecifierWithQuestionMark() {
+        Validate.validState(isBracketSpecifierWithQuestionMark(), "Not a BracketSpecifierWithQuestionMark");
+        return bracketSpecifierWithQuestionMark;
+    }
+
+    public void visit(Visitor visitor) {
+        if (isBracketSpecifierWithContents()) {
+            visitor.visitBracketSpecifierWithContents(asBracketSpecifierWithContents());
+        } else if (isBracketSpecifierWithoutContents()) {
+            visitor.visitBracketSpecifierWithoutContents(asBracketSpecifierWithoutContents());
+        } else if (isBracketSpecifierWithQuestionMark()) {
+            visitor.visitBracketSpecifierWithQuestionMark(asBracketSpecifierWithQuestionMark());
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    public interface Visitor {
+        default void visitBracketSpecifierWithContents(BracketSpecifierWithContents bracketSpecifierWithContents) {
+        }
+
+        default void visitBracketSpecifierWithoutContents(BracketSpecifierWithoutContents bracketSpecifierWithContents) {
+        }
+
+        default void visitBracketSpecifierWithQuestionMark(BracketSpecifierWithQuestionMark bracketSpecifierWithContents) {
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifierWithContents.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifierWithContents.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A {@link BracketSpecifier} with some kind of content. Either:
+ * <ul>
+ *     <li>A number, as in [1]</li>
+ *     <li>A star expression, as in [*]</li>
+ *     <li>A slice expression, as in [1:2:3]</li>
+ * </ul>
+ */
+public class BracketSpecifierWithContents {
+    private Integer number;
+    private WildcardExpression wildcardExpression;
+    private SliceExpression sliceExpression;
+
+    private BracketSpecifierWithContents() {
+    }
+
+    public static BracketSpecifierWithContents number(Integer number) {
+        Validate.notNull(number, "number");
+        BracketSpecifierWithContents result = new BracketSpecifierWithContents();
+        result.number = number;
+        return result;
+    }
+
+    public static BracketSpecifierWithContents wildcardExpression(WildcardExpression wildcardExpression) {
+        Validate.notNull(wildcardExpression, "wildcardExpression");
+        BracketSpecifierWithContents result = new BracketSpecifierWithContents();
+        result.wildcardExpression = wildcardExpression;
+        return result;
+    }
+
+    public static BracketSpecifierWithContents sliceExpression(SliceExpression sliceExpression) {
+        Validate.notNull(sliceExpression, "sliceExpression");
+        BracketSpecifierWithContents result = new BracketSpecifierWithContents();
+        result.sliceExpression = sliceExpression;
+        return result;
+    }
+
+    public boolean isNumber() {
+        return number != null;
+    }
+
+    public boolean isWildcardExpression() {
+        return wildcardExpression != null;
+    }
+
+    public boolean isSliceExpression() {
+        return sliceExpression != null;
+    }
+
+    public int asNumber() {
+        Validate.validState(isNumber(), "Not a Number");
+        return number;
+    }
+
+    public WildcardExpression asWildcardExpression() {
+        Validate.validState(isWildcardExpression(), "Not a WildcardExpression");
+        return wildcardExpression;
+    }
+
+    public SliceExpression asSliceExpression() {
+        Validate.validState(isSliceExpression(), "Not a SliceExpression");
+        return sliceExpression;
+    }
+
+    public void visit(Visitor visitor) {
+        if (isNumber()) {
+            visitor.visitNumber(asNumber());
+        } else if (isWildcardExpression()) {
+            visitor.visitWildcardExpression(asWildcardExpression());
+        } else if (isSliceExpression()) {
+            visitor.visitSliceExpression(asSliceExpression());
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    public interface Visitor {
+        default void visitNumber(int asNumber) {
+        }
+
+        default void visitWildcardExpression(WildcardExpression asWildcardExpression) {
+        }
+
+        default void visitSliceExpression(SliceExpression asSliceExpression) {
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifierWithQuestionMark.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifierWithQuestionMark.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A {@link BracketSpecifier} with a question-mark expression, as in [?Foo].
+ */
+public class BracketSpecifierWithQuestionMark {
+    private final Expression expression;
+
+    public BracketSpecifierWithQuestionMark(Expression expression) {
+        this.expression = expression;
+    }
+
+    public Expression expression() {
+        return expression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifierWithoutContents.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/BracketSpecifierWithoutContents.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A {@link BracketSpecifier} without content, i.e. [].
+ */
+public class BracketSpecifierWithoutContents {
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/Comparator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/Comparator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A comparator within a {@link ComparatorExpression}.
+ */
+public enum Comparator {
+    LESS_THAN_OR_EQUAL("<="),
+    EQUAL("=="),
+    GREATER_THAN_OR_EQUAL(">="),
+    NOT_EQUAL("!="),
+    LESS_THAN("<"),
+    GREATER_THAN(">");
+
+    private final String tokenSymbol;
+
+    Comparator(String tokenSymbol) {
+        this.tokenSymbol = tokenSymbol;
+    }
+
+    public String tokenSymbol() {
+        return tokenSymbol;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/ComparatorExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/ComparatorExpression.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A comparator expression is two expressions separated by a {@link Comparator}.
+ *
+ * Examples:
+ * <ul>
+ *     <li>Foo == Bar</li>
+ *     <li>Bar <= `101</li>
+ * </ul>
+ */
+public class ComparatorExpression {
+    private final Expression leftExpression;
+    private final Comparator comparator;
+    private final Expression rightExpression;
+
+    public ComparatorExpression(Expression leftExpression, Comparator comparator, Expression rightExpression) {
+        this.leftExpression = leftExpression;
+        this.comparator = comparator;
+        this.rightExpression = rightExpression;
+    }
+
+    public Expression leftExpression() {
+        return leftExpression;
+    }
+
+    public Comparator comparator() {
+        return comparator;
+    }
+
+    public Expression rightExpression() {
+        return rightExpression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/CurrentNode.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/CurrentNode.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * The current-node expression '@': https://jmespath.org/specification.html#current-node
+ */
+public class CurrentNode {
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/Expression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/Expression.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An expression is any statement that can be executed in isolation from other parts of a JMESPath string. Every valid JMESPath
+ * string is an expression, usually made up of other expressions.
+ *
+ * Examples: https://jmespath.org/examples.html
+ */
+public class Expression {
+    private SubExpression subExpression;
+    private IndexExpression indexExpression;
+    private ComparatorExpression comparatorExpression;
+    private OrExpression orExpression;
+    private String identifier;
+    private AndExpression andExpression;
+    private NotExpression notExpression;
+    private ParenExpression parenExpression;
+    private WildcardExpression wildcardExpression;
+    private MultiSelectList multiSelectList;
+    private MultiSelectHash multiSelectHash;
+    private Literal literal;
+    private FunctionExpression functionExpression;
+    private PipeExpression pipeExpression;
+    private String rawString;
+    private CurrentNode currentNode;
+
+    public static Expression subExpression(SubExpression subExpression) {
+        Validate.notNull(subExpression, "subExpression");
+        Expression expression = new Expression();
+        expression.subExpression = subExpression;
+        return expression;
+    }
+
+    public static Expression indexExpression(IndexExpression indexExpression) {
+        Validate.notNull(indexExpression, "indexExpression");
+        Expression expression = new Expression();
+        expression.indexExpression = indexExpression;
+        return expression;
+    }
+
+    public static Expression comparatorExpression(ComparatorExpression comparatorExpression) {
+        Validate.notNull(comparatorExpression, "comparatorExpression");
+        Expression expression = new Expression();
+        expression.comparatorExpression = comparatorExpression;
+        return expression;
+    }
+
+    public static Expression orExpression(OrExpression orExpression) {
+        Validate.notNull(orExpression, "orExpression");
+        Expression expression = new Expression();
+        expression.orExpression = orExpression;
+        return expression;
+    }
+
+    public static Expression identifier(String identifier) {
+        Validate.notNull(identifier, "identifier");
+        Expression expression = new Expression();
+        expression.identifier = identifier;
+        return expression;
+    }
+
+    public static Expression andExpression(AndExpression andExpression) {
+        Validate.notNull(andExpression, "andExpression");
+        Expression expression = new Expression();
+        expression.andExpression = andExpression;
+        return expression;
+    }
+
+    public static Expression notExpression(NotExpression notExpression) {
+        Validate.notNull(notExpression, "notExpression");
+        Expression expression = new Expression();
+        expression.notExpression = notExpression;
+        return expression;
+    }
+
+    public static Expression parenExpression(ParenExpression parenExpression) {
+        Validate.notNull(parenExpression, "parenExpression");
+        Expression expression = new Expression();
+        expression.parenExpression = parenExpression;
+        return expression;
+    }
+
+    public static Expression wildcardExpression(WildcardExpression wildcardExpression) {
+        Validate.notNull(wildcardExpression, "wildcardExpression");
+        Expression expression = new Expression();
+        expression.wildcardExpression = wildcardExpression;
+        return expression;
+    }
+
+    public static Expression multiSelectList(MultiSelectList multiSelectList) {
+        Validate.notNull(multiSelectList, "multiSelectList");
+        Expression expression = new Expression();
+        expression.multiSelectList = multiSelectList;
+        return expression;
+    }
+
+    public static Expression multiSelectHash(MultiSelectHash multiSelectHash) {
+        Validate.notNull(multiSelectHash, "multiSelectHash");
+        Expression expression = new Expression();
+        expression.multiSelectHash = multiSelectHash;
+        return expression;
+    }
+
+    public static Expression literal(Literal literal) {
+        Validate.notNull(literal, "literal");
+        Expression expression = new Expression();
+        expression.literal = literal;
+        return expression;
+    }
+
+    public static Expression functionExpression(FunctionExpression functionExpression) {
+        Validate.notNull(functionExpression, "functionExpression");
+        Expression expression = new Expression();
+        expression.functionExpression = functionExpression;
+        return expression;
+    }
+
+    public static Expression pipeExpression(PipeExpression pipeExpression) {
+        Validate.notNull(pipeExpression, "pipeExpression");
+        Expression expression = new Expression();
+        expression.pipeExpression = pipeExpression;
+        return expression;
+    }
+
+    public static Expression rawString(String rawString) {
+        Validate.notNull(rawString, "rawString");
+        Expression expression = new Expression();
+        expression.rawString = rawString;
+        return expression;
+    }
+
+    public static Expression currentNode(CurrentNode currentNode) {
+        Validate.notNull(currentNode, "currentNode");
+        Expression expression = new Expression();
+        expression.currentNode = currentNode;
+        return expression;
+    }
+
+    public boolean isSubExpression() {
+        return subExpression != null;
+    }
+
+    public boolean isIndexExpression() {
+        return indexExpression != null;
+    }
+
+    public boolean isComparatorExpression() {
+        return comparatorExpression != null;
+    }
+
+    public boolean isOrExpression() {
+        return orExpression != null;
+    }
+
+    public boolean isIdentifier() {
+        return identifier != null;
+    }
+
+    public boolean isAndExpression() {
+        return andExpression != null;
+    }
+
+    public boolean isNotExpression() {
+        return notExpression != null;
+    }
+
+    public boolean isParenExpression() {
+        return parenExpression != null;
+    }
+
+    public boolean isWildcardExpression() {
+        return wildcardExpression != null;
+    }
+
+    public boolean isMultiSelectList() {
+        return multiSelectList != null;
+    }
+
+    public boolean isMultiSelectHash() {
+        return multiSelectHash != null;
+    }
+
+    public boolean isLiteral() {
+        return literal != null;
+    }
+
+    public boolean isFunctionExpression() {
+        return functionExpression != null;
+    }
+
+    public boolean isPipeExpression() {
+        return pipeExpression != null;
+    }
+
+    public boolean isRawString() {
+        return rawString != null;
+    }
+
+    public boolean isCurrentNode() {
+        return currentNode != null;
+    }
+
+    public SubExpression asSubExpression() {
+        Validate.validState(isSubExpression(), "Not a SubExpression");
+        return subExpression;
+    }
+
+    public IndexExpression asIndexExpression() {
+        Validate.validState(isIndexExpression(), "Not a IndexExpression");
+        return indexExpression;
+    }
+
+    public ComparatorExpression asComparatorExpression() {
+        Validate.validState(isComparatorExpression(), "Not a ComparatorExpression");
+        return comparatorExpression;
+    }
+
+    public OrExpression asOrExpression() {
+        Validate.validState(isOrExpression(), "Not a OrExpression");
+        return orExpression;
+    }
+
+    public String asIdentifier() {
+        Validate.validState(isIdentifier(), "Not a Identifier");
+        return identifier;
+    }
+
+    public AndExpression asAndExpression() {
+        Validate.validState(isAndExpression(), "Not a AndExpression");
+        return andExpression;
+    }
+
+    public NotExpression asNotExpression() {
+        Validate.validState(isNotExpression(), "Not a NotExpression");
+        return notExpression;
+    }
+
+    public ParenExpression asParenExpression() {
+        Validate.validState(isParenExpression(), "Not a ParenExpression");
+        return parenExpression;
+    }
+
+    public WildcardExpression asWildcardExpression() {
+        Validate.validState(isWildcardExpression(), "Not a WildcardExpression");
+        return wildcardExpression;
+    }
+
+    public MultiSelectList asMultiSelectList() {
+        Validate.validState(isMultiSelectList(), "Not a MultiSelectList");
+        return multiSelectList;
+    }
+
+    public MultiSelectHash asMultiSelectHash() {
+        Validate.validState(isMultiSelectHash(), "Not a MultiSelectHash");
+        return multiSelectHash;
+    }
+
+    public Literal asLiteral() {
+        Validate.validState(isLiteral(), "Not a Literal");
+        return literal;
+    }
+
+    public FunctionExpression asFunctionExpression() {
+        Validate.validState(isFunctionExpression(), "Not a FunctionExpression");
+        return functionExpression;
+    }
+
+    public PipeExpression asPipeExpression() {
+        Validate.validState(isPipeExpression(), "Not a PipeExpression");
+        return pipeExpression;
+    }
+
+    public String asRawString() {
+        Validate.validState(isRawString(), "Not a RawString");
+        return rawString;
+    }
+
+    public CurrentNode asCurrentNode() {
+        Validate.validState(isCurrentNode(), "Not a CurrentNode");
+        return currentNode;
+    }
+
+    public void visit(Visitor visitor) {
+        if (isSubExpression()) {
+            visitor.visitSubExpression(asSubExpression());
+        } else if (isSubExpression()) {
+            visitor.visitSubExpression(asSubExpression());
+        } else if (isIndexExpression()) {
+            visitor.visitIndexExpression(asIndexExpression());
+        } else if (isComparatorExpression()) {
+            visitor.visitComparatorExpression(asComparatorExpression());
+        } else if (isOrExpression()) {
+            visitor.visitOrExpression(asOrExpression());
+        } else if (isIdentifier()) {
+            visitor.visitIdentifier(asIdentifier());
+        } else if (isAndExpression()) {
+            visitor.visitAndExpression(asAndExpression());
+        } else if (isNotExpression()) {
+            visitor.visitNotExpression(asNotExpression());
+        } else if (isParenExpression()) {
+            visitor.visitParenExpression(asParenExpression());
+        } else if (isWildcardExpression()) {
+            visitor.visitWildcardExpression(asWildcardExpression());
+        } else if (isMultiSelectList()) {
+            visitor.visitMultiSelectList(asMultiSelectList());
+        } else if (isMultiSelectHash()) {
+            visitor.visitMultiSelectHash(asMultiSelectHash());
+        } else if (isLiteral()) {
+            visitor.visitLiteral(asLiteral());
+        } else if (isFunctionExpression()) {
+            visitor.visitFunctionExpression(asFunctionExpression());
+        } else if (isPipeExpression()) {
+            visitor.visitPipeExpression(asPipeExpression());
+        } else if (isRawString()) {
+            visitor.visitRawString(asRawString());
+        } else if (isCurrentNode()) {
+            visitor.visitCurrentNode(asCurrentNode());
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    public interface Visitor {
+        default void visitExpression(Expression expression) {
+        }
+
+        default void visitSubExpression(SubExpression subExpression) {
+        }
+
+        default void visitIndexExpression(IndexExpression indexExpression) {
+        }
+
+        default void visitComparatorExpression(ComparatorExpression comparatorExpression) {
+        }
+
+        default void visitOrExpression(OrExpression orExpression) {
+        }
+
+        default void visitIdentifier(String identifier) {
+        }
+
+        default void visitAndExpression(AndExpression andExpression) {
+        }
+
+        default void visitNotExpression(NotExpression notExpression) {
+        }
+
+        default void visitParenExpression(ParenExpression parenExpression) {
+        }
+
+        default void visitWildcardExpression(WildcardExpression star) {
+        }
+
+        default void visitMultiSelectList(MultiSelectList multiSelectList) {
+        }
+
+        default void visitMultiSelectHash(MultiSelectHash multiSelectHash) {
+        }
+
+        default void visitLiteral(Literal literal) {
+        }
+
+        default void visitFunctionExpression(FunctionExpression functionExpression) {
+        }
+
+        default void visitPipeExpression(PipeExpression pipeExpression) {
+        }
+
+        default void visitRawString(String rawString) {
+        }
+
+        default void visitCurrentNode(CurrentNode currentNode) {
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/ExpressionType.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/ExpressionType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * An expression type is an expression prefixed by "&". These are used within {@link FunctionExpression}s as a lambda to be
+ * invoked by the JMESPath function where they are needed.
+ *
+ * For an example in practice, see the sort_by function: https://jmespath.org/specification.html#func-sort-by
+ */
+public class ExpressionType {
+    private final Expression expression;
+
+    public ExpressionType(Expression expression) {
+        this.expression = expression;
+    }
+
+    public Expression expression() {
+        return expression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/FunctionArg.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/FunctionArg.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An argument to a {@link FunctionExpression}. Either a {@link Expression} that is evaluated and passed to the function or a
+ * {@link ExpressionType} that is passed to the function as-is and is evaluated by the function.
+ */
+public class FunctionArg {
+    private Expression expression;
+    private ExpressionType expressionType;
+
+    private FunctionArg() {
+    }
+
+    public static FunctionArg expression(Expression expression) {
+        Validate.notNull(expression, "expression");
+        FunctionArg result = new FunctionArg();
+        result.expression = expression;
+        return result;
+    }
+
+    public static FunctionArg expressionType(ExpressionType expressionType) {
+        Validate.notNull(expressionType, "expressionType");
+        FunctionArg result = new FunctionArg();
+        result.expressionType = expressionType;
+        return result;
+    }
+
+    public boolean isExpression() {
+        return expression != null;
+    }
+
+    public boolean isExpressionType() {
+        return expressionType != null;
+    }
+
+
+    public Expression asExpression() {
+        Validate.validState(isExpression(), "Not a Expression");
+        return expression;
+    }
+
+    public ExpressionType asExpressionType() {
+        Validate.validState(isExpressionType(), "Not a ExpressionType");
+        return expressionType;
+    }
+
+    public void visit(Visitor visitor) {
+        if (isExpression()) {
+            visitor.visitExpression(asExpression());
+        } else if (isExpressionType()) {
+            visitor.visitExpressionType(asExpressionType());
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    interface Visitor {
+        default void visitExpression(Expression expression) {
+        }
+
+        default void visitExpressionType(ExpressionType expressionType) {
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/FunctionExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/FunctionExpression.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import java.util.List;
+
+/**
+ * A function allowing users to easily transform and filter data in JMESPath expressions.
+ *
+ * https://jmespath.org/specification.html#functions-expressions
+ */
+public class FunctionExpression {
+    private final String function;
+    private final List<FunctionArg> functionArgs;
+
+    public FunctionExpression(String function, List<FunctionArg> functionArgs) {
+        this.function = function;
+        this.functionArgs = functionArgs;
+    }
+
+    public String function() {
+        return function;
+    }
+
+    public List<FunctionArg> functionArgs() {
+        return functionArgs;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/IndexExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/IndexExpression.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import java.util.Optional;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An index expression is used to access elements in a list. Indexing is 0 based, the index of 0 refers to the first element
+ * of the list. A negative number is a valid index. A negative number indicates that indexing is relative to the end of the
+ * list.
+ *
+ * https://jmespath.org/specification.html#index-expressions
+ */
+public class IndexExpression {
+    private final Expression expression;
+    private final BracketSpecifier bracketSpecifier;
+
+    private IndexExpression(Expression expression, BracketSpecifier bracketSpecifier) {
+        this.expression = expression;
+        this.bracketSpecifier = bracketSpecifier;
+    }
+
+    public static IndexExpression indexExpression(Expression expression, BracketSpecifier bracketSpecifier) {
+        Validate.notNull(bracketSpecifier, "bracketSpecifier");
+        return new IndexExpression(expression, bracketSpecifier);
+    }
+
+    public Optional<Expression> expression() {
+        return Optional.ofNullable(expression);
+    }
+
+    public BracketSpecifier bracketSpecifier() {
+        return bracketSpecifier;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/KeyValueExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/KeyValueExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A key-value expression within a {@link MultiSelectHash}.
+ */
+public class KeyValueExpression {
+    private final String key;
+    private final Expression value;
+
+    public KeyValueExpression(String key, Expression value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public Expression value() {
+        return value;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/Literal.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/Literal.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import com.fasterxml.jackson.jr.stree.JrsValue;
+
+/**
+ * A literal JSON value embedded in a JMESPath expression.
+ *
+ * https://jmespath.org/specification.html#literal-expressions
+ */
+public class Literal {
+    private final JrsValue jsonValue;
+
+    public Literal(JrsValue jsonValue) {
+        this.jsonValue = jsonValue;
+    }
+
+    public JrsValue jsonValue() {
+        return jsonValue;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/MultiSelectHash.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/MultiSelectHash.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A multi-select-hash expression is similar to a multi-select-list {@link MultiSelectList} expression, except that a hash is
+ * created instead of a list. A multi-select-hash expression also requires key names to be provided, as specified in the
+ * keyval-expr ({@link KeyValueExpression} rule.
+ *
+ * https://jmespath.org/specification.html#multiselect-hash
+ */
+public class MultiSelectHash {
+    private final List<KeyValueExpression> expressions;
+
+    public MultiSelectHash(KeyValueExpression... expressions) {
+        this.expressions = Arrays.asList(expressions);
+    }
+
+    public MultiSelectHash(Collection<KeyValueExpression> expressions) {
+        this.expressions = new ArrayList<>(expressions);
+    }
+
+    public List<KeyValueExpression> keyValueExpressions() {
+        return Collections.unmodifiableList(expressions);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/MultiSelectList.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/MultiSelectList.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A multiselect expression is used to extract a subset of elements from a JSON hash. Each expression in the multi-select-list
+ * will be evaluated against the JSON document. Each returned element will be the result of evaluating the expression.
+ *
+ * https://jmespath.org/specification.html#multiselect-list
+ */
+public class MultiSelectList {
+    private final List<Expression> expressions;
+
+    public MultiSelectList(Expression... expressions) {
+        this.expressions = Arrays.asList(expressions);
+    }
+
+    public MultiSelectList(Collection<Expression> expressions) {
+        this.expressions = new ArrayList<>(expressions);
+    }
+
+    public List<Expression> expressions() {
+        return Collections.unmodifiableList(expressions);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/NotExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/NotExpression.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A not-expression negates the result of an expression. If the expression results in a truth-like value, a
+ * not-expression will change this value to false. If the expression results in a false-like value, a not-expression will
+ * change this value to true.
+ *
+ * https://jmespath.org/specification.html#not-expressions
+ */
+public class NotExpression {
+    private final Expression expression;
+
+    public NotExpression(Expression expression) {
+        this.expression = expression;
+    }
+
+    public Expression expression() {
+        return expression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/OrExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/OrExpression.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * An or expression will evaluate to either the left expression or the right expression. If the evaluation of the left
+ * expression is not false it is used as the return value. If the evaluation of the right expression is not false it is
+ * used as the return value. If neither the left or right expression are non-null, then a value of null is returned.
+ *
+ * Examples:
+ * <ul>
+ * <li>True || False</li>
+ * <li>Number || EmptyList</li>
+ * <li>a == `1` || b == `2`</li>
+ * </ul>
+ *
+ * https://jmespath.org/specification.html#or-expressions
+ */
+public class OrExpression {
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+
+    public OrExpression(Expression leftExpression, Expression rightExpression) {
+        this.leftExpression = leftExpression;
+        this.rightExpression = rightExpression;
+    }
+
+    public Expression leftExpression() {
+        return leftExpression;
+    }
+
+    public Expression rightExpression() {
+        return rightExpression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/ParenExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/ParenExpression.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A paren-expression allows a user to override the precedence order of an expression, e.g. (a || b) && c.
+ *
+ * https://jmespath.org/specification.html#paren-expressions
+ */
+public class ParenExpression {
+    private final Expression expression;
+
+    public ParenExpression(Expression expression) {
+        this.expression = expression;
+    }
+
+    public Expression expression() {
+        return expression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/PipeExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/PipeExpression.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A pipe expression combines two expressions, separated by the | character. It is similar to a sub-expression with two
+ * important distinctions:
+ *
+ * <ol>
+ *     <li>Any expression can be used on the right hand side. A sub-expression restricts the type of expression that can be used
+ *     on the right hand side.</li>
+ *     <li>A pipe-expression stops projections on the left hand side from propagating to the right hand side. If the left
+ *     expression creates a projection, it does not apply to the right hand side.</li>
+ * </ol>
+ *
+ * https://jmespath.org/specification.html#pipe-expressions
+ */
+public class PipeExpression {
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+
+    public PipeExpression(Expression leftExpression, Expression rightExpression) {
+        this.leftExpression = leftExpression;
+        this.rightExpression = rightExpression;
+    }
+
+    public Expression leftExpression() {
+        return leftExpression;
+    }
+
+    public Expression rightExpression() {
+        return rightExpression;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/SliceExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/SliceExpression.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import java.util.OptionalInt;
+
+/**
+ * A slice expression allows you to select a contiguous subset of an array. A slice has a start, stop, and step value. The
+ * general form of a slice is [start:stop:step], but each component is optional and can be omitted.
+ *
+ * https://jmespath.org/specification.html#slices
+ */
+public class SliceExpression {
+    private final Integer start;
+    private final Integer stop;
+    private final Integer step;
+
+    public SliceExpression(Integer start, Integer stop, Integer step) {
+        this.start = start;
+        this.stop = stop;
+        this.step = step;
+    }
+
+    public OptionalInt start() {
+        return toOptional(start);
+    }
+
+    public OptionalInt stop() {
+        return toOptional(stop);
+    }
+
+    public OptionalInt step() {
+        return toOptional(step);
+    }
+
+    private OptionalInt toOptional(Integer n) {
+        return n == null ? OptionalInt.empty() : OptionalInt.of(n);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/SubExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/SubExpression.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A subexpression is a combination of two expressions separated by the ‘.’ char. A subexpression is evaluated as follows:
+ * <ol>
+ *     <li>Evaluate the expression on the left with the original JSON document.</li>
+ *     <li>Evaluate the expression on the right with the result of the left expression evaluation.</li>
+ * </ol>
+ *
+ * https://jmespath.org/specification.html#subexpressions
+ */
+public class SubExpression {
+    private final Expression leftExpression;
+    private final SubExpressionRight rightSide;
+
+    public SubExpression(Expression leftExpression, SubExpressionRight rightSide) {
+        this.leftExpression = leftExpression;
+        this.rightSide = rightSide;
+    }
+
+    public Expression leftExpression() {
+        return leftExpression;
+    }
+
+    public SubExpressionRight rightSubExpression() {
+        return rightSide;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/SubExpressionRight.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/SubExpressionRight.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * The right side of a {@link SubExpression}.
+ */
+public class SubExpressionRight {
+    private String identifier;
+    private MultiSelectList multiSelectList;
+    private MultiSelectHash multiSelectHash;
+    private FunctionExpression functionExpression;
+    private WildcardExpression wildcardExpression;
+
+    public static SubExpressionRight identifier(String identifier) {
+        Validate.notNull(identifier, "identifier");
+        SubExpressionRight result = new SubExpressionRight();
+        result.identifier = identifier;
+        return result;
+    }
+
+    public static SubExpressionRight multiSelectList(MultiSelectList multiSelectList) {
+        Validate.notNull(multiSelectList, "multiSelectList");
+        SubExpressionRight result = new SubExpressionRight();
+        result.multiSelectList = multiSelectList;
+        return result;
+    }
+
+    public static SubExpressionRight multiSelectHash(MultiSelectHash multiSelectHash) {
+        Validate.notNull(multiSelectHash, "multiSelectHash");
+        SubExpressionRight result = new SubExpressionRight();
+        result.multiSelectHash = multiSelectHash;
+        return result;
+    }
+
+    public static SubExpressionRight functionExpression(FunctionExpression functionExpression) {
+        Validate.notNull(functionExpression, "functionExpression");
+        SubExpressionRight result = new SubExpressionRight();
+        result.functionExpression = functionExpression;
+        return result;
+    }
+
+    public static SubExpressionRight wildcardExpression(WildcardExpression wildcardExpression) {
+        Validate.notNull(wildcardExpression, "wildcardExpression");
+        SubExpressionRight result = new SubExpressionRight();
+        result.wildcardExpression = wildcardExpression;
+        return result;
+    }
+
+
+    public boolean isIdentifier() {
+        return identifier != null;
+    }
+
+    public boolean isMultiSelectList() {
+        return multiSelectList != null;
+    }
+
+    public boolean isMultiSelectHash() {
+        return multiSelectHash != null;
+    }
+
+    public boolean isFunctionExpression() {
+        return functionExpression != null;
+    }
+
+    public boolean isWildcardExpression() {
+        return wildcardExpression != null;
+    }
+
+    public String asIdentifier() {
+        Validate.validState(isIdentifier(), "Not an Identifier");
+        return identifier;
+    }
+
+    public MultiSelectList asMultiSelectList() {
+        Validate.validState(isMultiSelectList(), "Not a MultiSelectList");
+        return multiSelectList;
+    }
+
+    public MultiSelectHash asMultiSelectHash() {
+        Validate.validState(isMultiSelectHash(), "Not a MultiSelectHash");
+        return multiSelectHash;
+    }
+
+    public FunctionExpression asFunctionExpression() {
+        Validate.validState(isFunctionExpression(), "Not a FunctionExpression");
+        return functionExpression;
+    }
+
+    public WildcardExpression asWildcardExpression() {
+        Validate.validState(isWildcardExpression(), "Not a WildcardExpression");
+        return wildcardExpression;
+    }
+
+
+    public void visit(Visitor visitor) {
+        if (isIdentifier()) {
+            visitor.visitIdentifier(asIdentifier());
+        } else if (isMultiSelectList()) {
+            visitor.visitMultiSelectList(asMultiSelectList());
+        } else if (isMultiSelectHash()) {
+            visitor.visitMultiSelectHash(asMultiSelectHash());
+        } else if (isFunctionExpression()) {
+            visitor.visitFunctionExpression(asFunctionExpression());
+        } else if (isWildcardExpression()) {
+            visitor.visitWildcardExpression(asWildcardExpression());
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    interface Visitor {
+        default void visitIdentifier(String identifier) {
+        }
+
+        default void visitMultiSelectList(MultiSelectList multiSelectList) {
+        }
+
+        default void visitMultiSelectHash(MultiSelectHash multiSelectHash) {
+        }
+
+        default void visitFunctionExpression(FunctionExpression functionExpression) {
+        }
+
+        default void visitWildcardExpression(WildcardExpression wildcardExpression) {
+        }
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/WildcardExpression.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/component/WildcardExpression.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.component;
+
+/**
+ * A wildcard expression is a expression of either * or [*]. A wildcard expression can return multiple elements, and the
+ * remaining expressions are evaluated against each returned element from a wildcard expression. The [*] syntax applies to a
+ * list type and the * syntax applies to a hash type.
+ *
+ * https://jmespath.org/specification.html#wildcard-expressions
+ */
+public class WildcardExpression {
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/JmesPathParser.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/JmesPathParser.java
@@ -1,0 +1,1090 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.parser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.BiFunction;
+import software.amazon.awssdk.codegen.internal.Jackson;
+import software.amazon.awssdk.codegen.jmespath.component.AndExpression;
+import software.amazon.awssdk.codegen.jmespath.component.BracketSpecifier;
+import software.amazon.awssdk.codegen.jmespath.component.BracketSpecifierWithQuestionMark;
+import software.amazon.awssdk.codegen.jmespath.component.Comparator;
+import software.amazon.awssdk.codegen.jmespath.component.ComparatorExpression;
+import software.amazon.awssdk.codegen.jmespath.component.CurrentNode;
+import software.amazon.awssdk.codegen.jmespath.component.Expression;
+import software.amazon.awssdk.codegen.jmespath.component.ExpressionType;
+import software.amazon.awssdk.codegen.jmespath.component.FunctionArg;
+import software.amazon.awssdk.codegen.jmespath.component.FunctionExpression;
+import software.amazon.awssdk.codegen.jmespath.component.IndexExpression;
+import software.amazon.awssdk.codegen.jmespath.component.KeyValueExpression;
+import software.amazon.awssdk.codegen.jmespath.component.Literal;
+import software.amazon.awssdk.codegen.jmespath.component.MultiSelectHash;
+import software.amazon.awssdk.codegen.jmespath.component.MultiSelectList;
+import software.amazon.awssdk.codegen.jmespath.component.NotExpression;
+import software.amazon.awssdk.codegen.jmespath.component.OrExpression;
+import software.amazon.awssdk.codegen.jmespath.component.ParenExpression;
+import software.amazon.awssdk.codegen.jmespath.component.PipeExpression;
+import software.amazon.awssdk.codegen.jmespath.component.SliceExpression;
+import software.amazon.awssdk.codegen.jmespath.component.SubExpression;
+import software.amazon.awssdk.codegen.jmespath.component.SubExpressionRight;
+import software.amazon.awssdk.codegen.jmespath.component.WildcardExpression;
+import software.amazon.awssdk.codegen.jmespath.parser.util.CompositeParser;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Parses a JMESPath expression string into an {@link Expression}.
+ *
+ * This implements the grammar described here: https://jmespath.org/specification.html#grammar
+ */
+public class JmesPathParser {
+    private static final Logger log = Logger.loggerFor(JmesPathParser.class);
+
+    private final String input;
+
+    private JmesPathParser(String input) {
+        this.input = input;
+    }
+
+    /**
+     * Parses a JMESPath expression string into a {@link Expression}.
+     */
+    public static Expression parse(String jmesPathString) {
+        return new JmesPathParser(jmesPathString).parse();
+    }
+
+    private Expression parse() {
+        ParseResult<Expression> expression = parseExpression(0, input.length());
+        if (!expression.hasResult()) {
+            throw new IllegalArgumentException("Failed to parse expression.");
+        }
+
+        return expression.result();
+    }
+
+    /**
+     * expression        = sub-expression / index-expression  / comparator-expression
+     * expression        =/ or-expression / identifier
+     * expression        =/ and-expression / not-expression / paren-expression
+     * expression        =/ "*" / multi-select-list / multi-select-hash / literal
+     * expression        =/ function-expression / pipe-expression / raw-string
+     * expression        =/ current-node
+     */
+    private ParseResult<Expression> parseExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (startPosition < 0 || endPosition > input.length() + 1) {
+            return ParseResult.error();
+        }
+
+        return CompositeParser.firstTry(this::parseSubExpression, Expression::subExpression)
+                              .thenTry(this::parseIndexExpression, Expression::indexExpression)
+                              .thenTry(this::parseComparatorExpression, Expression::comparatorExpression)
+                              .thenTry(this::parseOrExpression, Expression::orExpression)
+                              .thenTry(this::parseIdentifier, Expression::identifier)
+                              .thenTry(this::parseAndExpression, Expression::andExpression)
+                              .thenTry(this::parseNotExpression, Expression::notExpression)
+                              .thenTry(this::parseParenExpression, Expression::parenExpression)
+                              .thenTry(this::parseWildcardExpression, Expression::wildcardExpression)
+                              .thenTry(this::parseMultiSelectList, Expression::multiSelectList)
+                              .thenTry(this::parseMultiSelectHash, Expression::multiSelectHash)
+                              .thenTry(this::parseLiteral, Expression::literal)
+                              .thenTry(this::parseFunctionExpression, Expression::functionExpression)
+                              .thenTry(this::parsePipeExpression, Expression::pipeExpression)
+                              .thenTry(this::parseRawString, Expression::rawString)
+                              .thenTry(this::parseCurrentNode, Expression::currentNode)
+                              .parse(startPosition, endPosition);
+    }
+
+    /**
+     * sub-expression    = expression "." ( identifier /
+     * multi-select-list /
+     * multi-select-hash /
+     * function-expression /
+     * "*" )
+     */
+    private ParseResult<SubExpression> parseSubExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        List<Integer> dotPositions = findCharacters(startPosition + 1, endPosition - 1, ".");
+        for (Integer dotPosition : dotPositions) {
+            ParseResult<Expression> leftSide = parseExpression(startPosition, dotPosition);
+            if (!leftSide.hasResult()) {
+                continue;
+            }
+
+            ParseResult<SubExpressionRight> rightSide =
+                CompositeParser.firstTry(this::parseIdentifier, SubExpressionRight::identifier)
+                               .thenTry(this::parseMultiSelectList, SubExpressionRight::multiSelectList)
+                               .thenTry(this::parseMultiSelectHash, SubExpressionRight::multiSelectHash)
+                               .thenTry(this::parseFunctionExpression, SubExpressionRight::functionExpression)
+                               .thenTry(this::parseWildcardExpression, SubExpressionRight::wildcardExpression)
+                               .parse(dotPosition + 1, endPosition);
+
+            if (!rightSide.hasResult()) {
+                continue;
+            }
+
+            return ParseResult.success(new SubExpression(leftSide.result(), rightSide.result()));
+        }
+
+        logError("sub-expression", "Invalid sub-expression", startPosition);
+        return ParseResult.error();
+    }
+
+    /**
+     * pipe-expression   = expression "|" expression
+     */
+    private ParseResult<PipeExpression> parsePipeExpression(int startPosition, int endPosition) {
+        return parseBinaryExpression(startPosition, endPosition, "|", PipeExpression::new);
+    }
+
+    /**
+     * or-expression     = expression "||" expression
+     */
+    private ParseResult<OrExpression> parseOrExpression(int startPosition, int endPosition) {
+        return parseBinaryExpression(startPosition, endPosition, "||", OrExpression::new);
+    }
+
+    /**
+     * and-expression    = expression "&&" expression
+     */
+    private ParseResult<AndExpression> parseAndExpression(int startPosition, int endPosition) {
+        return parseBinaryExpression(startPosition, endPosition, "&&", AndExpression::new);
+    }
+
+    private <T> ParseResult<T> parseBinaryExpression(int startPosition, int endPosition, String delimiter,
+                                                     BiFunction<Expression, Expression, T> constructor) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        List<Integer> delimiterPositions = findCharacters(startPosition + 1, endPosition - 1, delimiter);
+        for (Integer delimiterPosition : delimiterPositions) {
+            ParseResult<Expression> leftSide = parseExpression(startPosition, delimiterPosition);
+            if (!leftSide.hasResult()) {
+                continue;
+            }
+
+            ParseResult<Expression> rightSide = parseExpression(delimiterPosition + delimiter.length(), endPosition);
+            if (!rightSide.hasResult()) {
+                continue;
+            }
+
+            return ParseResult.success(constructor.apply(leftSide.result(), rightSide.result()));
+        }
+
+        logError("binary-expression", "Invalid binary-expression", startPosition);
+        return ParseResult.error();
+    }
+
+    /**
+     * not-expression    = "!" expression
+     */
+    private ParseResult<NotExpression> parseNotExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsWith(startPosition, '!')) {
+            logError("not-expression", "Expected '!'", startPosition);
+            return ParseResult.error();
+        }
+
+        return parseExpression(startPosition + 1, endPosition).mapResult(NotExpression::new);
+    }
+
+    /**
+     * paren-expression  = "(" expression ")"
+     */
+    private ParseResult<ParenExpression> parseParenExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsAndEndsWith(startPosition, endPosition, '(', ')')) {
+            logError("paren-expression", "Expected '(' and ')'", startPosition);
+            return ParseResult.error();
+        }
+
+        return parseExpression(startPosition + 1, endPosition - 1).mapResult(ParenExpression::new);
+    }
+
+    /**
+     * index-expression  = expression bracket-specifier / bracket-specifier
+     */
+    private ParseResult<IndexExpression> parseIndexExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        return CompositeParser.firstTry(this::parseIndexExpressionWithLhsExpression)
+                              .thenTry(this::parseBracketSpecifier, b -> IndexExpression.indexExpression(null, b))
+                              .parse(startPosition, endPosition);
+    }
+
+    /**
+     * expression bracket-specifier
+     */
+    private ParseResult<IndexExpression> parseIndexExpressionWithLhsExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        List<Integer> bracketPositions = findCharacters(startPosition + 1, endPosition - 1, "[");
+        for (Integer bracketPosition : bracketPositions) {
+            ParseResult<Expression> leftSide = parseExpression(startPosition, bracketPosition);
+            if (!leftSide.hasResult()) {
+                continue;
+            }
+
+            ParseResult<BracketSpecifier> rightSide = parseBracketSpecifier(bracketPosition, endPosition);
+            if (!rightSide.hasResult()) {
+                continue;
+            }
+
+            return ParseResult.success(IndexExpression.indexExpression(leftSide.result(), rightSide.result()));
+        }
+
+        logError("index-expression with lhs-expression", "Invalid index-expression with lhs-expression", startPosition);
+        return ParseResult.error();
+    }
+
+    /**
+     * multi-select-list = "[" ( expression *( "," expression ) ) "]"
+     */
+    private ParseResult<MultiSelectList> parseMultiSelectList(int startPosition, int endPosition) {
+        return parseMultiSelect(startPosition, endPosition, '[', ']', this::parseExpression)
+            .mapResult(MultiSelectList::new);
+    }
+
+    /**
+     * multi-select-hash = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
+     */
+    private ParseResult<MultiSelectHash> parseMultiSelectHash(int startPosition, int endPosition) {
+        return parseMultiSelect(startPosition, endPosition, '{', '}', this::parseKeyValueExpression)
+            .mapResult(MultiSelectHash::new);
+    }
+
+    /**
+     * Parses "startDelimiter" ( entryParserType *( "," entryParserType ) ) "endDelimiter"
+     * <p>
+     * Used by {@link #parseMultiSelectHash}, {@link #parseMultiSelectList}.
+     */
+    private <T> ParseResult<List<T>> parseMultiSelect(int startPosition, int endPosition,
+                                                      char startDelimiter, char endDelimiter,
+                                                      Parser<T> entryParser) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsAndEndsWith(startPosition, endPosition, startDelimiter, endDelimiter)) {
+            logError("multi-select", "Expected '" + startDelimiter + "' and '" + endDelimiter + "'", startPosition);
+            return ParseResult.error();
+        }
+
+        List<Integer> commaPositions = findCharacters(startPosition + 1, endPosition - 1, ",");
+
+        if (commaPositions.isEmpty()) {
+            return entryParser.parse(startPosition + 1, endPosition - 1).mapResult(Collections::singletonList);
+        }
+
+        List<T> results = new ArrayList<>();
+
+        // Find first valid entries before a comma
+        int startOfSecondEntry = -1;
+        for (Integer comma : commaPositions) {
+            ParseResult<T> result = entryParser.parse(startPosition + 1, comma);
+            if (!result.hasResult()) {
+                continue;
+            }
+
+            results.add(result.result());
+            startOfSecondEntry = comma + 1;
+        }
+
+        if (results.size() == 0) {
+            logError("multi-select", "Invalid value", startPosition + 1);
+            return ParseResult.error();
+        }
+
+        if (results.size() > 1) {
+            logError("multi-select", "Ambiguous separation", startPosition);
+            return ParseResult.error();
+        }
+
+        // Find any subsequent entries
+        int startPositionAfterComma = startOfSecondEntry;
+        for (Integer commaPosition : commaPositions) {
+            if (startPositionAfterComma > commaPosition) {
+                continue;
+            }
+
+            ParseResult<T> entry = entryParser.parse(startPositionAfterComma, commaPosition);
+            if (!entry.hasResult()) {
+                continue;
+            }
+
+            results.add(entry.result());
+
+            startPositionAfterComma = commaPosition + 1;
+        }
+
+        ParseResult<T> entry = entryParser.parse(startPositionAfterComma, endPosition - 1);
+        if (!entry.hasResult()) {
+            logError("multi-select", "Ambiguous separation", startPosition);
+            return ParseResult.error();
+        }
+        results.add(entry.result());
+
+        return ParseResult.success(results);
+    }
+
+    /**
+     * keyval-expr       = identifier ":" expression
+     */
+    private ParseResult<KeyValueExpression> parseKeyValueExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        List<Integer> delimiterPositions = findCharacters(startPosition + 1, endPosition - 1, ":");
+        for (Integer delimiterPosition : delimiterPositions) {
+            ParseResult<String> identifier = parseIdentifier(startPosition, delimiterPosition);
+            if (!identifier.hasResult()) {
+                continue;
+            }
+
+            ParseResult<Expression> expression = parseExpression(delimiterPosition + 1, endPosition);
+            if (!expression.hasResult()) {
+                continue;
+            }
+
+            return ParseResult.success(new KeyValueExpression(identifier.result(), expression.result()));
+        }
+
+        logError("keyval-expr", "Invalid keyval-expr", startPosition);
+        return ParseResult.error();
+    }
+
+    /**
+     * bracket-specifier = "[" (number / "*" / slice-expression) "]" / "[]"
+     * bracket-specifier =/ "[?" expression "]"
+     */
+    private ParseResult<BracketSpecifier> parseBracketSpecifier(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsAndEndsWith(startPosition, endPosition, '[', ']')) {
+            logError("bracket-specifier", "Expecting '[' and ']'", startPosition);
+            return ParseResult.error();
+        }
+
+        // "[]"
+        if (charsInRange(startPosition, endPosition) == 2) {
+            return ParseResult.success(BracketSpecifier.withoutContents());
+        }
+
+        // "[?" expression "]"
+        if (input.charAt(startPosition + 1) == '?') {
+            return parseExpression(startPosition + 2, endPosition - 1)
+                .mapResult(e -> BracketSpecifier.withQuestionMark(new BracketSpecifierWithQuestionMark(e)));
+        }
+
+        // "[" (number / "*" / slice-expression) "]"
+        return CompositeParser.firstTry(this::parseNumber, BracketSpecifier::withNumberContents)
+                              .thenTry(this::parseWildcardExpression, BracketSpecifier::withWildcardExpressionContents)
+                              .thenTry(this::parseSliceExpression, BracketSpecifier::withSliceExpressionContents)
+                              .parse(startPosition + 1, endPosition - 1);
+    }
+
+    /**
+     * comparator-expression = expression comparator expression
+     */
+    private ParseResult<ComparatorExpression> parseComparatorExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        for (Comparator comparator : Comparator.values()) {
+            List<Integer> comparatorPositions = findCharacters(startPosition, endPosition, comparator.tokenSymbol());
+
+            for (Integer comparatorPosition : comparatorPositions) {
+                ParseResult<Expression> lhsExpression = parseExpression(startPosition, comparatorPosition);
+                if (!lhsExpression.hasResult()) {
+                    continue;
+                }
+
+                ParseResult<Expression> rhsExpression =
+                    parseExpression(comparatorPosition + comparator.tokenSymbol().length(), endPosition);
+                if (!rhsExpression.hasResult()) {
+                    continue;
+                }
+
+                return ParseResult.success(new ComparatorExpression(lhsExpression.result(),
+                                                                    comparator,
+                                                                    rhsExpression.result()));
+            }
+        }
+
+
+        logError("comparator-expression", "Invalid comparator expression", startPosition);
+        return ParseResult.error();
+    }
+
+    /**
+     * slice-expression  = [number] ":" [number] [ ":" [number] ]
+     */
+    private ParseResult<SliceExpression> parseSliceExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        // Find the first colon
+        int firstColonIndex = input.indexOf(':', startPosition);
+        if (firstColonIndex < 0 || firstColonIndex >= endPosition) {
+            logError("slice-expression", "Expected slice expression", startPosition);
+            return ParseResult.error();
+        }
+
+        // Find the second colon (if it exists)
+        int maybeSecondColonIndex = input.indexOf(':', firstColonIndex + 1);
+        OptionalInt secondColonIndex = maybeSecondColonIndex < 0 || maybeSecondColonIndex >= endPosition
+                                       ? OptionalInt.empty()
+                                       : OptionalInt.of(maybeSecondColonIndex);
+
+        // Find the first number bounds (if it exists)
+        int firstNumberStart = startPosition;
+        int firstNumberEnd = firstColonIndex;
+
+        // Find the second number bounds (if it exists)
+        int secondNumberStart = firstColonIndex + 1;
+        int secondNumberEnd = secondColonIndex.orElse(endPosition);
+
+        // Find the third number bounds (if it exists)
+        int thirdNumberStart = secondColonIndex.orElse(endPosition) + 1;
+        int thirdNumberEnd = endPosition;
+
+        // Parse the first number (if it exists)
+        Optional<Integer> firstNumber = Optional.empty();
+        if (firstNumberStart < firstNumberEnd) {
+            ParseResult<Integer> firstNumberParse = parseNumber(firstNumberStart, firstNumberEnd);
+            if (!firstNumberParse.hasResult()) {
+                return ParseResult.error();
+            }
+            firstNumber = Optional.of(firstNumberParse.result());
+        }
+
+        // Parse the second number (if it exists)
+        Optional<Integer> secondNumber = Optional.empty();
+        if (secondNumberStart < secondNumberEnd) {
+            ParseResult<Integer> secondNumberParse = parseNumber(secondNumberStart, secondNumberEnd);
+            if (!secondNumberParse.hasResult()) {
+                return ParseResult.error();
+            }
+            secondNumber = Optional.of(secondNumberParse.result());
+        }
+
+        // Parse the third number (if it exists)
+        Optional<Integer> thirdNumber = Optional.empty();
+        if (thirdNumberStart < thirdNumberEnd) {
+            ParseResult<Integer> thirdNumberParse = parseNumber(thirdNumberStart, thirdNumberEnd);
+            if (!thirdNumberParse.hasResult()) {
+                return ParseResult.error();
+            }
+            thirdNumber = Optional.of(thirdNumberParse.result());
+        }
+
+        return ParseResult.success(new SliceExpression(firstNumber.orElse(null),
+                                                       secondNumber.orElse(null),
+                                                       thirdNumber.orElse(null)));
+    }
+
+    /**
+     * function-expression = unquoted-string ( no-args / one-or-more-args )
+     */
+    private ParseResult<FunctionExpression> parseFunctionExpression(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        int paramIndex = input.indexOf('(', startPosition);
+        if (paramIndex <= 0) {
+            logError("function-expression", "Expected function", startPosition);
+            return ParseResult.error();
+        }
+
+        ParseResult<String> functionNameParse = parseUnquotedString(startPosition, paramIndex);
+        if (!functionNameParse.hasResult()) {
+            logError("function-expression", "Expected valid function name", startPosition);
+            return ParseResult.error();
+        }
+
+        return CompositeParser.firstTry(this::parseNoArgs)
+                              .thenTry(this::parseOneOrMoreArgs)
+                              .parse(paramIndex, endPosition)
+                              .mapResult(args -> new FunctionExpression(functionNameParse.result(), args));
+    }
+
+    /**
+     * no-args             = "(" ")"
+     */
+    private ParseResult<List<FunctionArg>> parseNoArgs(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsWith(startPosition, '(')) {
+            logError("no-args", "Expected '('", startPosition);
+            return ParseResult.error();
+        }
+
+        int closePosition = trimLeftWhitespace(startPosition + 1, endPosition);
+
+        if (input.charAt(closePosition) != ')') {
+            logError("no-args", "Expected ')'", closePosition);
+            return ParseResult.error();
+        }
+
+        if (closePosition + 1 != endPosition) {
+            logError("no-args", "Unexpected character", closePosition + 1);
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(Collections.emptyList());
+    }
+
+    /**
+     * one-or-more-args    = "(" ( function-arg *( "," function-arg ) ) ")"
+     */
+    private ParseResult<List<FunctionArg>> parseOneOrMoreArgs(int startPosition, int endPosition) {
+        return parseMultiSelect(startPosition, endPosition, '(', ')', this::parseFunctionArg);
+    }
+
+    /**
+     * function-arg        = expression / expression-type
+     */
+    private ParseResult<FunctionArg> parseFunctionArg(int startPosition, int endPosition) {
+        return CompositeParser.firstTry(this::parseExpression, FunctionArg::expression)
+                              .thenTry(this::parseExpressionType, FunctionArg::expressionType)
+                              .parse(startPosition, endPosition);
+    }
+
+    /**
+     * current-node        = "@"
+     */
+    private ParseResult<CurrentNode> parseCurrentNode(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        return parseExpectedToken("current-node", startPosition, endPosition, '@').mapResult(x -> new CurrentNode());
+    }
+
+    /**
+     * expression-type     = "&" expression
+     */
+    private ParseResult<ExpressionType> parseExpressionType(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsWith(startPosition, '&')) {
+            logError("expression-type", "Expected '&'", startPosition);
+            return ParseResult.error();
+        }
+
+        return parseExpression(startPosition + 1, endPosition).mapResult(ExpressionType::new);
+    }
+
+    /**
+     * raw-string        = "'" *raw-string-char "'"
+     */
+    private ParseResult<String> parseRawString(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (charsInRange(startPosition, endPosition) < 2) {
+            logError("raw-string", "Invalid length", startPosition);
+            return ParseResult.error();
+        }
+
+        if (!startsAndEndsWith(startPosition, endPosition, '\'', '\'')) {
+            logError("raw-string", "Expected opening and closing \"'\"", startPosition);
+            return ParseResult.error();
+        }
+
+        if (charsInRange(startPosition, endPosition) == 2) {
+            return ParseResult.success("");
+        }
+
+        return parseRawStringChars(startPosition + 1, endPosition - 1);
+    }
+
+    /**
+     * raw-string-char   = (%x20-26 / %x28-5B / %x5D-10FFFF) / preserved-escape / raw-string-escape
+     */
+    private ParseResult<String> parseRawStringChars(int startPosition, int endPosition) {
+        StringBuilder result = new StringBuilder();
+        for (int i = startPosition; i < endPosition; i++) {
+            ParseResult<String> rawStringChar = parseLegalRawStringChar(i, i + 1);
+            if (rawStringChar.hasResult()) {
+                result.append(rawStringChar.result());
+                continue;
+            }
+
+            ParseResult<String> preservedEscape = parsePreservedEscape(i, i + 2);
+            if (preservedEscape.hasResult()) {
+                result.append(preservedEscape.result());
+                ++i;
+                continue;
+            }
+
+            ParseResult<String> rawStringEscape = parseRawStringEscape(i, i + 2);
+            if (rawStringEscape.hasResult()) {
+                result.append(rawStringEscape.result());
+                ++i;
+                continue;
+            }
+
+            logError("raw-string", "Unexpected character", i);
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(result.toString());
+    }
+
+    /**
+     * %x20-26 / %x28-5B / %x5D-10FFFF
+     */
+    private ParseResult<String> parseLegalRawStringChar(int startPosition, int endPosition) {
+        if (charsInRange(startPosition, endPosition) != 1) {
+            logError("raw-string-chars", "Invalid bounds", startPosition);
+            return ParseResult.error();
+        }
+
+        if (!isLegalRawStringChar(input.charAt(startPosition))) {
+            logError("raw-string-chars", "Invalid character in sequence", startPosition);
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(input.substring(startPosition, endPosition));
+    }
+
+    private boolean isLegalRawStringChar(char c) {
+        return (c >= 0x20 && c <= 0x26) ||
+               (c >= 0x28 && c <= 0x5B) ||
+               (c >= 0x5D);
+    }
+
+    /**
+     * preserved-escape  = escape (%x20-26 / %28-5B / %x5D-10FFFF)
+     */
+    private ParseResult<String> parsePreservedEscape(int startPosition, int endPosition) {
+        if (endPosition > input.length()) {
+            logError("preserved-escape", "Invalid end position", startPosition);
+            return ParseResult.error();
+        }
+
+        if (charsInRange(startPosition, endPosition) != 2) {
+            logError("preserved-escape", "Invalid length", startPosition);
+            return ParseResult.error();
+        }
+
+        if (!startsWith(startPosition, '\\')) {
+            logError("preserved-escape", "Expected \\", startPosition);
+            return ParseResult.error();
+        }
+
+        return parseLegalRawStringChar(startPosition + 1, endPosition).mapResult(v -> "\\" + v);
+    }
+
+    /**
+     * raw-string-escape = escape ("'" / escape)
+     */
+    private ParseResult<String> parseRawStringEscape(int startPosition, int endPosition) {
+        if (endPosition > input.length()) {
+            logError("preserved-escape", "Invalid end position", startPosition);
+            return ParseResult.error();
+        }
+
+        if (charsInRange(startPosition, endPosition) != 2) {
+            logError("raw-string-escape", "Invalid length", startPosition);
+            return ParseResult.error();
+        }
+
+        if (!startsWith(startPosition, '\\')) {
+            logError("raw-string-escape", "Expected '\\'", startPosition);
+            return ParseResult.error();
+        }
+
+        if (input.charAt(startPosition + 1) != '\'' && input.charAt(startPosition + 1) != '\\') {
+            logError("raw-string-escape", "Expected \"'\" or \"\\\"", startPosition);
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(input.substring(startPosition, endPosition));
+    }
+
+    /**
+     * literal           = "`" json-value "`"
+     */
+    private ParseResult<Literal> parseLiteral(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (charsInRange(startPosition, endPosition) < 2) {
+            logError("literal", "Invalid bounds", startPosition);
+            return ParseResult.error();
+        }
+
+        if (!startsAndEndsWith(startPosition, endPosition, '`', '`')) {
+            logError("literal", "Expected opening and closing '`'", startPosition);
+            return ParseResult.error();
+        }
+
+        StringBuilder jsonString = new StringBuilder();
+        for (int i = startPosition + 1; i < endPosition - 1; i++) {
+            char character = input.charAt(i);
+            if (character == '`') {
+                int lastChar = i - 1;
+                if (lastChar <= 0) {
+                    logError("literal", "Unexpected '`'", startPosition);
+                    return ParseResult.error();
+                }
+
+                int escapeCount = 0;
+                for (int j = i - 1; j >= startPosition; j--) {
+                    if (input.charAt(j) == '\\') {
+                        ++escapeCount;
+                    } else {
+                        break;
+                    }
+                }
+
+                if (escapeCount % 2 == 0) {
+                    logError("literal", "Unescaped '`'", startPosition);
+                    return ParseResult.error();
+                }
+
+                jsonString.setLength(jsonString.length() - 1); // Remove escape.
+                jsonString.append('`');
+            } else {
+                jsonString.append(character);
+            }
+        }
+
+        try {
+            return ParseResult.success(new Literal(Jackson.readJrsValue(jsonString.toString())));
+        } catch (IOException e) {
+            logError("literal", "Invalid JSON: " + e.getMessage(), startPosition);
+            return ParseResult.error();
+        }
+    }
+
+    /**
+     * number            = ["-"]1*digit
+     * digit             = %x30-39
+     */
+    private ParseResult<Integer> parseNumber(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (startsWith(startPosition, '-')) {
+            return parseNonNegativeNumber(startPosition + 1, endPosition).mapResult(i -> -i);
+        }
+
+        return parseNonNegativeNumber(startPosition, endPosition);
+    }
+
+    private ParseResult<Integer> parseNonNegativeNumber(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (charsInRange(startPosition, endPosition) < 1) {
+            logError("number", "Expected number", startPosition);
+            return ParseResult.error();
+        }
+
+        try {
+            return ParseResult.success(Integer.parseInt(input.substring(startPosition, endPosition)));
+        } catch (NumberFormatException e) {
+            logError("number", "Expected number", startPosition);
+            return ParseResult.error();
+        }
+    }
+
+    /**
+     * identifier        = unquoted-string / quoted-string
+     */
+    private ParseResult<String> parseIdentifier(int startPosition, int endPosition) {
+        return CompositeParser.firstTry(this::parseUnquotedString)
+                              .thenTry(this::parseQuotedString)
+                              .parse(startPosition, endPosition);
+    }
+
+    /**
+     * unquoted-string   = (%x41-5A / %x61-7A / %x5F) *(  ; A-Za-z_
+     * %x30-39  /  ; 0-9
+     * %x41-5A /  ; A-Z
+     * %x5F    /  ; _
+     * %x61-7A)   ; a-z
+     */
+    private ParseResult<String> parseUnquotedString(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (charsInRange(startPosition, endPosition) < 1) {
+            logError("unquoted-string", "Invalid unquoted-string", startPosition);
+            return ParseResult.error();
+        }
+
+        char firstToken = input.charAt(startPosition);
+        if (!Character.isLetter(firstToken) && firstToken != '_') {
+            logError("unquoted-string", "Unescaped strings must start with [A-Za-z_]", startPosition);
+            return ParseResult.error();
+        }
+
+        for (int i = startPosition; i < endPosition; i++) {
+            char c = input.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_') {
+                logError("unquoted-string", "Invalid character in unescaped-string", i);
+                return ParseResult.error();
+            }
+        }
+
+        return ParseResult.success(input.substring(startPosition, endPosition));
+    }
+
+    /**
+     * quoted-string     = quote 1*(unescaped-char / escaped-char) quote
+     * quote = '"'
+     */
+    private ParseResult<String> parseQuotedString(int startPosition, int endPosition) {
+        startPosition = trimLeftWhitespace(startPosition, endPosition);
+        endPosition = trimRightWhitespace(startPosition, endPosition);
+
+        if (!startsAndEndsWith(startPosition, endPosition, '"', '"')) {
+            logError("quoted-string", "Expected opening and closing '\"'", startPosition);
+            return ParseResult.error();
+        }
+
+        int stringStart = startPosition + 1;
+        int stringEnd = endPosition - 1;
+
+        int stringTokenCount = charsInRange(stringStart, stringEnd);
+        if (stringTokenCount < 1) {
+            logError("quoted-string", "Invalid quoted-string", startPosition);
+            return ParseResult.error();
+        }
+
+        StringBuilder result = new StringBuilder();
+        for (int i = stringStart; i < stringEnd; i++) {
+            ParseResult<String> unescapedChar = parseUnescapedChar(i, i + 1);
+            if (unescapedChar.hasResult()) {
+                result.append(unescapedChar.result());
+                continue;
+            }
+
+            ParseResult<String> escapedChar = parseEscapedChar(i, i + 2);
+            if (escapedChar.hasResult()) {
+                result.append(escapedChar.result());
+                ++i;
+                continue;
+            }
+
+            ParseResult<String> escapedUnicodeSequence = parseEscapedUnicodeSequence(i, i + 6);
+            if (escapedUnicodeSequence.hasResult()) {
+                result.append(escapedUnicodeSequence.result());
+                i += 5;
+                continue;
+            }
+
+            if (input.charAt(i) == '\\') {
+                logError("quoted-string", "Unsupported escape sequence", i);
+            } else {
+                logError("quoted-string", "Unexpected character", i);
+            }
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(result.toString());
+    }
+
+    /**
+     * unescaped-char    = %x20-21 / %x23-5B / %x5D-10FFFF
+     */
+    private ParseResult<String> parseUnescapedChar(int startPosition, int endPosition) {
+        for (int i = startPosition; i < endPosition; i++) {
+            if (!isLegalUnescapedChar(input.charAt(i))) {
+                logError("unescaped-char", "Invalid character in sequence", startPosition);
+                return ParseResult.error();
+            }
+        }
+
+        return ParseResult.success(input.substring(startPosition, endPosition));
+    }
+
+    private boolean isLegalUnescapedChar(char c) {
+        return (c >= 0x20 && c <= 0x21) ||
+               (c >= 0x23 && c <= 0x5B) ||
+               (c >= 0x5D);
+    }
+
+    /**
+     * escaped-char      = escape (
+     * %x22 /          ; "    quotation mark  U+0022
+     * %x5C /          ; \    reverse solidus U+005C
+     * %x2F /          ; /    solidus         U+002F
+     * %x62 /          ; b    backspace       U+0008
+     * %x66 /          ; f    form feed       U+000C
+     * %x6E /          ; n    line feed       U+000A
+     * %x72 /          ; r    carriage return U+000D
+     * %x74 /          ; t    tab             U+0009
+     * %x75 4HEXDIG )  ; uXXXX                U+XXXX (this is handled as part of parseEscapedUnicodeSequence)
+     */
+    private ParseResult<String> parseEscapedChar(int startPosition, int endPosition) {
+        if (endPosition > input.length()) {
+            logError("escaped-char", "Invalid end position", startPosition);
+            return ParseResult.error();
+        }
+
+        if (charsInRange(startPosition, endPosition) != 2) {
+            logError("escaped-char", "Invalid length", startPosition);
+            return ParseResult.error();
+        }
+
+        if (!startsWith(startPosition, '\\')) {
+            logError("escaped-char", "Expected '\\'", startPosition);
+            return ParseResult.error();
+        }
+
+        char escapedChar = input.charAt(startPosition + 1);
+        switch (escapedChar) {
+            case '"': return ParseResult.success("\"");
+            case '\\': return ParseResult.success("\\");
+            case '/': return ParseResult.success("/");
+            case 'b': return ParseResult.success("\b");
+            case 'f': return ParseResult.success("\f");
+            case 'n': return ParseResult.success("\n");
+            case 'r': return ParseResult.success("\r");
+            case 't': return ParseResult.success("\t");
+            default:
+                logError("escaped-char", "Invalid escape sequence", startPosition);
+                return ParseResult.error();
+        }
+    }
+
+    private ParseResult<String> parseEscapedUnicodeSequence(int startPosition, int endPosition) {
+        if (endPosition > input.length()) {
+            logError("escaped-unicode-sequence", "Invalid end position", startPosition);
+            return ParseResult.error();
+        }
+
+        if (charsInRange(startPosition, endPosition) != 6) {
+            logError("escaped-unicode-sequence", "Invalid length", startPosition);
+            return ParseResult.error();
+        }
+
+        if (input.charAt(startPosition) != '\\') {
+            logError("escaped-unicode-sequence", "Expected '\\'", startPosition);
+            return ParseResult.error();
+        }
+
+        char escapedChar = input.charAt(startPosition + 1);
+        if (escapedChar != 'u') {
+            logError("escaped-unicode-sequence", "Invalid escape sequence", startPosition);
+            return ParseResult.error();
+        }
+
+        String unicodePattern = input.substring(startPosition + 2, startPosition + 2 + 4);
+        char unicodeChar;
+        try {
+            unicodeChar = (char) Integer.parseInt(unicodePattern, 16);
+        } catch (NumberFormatException e) {
+            logError("escaped-unicode-sequence", "Invalid unicode hex sequence", startPosition);
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(String.valueOf(unicodeChar));
+    }
+
+    /**
+     * "*"
+     */
+    private ParseResult<WildcardExpression> parseWildcardExpression(int startPosition, int endPosition) {
+        return parseExpectedToken("star-expression", startPosition, endPosition, '*').mapResult(v -> new WildcardExpression());
+    }
+
+    private int charsInRange(int startPosition, int endPosition) {
+        return endPosition - startPosition;
+    }
+
+    private List<Integer> findCharacters(int startPosition, int endPosition, String symbol) {
+        List<Integer> results = new ArrayList<>();
+
+        int start = startPosition;
+        while (true) {
+            int match = input.indexOf(symbol, start);
+            if (match < 0 || match >= endPosition) {
+                break;
+            }
+            results.add(match);
+            start = match + 1;
+        }
+
+        return results;
+    }
+
+    private ParseResult<Character> parseExpectedToken(String parser, int startPosition, int endPosition, char expectedToken) {
+        if (input.charAt(startPosition) != expectedToken) {
+            logError(parser, "Expected '" + expectedToken + "'", startPosition);
+            return ParseResult.error();
+        }
+
+        if (charsInRange(startPosition, endPosition) != 1) {
+            logError(parser, "Unexpected character", startPosition + 1);
+            return ParseResult.error();
+        }
+
+        return ParseResult.success(expectedToken);
+    }
+
+    private int trimLeftWhitespace(int startPosition, int endPosition) {
+        while (input.charAt(startPosition) == ' ' && startPosition < endPosition - 1) {
+            ++startPosition;
+        }
+
+        return startPosition;
+    }
+
+    private int trimRightWhitespace(int startPosition, int endPosition) {
+        while (input.charAt(endPosition - 1) == ' ' && startPosition < endPosition - 1) {
+            --endPosition;
+        }
+
+        return endPosition;
+    }
+
+    private boolean startsWith(int startPosition, char character) {
+        return input.charAt(startPosition) == character;
+    }
+
+    private boolean endsWith(int endPosition, char character) {
+        return input.charAt(endPosition - 1) == character;
+    }
+
+    private boolean startsAndEndsWith(int startPosition, int endPosition, char startChar, char endChar) {
+        return startsWith(startPosition, startChar) && endsWith(endPosition, endChar);
+    }
+
+    private void logError(String parser, String message, int position) {
+        log.debug(() -> parser + " at " + position + ": " + message);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/ParseResult.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/ParseResult.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.parser;
+
+import java.util.function.Function;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * The result of a {@link Parser#parse(int, int)} call. This is either successful ({@link #success}) or an error
+ * ({@link #error()}).
+ */
+public final class ParseResult<T> {
+    private final T result;
+
+    private ParseResult(T result) {
+        this.result = result;
+    }
+
+    /**
+     * Create a successful result with the provided value.
+     */
+    public static <T> ParseResult<T> success(T result) {
+        Validate.notNull(result, "result");
+        return new ParseResult<>(result);
+    }
+
+    /**
+     * Create an error result.
+     */
+    public static <T> ParseResult<T> error() {
+        return new ParseResult<>(null);
+    }
+
+    /**
+     * Convert the value in this parse result (if successful) using the provided function.
+     */
+    public <U> ParseResult<U> mapResult(Function<T, U> mapper) {
+        if (hasResult()) {
+            return ParseResult.success(mapper.apply(result));
+        } else {
+            return ParseResult.error();
+        }
+    }
+
+    /**
+     * Returns true if the parse result was successful.
+     */
+    public boolean hasResult() {
+        return result != null;
+    }
+
+    /**
+     * Returns the result of parsing.
+     */
+    public T result() {
+        Validate.validState(hasResult(), "Result not available");
+        return result;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/Parser.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/Parser.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.parser;
+
+/**
+ * A JMESPath parser, for generating a {@link ParseResult} from a string between two provided bounds.
+ */
+@FunctionalInterface
+public interface Parser<T> {
+    /**
+     * Parse a JMESPath string between the start position (inclusive) and end position (exclusive).
+     */
+    ParseResult<T> parse(int startPosition, int endPosition);
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/util/CompositeParser.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/jmespath/parser/util/CompositeParser.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath.parser.util;
+
+import java.util.function.Function;
+import software.amazon.awssdk.codegen.jmespath.parser.ParseResult;
+import software.amazon.awssdk.codegen.jmespath.parser.Parser;
+
+/**
+ * A {@link Parser} that invokes a list of converters, returning the first converter that was successful. This is created
+ * using {@link #firstTry(Parser)} and new converters are added via {@link #thenTry(Parser)}.
+ */
+public final class CompositeParser<T> implements Parser<T> {
+    private final Parser<T> parser;
+
+    private CompositeParser(Parser<T> parser) {
+        this.parser = parser;
+    }
+
+    /**
+     * Create a {@link CompositeParser} that tries the provided parser first.
+     */
+    public static <T> CompositeParser<T> firstTry(Parser<T> parser) {
+        return new CompositeParser<>(parser);
+    }
+
+    /**
+     * Create a {@link CompositeParser} that tries the provided parser first, converting the result of that parser using the
+     * provided function.
+     */
+    public static <T, U> CompositeParser<U> firstTry(Parser<T> parser, Function<T, U> resultConverter) {
+        return firstTry((start, end) -> parser.parse(start, end).mapResult(resultConverter));
+    }
+
+    /**
+     * Create a new {@link CompositeParser} that tries the provided parser after all previous parsers.
+     */
+    public CompositeParser<T> thenTry(Parser<T> nextParser) {
+        return new CompositeParser<>((start, end) -> {
+            ParseResult<T> parse = parser.parse(start, end);
+            if (!parse.hasResult()) {
+                return nextParser.parse(start, end);
+            }
+
+            return parse;
+        });
+    }
+
+    /**
+     * Create a new {@link CompositeParser} that tries the provided parser after all previous parsers, converting the result of
+     * that parser using the provided function.
+     */
+    public <S> CompositeParser<T> thenTry(Parser<S> nextParser, Function<S, T> resultConverter) {
+        return thenTry((start, end) -> nextParser.parse(start, end).mapResult(resultConverter));
+    }
+
+    @Override
+    public ParseResult<T> parse(int startPosition, int endPosition) {
+        return parser.parse(startPosition, endPosition);
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/jmespath/JmesPathParserTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/jmespath/JmesPathParserTest.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.jmespath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import software.amazon.awssdk.codegen.jmespath.component.Comparator;
+import software.amazon.awssdk.codegen.jmespath.component.Expression;
+import software.amazon.awssdk.codegen.jmespath.parser.JmesPathParser;
+
+public class JmesPathParserTest {
+    @Test
+    public void testSubExpressionWithIdentifier() {
+        Expression expression = JmesPathParser.parse("foo.bar");
+        assertThat(expression.asSubExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asSubExpression().rightSubExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testSubExpressionWithMultiSelectList() {
+        Expression expression = JmesPathParser.parse("foo.[bar]");
+        assertThat(expression.asSubExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asSubExpression().rightSubExpression().asMultiSelectList().expressions()).hasSize(1);
+        assertThat(expression.asSubExpression().rightSubExpression().asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testSubExpressionWithMultiSelectHash() {
+        Expression expression = JmesPathParser.parse("foo.{bar : baz}");
+        assertThat(expression.asSubExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asSubExpression().rightSubExpression().asMultiSelectHash().keyValueExpressions()).hasSize(1);
+        assertThat(expression.asSubExpression().rightSubExpression().asMultiSelectHash().keyValueExpressions().get(0).key()).isEqualTo("bar");
+        assertThat(expression.asSubExpression().rightSubExpression().asMultiSelectHash().keyValueExpressions().get(0).value().asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testSubExpressionWithFunction() {
+        Expression expression = JmesPathParser.parse("foo.length()");
+        assertThat(expression.asSubExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asSubExpression().rightSubExpression().asFunctionExpression().function()).isEqualTo("length");
+    }
+
+    @Test
+    public void testSubExpressionWithStar() {
+        Expression expression = JmesPathParser.parse("foo.*");
+        assertThat(expression.asSubExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asSubExpression().rightSubExpression().isWildcardExpression()).isTrue();
+    }
+
+    @Test
+    public void testPipeExpression() {
+        Expression expression = JmesPathParser.parse("foo | bar");
+        assertThat(expression.asPipeExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asPipeExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testOrExpression() {
+        Expression expression = JmesPathParser.parse("foo || bar");
+        assertThat(expression.asOrExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asOrExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testAndExpression() {
+        Expression expression = JmesPathParser.parse("foo && bar");
+        assertThat(expression.asAndExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asAndExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testNotExpression() {
+        Expression expression = JmesPathParser.parse("!foo");
+        assertThat(expression.asNotExpression().expression().asIdentifier()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testParenExpression() {
+        Expression expression = JmesPathParser.parse("(foo)");
+        assertThat(expression.asParenExpression().expression().asIdentifier()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testWildcardExpression() {
+        Expression expression = JmesPathParser.parse("*");
+        assertThat(expression.isWildcardExpression()).isTrue();
+    }
+
+    @Test
+    public void testIndexedExpressionWithoutLeftExpressionWithoutContents() {
+        Expression expression = JmesPathParser.parse("[]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().isBracketSpecifierWithoutContents()).isTrue();
+    }
+
+    @Test
+    public void testIndexedExpressionWithoutLeftExpressionWithNumberContents() {
+        Expression expression = JmesPathParser.parse("[10]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asNumber()).isEqualTo(10);
+    }
+
+    @Test
+    public void testIndexedExpressionWithoutLeftExpressionWithStarContents() {
+        Expression expression = JmesPathParser.parse("[*]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().isWildcardExpression()).isTrue();
+    }
+
+    @Test
+    public void testIndexedExpressionWithoutLeftExpressionWithQuestionMark() {
+        Expression expression = JmesPathParser.parse("[?foo]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithQuestionMark().expression().asIdentifier()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testIndexedExpressionWithLeftExpressionWithoutContents() {
+        Expression expression = JmesPathParser.parse("foo[]");
+        assertThat(expression.asIndexExpression().expression()).hasValueSatisfying(e -> assertThat(e.asIdentifier()).isEqualTo("foo"));
+        assertThat(expression.asIndexExpression().bracketSpecifier().isBracketSpecifierWithoutContents()).isTrue();
+    }
+
+    @Test
+    public void testIndexedExpressionWithLeftExpressionWithContents() {
+        Expression expression = JmesPathParser.parse("foo[10]");
+        assertThat(expression.asIndexExpression().expression()).hasValueSatisfying(e -> assertThat(e.asIdentifier()).isEqualTo("foo"));
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asNumber()).isEqualTo(10);
+    }
+
+    @Test
+    public void testIndexedExpressionWithLeftExpressionWithStarContents() {
+        Expression expression = JmesPathParser.parse("foo[*]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).hasValueSatisfying(e -> assertThat(e.asIdentifier()).isEqualTo("foo"));
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().isWildcardExpression()).isTrue();
+    }
+
+    @Test
+    public void testIndexedExpressionWithLeftExpressionWithQuestionMark() {
+        Expression expression = JmesPathParser.parse("foo[?bar]");
+        assertThat(expression.isIndexExpression()).isTrue();
+
+        assertThat(expression.asIndexExpression().expression()).hasValueSatisfying(e -> assertThat(e.asIdentifier()).isEqualTo("foo"));
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithQuestionMark().expression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testMultiSelectList2() {
+        Expression expression = JmesPathParser.parse("[foo, bar]");
+        assertThat(expression.asMultiSelectList().expressions()).hasSize(2);
+        assertThat(expression.asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testMultiSelectList3() {
+        Expression expression = JmesPathParser.parse("[foo, bar, baz]");
+        assertThat(expression.asMultiSelectList().expressions()).hasSize(3);
+        assertThat(expression.asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asMultiSelectList().expressions().get(2).asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testNestedMultiSelectListsRight() {
+        Expression expression = JmesPathParser.parse("[foo, [bar, baz]]");
+        assertThat(expression.asMultiSelectList().expressions()).hasSize(2);
+        assertThat(expression.asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asMultiSelectList().expressions()).hasSize(2);
+        assertThat(expression.asMultiSelectList().expressions().get(1).asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asMultiSelectList().expressions().get(1).asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testNestedMultiSelectListsCenter() {
+        Expression expression = JmesPathParser.parse("[foo, [bar, baz], bam]");
+        assertThat(expression.asMultiSelectList().expressions()).hasSize(3);
+        assertThat(expression.asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asMultiSelectList().expressions()).hasSize(2);
+        assertThat(expression.asMultiSelectList().expressions().get(1).asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asMultiSelectList().expressions().get(1).asIdentifier()).isEqualTo("baz");
+        assertThat(expression.asMultiSelectList().expressions().get(2).asIdentifier()).isEqualTo("bam");
+    }
+
+    @Test
+    public void testNestedMultiSelectListsLeft() {
+        Expression expression = JmesPathParser.parse("[[foo, bar], baz]");
+        assertThat(expression.asMultiSelectList().expressions()).hasSize(2);
+        assertThat(expression.asMultiSelectList().expressions().get(0).asMultiSelectList().expressions().get(0).asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asMultiSelectList().expressions().get(0).asMultiSelectList().expressions().get(1).asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asMultiSelectList().expressions().get(1).asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testMultiSelectHash2() {
+        Expression expression = JmesPathParser.parse("{fooK : fooV, barK : barV}");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions()).hasSize(2);
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(0).key()).isEqualTo("fooK");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(0).value().asIdentifier()).isEqualTo("fooV");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(1).key()).isEqualTo("barK");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(1).value().asIdentifier()).isEqualTo("barV");
+    }
+
+    @Test
+    public void testMultiSelectHash3() {
+        Expression expression = JmesPathParser.parse("{fooK : fooV, barK : barV, bazK : bazV}");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions()).hasSize(3);
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(0).key()).isEqualTo("fooK");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(0).value().asIdentifier()).isEqualTo("fooV");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(1).key()).isEqualTo("barK");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(1).value().asIdentifier()).isEqualTo("barV");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(2).key()).isEqualTo("bazK");
+        assertThat(expression.asMultiSelectHash().keyValueExpressions().get(2).value().asIdentifier()).isEqualTo("bazV");
+    }
+
+    @Test
+    public void testComparatorExpressionLT() {
+        Expression expression = JmesPathParser.parse("foo < bar");
+        assertThat(expression.asComparatorExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asComparatorExpression().comparator()).isEqualTo(Comparator.LESS_THAN);
+        assertThat(expression.asComparatorExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testComparatorExpressionGT() {
+        Expression expression = JmesPathParser.parse("foo > bar");
+        assertThat(expression.asComparatorExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asComparatorExpression().comparator()).isEqualTo(Comparator.GREATER_THAN);
+        assertThat(expression.asComparatorExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testComparatorExpressionLTE() {
+        Expression expression = JmesPathParser.parse("foo <= bar");
+        assertThat(expression.asComparatorExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asComparatorExpression().comparator()).isEqualTo(Comparator.LESS_THAN_OR_EQUAL);
+        assertThat(expression.asComparatorExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testComparatorExpressionGTE() {
+        Expression expression = JmesPathParser.parse("foo >= bar");
+        assertThat(expression.asComparatorExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asComparatorExpression().comparator()).isEqualTo(Comparator.GREATER_THAN_OR_EQUAL);
+        assertThat(expression.asComparatorExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testComparatorExpressionEQ() {
+        Expression expression = JmesPathParser.parse("foo == bar");
+        assertThat(expression.asComparatorExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asComparatorExpression().comparator()).isEqualTo(Comparator.EQUAL);
+        assertThat(expression.asComparatorExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testComparatorExpressionNEQ() {
+        Expression expression = JmesPathParser.parse("foo != bar");
+        assertThat(expression.asComparatorExpression().leftExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asComparatorExpression().comparator()).isEqualTo(Comparator.NOT_EQUAL);
+        assertThat(expression.asComparatorExpression().rightExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testSliceExpressionWithNoNumbers2() {
+        Expression expression = JmesPathParser.parse("[:]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithNoNumbers3() {
+        Expression expression = JmesPathParser.parse("[::]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStartNumber2() {
+        Expression expression = JmesPathParser.parse("[10:]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStopNumber2() {
+        Expression expression = JmesPathParser.parse("[:10]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStartStopNumber2() {
+        Expression expression = JmesPathParser.parse("[10:20]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).hasValue(20);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStartNumber3() {
+        Expression expression = JmesPathParser.parse("[10::]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStopNumber3() {
+        Expression expression = JmesPathParser.parse("[:10:]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStartStopNumber3() {
+        Expression expression = JmesPathParser.parse("[10:20:]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).hasValue(20);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).isNotPresent();
+    }
+
+    @Test
+    public void testSliceExpressionWithStartStopStepNumber3() {
+        Expression expression = JmesPathParser.parse("[10:20:30]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).hasValue(10);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).hasValue(20);
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).hasValue(30);
+    }
+
+    @Test
+    public void testSliceExpressionWithStepNumber3() {
+        Expression expression = JmesPathParser.parse("[::30]");
+        assertThat(expression.isIndexExpression()).isTrue();
+        assertThat(expression.asIndexExpression().expression()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().start()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().stop()).isNotPresent();
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asSliceExpression().step()).hasValue(30);
+    }
+
+    @Test
+    public void testFunction0Args() {
+        Expression expression = JmesPathParser.parse("length()");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).isEmpty();
+    }
+
+    @Test
+    public void testFunction1ExpressionArg() {
+        Expression expression = JmesPathParser.parse("length(foo)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(1);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpression().asIdentifier()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testFunction2ExpressionArg() {
+        Expression expression = JmesPathParser.parse("length(foo, bar)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(2);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asFunctionExpression().functionArgs().get(1).asExpression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testFunction3ExpressionArg() {
+        Expression expression = JmesPathParser.parse("length(foo, bar, baz)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(3);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asFunctionExpression().functionArgs().get(1).asExpression().asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asFunctionExpression().functionArgs().get(2).asExpression().asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testFunction1ExpressionTypeArg() {
+        Expression expression = JmesPathParser.parse("length(&foo)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(1);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpressionType().expression().asIdentifier()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testFunction2ExpressionTypeArg() {
+        Expression expression = JmesPathParser.parse("length(&foo, &bar)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(2);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpressionType().expression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asFunctionExpression().functionArgs().get(1).asExpressionType().expression().asIdentifier()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testFunction3ExpressionTypeArg() {
+        Expression expression = JmesPathParser.parse("length(&foo, &bar, &baz)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(3);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpressionType().expression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asFunctionExpression().functionArgs().get(1).asExpressionType().expression().asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asFunctionExpression().functionArgs().get(2).asExpressionType().expression().asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testFunction3MixedExpressionTypeArg() {
+        Expression expression = JmesPathParser.parse("length(foo, &bar, baz)");
+        assertThat(expression.asFunctionExpression().function()).isEqualTo("length");
+        assertThat(expression.asFunctionExpression().functionArgs()).hasSize(3);
+        assertThat(expression.asFunctionExpression().functionArgs().get(0).asExpression().asIdentifier()).isEqualTo("foo");
+        assertThat(expression.asFunctionExpression().functionArgs().get(1).asExpressionType().expression().asIdentifier()).isEqualTo("bar");
+        assertThat(expression.asFunctionExpression().functionArgs().get(2).asExpression().asIdentifier()).isEqualTo("baz");
+    }
+
+    @Test
+    public void testCurrentNode() {
+        Expression expression = JmesPathParser.parse("@");
+        assertThat(expression.isCurrentNode()).isTrue();
+    }
+
+    @Test
+    public void testEmptyIdentifierUnquoted() {
+        Expression expression = JmesPathParser.parse("foo_bar");
+        assertThat(expression.asIdentifier()).isEqualTo("foo_bar");
+    }
+
+    @Test
+    public void testIdentifierUnquoted() {
+        Expression expression = JmesPathParser.parse("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_");
+        assertThat(expression.asIdentifier()).isEqualTo("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_");
+    }
+
+    @Test
+    public void testIdentifierQuoted() {
+        Expression expression = JmesPathParser.parse("\"foo bar\"");
+        assertThat(expression.asIdentifier()).isEqualTo("foo bar");
+    }
+
+    @Test
+    public void testIdentifierQuotedWithEscapes() {
+        Expression expression = JmesPathParser.parse("\"foo \\\" \\\\ \\/ \\b \\f \\n \\r \\t \\u0000 \\uffff bar\"");
+        assertThat(expression.asIdentifier()).isEqualTo("foo \" \\ / \b \f \n \r \t \u0000 \uffff bar");
+    }
+
+    @Test
+    public void testRawStringEmpty() {
+        Expression expression = JmesPathParser.parse("''");
+        assertThat(expression.asRawString()).isEmpty();
+    }
+
+    @Test
+    public void testRawStringWithValue() {
+        Expression expression = JmesPathParser.parse("'foo bar'");
+        assertThat(expression.asRawString()).isEqualTo("foo bar");
+    }
+
+    @Test
+    public void testRawStringWithEscapedSequences() {
+        Expression expression = JmesPathParser.parse("'foo \\' \\\\ \\/ \\b \\f \\n \\r \\t \\u0000 \\uffff bar'");
+        assertThat(expression.asRawString()).isEqualTo("foo \\' \\\\ \\/ \\b \\f \\n \\r \\t \\u0000 \\uffff bar");
+    }
+
+    @Test
+    public void testNegativeNumber() {
+        Expression expression = JmesPathParser.parse("[-10]");
+        assertThat(expression.asIndexExpression().bracketSpecifier().asBracketSpecifierWithContents().asNumber()).isEqualTo(-10);
+    }
+}


### PR DESCRIPTION
The added JmesPathParser.parse method can convert a valid JMESPath expression into an Expression, which is a syntax tree representation of an JMESPath expression.

The next step will be to interpret this JMESPath expression to generate an acceptor for waiters. It's likely that this interpreter will only implement a subset of the JMESPath features.