### PR TITLE
Upgrade Netty 4.1.52.Final, OpenSsl 2.0.34.Final

### DIFF
--- a/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/archetype.properties
+++ b/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/archetype.properties
@@ -7,4 +7,4 @@ httpClient=apache-client
 handlerClassName=MyApacheFunction
 region=null
 javaSdkVersion=2.11.0
-nettyOpenSslVersion=2.0.29.Final
+nettyOpenSslVersion=2.0.34.Final

--- a/archetypes/archetype-lambda/src/test/resources/projects/dynamodbstreamsclient/archetype.properties
+++ b/archetypes/archetype-lambda/src/test/resources/projects/dynamodbstreamsclient/archetype.properties
@@ -22,4 +22,4 @@ httpClient=apache-client
 handlerClassName=MyDynamoDbStreamsFunction
 region=ap-southeast-1
 javaSdkVersion=2.11.0
-nettyOpenSslVersion=2.0.29.Final
+nettyOpenSslVersion=2.0.34.Final

--- a/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/archetype.properties
+++ b/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/archetype.properties
@@ -7,5 +7,5 @@ httpClient=netty-nio-client
 handlerClassName=MyNettyFunction
 region=us-east-1
 javaSdkVersion=2.11.0
-nettyOpenSslVersion=2.0.29.Final
+nettyOpenSslVersion=2.0.34.Final
 

--- a/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/reference/pom.xml
@@ -16,7 +16,7 @@
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
         <junit5.version>5.4.2</junit5.version>
-        <netty.openssl.version>2.0.29.Final</netty.openssl.version>
+        <netty.openssl.version>2.0.34.Final</netty.openssl.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-lambda/src/test/resources/projects/urlhttpclient/archetype.properties
+++ b/archetypes/archetype-lambda/src/test/resources/projects/urlhttpclient/archetype.properties
@@ -7,4 +7,4 @@ httpClient=url-connection-client
 handlerClassName=App
 region=us-west-2
 javaSdkVersion=2.11.0
-nettyOpenSslVersion=2.0.29.Final
+nettyOpenSslVersion=2.0.34.Final

--- a/archetypes/archetype-lambda/src/test/resources/projects/wafregionalclient/archetype.properties
+++ b/archetypes/archetype-lambda/src/test/resources/projects/wafregionalclient/archetype.properties
@@ -22,4 +22,4 @@ httpClient=apache-client
 handlerClassName=MyWafRegionalFunction
 region=ap-southeast-1
 javaSdkVersion=2.11.0
-nettyOpenSslVersion=2.0.29.Final
+nettyOpenSslVersion=2.0.34.Final

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <equalsverifier.version>3.1.13</equalsverifier.version>
         <!-- Update netty-open-ssl-version accordingly whenever we update netty version-->
         <!-- https://github.com/netty/netty/blob/4.1/pom.xml#L286 -->
-        <netty.version>4.1.46.Final</netty.version>
+        <netty.version>4.1.52.Final</netty.version>
         <unitils.version>3.3</unitils.version>
         <xmlunit.version>1.3</xmlunit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -122,12 +122,12 @@
         <jimfs.version>1.1</jimfs.version>
         <testng.version>7.1.0</testng.version> <!-- TCK Tests -->
         <commons-lang.verson>2.3</commons-lang.verson>
-        <netty-open-ssl-version>2.0.29.Final</netty-open-ssl-version>
+        <netty-open-ssl-version>2.0.34.Final</netty-open-ssl-version>
         <dynamodb-local.version>1.11.477</dynamodb-local.version>
         <sqllite.version>1.0.392</sqllite.version>
 
         <!-- build plugin dependencies-->
-        <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
- Update Netty to 4.1.52 and OpenSsl to 2.0.34.Final which includes both security fixes and AArch64 performance improvements
- Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/09/08/4-1-52-Final.html
- Upgraded surefire to 3.0.0-M5 due to compatibility