### PR TITLE
Add support for plus (+) character in profile names

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e2f5442.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e2f5442.json
@@ -1,0 +1,5 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "description": "Add support for plus (+) character in profile names"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## __AWS SDK for Java v2__
+  - ### Bugfixes
+    - The plus sign is now allowed in profile names.
+
 # __2.14.21__ __2020-09-18__
 ## __AWS CodeStar connections__
   - ### Features
@@ -8368,4 +8372,3 @@
 ## __AWS SDK for Java v2__
   - ### Features
     - Initial release of the AWS SDK for Java v2. See our [blog post](https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-0-developer-preview) for information about this new major veresion. This release is considered a developer preview and is not intended for production use cases.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## __AWS SDK for Java v2__
-  - ### Bugfixes
-    - The plus sign is now allowed in profile names.
-
 # __2.14.21__ __2020-09-18__
 ## __AWS CodeStar connections__
   - ### Features

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/ProfileFileReader.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/ProfileFileReader.java
@@ -42,7 +42,7 @@ public final class ProfileFileReader {
 
     private static final Pattern EMPTY_LINE = Pattern.compile("^[\t ]*$");
 
-    private static final Pattern VALID_IDENTIFIER = Pattern.compile("^[A-Za-z0-9_\\-/.%@:]*$");
+    private static final Pattern VALID_IDENTIFIER = Pattern.compile("^[A-Za-z0-9_\\-/.%@:\\+]*$");
 
     private ProfileFileReader() {
     }
@@ -214,7 +214,7 @@ public final class ProfileFileReader {
         // If the profile name includes invalid characters, it should be ignored.
         if (!isValidIdentifier(profileName)) {
             log.warn(() -> "Ignoring profile '" + standardizedProfileName + "' on line " + state.currentLineNumber + " because " +
-                           "it was not alphanumeric with only these special characters: - / . % @ _ :");
+                           "it was not alphanumeric with only these special characters: - / . % @ _ : +");
             return Optional.empty();
         }
 
@@ -257,7 +257,7 @@ public final class ProfileFileReader {
         // If the profile name includes invalid characters, it should be ignored.
         if (!isValidIdentifier(propertyKey)) {
             log.warn(() -> "Ignoring property '" + propertyKey + "' on line " + state.currentLineNumber + " because " +
-                           "its name was not alphanumeric with only these special characters: - / . % @ _ :");
+                           "its name was not alphanumeric with only these special characters: - / . % @ _ : +");
             return Optional.empty();
         }
 

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
@@ -326,14 +326,14 @@ public class ProfileFileTest {
 
     @Test
     public void allValidProfileNameCharactersAreSupported() {
-        assertThat(configFileProfiles("[profile ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:]"))
-            .isEqualTo(profiles(profile("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:")));
+        assertThat(configFileProfiles("[profile ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:+]"))
+            .isEqualTo(profiles(profile("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:+")));
     }
 
     @Test
     public void allValidPropertyNameCharactersAreSupported() {
-        assertThat(configFileProfiles("[profile foo]\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@: = value"))
-            .isEqualTo(profiles(profile("foo", property("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:",
+        assertThat(configFileProfiles("[profile foo]\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:+ = value"))
+            .isEqualTo(profiles(profile("foo", property("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_./%@:+",
                                                         "value"))));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

SDK doesn't support plus ('+') character in profile names. Similar to #1847 and #389.

## Description
<!--- Describe your changes in detail -->

Adds '+' character to allowed list of characters so that `ProfileFileReader` doesn't ignore profile names with '+' character in it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

When using "namespaced" profile names (e.g.: `profileBaseName+customId`) this is a hard limitation. Ideally, SDKs should support similar core features (such as handling profile names the similar way) independently of implementation language.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

## Screenshots (if appropriate)

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
