### PR TITLE
DDB Enhanced:Added support to read Nested objects in attributesToProj…

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/QueryEnhancedRequest.java
@@ -47,6 +47,7 @@ public final class QueryEnhancedRequest {
     private final Boolean consistentRead;
     private final Expression filterExpression;
     private final List<String> attributesToProject;
+    private final Map<String, String> attributesToProjectExpressionNames;
 
     private QueryEnhancedRequest(Builder builder) {
         this.queryConditional = builder.queryConditional;
@@ -58,6 +59,8 @@ public final class QueryEnhancedRequest {
         this.attributesToProject = builder.attributesToProject != null
                 ? Collections.unmodifiableList(builder.attributesToProject)
                 : null;
+        this.attributesToProjectExpressionNames = builder.attributesToProjectExpressionNames;
+
     }
 
     /**
@@ -77,7 +80,9 @@ public final class QueryEnhancedRequest {
                         .limit(limit)
                         .consistentRead(consistentRead)
                         .filterExpression(filterExpression)
-                        .attributesToProject(attributesToProject);
+                        .attributesToProject(attributesToProject)
+                        .attributesToProjectExpressionNames(attributesToProjectExpressionNames);
+
     }
 
     /**
@@ -130,6 +135,13 @@ public final class QueryEnhancedRequest {
         return attributesToProject;
     }
 
+    /**
+     * Returns the Map of the name expressions used in defining expression for attributesToProject.
+     */
+    public Map<String, String> attributesToProjectExpressionNames() {
+        return attributesToProjectExpressionNames;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -165,6 +177,11 @@ public final class QueryEnhancedRequest {
         ) {
             return false;
         }
+        if (attributesToProjectExpressionNames != null
+                ? ! attributesToProjectExpressionNames.equals(query.attributesToProjectExpressionNames)
+                : query.attributesToProjectExpressionNames != null) {
+            return false;
+        }
         return filterExpression != null ? filterExpression.equals(query.filterExpression) : query.filterExpression == null;
     }
 
@@ -177,6 +194,7 @@ public final class QueryEnhancedRequest {
         result = 31 * result + (consistentRead != null ? consistentRead.hashCode() : 0);
         result = 31 * result + (filterExpression != null ? filterExpression.hashCode() : 0);
         result = 31 * result + (attributesToProject != null ? attributesToProject.hashCode() : 0);
+        result = 31 * result + (attributesToProjectExpressionNames != null ? attributesToProjectExpressionNames.hashCode() : 0);
         return result;
     }
 
@@ -193,6 +211,7 @@ public final class QueryEnhancedRequest {
         private Boolean consistentRead;
         private Expression filterExpression;
         private List<String> attributesToProject;
+        private Map<String, String> attributesToProjectExpressionNames;
 
         private Builder() {
         }
@@ -344,6 +363,34 @@ public final class QueryEnhancedRequest {
                 attributesToProject = new ArrayList<>();
             }
             attributesToProject.add(attributeToProject);
+            return this;
+        }
+
+        /**
+
+         * <p>
+         * Adds Attributes Name expression if there are expressions used in addAttributeToProject.
+         * </p>
+         * <p>
+         * Used while trying to access Nested attributes via attributesToProject.
+         * When we want to project a Nested Attribute the "."(DOT) is not recognized directly in the attributesToProject.
+         * Thus we need to supply the attributesToProject as expression Values like "#ParentAttrib.#InnerAttrib"
+         * as attributesToProject.
+         * Then in expressionAttributeNames supply the the corresponding attribute Name map.
+         * </p>
+         * <p>
+         * One or more substitution tokens for attribute names in an expression.
+         * For more information, see <a href=
+         *         "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html
+         *         #Expressions.ExpressionAttributeNames.NestedAttributes
+         *         >NestedAttributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+         * </p>
+         * @param attributesToProjectExpressionNames Map of the expressions used if expressions used addAttributeToProject.
+         * @return a builder of this type
+         */
+        public Builder attributesToProjectExpressionNames(Map<String, String> attributesToProjectExpressionNames) {
+            this.attributesToProjectExpressionNames = attributesToProjectExpressionNames != null
+                    ? new HashMap<>(attributesToProjectExpressionNames) : null;
             return this;
         }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ScanEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/ScanEnhancedRequest.java
@@ -41,6 +41,7 @@ public final class ScanEnhancedRequest {
     private final Boolean consistentRead;
     private final Expression filterExpression;
     private final List<String> attributesToProject;
+    private final Map<String, String> attributesToProjectExpressionNames;
 
     private ScanEnhancedRequest(Builder builder) {
         this.exclusiveStartKey = builder.exclusiveStartKey;
@@ -50,6 +51,8 @@ public final class ScanEnhancedRequest {
         this.attributesToProject = builder.attributesToProject != null
                 ? Collections.unmodifiableList(builder.attributesToProject)
                 : null;
+        this.attributesToProjectExpressionNames = builder.attributesToProjectExpressionNames;
+
     }
 
     /**
@@ -67,7 +70,9 @@ public final class ScanEnhancedRequest {
                         .limit(limit)
                         .consistentRead(consistentRead)
                         .filterExpression(filterExpression)
-                        .attributesToProject(attributesToProject);
+                        .attributesToProject(attributesToProject)
+                        .attributesToProjectExpressionNames(attributesToProjectExpressionNames);
+
     }
 
     /**
@@ -105,6 +110,13 @@ public final class ScanEnhancedRequest {
         return attributesToProject;
     }
 
+    /**
+     * Returns the Map of the name expressions used in defining expression for attributesToProject.
+     */
+    public Map<String, String> attributesToProjectExpressionNames() {
+        return attributesToProjectExpressionNames;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -132,6 +144,11 @@ public final class ScanEnhancedRequest {
         ) {
             return false;
         }
+        if (attributesToProjectExpressionNames != null
+                ? ! attributesToProjectExpressionNames.equals(scan.attributesToProjectExpressionNames)
+                : scan.attributesToProjectExpressionNames != null) {
+            return false;
+        }
         return filterExpression != null ? filterExpression.equals(scan.filterExpression) : scan.filterExpression == null;
     }
 
@@ -142,6 +159,7 @@ public final class ScanEnhancedRequest {
         result = 31 * result + (consistentRead != null ? consistentRead.hashCode() : 0);
         result = 31 * result + (filterExpression != null ? filterExpression.hashCode() : 0);
         result = 31 * result + (attributesToProject != null ? attributesToProject.hashCode() : 0);
+        result = 31 * result + (attributesToProjectExpressionNames != null ? attributesToProjectExpressionNames.hashCode() : 0);
         return result;
     }
 
@@ -154,6 +172,7 @@ public final class ScanEnhancedRequest {
         private Boolean consistentRead;
         private Expression filterExpression;
         private List<String> attributesToProject;
+        private Map<String, String> attributesToProjectExpressionNames;
 
         private Builder() {
         }
@@ -281,6 +300,35 @@ public final class ScanEnhancedRequest {
                 attributesToProject = new ArrayList<>();
             }
             attributesToProject.add(attributeToProject);
+            return this;
+        }
+
+        /**
+
+         * <p>
+         * Adds Attributes Name expression if there are expressions used in addAttributeToProject.
+         * </p>
+         * <p>
+         * Used while trying to access Nested attributes via attributesToProject.
+         * When we want to project a Nested Attribute the "."(DOT) is not recognized directly in the attributesToProject.
+         * Thus we need to supply the attributesToProject as expression Values like "#ParentAttrib.#InnerAttrib"
+         * as attributesToProject.
+         * Then in expressionAttributeNames supply the the corresponding attribute Name map.
+         * </p>
+         * <p>
+         * One or more substitution tokens for attribute names in an expression.
+         * For more information, see <a href=
+         *         "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html
+         *         #Expressions.ExpressionAttributeNames.NestedAttributes
+         *         >NestedAttributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+         * </p>
+         * @param attributesToProjectExpressionNames Map of the expressions used if expressions used addAttributeToProject.
+         * @return a builder of this type
+         */
+        public ScanEnhancedRequest.Builder attributesToProjectExpressionNames(Map<String,
+                String> attributesToProjectExpressionNames) {
+            this.attributesToProjectExpressionNames = attributesToProjectExpressionNames != null
+                    ? new HashMap<>(attributesToProjectExpressionNames) : null;
             return this;
         }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicScanTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicScanTest.java
@@ -41,6 +41,8 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.InnerAttributeRecord;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.NestedTestRecord;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
@@ -103,25 +105,49 @@ public class BasicScanTest extends LocalDynamoDbSyncTestBase {
                  .mapToObj(i -> new Record().setId("id-value").setSort(i))
                  .collect(Collectors.toList());
 
+    private static final List<NestedTestRecord> NESTED_TEST_RECORDS =
+            IntStream.range(0, 10)
+                    .mapToObj(i -> {
+                        final NestedTestRecord nestedTestRecord = new NestedTestRecord();
+                        nestedTestRecord.setOuterAttribOne("id-value-" + i);
+                        nestedTestRecord.setSort(i);
+                        final InnerAttributeRecord innerAttributeRecord = new InnerAttributeRecord();
+                        innerAttributeRecord.setAttribOne("attribOne-"+i);
+                        innerAttributeRecord.setAttribTwo(i);
+                        nestedTestRecord.setInnerAttributeRecord(innerAttributeRecord);
+                        return nestedTestRecord;
+                    })
+                    .collect(Collectors.toList());
+
+
     private DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
                                                                           .dynamoDbClient(getDynamoDbClient())
                                                                           .build();
 
     private DynamoDbTable<Record> mappedTable = enhancedClient.table(getConcreteTableName("table-name"), TABLE_SCHEMA);
 
+    private DynamoDbTable<NestedTestRecord> mappedNestedTable = enhancedClient.table(getConcreteTableName("nested-table-name"),
+            TableSchema.fromClass(NestedTestRecord.class));
+
     private void insertRecords() {
         RECORDS.forEach(record -> mappedTable.putItem(r -> r.item(record)));
+        NESTED_TEST_RECORDS.forEach(nestedTestRecord -> mappedNestedTable.putItem(r -> r.item(nestedTestRecord)));
+
     }
 
     @Before
     public void createTable() {
         mappedTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+        mappedNestedTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
     }
 
     @After
     public void deleteTable() {
         getDynamoDbClient().deleteTable(DeleteTableRequest.builder()
                                                           .tableName(getConcreteTableName("table-name"))
+                                                          .build());
+        getDynamoDbClient().deleteTable(DeleteTableRequest.builder()
+                                                          .tableName(getConcreteTableName("nested-table-name"))
                                                           .build());
     }
 
@@ -221,6 +247,152 @@ public class BasicScanTest extends LocalDynamoDbSyncTestBase {
         assertThat(record.id, is(nullValue()));
         assertThat(record.sort, is(3));
     }
+
+    @Test
+    public void scanAllRecordsWithFilterAndNestedProjectionSingleAttribute() {
+        insertRecords();
+        Map<String, AttributeValue> expressionValues = new HashMap<>();
+        expressionValues.put(":min_value", numberValue(3));
+        expressionValues.put(":max_value", numberValue(5));
+        Expression expression = Expression.builder()
+                .expression("#sort >= :min_value AND #sort <= :max_value")
+                .expressionValues(expressionValues)
+                .putExpressionName("#sort", "sort")
+                .build();
+
+
+        final Map<String, String> nameMap = new HashMap<>();
+        nameMap.put("#inner", "innerAttributeRecord");
+        nameMap.put("#attribOne", "attribOne");
+        Iterator<Page<NestedTestRecord>> results =
+                mappedNestedTable.scan(
+                        ScanEnhancedRequest.builder()
+                                .filterExpression(expression)
+                                .attributesToProject("#inner.#attribOne")
+                                .attributesToProjectExpressionNames(nameMap)
+                                .build()
+                ).iterator();
+
+        assertThat(results.hasNext(), is(true));
+        Page<NestedTestRecord> page = results.next();
+        assertThat(results.hasNext(), is(false));
+        assertThat(page.items().size(), is(3));
+        Collections.sort(page.items(), (item1, item2) ->
+                item1.getInnerAttributeRecord().getAttribOne()
+        .compareTo(item2.getInnerAttributeRecord().getAttribOne()));
+        NestedTestRecord firstRecord = page.items().get(0);
+        assertThat(firstRecord.getOuterAttribOne(), is(nullValue()));
+        assertThat(firstRecord.getSort(), is(nullValue()));
+        assertThat(firstRecord.getInnerAttributeRecord().getAttribOne(), is("attribOne-3"));
+        assertThat(firstRecord.getInnerAttributeRecord().getAttribTwo(), is(nullValue()));
+    }
+
+    @Test
+    public void scanAllRecordsWithFilterAndNestedProjectionMultipleAttribute() {
+        insertRecords();
+        Map<String, AttributeValue> expressionValues = new HashMap<>();
+        expressionValues.put(":min_value", numberValue(3));
+        expressionValues.put(":max_value", numberValue(5));
+        Expression expression = Expression.builder()
+                .expression("#sort >= :min_value AND #sort <= :max_value")
+                .expressionValues(expressionValues)
+                .putExpressionName("#sort", "sort")
+                .build();
+
+        final Map<String, String> nameMap = new HashMap<>();
+        nameMap.put("#inner", "innerAttributeRecord");
+        nameMap.put("#attribOne", "attribOne");
+        Iterator<Page<NestedTestRecord>> results =
+                mappedNestedTable.scan(
+                        ScanEnhancedRequest.builder()
+                                .filterExpression(expression)
+                                .attributesToProject("#inner.#attribOne","outerAttribOne","#inner.attribTwo")
+                                .attributesToProjectExpressionNames(nameMap)
+                                .build()
+                ).iterator();
+
+
+        assertThat(results.hasNext(), is(true));
+        Page<NestedTestRecord> page = results.next();
+        assertThat(results.hasNext(), is(false));
+        assertThat(page.items().size(), is(3));
+        Collections.sort(page.items(), (item1, item2) ->
+                item1.getInnerAttributeRecord().getAttribOne()
+                        .compareTo(item2.getInnerAttributeRecord().getAttribOne()));
+        NestedTestRecord firstRecord = page.items().get(0);
+        assertThat(firstRecord.getOuterAttribOne(), is("id-value-3"));
+        assertThat(firstRecord.getSort(), is(nullValue()));
+        assertThat(firstRecord.getInnerAttributeRecord().getAttribOne(), is("attribOne-3"));
+        assertThat(firstRecord.getInnerAttributeRecord().getAttribTwo(), is(3));
+
+    }
+
+    @Test
+    public void scanAllRecordsWithNestedProjectionNamesNotInNameMa() {
+        insertRecords();
+        Map<String, AttributeValue> expressionValues = new HashMap<>();
+        expressionValues.put(":min_value", numberValue(3));
+        expressionValues.put(":max_value", numberValue(5));
+        Expression expression = Expression.builder()
+                .expression("#sort >= :min_value AND #sort <= :max_value")
+                .expressionValues(expressionValues)
+                .putExpressionName("#sort", "sort")
+                .build();
+
+        final Map<String, String> nameMap = new HashMap<>();
+        nameMap.put("#nonExistent", "nonExistentSlot");
+
+        Iterator<Page<NestedTestRecord>> results =
+                mappedNestedTable.scan(
+                        ScanEnhancedRequest.builder()
+                                .filterExpression(expression)
+                                .attributesToProject("#nonExistent").attributesToProjectExpressionNames(nameMap)
+                                .build()
+                ).iterator();
+        assertThat(results.hasNext(), is(true));
+        Page<NestedTestRecord> page = results.next();
+        assertThat(results.hasNext(), is(false));
+        assertThat(page.items().size(), is(3));
+        NestedTestRecord firstRecord = page.items().get(0);
+        assertThat(firstRecord, is(nullValue()));
+    }
+
+    @Test
+    public void scanAllRecordsWithNestedProjectionNameEmptyNameMap() {
+        insertRecords();
+        Map<String, AttributeValue> expressionValues = new HashMap<>();
+        expressionValues.put(":min_value", numberValue(3));
+        expressionValues.put(":max_value", numberValue(5));
+        Expression expression = Expression.builder()
+                .expression("#sort >= :min_value AND #sort <= :max_value")
+                .expressionValues(expressionValues)
+                .putExpressionName("#sort", "sort")
+                .build();
+
+        final Map<String, String> nameMap = new HashMap<>();
+
+        Iterator<Page<NestedTestRecord>> results =
+                mappedNestedTable.scan(
+                        ScanEnhancedRequest.builder()
+                                .filterExpression(expression)
+                                .attributesToProject("innerAttributeRecord").attributesToProjectExpressionNames(nameMap)
+                                .build()
+                ).iterator();
+        assertThat(results.hasNext(), is(true));
+        Page<NestedTestRecord> page = results.next();
+        assertThat(results.hasNext(), is(false));
+        assertThat(page.items().size(), is(3));
+        Collections.sort(page.items(), (item1, item2) ->
+                item1.getInnerAttributeRecord().getAttribOne()
+                        .compareTo(item2.getInnerAttributeRecord().getAttribOne()));
+
+        NestedTestRecord firstRecord = page.items().get(0);
+        assertThat(firstRecord.getOuterAttribOne(), is(nullValue()));
+        assertThat(firstRecord.getSort(), is(nullValue()));
+        assertThat(firstRecord.getInnerAttributeRecord().getAttribOne(), is("attribOne-3"));
+        assertThat(firstRecord.getInnerAttributeRecord().getAttribTwo(), is(3));
+    }
+
 
     @Test
     public void scanLimit() {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/InnerAttribConverter.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/InnerAttribConverter.java
@@ -1,0 +1,84 @@
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
+
+/**
+ * Event Payload Converter to save the record on the class
+ */
+public class InnerAttribConverter<T> implements AttributeConverter<T> {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * This No Args constuctor is needed by the DynamoDbConvertedBy annotation
+     */
+    public InnerAttribConverter() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        final AttributeValue dd = stringValue("dd");
+        System.out.println(dd);
+        AttributeConverter<String> attributeConverter = null;
+        AttributeValueType attributeValueType = null;
+
+        EnhancedType enhancedType = null;
+        System.out.println(enhancedType);
+        // add this to preserve the same offset (don't convert to UTC)
+        this.objectMapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+    }
+
+        @Override
+    public AttributeValue transformFrom(final T input) {
+
+        Map<String, AttributeValue> map = null;
+        if (input != null) {
+            map = new HashMap<>();
+            InnerAttributeRecord innerAttributeRecord = (InnerAttributeRecord) input;
+            if (innerAttributeRecord.getAttribOne() != null) {
+
+                final AttributeValue attributeValue = stringValue(innerAttributeRecord.getAttribOne());
+                map.put("attribOne", stringValue(innerAttributeRecord.getAttribOne()));
+            }
+            if (innerAttributeRecord.getAttribTwo() != null) {
+                map.put("attribTwo", stringValue(String.valueOf(innerAttributeRecord.getAttribTwo())));
+            }
+        }
+        return AttributeValue.builder().m(map).build();
+
+    }
+
+    @Override
+    public T transformTo(final AttributeValue attributeValue) {
+        InnerAttributeRecord innerMetadata = new InnerAttributeRecord();
+        if (attributeValue.m().get("attribOne") != null) {
+            innerMetadata.setAttribOne(attributeValue.m().get("attribOne").s());
+        }
+        if (attributeValue.m().get("attribTwo") != null) {
+            innerMetadata.setAttribTwo(Integer.valueOf(attributeValue.m().get("attribTwo").s()));
+        }
+        return (T) innerMetadata;
+    }
+
+    @Override
+    public EnhancedType<T> type() {
+        return (EnhancedType<T>) EnhancedType.of(InnerAttributeRecord.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.S;
+    }
+
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/InnerAttribConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/InnerAttribConverterProvider.java
@@ -1,0 +1,18 @@
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+
+/**
+ * Event Payload Converter to save the record on the class
+ */
+public class InnerAttribConverterProvider<T> implements AttributeConverterProvider {
+
+
+    @Override
+    public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+        return new InnerAttribConverter<T>();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/InnerAttributeRecord.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/InnerAttributeRecord.java
@@ -1,0 +1,34 @@
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+
+public class InnerAttributeRecord {
+    private String attribOne;
+    private Integer attribTwo;
+
+    @DynamoDbPartitionKey
+    public String getAttribOne() {
+        return attribOne;
+    }
+
+    public void setAttribOne(String attribOne) {
+        this.attribOne = attribOne;
+    }
+
+    public Integer getAttribTwo() {
+        return attribTwo;
+    }
+
+    public void setAttribTwo(Integer attribTwo) {
+        this.attribTwo = attribTwo;
+    }
+
+    @Override
+    public String toString() {
+        return "InnerAttributeRecord{" +
+                "attribOne='" + attribOne + '\'' +
+                ", attribTwo=" + attribTwo +
+                '}';
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/NestedTestRecord.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/NestedTestRecord.java
@@ -1,0 +1,51 @@
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+
+@DynamoDbBean
+public class NestedTestRecord {
+    private String outerAttribOne;
+    private Integer sort;
+    private InnerAttributeRecord innerAttributeRecord;
+
+    @DynamoDbPartitionKey
+    public String getOuterAttribOne() {
+        return outerAttribOne;
+    }
+
+    public void setOuterAttribOne(String outerAttribOne) {
+        this.outerAttribOne = outerAttribOne;
+    }
+
+    @DynamoDbSortKey
+    public Integer getSort() {
+        return sort;
+    }
+
+    public void setSort(Integer sort) {
+        this.sort = sort;
+    }
+
+    @DynamoDbConvertedBy(InnerAttribConverter.class)
+    public InnerAttributeRecord getInnerAttributeRecord() {
+        return innerAttributeRecord;
+    }
+
+    public void setInnerAttributeRecord(InnerAttributeRecord innerAttributeRecord) {
+        this.innerAttributeRecord = innerAttributeRecord;
+    }
+
+
+    @Override
+    public String toString() {
+        return "NestedTestRecord{" +
+                "outerAttribOne='" + outerAttribOne + '\'' +
+                ", outerAttribTwo='" + sort + '\'' +
+                ", innerAttributeRecord=" + innerAttributeRecord +
+                '}';
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description  DDB Enhanced: Added support for Nested objects projection expressions [BugReportLink](https://github.com/aws/aws-sdk-java-v2/commit/8b85f34e829b5774aae758352818ab570cfc45f5)
<!--- Describe your changes in detail -->

## Motivation and Context
- [DDB Enhanced: Added support for projection expression #1756](https://github.com/aws/aws-sdk-java-v2/pull/1756) missed out to support projecting Nested Attributes
- with this fix we can project Nested atributes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

### Root Cause
-  [BugReportLink](https://github.com/aws/aws-sdk-java-v2/commit/8b85f34e829b5774aae758352818ab570cfc45f5) Didnot support the nested queries
- DDB expects the DOT or special characters as Expression. 
- Support for expression was not initially provided by implementing "attributeToProject"

### Fix
- In order to pass nested attribs we need to mention the attributesToProject as DOT, we need to create expressions seperated by DOTS.
- Refer [developerguide-Link](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html#Expressions.ExpressionAttributeNames.NestedAttributes) for more details.
#### Why have we created a new parameter called attributesToProjectExpressionNames and not used expressionAttributeNames of ```software.amazon.awssdk.services.dynamodb.model.QueryRequest``` ?
- The expressionAttributeNames of QueryRequest is internally used for Filter Expression in QueryConditional in QueryEnhancedRequest. We cannot expose this directly as a part pf QueryEnhancedRequest parameters. Thus we have provided a decicated name map for parameters used in attributesToProject.



## Testing

- Connected to DDb and tested for Nested attributes
- Junit for Single Nested Attribute projection

```
attributesToProjectExpressionNames (("#attribOne", "attribOne") , "#attribOne", "attribOne");
attributesToProject("#inner.#attribOne")

```

- Junit for Multiple Nested Attribute projection and one outer Atrribute

```
attributesToProjectExpressionNames (("#inner", "innerAttributeRecord") , "#attribOne", "attribOne");
attributesToProject(#inner.#attribOne","outerAttribOne","#inner.attribTwo")

```

- Junit for Attribute that doenot exsist

```
attributesToProjectExpressionNames (("#nonExistent", "nonExistentSlot") ;
attributesToProject("#nonExistent")

```


- Junit for Empty expression name Map

```
attributesToProjectExpressionNames ( new HashMap<>()) ;
attributesToProject("innerAttributeRecord")

```
This case is same as attributesToProjectExpressionNames not specified or null.


<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
