### PR TITLE
Add consumer builder overload methods

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/WaiterDocs.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/WaiterDocs.java
@@ -85,6 +85,17 @@ public final class WaiterDocs {
                         .build();
     }
 
+    public static CodeBlock waiterCreateMethodJavadoc(ClassName className) {
+        String javadocs = new DocumentationBuilder()
+            .description("Create an instance of {@link $T} with the default configuration")
+            .returns("an instance of {@link $T}")
+            .build();
+
+        return CodeBlock.builder()
+                        .add(javadocs, className, className)
+                        .build();
+    }
+
     public static CodeBlock waiterBuilderPollingStrategy() {
         String javadocs = new DocumentationBuilder()
             .description("Defines a {@link $T} to use when polling a resource")

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/WaiterDocs.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/WaiterDocs.java
@@ -51,6 +51,29 @@ public final class WaiterDocs {
 
     }
 
+    public static CodeBlock waiterOperationConsumerBuilderJavadoc(ClassName clientClassName,
+                                                                  ClassName requestClassName,
+                                                                  Map.Entry<String, WaiterDefinition> waiterDefinition,
+                                                                  OperationModel operationModel) {
+        String javadocs = new DocumentationBuilder().description("Polls {@link $T#$N} API until the desired condition "
+                                                                 + "{@code $N} is met, "
+                                                                 + "or until it is determined that the resource will never "
+                                                                 + "enter into the desired state. \n "
+                                                                 + "<p>This is a convenience method to create an instance of "
+                                                                 + "the request builder without the need "
+                                                                 + "to create one manually using {@link $T.builder()} ")
+                                                    .param(operationModel.getInput().getVariableName(), "the request to be used"
+                                                                                                        + " for polling")
+                                                    .returns("WaiterResponse containing either a response or an exception that "
+                                                             + "has matched with the waiter success condition")
+                                                    .build();
+        return CodeBlock.builder()
+                        .add(javadocs, clientClassName, operationModel.getMethodName(), waiterDefinition.getKey(),
+                             requestClassName)
+                        .build();
+
+    }
+
     public static CodeBlock waiterBuilderMethodJavadoc(ClassName className) {
         String javadocs = new DocumentationBuilder()
             .description("Create a builder that can be used to configure and create a {@link $T}.")
@@ -71,6 +94,21 @@ public final class WaiterDocs {
 
         return CodeBlock.builder()
                         .add(javadocs, ClassName.get(PollingStrategy.class))
+                        .build();
+    }
+
+    public static CodeBlock waiterBuilderPollingStrategyConsumerBuilder() {
+        String javadocs = new DocumentationBuilder()
+            .description("This is a convenient method to pass the configuration of the {@link $T} without the need to "
+                         + "create an instance manually via {@link $T.builder()}")
+            .param("pollingStrategy", "the polling strategy to set")
+            .see("#pollingStrategy(PollingStrategy)")
+            .returns("a reference to this object so that method calls can be chained together.")
+            .build();
+
+        return CodeBlock.builder()
+                        .add(javadocs, ClassName.get(PollingStrategy.class),
+                             ClassName.get(PollingStrategy.class))
                         .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/BaseWaiterInterfaceSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/BaseWaiterInterfaceSpec.java
@@ -65,6 +65,12 @@ public abstract class BaseWaiterInterfaceSpec implements ClassSpec {
                                    .returns(className().nestedClass("Builder"))
                                    .addStatement("return $T.builder()", waiterImplName())
                                    .build());
+        result.addMethod(MethodSpec.methodBuilder("create")
+                                   .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                                   .addJavadoc(WaiterDocs.waiterCreateMethodJavadoc(className()))
+                                   .returns(className())
+                                   .addStatement("return $T.builder().build()", waiterImplName())
+                                   .build());
         result.addJavadoc(WaiterDocs.waiterInterfaceJavadoc());
 
         result.addType(builderInterface());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-interface.java
@@ -2,6 +2,7 @@ package software.amazon.awssdk.services.query.waiters;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.waiters.PollingStrategy;
@@ -30,6 +31,23 @@ public interface QueryAsyncWaiter extends SdkAutoCloseable {
     default CompletableFuture<WaiterResponse<APostOperationResponse>> waitUntilPostOperationSuccess(
         APostOperationRequest aPostOperationRequest) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Polls {@link QueryAsyncClient#aPostOperation} API until the desired condition {@code PostOperationSuccess} is
+     * met, or until it is determined that the resource will never enter into the desired state.
+     * <p>
+     * This is a convenience method to create an instance of the request builder without the need to create one manually
+     * using {@link APostOperationRequest.builder()}
+     *
+     * @param aPostOperationRequest
+     *        the request to be used for polling
+     * @return WaiterResponse containing either a response or an exception that has matched with the waiter success
+     *         condition
+     */
+    default CompletableFuture<WaiterResponse<APostOperationResponse>> waitUntilPostOperationSuccess(
+        Consumer<APostOperationRequest.Builder> aPostOperationRequest) {
+        return waitUntilPostOperationSuccess(APostOperationRequest.builder().applyMutation(aPostOperationRequest).build());
     }
 
     /**
@@ -62,6 +80,21 @@ public interface QueryAsyncWaiter extends SdkAutoCloseable {
          * @return a reference to this object so that method calls can be chained together.
          */
         Builder pollingStrategy(PollingStrategy pollingStrategy);
+
+        /**
+         * This is a convenient method to pass the configuration of the {@link PollingStrategy} without the need to
+         * create an instance manually via {@link PollingStrategy.builder()}
+         *
+         * @param pollingStrategy
+         *        the polling strategy to set
+         * @return a reference to this object so that method calls can be chained together.
+         * @see #pollingStrategy(PollingStrategy)
+         */
+        default Builder pollingStrategy(Consumer<PollingStrategy.Builder> pollingStrategy) {
+            PollingStrategy.Builder builder = PollingStrategy.builder();
+            pollingStrategy.accept(builder);
+            return pollingStrategy(builder.build());
+        }
 
         /**
          * Sets a custom {@link QueryAsyncClient} that will be used to pool the resource

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-interface.java
@@ -59,6 +59,15 @@ public interface QueryAsyncWaiter extends SdkAutoCloseable {
         return DefaultQueryAsyncWaiter.builder();
     }
 
+    /**
+     * Create an instance of {@link QueryAsyncWaiter} with the default configuration
+     *
+     * @return an instance of {@link QueryAsyncWaiter}
+     */
+    static QueryAsyncWaiter create() {
+        return DefaultQueryAsyncWaiter.builder().build();
+    }
+
     interface Builder {
         /**
          * Sets a custom {@link ScheduledExecutorService} that will be used to schedule async polling attempts

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-interface.java
@@ -1,5 +1,6 @@
 package software.amazon.awssdk.services.query.waiters;
 
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.waiters.PollingStrategy;
@@ -30,6 +31,23 @@ public interface QueryWaiter extends SdkAutoCloseable {
     }
 
     /**
+     * Polls {@link QueryClient#aPostOperation} API until the desired condition {@code PostOperationSuccess} is met, or
+     * until it is determined that the resource will never enter into the desired state.
+     * <p>
+     * This is a convenience method to create an instance of the request builder without the need to create one manually
+     * using {@link APostOperationRequest.builder()}
+     *
+     * @param aPostOperationRequest
+     *        the request to be used for polling
+     * @return WaiterResponse containing either a response or an exception that has matched with the waiter success
+     *         condition
+     */
+    default WaiterResponse<APostOperationResponse> waitUntilPostOperationSuccess(
+        Consumer<APostOperationRequest.Builder> aPostOperationRequest) {
+        return waitUntilPostOperationSuccess(APostOperationRequest.builder().applyMutation(aPostOperationRequest).build());
+    }
+
+    /**
      * Create a builder that can be used to configure and create a {@link QueryWaiter}.
      *
      * @return a builder
@@ -47,6 +65,21 @@ public interface QueryWaiter extends SdkAutoCloseable {
          * @return a reference to this object so that method calls can be chained together.
          */
         Builder pollingStrategy(PollingStrategy pollingStrategy);
+
+        /**
+         * This is a convenient method to pass the configuration of the {@link PollingStrategy} without the need to
+         * create an instance manually via {@link PollingStrategy.builder()}
+         *
+         * @param pollingStrategy
+         *        the polling strategy to set
+         * @return a reference to this object so that method calls can be chained together.
+         * @see #pollingStrategy(PollingStrategy)
+         */
+        default Builder pollingStrategy(Consumer<PollingStrategy.Builder> pollingStrategy) {
+            PollingStrategy.Builder builder = PollingStrategy.builder();
+            pollingStrategy.accept(builder);
+            return pollingStrategy(builder.build());
+        }
 
         /**
          * Sets a custom {@link QueryClient} that will be used to pool the resource

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-interface.java
@@ -56,6 +56,15 @@ public interface QueryWaiter extends SdkAutoCloseable {
         return DefaultQueryWaiter.builder();
     }
 
+    /**
+     * Create an instance of {@link QueryWaiter} with the default configuration
+     *
+     * @return an instance of {@link QueryWaiter}
+     */
+    static QueryWaiter create() {
+        return DefaultQueryWaiter.builder().build();
+    }
+
     interface Builder {
         /**
          * Defines a {@link PollingStrategy} to use when polling a resource


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add consumer builder overload for waiter methods and pollingStrategy
- add static create method in service waiters

## Testing
updated codegen tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
