### PR TITLE
Remove runtime from no-op buildspec.

### DIFF
--- a/buildspecs/noop.yml
+++ b/buildspecs/noop.yml
@@ -1,9 +1,6 @@
 version: 0.2
 
 phases:
-  install:
-    runtime-versions:
-      java: openjdk8
   build:
     commands:
     - echo "No-op."


### PR DESCRIPTION
Runtimes aren't needed, and the runtimes available depend on the image, so we shouldn't depend on any specific runtime so that we can use the no-op buildspec on any image.