### PR TITLE
Append User-Agent for Waiters operations

### DIFF
--- a/services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/waiters/AutoScalingWaiterTest.java
+++ b/services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/waiters/AutoScalingWaiterTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.autoscaling.waiters;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.services.autoscaling.model.LifecycleState.IN_SERVICE;
@@ -68,7 +69,7 @@ public class AutoScalingWaiterTest {
                                                                                      i -> i.lifecycleState(IN_SERVICE)))
                                              .build();
 
-        when(client.describeAutoScalingGroups(request)).thenReturn(response1, response2);
+        when(client.describeAutoScalingGroups(any(DescribeAutoScalingGroupsRequest.class))).thenReturn(response1, response2);
 
         AutoScalingWaiter waiter = AutoScalingWaiter.builder()
                                                     .pollingStrategy(PollingStrategy.builder()

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/WaitersUserAgentTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/WaitersUserAgentTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbAsyncWaiter;
+import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
+
+public class WaitersUserAgentTest {
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(options().notifier(new ConsoleNotifier(true)).dynamicHttpsPort());
+
+    private DynamoDbClient dynamoDbClient;
+    private DynamoDbAsyncClient dynamoDbAsyncClient;
+    private ExecutionInterceptor interceptor;
+
+    @Before
+    public void setup() {
+        interceptor = Mockito.spy(AbstractExecutionInterceptor.class);
+
+        dynamoDbClient = DynamoDbClient.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test",
+                                                                                                                        "test")))
+                                       .region(Region.US_WEST_2)
+                                       .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
+                                       .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor))
+                                       .build();
+
+        dynamoDbAsyncClient = DynamoDbAsyncClient.builder()
+                                                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials
+                                                                                                           .create("test",
+                                                                                                                   "test")))
+                                                 .region(Region.US_WEST_2)
+                                                 .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
+                                                 .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor))
+                                                 .build();
+    }
+
+    @Test
+    public void syncWaiters_shouldHaveWaitersUserAgent() {
+        stubFor(any(urlEqualTo("/")).willReturn(aResponse().withStatus(500)));
+
+        DynamoDbWaiter waiter = dynamoDbClient.waiter();
+        assertThatThrownBy(() -> waiter.waitUntilTableExists(DescribeTableRequest.builder().tableName("table").build())).isNotNull();
+
+        ArgumentCaptor<Context.BeforeTransmission> context = ArgumentCaptor.forClass(Context.BeforeTransmission.class);
+        Mockito.verify(interceptor).beforeTransmission(context.capture(), Matchers.any());
+
+        assertTrue(context.getValue().httpRequest().headers().get("User-Agent").toString().contains("waiter"));
+    }
+
+    @Test
+    public void asyncWaiters_shouldHaveWaitersUserAgent() {
+        DynamoDbAsyncWaiter waiter = dynamoDbAsyncClient.waiter();
+        CompletableFuture<WaiterResponse<DescribeTableResponse>> responseFuture = waiter.waitUntilTableExists(DescribeTableRequest.builder().tableName("table").build());
+
+        ArgumentCaptor<Context.BeforeTransmission> context = ArgumentCaptor.forClass(Context.BeforeTransmission.class);
+        Mockito.verify(interceptor).beforeTransmission(context.capture(), Matchers.any());
+
+        assertTrue(context.getValue().httpRequest().headers().get("User-Agent").toString().contains("waiter"));
+
+        responseFuture.cancel(true);
+    }
+
+    public static abstract class AbstractExecutionInterceptor implements ExecutionInterceptor {
+        @Override
+        public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+            throw new RuntimeException("Interrupting the request.");
+        }
+    }
+}

--- a/services/ecs/src/it/java/software/amazon/awssdk/services/ecs/waiters/EcsWaiterTest.java
+++ b/services/ecs/src/it/java/software/amazon/awssdk/services/ecs/waiters/EcsWaiterTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.ecs.waiters;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +58,7 @@ public class EcsWaiterTest {
                                                     .runningCount(2))
                                     .build();
 
-        when(client.describeServices(request)).thenReturn(response1, response2);
+        when(client.describeServices(any(DescribeServicesRequest.class))).thenReturn(response1, response2);
 
         EcsWaiter waiter = EcsWaiter.builder()
                                     .pollingStrategy(PollingStrategy.builder()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, there is no signs for Waiters in the ```User-Agent``` header, and to track the usage of waiters, we should append a specific user agent for waiters in the header.

## Description
<!--- Describe your changes in detail -->
The ```codegen``` module is modified, adding the method appending userAgent for waiters in all the operations related to the waiters.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The generated dynamodb client is tested with the waiters. There are two WireMock tests verifying if the requests triggered by the waiters include the ```WAITERS``` user agent in them.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
