### PR TITLE
Parse XML errors like in S3

### DIFF
--- a/.changes/next-release/bugfix-AWSS3Control-1ad7752.json
+++ b/.changes/next-release/bugfix-AWSS3Control-1ad7752.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS S3 Control", 
+    "type": "bugfix", 
+    "description": "Changes document error root definition for XML based errors to same as AWS S3, so that errors are fully parsed."
+}

--- a/services/s3control/pom.xml
+++ b/services/s3control/pom.xml
@@ -78,5 +78,10 @@
             <version>${awsjavasdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/s3control/src/main/resources/codegen-resources/customization.config
+++ b/services/s3control/src/main/resources/codegen-resources/customization.config
@@ -3,5 +3,6 @@
     "customResponseMetadata": {
         "EXTENDED_REQUEST_ID": "x-amz-id-2",
         "REQUEST_ID": "x-amz-request-id"
-    }
+    },
+    "customProtocolFactoryFqcn": "software.amazon.awssdk.protocols.xml.AwsS3ProtocolFactory"
 }

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/functionaltests/CreateJobFunctionalTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/functionaltests/CreateJobFunctionalTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3control.functionaltests;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.util.concurrent.CompletionException;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
+import software.amazon.awssdk.services.s3control.S3ControlClient;
+import software.amazon.awssdk.services.s3control.S3ControlClientBuilder;
+import software.amazon.awssdk.services.s3control.model.S3ControlException;
+
+public class CreateJobFunctionalTest {
+
+    private static final URI HTTP_LOCALHOST_URI = URI.create("http://localhost:8080/");
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule();
+
+    private S3ControlClientBuilder getSyncClientBuilder() {
+        return S3ControlClient.builder()
+                              .region(Region.US_EAST_1)
+                              .overrideConfiguration(c -> c.addExecutionInterceptor(new LocalhostEndpointAddressInterceptor()))
+                              .credentialsProvider(
+                                  StaticCredentialsProvider.create(
+                                      AwsBasicCredentials.create("key", "secret")));
+    }
+
+    private S3ControlAsyncClientBuilder getAsyncClientBuilder() {
+        return S3ControlAsyncClient.builder()
+                                   .region(Region.US_EAST_1)
+                                   .overrideConfiguration(c -> c.addExecutionInterceptor(new LocalhostEndpointAddressInterceptor()))
+                                   .credentialsProvider(
+                                       StaticCredentialsProvider.create(
+                                           AwsBasicCredentials.create("key", "secret")));
+    }
+
+    @Test
+    public void createJob_syncClient_errorInResponseBody_correct() {
+        String accountId = "Account-Id";
+        String xmlResponseBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                 + "<Error>\n"
+                                 + "<Code>InvalidRequest</Code>\n"
+                                 + "<Message>Missing role arn</Message>\n"
+                                 + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                                 + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                                 + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(xmlResponseBody)));
+
+        S3ControlClient s3Client = getSyncClientBuilder().build();
+
+        assertThatThrownBy(() -> s3Client.createJob(r -> r.accountId(accountId)))
+            .isInstanceOf(S3ControlException.class)
+            .satisfies(e -> assertThat(((S3ControlException) e).awsErrorDetails().errorCode()).isEqualTo("InvalidRequest"))
+            .satisfies(e -> assertThat(((S3ControlException) e).awsErrorDetails().errorMessage()).isEqualTo("Missing role arn"));
+    }
+
+    @Test
+    public void createJob_asyncClient_errorInResponseBody_correct() {
+        String accountId = "Account-Id";
+        String xmlResponseBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                 + "<Error>\n"
+                                 + "<Code>InvalidRequest</Code>\n"
+                                 + "<Message>Missing role arn</Message>\n"
+                                 + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                                 + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                                 + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(xmlResponseBody)));
+
+        S3ControlAsyncClient s3Client = getAsyncClientBuilder().build();
+
+        assertThatThrownBy(() -> s3Client.createJob(r -> r.accountId(accountId)).join())
+            .isInstanceOf(CompletionException.class)
+            .hasCauseInstanceOf(S3ControlException.class)
+            .satisfies(e -> {
+                S3ControlException s3ControlException = (S3ControlException) e.getCause();
+                assertThat(s3ControlException.awsErrorDetails().errorCode()).isEqualTo("InvalidRequest");
+                assertThat(s3ControlException.awsErrorDetails().errorMessage()).isEqualTo("Missing role arn");
+            });
+    }
+
+    private static final class LocalhostEndpointAddressInterceptor implements ExecutionInterceptor {
+
+        @Override
+        public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+            return context.httpRequest()
+                          .toBuilder()
+                          .protocol(HTTP_LOCALHOST_URI.getScheme())
+                          .host(HTTP_LOCALHOST_URI.getHost())
+                          .port(HTTP_LOCALHOST_URI.getPort())
+                          .build();
+        }
+    }
+
+}

--- a/services/s3control/src/test/resources/log4j.properties
+++ b/services/s3control/src/test/resources/log4j.properties
@@ -1,0 +1,33 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+log4j.rootLogger=WARN, A1
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+
+# Print the date in ISO 8601 format
+log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+# Adjust to see more / less logging
+#log4j.logger.com.amazonaws.ec2=DEBUG
+
+# HttpClient 3 Wire Logging
+#log4j.logger.httpclient.wire=DEBUG
+
+# HttpClient 4 Wire Logging
+#log4j.logger.org.apache.http.wire=DEBUG
+#log4j.logger.org.apache.http=DEBUG
+#log4j.logger.org.apache.http.wire=WARN
+#log4j.logger.software.amazon.awssdk=DEBUG


### PR DESCRIPTION
Changes the definition of the document error root to what is used in AWS S3, so that errors are fully parsed. 

## Motivation and Context
To this point, errors returned from S3Control have lost their XML content and only the error type has been returned, showing null: 
~~~
software.amazon.awssdk.services.s3control.model.S3ControlException: null
~~~
With this change, errors are parsed correctly as:
~~~
software.amazon.awssdk.services.s3control.model.S3ControlException: Missing role arn 
(Service: S3Control, Status Code: 400, Request ID: 4T5H9GEV7H3K9MCJ, Extended Request ID: USkN9APZoEVT0...)
~~~

## Testing
- Unit tests and functional tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
