### PR TITLE
Various renaming and provide default values for waiterOverrideConfiguration

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/docs/WaiterDocs.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/docs/WaiterDocs.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.service.WaiterDefinition;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 
 public final class WaiterDocs {
 
@@ -98,28 +98,28 @@ public final class WaiterDocs {
 
     public static CodeBlock waiterBuilderPollingStrategy() {
         String javadocs = new DocumentationBuilder()
-            .description("Defines a {@link $T} to use when polling a resource")
-            .param("pollingStrategy", "the polling strategy to set")
+            .description("Defines overrides to the default SDK waiter configuration that should be used for waiters created "
+                         + "from this builder")
+            .param("overrideConfiguration", "the override configuration to set")
             .returns("a reference to this object so that method calls can be chained together.")
             .build();
 
         return CodeBlock.builder()
-                        .add(javadocs, ClassName.get(PollingStrategy.class))
+                        .add(javadocs)
                         .build();
     }
 
     public static CodeBlock waiterBuilderPollingStrategyConsumerBuilder() {
         String javadocs = new DocumentationBuilder()
-            .description("This is a convenient method to pass the configuration of the {@link $T} without the need to "
+            .description("This is a convenient method to pass the override configuration without the need to "
                          + "create an instance manually via {@link $T.builder()}")
-            .param("pollingStrategy", "the polling strategy to set")
-            .see("#pollingStrategy(PollingStrategy)")
+            .param("overrideConfiguration", "The consumer that will configure the overrideConfiguration")
+            .see("#overrideConfiguration(WaiterOverrideConfiguration)")
             .returns("a reference to this object so that method calls can be chained together.")
             .build();
 
         return CodeBlock.builder()
-                        .add(javadocs, ClassName.get(PollingStrategy.class),
-                             ClassName.get(PollingStrategy.class))
+                        .add(javadocs, ClassName.get(WaiterOverrideConfiguration.class))
                         .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -345,7 +345,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
                          .addModifiers(Modifier.PUBLIC)
                          .addAnnotation(Override.class)
                          .addStatement("return $T.builder().client(this)"
-                                       + ".executorService(executorService).build()",
+                                       + ".scheduledExecutorService(executorService).build()",
                                        poetExtensions.getAsyncWaiterInterface())
                          .returns(poetExtensions.getAsyncWaiterInterface())
                          .build();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/AsyncWaiterClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/AsyncWaiterClassSpec.java
@@ -111,7 +111,7 @@ public class AsyncWaiterClassSpec extends BaseWaiterClassSpec {
     @Override
     protected void additionalBuilderTypeSpecModification(TypeSpec.Builder type) {
         type.addField(ClassName.get(ScheduledExecutorService.class), "executorService", PRIVATE);
-        type.addMethod(MethodSpec.methodBuilder("executorService")
+        type.addMethod(MethodSpec.methodBuilder("scheduledExecutorService")
                                  .addModifiers(Modifier.PUBLIC)
                                  .addAnnotation(Override.class)
                                  .addParameter(ClassName.get(ScheduledExecutorService.class), "executorService")

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/AsyncWaiterInterfaceSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/AsyncWaiterInterfaceSpec.java
@@ -69,7 +69,7 @@ public final class AsyncWaiterInterfaceSpec extends BaseWaiterInterfaceSpec {
 
     @Override
     protected void additionalBuilderTypeSpecModification(TypeSpec.Builder type) {
-        type.addMethod(MethodSpec.methodBuilder("executorService")
+        type.addMethod(MethodSpec.methodBuilder("scheduledExecutorService")
                                  .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                                  .addParameter(ClassName.get(ScheduledExecutorService.class), "executorService")
                                  .addJavadoc(WaiterDocs.waiterBuilderScheduledExecutorServiceJavadoc())

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/BaseWaiterInterfaceSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/waiters/BaseWaiterInterfaceSpec.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.service.WaiterDefinition;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
@@ -167,23 +167,23 @@ public abstract class BaseWaiterInterfaceSpec implements ClassSpec {
 
     private List<MethodSpec> builderMethods() {
         List<MethodSpec> builderMethods = new ArrayList<>();
-        builderMethods.add(MethodSpec.methodBuilder("pollingStrategy")
+        builderMethods.add(MethodSpec.methodBuilder("overrideConfiguration")
                                      .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-                                     .addParameter(ClassName.get(PollingStrategy.class), "pollingStrategy")
+                                     .addParameter(ClassName.get(WaiterOverrideConfiguration.class), "overrideConfiguration")
                                      .addJavadoc(WaiterDocs.waiterBuilderPollingStrategy())
                                      .returns(className().nestedClass("Builder"))
                                      .build());
         ParameterizedTypeName parameterizedTypeName =
             ParameterizedTypeName.get(ClassName.get(Consumer.class),
-                                      ClassName.get(PollingStrategy.class).nestedClass("Builder"));
-        builderMethods.add(MethodSpec.methodBuilder("pollingStrategy")
+                                      ClassName.get(WaiterOverrideConfiguration.class).nestedClass("Builder"));
+        builderMethods.add(MethodSpec.methodBuilder("overrideConfiguration")
                                      .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
-                                     .addParameter(parameterizedTypeName, "pollingStrategy")
+                                     .addParameter(parameterizedTypeName, "overrideConfiguration")
                                      .addJavadoc(WaiterDocs.waiterBuilderPollingStrategyConsumerBuilder())
                                      .addStatement("$T.Builder builder = $T.builder()",
-                                                   PollingStrategy.class, PollingStrategy.class)
-                                     .addStatement("pollingStrategy.accept(builder)")
-                                     .addStatement("return pollingStrategy(builder.build())")
+                                                   WaiterOverrideConfiguration.class, WaiterOverrideConfiguration.class)
+                                     .addStatement("overrideConfiguration.accept(builder)")
+                                     .addStatement("return overrideConfiguration(builder.build())")
                                      .returns(className().nestedClass("Builder"))
                                      .build());
         builderMethods.add(MethodSpec.methodBuilder("client")

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -352,6 +352,6 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
 
     @Override
     public QueryAsyncWaiter waiter() {
-        return QueryAsyncWaiter.builder().client(this).executorService(executorService).build();
+        return QueryAsyncWaiter.builder().client(this).scheduledExecutorService(executorService).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-class.java
@@ -17,8 +17,8 @@ import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.internal.waiters.WaiterAttribute;
 import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
 import software.amazon.awssdk.core.waiters.AsyncWaiter;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.core.waiters.WaiterState;
 import software.amazon.awssdk.services.query.QueryAsyncClient;
@@ -63,11 +63,11 @@ final class DefaultQueryAsyncWaiter implements QueryAsyncWaiter {
             this.executorService = builder.executorService;
         }
         managedResources = attributeMapBuilder.build();
-        PollingStrategy postOperationSuccessStrategy = builder.pollingStrategy == null ? PollingStrategy.builder()
-                                                                                                        .maxAttempts(40).backoffStrategy(FixedDelayBackoffStrategy.create(Duration.ofSeconds(1))).build()
-                                                                                       : builder.pollingStrategy;
+        WaiterOverrideConfiguration postOperationSuccessStrategy = builder.overrideConfiguration == null ? WaiterOverrideConfiguration
+            .builder().maxAttempts(40).backoffStrategy(FixedDelayBackoffStrategy.create(Duration.ofSeconds(1))).build()
+                                                                                                         : builder.overrideConfiguration;
         this.postOperationSuccessWaiter = AsyncWaiter.builder(APostOperationResponse.class)
-                                                     .pollingStrategy(postOperationSuccessStrategy).acceptors(postOperationSuccessWaiterAcceptors())
+                                                     .overrideConfiguration(postOperationSuccessStrategy).acceptors(postOperationSuccessWaiterAcceptors())
                                                      .scheduledExecutorService(executorService).build();
     }
 
@@ -118,7 +118,7 @@ final class DefaultQueryAsyncWaiter implements QueryAsyncWaiter {
     public static final class DefaultBuilder implements QueryAsyncWaiter.Builder {
         private QueryAsyncClient client;
 
-        private PollingStrategy pollingStrategy;
+        private WaiterOverrideConfiguration overrideConfiguration;
 
         private ScheduledExecutorService executorService;
 
@@ -126,14 +126,14 @@ final class DefaultQueryAsyncWaiter implements QueryAsyncWaiter {
         }
 
         @Override
-        public QueryAsyncWaiter.Builder executorService(ScheduledExecutorService executorService) {
+        public QueryAsyncWaiter.Builder scheduledExecutorService(ScheduledExecutorService executorService) {
             this.executorService = executorService;
             return this;
         }
 
         @Override
-        public QueryAsyncWaiter.Builder pollingStrategy(PollingStrategy pollingStrategy) {
-            this.pollingStrategy = pollingStrategy;
+        public QueryAsyncWaiter.Builder overrideConfiguration(WaiterOverrideConfiguration overrideConfiguration) {
+            this.overrideConfiguration = overrideConfiguration;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-async-waiter-interface.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.services.query.QueryAsyncClient;
 import software.amazon.awssdk.services.query.model.APostOperationRequest;
@@ -79,30 +79,31 @@ public interface QueryAsyncWaiter extends SdkAutoCloseable {
          *        the executorService to set
          * @return a reference to this object so that method calls can be chained together.
          */
-        Builder executorService(ScheduledExecutorService executorService);
+        Builder scheduledExecutorService(ScheduledExecutorService executorService);
 
         /**
-         * Defines a {@link PollingStrategy} to use when polling a resource
+         * Defines overrides to the default SDK waiter configuration that should be used for waiters created from this
+         * builder
          *
-         * @param pollingStrategy
-         *        the polling strategy to set
+         * @param overrideConfiguration
+         *        the override configuration to set
          * @return a reference to this object so that method calls can be chained together.
          */
-        Builder pollingStrategy(PollingStrategy pollingStrategy);
+        Builder overrideConfiguration(WaiterOverrideConfiguration overrideConfiguration);
 
         /**
-         * This is a convenient method to pass the configuration of the {@link PollingStrategy} without the need to
-         * create an instance manually via {@link PollingStrategy.builder()}
+         * This is a convenient method to pass the override configuration without the need to create an instance
+         * manually via {@link WaiterOverrideConfiguration.builder()}
          *
-         * @param pollingStrategy
-         *        the polling strategy to set
+         * @param overrideConfiguration
+         *        The consumer that will configure the overrideConfiguration
          * @return a reference to this object so that method calls can be chained together.
-         * @see #pollingStrategy(PollingStrategy)
+         * @see #overrideConfiguration(WaiterOverrideConfiguration)
          */
-        default Builder pollingStrategy(Consumer<PollingStrategy.Builder> pollingStrategy) {
-            PollingStrategy.Builder builder = PollingStrategy.builder();
-            pollingStrategy.accept(builder);
-            return pollingStrategy(builder.build());
+        default Builder overrideConfiguration(Consumer<WaiterOverrideConfiguration.Builder> overrideConfiguration) {
+            WaiterOverrideConfiguration.Builder builder = WaiterOverrideConfiguration.builder();
+            overrideConfiguration.accept(builder);
+            return overrideConfiguration(builder.build());
         }
 
         /**

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-class.java
@@ -13,9 +13,9 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.internal.waiters.WaiterAttribute;
 import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
 import software.amazon.awssdk.core.waiters.Waiter;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.core.waiters.WaiterState;
 import software.amazon.awssdk.services.query.QueryClient;
@@ -47,11 +47,11 @@ final class DefaultQueryWaiter implements QueryWaiter {
             this.client = builder.client;
         }
         managedResources = attributeMapBuilder.build();
-        PollingStrategy postOperationSuccessStrategy = builder.pollingStrategy == null ? PollingStrategy.builder()
-                                                                                                        .maxAttempts(40).backoffStrategy(FixedDelayBackoffStrategy.create(Duration.ofSeconds(1))).build()
-                                                                                       : builder.pollingStrategy;
+        WaiterOverrideConfiguration postOperationSuccessStrategy = builder.overrideConfiguration == null ? WaiterOverrideConfiguration
+            .builder().maxAttempts(40).backoffStrategy(FixedDelayBackoffStrategy.create(Duration.ofSeconds(1))).build()
+                                                                                                         : builder.overrideConfiguration;
         this.postOperationSuccessWaiter = Waiter.builder(APostOperationResponse.class)
-                                                .pollingStrategy(postOperationSuccessStrategy).acceptors(postOperationSuccessWaiterAcceptors()).build();
+                                                .overrideConfiguration(postOperationSuccessStrategy).acceptors(postOperationSuccessWaiterAcceptors()).build();
     }
 
     private static String errorCode(Throwable error) {
@@ -100,14 +100,14 @@ final class DefaultQueryWaiter implements QueryWaiter {
     public static final class DefaultBuilder implements QueryWaiter.Builder {
         private QueryClient client;
 
-        private PollingStrategy pollingStrategy;
+        private WaiterOverrideConfiguration overrideConfiguration;
 
         private DefaultBuilder() {
         }
 
         @Override
-        public QueryWaiter.Builder pollingStrategy(PollingStrategy pollingStrategy) {
-            this.pollingStrategy = pollingStrategy;
+        public QueryWaiter.Builder overrideConfiguration(WaiterOverrideConfiguration overrideConfiguration) {
+            this.overrideConfiguration = overrideConfiguration;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/waiters/query-sync-waiter-interface.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.query.waiters;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.services.query.QueryClient;
 import software.amazon.awssdk.services.query.model.APostOperationRequest;
@@ -67,27 +67,28 @@ public interface QueryWaiter extends SdkAutoCloseable {
 
     interface Builder {
         /**
-         * Defines a {@link PollingStrategy} to use when polling a resource
+         * Defines overrides to the default SDK waiter configuration that should be used for waiters created from this
+         * builder
          *
-         * @param pollingStrategy
-         *        the polling strategy to set
+         * @param overrideConfiguration
+         *        the override configuration to set
          * @return a reference to this object so that method calls can be chained together.
          */
-        Builder pollingStrategy(PollingStrategy pollingStrategy);
+        Builder overrideConfiguration(WaiterOverrideConfiguration overrideConfiguration);
 
         /**
-         * This is a convenient method to pass the configuration of the {@link PollingStrategy} without the need to
-         * create an instance manually via {@link PollingStrategy.builder()}
+         * This is a convenient method to pass the override configuration without the need to create an instance
+         * manually via {@link WaiterOverrideConfiguration.builder()}
          *
-         * @param pollingStrategy
-         *        the polling strategy to set
+         * @param overrideConfiguration
+         *        The consumer that will configure the overrideConfiguration
          * @return a reference to this object so that method calls can be chained together.
-         * @see #pollingStrategy(PollingStrategy)
+         * @see #overrideConfiguration(WaiterOverrideConfiguration)
          */
-        default Builder pollingStrategy(Consumer<PollingStrategy.Builder> pollingStrategy) {
-            PollingStrategy.Builder builder = PollingStrategy.builder();
-            pollingStrategy.accept(builder);
-            return pollingStrategy(builder.build());
+        default Builder overrideConfiguration(Consumer<WaiterOverrideConfiguration.Builder> overrideConfiguration) {
+            WaiterOverrideConfiguration.Builder builder = WaiterOverrideConfiguration.builder();
+            overrideConfiguration.accept(builder);
+            return overrideConfiguration(builder.build());
         }
 
         /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/AsyncWaiterExecutor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/AsyncWaiterExecutor.java
@@ -24,7 +24,6 @@ import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.core.waiters.WaiterState;
@@ -42,12 +41,12 @@ public final class AsyncWaiterExecutor<T> {
     private final ScheduledExecutorService executorService;
     private final WaiterExecutorHelper<T> executorHelper;
 
-    public AsyncWaiterExecutor(PollingStrategy pollingStrategy,
+    public AsyncWaiterExecutor(WaiterConfiguration configuration,
                                List<WaiterAcceptor<? super T>> waiterAcceptors,
                                ScheduledExecutorService executorService) {
         Validate.paramNotNull(waiterAcceptors, "waiterAcceptors");
         this.executorService = Validate.paramNotNull(executorService, "executorService");
-        this.executorHelper = new WaiterExecutorHelper<>(waiterAcceptors, pollingStrategy);
+        this.executorHelper = new WaiterExecutorHelper<>(waiterAcceptors, configuration);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/DefaultAsyncWaiter.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/DefaultAsyncWaiter.java
@@ -24,10 +24,9 @@ import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.waiters.AsyncWaiter;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * Default implementation of the generic {@link AsyncWaiter}.
@@ -36,16 +35,15 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 @ThreadSafe
 public final class DefaultAsyncWaiter<T> implements AsyncWaiter<T> {
-    private final PollingStrategy pollingStrategy;
     private final ScheduledExecutorService executorService;
     private final List<WaiterAcceptor<? super T>> waiterAcceptors;
     private final AsyncWaiterExecutor<T> handler;
 
     private DefaultAsyncWaiter(DefaultBuilder<T> builder) {
         this.executorService = builder.scheduledExecutorService;
-        this.pollingStrategy = Validate.paramNotNull(builder.pollingStrategy, "pollingStrategy");
+        WaiterConfiguration configuration = new WaiterConfiguration(builder.overrideConfiguration);
         this.waiterAcceptors = Collections.unmodifiableList(builder.waiterAcceptors);
-        this.handler = new AsyncWaiterExecutor<>(pollingStrategy, waiterAcceptors, executorService);
+        this.handler = new AsyncWaiterExecutor<>(configuration, waiterAcceptors, executorService);
     }
 
     @Override
@@ -60,7 +58,7 @@ public final class DefaultAsyncWaiter<T> implements AsyncWaiter<T> {
     public static final class DefaultBuilder<T> implements Builder<T> {
         private List<WaiterAcceptor<? super T>> waiterAcceptors = new ArrayList<>();
         private ScheduledExecutorService scheduledExecutorService;
-        private PollingStrategy pollingStrategy;
+        private WaiterOverrideConfiguration overrideConfiguration;
 
         private DefaultBuilder() {
         }
@@ -78,8 +76,8 @@ public final class DefaultAsyncWaiter<T> implements AsyncWaiter<T> {
         }
 
         @Override
-        public Builder<T> pollingStrategy(PollingStrategy pollingStrategy) {
-            this.pollingStrategy = pollingStrategy;
+        public Builder<T> overrideConfiguration(WaiterOverrideConfiguration overrideConfiguration) {
+            this.overrideConfiguration = overrideConfiguration;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/DefaultWaiterResponse.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/DefaultWaiterResponse.java
@@ -47,7 +47,7 @@ public final class DefaultWaiterResponse<T> implements WaiterResponse<T> {
     }
 
     @Override
-    public ResponseOrException<T> responseOrException() {
+    public ResponseOrException<T> matched() {
         return result != null ? ResponseOrException.response(result) : ResponseOrException.exception(exception);
     }
 
@@ -89,7 +89,7 @@ public final class DefaultWaiterResponse<T> implements WaiterResponse<T> {
         ToString toString = ToString.builder("DefaultWaiterResponse")
                                     .add("attemptsExecuted", attemptsExecuted);
 
-        responseOrException().apply(r -> toString.add("response", r), e -> toString.add("exception", e.getMessage()));
+        matched().apply(r -> toString.add("response", r), e -> toString.add("exception", e.getMessage()));
         return toString.build();
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/WaiterConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/WaiterConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.waiters;
+
+import java.time.Duration;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
+
+/**
+ * Internal waiter configuration class that provides default values if not overridden.
+ */
+@SdkInternalApi
+public final class WaiterConfiguration {
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+    private static final BackoffStrategy DEFAULT_BACKOFF_STRATEGY = FixedDelayBackoffStrategy.create(Duration.ofSeconds(5));
+    private final Integer maxAttempts;
+    private final BackoffStrategy backoffStrategy;
+    private final Duration waitTimeout;
+
+    public WaiterConfiguration(WaiterOverrideConfiguration overrideConfiguration) {
+        Optional<WaiterOverrideConfiguration> configuration = Optional.ofNullable(overrideConfiguration);
+        this.backoffStrategy =
+            configuration.flatMap(WaiterOverrideConfiguration::backoffStrategy).orElse(DEFAULT_BACKOFF_STRATEGY);
+        this.waitTimeout = configuration.flatMap(WaiterOverrideConfiguration::waitTimeout).orElse(null);
+        this.maxAttempts = configuration.flatMap(WaiterOverrideConfiguration::maxAttempts).orElse(DEFAULT_MAX_ATTEMPTS);
+    }
+
+    public Duration waitTimeout() {
+        return waitTimeout;
+    }
+
+    public BackoffStrategy backoffStrategy() {
+        return backoffStrategy;
+    }
+
+    public int maxAttempts() {
+        return maxAttempts;
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/WaiterExecutor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/waiters/WaiterExecutor.java
@@ -21,7 +21,6 @@ import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.core.waiters.WaiterState;
@@ -38,11 +37,11 @@ import software.amazon.awssdk.utils.Validate;
 public final class WaiterExecutor<T> {
     private final WaiterExecutorHelper<T> executorHelper;
 
-    public WaiterExecutor(PollingStrategy pollingStrategy,
+    public WaiterExecutor(WaiterConfiguration configuration,
                           List<WaiterAcceptor<? super T>> waiterAcceptors) {
-        Validate.paramNotNull(pollingStrategy, "pollingStrategy");
+        Validate.paramNotNull(configuration, "configuration");
         Validate.paramNotNull(waiterAcceptors, "waiterAcceptors");
-        this.executorHelper = new WaiterExecutorHelper<>(waiterAcceptors, pollingStrategy);
+        this.executorHelper = new WaiterExecutorHelper<>(waiterAcceptors, configuration);
     }
 
     WaiterResponse<T> execute(Supplier<T> pollingFunction) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/waiters/WaiterBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/waiters/WaiterBuilder.java
@@ -50,23 +50,24 @@ public interface WaiterBuilder<T, B> {
     B addAcceptor(WaiterAcceptor<? super T> waiterAcceptors);
 
     /**
-     * Defines a {@link PollingStrategy} to use when polling a resource
+     * Defines overrides to the default SDK waiter configuration that should be used
+     * for waiters created by this builder.
      *
-     * @param pollingStrategy the polling strategy to use
+     * @param overrideConfiguration the override configuration
      * @return a reference to this object so that method calls can be chained together.
      */
-    B pollingStrategy(PollingStrategy pollingStrategy);
+    B overrideConfiguration(WaiterOverrideConfiguration overrideConfiguration);
 
     /**
-     * Defines a {@link PollingStrategy} to use when polling a resource
+     * Defines a {@link WaiterOverrideConfiguration} to use when polling a resource
      *
-     * @param pollingStrategy the polling strategy to use
+     * @param overrideConfiguration the polling strategy to use
      * @return a reference to this object so that method calls can be chained together.
      */
-    default B pollingStrategy(Consumer<PollingStrategy.Builder> pollingStrategy) {
-        PollingStrategy.Builder builder = PollingStrategy.builder();
-        pollingStrategy.accept(builder);
-        return pollingStrategy(builder.build());
+    default B overrideConfiguration(Consumer<WaiterOverrideConfiguration.Builder> overrideConfiguration) {
+        WaiterOverrideConfiguration.Builder builder = WaiterOverrideConfiguration.builder();
+        overrideConfiguration.accept(builder);
+        return overrideConfiguration(builder.build());
     }
 
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/waiters/WaiterOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/waiters/WaiterOverrideConfiguration.java
@@ -16,24 +16,26 @@
 package software.amazon.awssdk.core.waiters;
 
 import java.time.Duration;
+import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * Define the polling strategy for a {@link Waiter} to poll the resource
+ * Configuration values for the {@link Waiter}. All values are optional, and not specifying them
+ * will use the default values.
  */
 @SdkPublicApi
-public final class PollingStrategy {
+public final class WaiterOverrideConfiguration {
 
-    private final int maxAttempts;
+    private final Integer maxAttempts;
     private final BackoffStrategy backoffStrategy;
-    private final Duration maxWaitTime;
+    private final Duration waitTimeout;
 
-    public PollingStrategy(Builder builder) {
-        this.maxAttempts = Validate.paramNotNull(builder.maxAttempts, "maxAttempts");
-        this.backoffStrategy = Validate.paramNotNull(builder.backoffStrategy, "backoffStrategy");
-        this.maxWaitTime = Validate.isPositiveOrNull(builder.maxWaitTime, "maxWaitTime");
+    public WaiterOverrideConfiguration(Builder builder) {
+        this.maxAttempts = Validate.isPositiveOrNull(builder.maxAttempts, "maxAttempts");
+        this.backoffStrategy = builder.backoffStrategy;
+        this.waitTimeout = Validate.isPositiveOrNull(builder.waitTimeout, "waitTimeout");
     }
 
     public static Builder builder() {
@@ -41,38 +43,31 @@ public final class PollingStrategy {
     }
 
     /**
-     * Define the maximum number of attempts to try before transitioning the waiter to a failure state.
-     * @return a reference to this object so that method calls can be chained together.
+     * @return the optional maximum number of attempts that should be used when polling the resource
      */
-    public int maxAttempts() {
-        return maxAttempts;
+    public Optional<Integer> maxAttempts() {
+        return Optional.ofNullable(maxAttempts);
     }
 
     /**
-     * Define the {@link BackoffStrategy} that computes the delay before the next retry request.
-     *
-     * @return a reference to this object so that method calls can be chained together.
+     * @return the optional {@link BackoffStrategy} that should be used when polling the resource
      */
-    public BackoffStrategy backoffStrategy() {
-        return backoffStrategy;
+    public Optional<BackoffStrategy> backoffStrategy() {
+        return Optional.ofNullable(backoffStrategy);
     }
 
     /**
-     * Define the amount of time to wait for the resource to transition to the desired state before
-     * giving up. This wait time doesn't have strict guarantees on how quickly a request is aborted
-     * when the timeout is breached. The request can timeout early if it is determined that the next
-     * retry will breach the max wait time.
+     * @return the optional amount of time to wait that should be used when polling the resource
      *
-     * @return a reference to this object so that method calls can be chained together.
      */
-    public Duration maxWaitTime() {
-        return maxWaitTime;
+    public Optional<Duration> waitTimeout() {
+        return Optional.ofNullable(waitTimeout);
     }
 
     public static final class Builder {
         private BackoffStrategy backoffStrategy;
         private Integer maxAttempts;
-        private Duration maxWaitTime;
+        private Duration waitTimeout;
 
         private Builder() {
         }
@@ -100,17 +95,21 @@ public final class PollingStrategy {
         }
 
         /**
-         * Define the maximum time to try before transitioning the waiter to a failure state.
-         * @param maxWaitTime The new maxWaitTime value.
+         * Define the amount of time to wait for the resource to transition to the desired state before
+         * timing out. This wait timeout doesn't have strict guarantees on how quickly a request is aborted
+         * when the timeout is breached. The request can timeout early if it is determined that the next
+         * retry will breach the max wait time. It's disabled by default.
+         *
+         * @param waitTimeout The new waitTimeout value.
          * @return This object for method chaining.
          */
-        public Builder maxWaitTime(Duration maxWaitTime) {
-            this.maxWaitTime = maxWaitTime;
+        public Builder waitTimeout(Duration waitTimeout) {
+            this.waitTimeout = waitTimeout;
             return this;
         }
 
-        public PollingStrategy build() {
-            return new PollingStrategy(this);
+        public WaiterOverrideConfiguration build() {
+            return new WaiterOverrideConfiguration(this);
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/waiters/WaiterResponse.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/waiters/WaiterResponse.java
@@ -28,7 +28,7 @@ public interface WaiterResponse<T> {
     /**
      * @return the ResponseOrException union received that has matched with the waiter success condition
      */
-    ResponseOrException<T> responseOrException();
+    ResponseOrException<T> matched();
 
     /**
      * @return the number of attempts executed

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/waiters/DefaultWaiterResponseTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/waiters/DefaultWaiterResponseTest.java
@@ -69,8 +69,8 @@ public class DefaultWaiterResponseTest {
             .attemptsExecuted(1)
             .build();
 
-        assertThat(response.responseOrException().exception()).contains(exception);
-        assertThat(response.responseOrException().response()).isEmpty();
+        assertThat(response.matched().exception()).contains(exception);
+        assertThat(response.matched().response()).isEmpty();
         assertThat(response.attemptsExecuted()).isEqualTo(1);
     }
 
@@ -82,8 +82,8 @@ public class DefaultWaiterResponseTest {
             .build();
 
 
-        assertThat(response.responseOrException().response()).contains("helloworld");
-        assertThat(response.responseOrException().exception()).isEmpty();
+        assertThat(response.matched().response()).contains("helloworld");
+        assertThat(response.matched().exception()).isEmpty();
         assertThat(response.attemptsExecuted()).isEqualTo(2);
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/waiters/WaiterConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/waiters/WaiterConfigurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.waiters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.Test;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
+
+public class WaiterConfigurationTest {
+
+    @Test
+    public void overrideConfigurationNull_shouldUseDefaultValue() {
+        WaiterConfiguration waiterConfiguration = new WaiterConfiguration(null);
+
+        assertThat(waiterConfiguration.backoffStrategy())
+            .isEqualTo(FixedDelayBackoffStrategy.create(Duration.ofSeconds(5)));
+        assertThat(waiterConfiguration.maxAttempts()).isEqualTo(3);
+        assertThat(waiterConfiguration.waitTimeout()).isNull();
+    }
+
+    @Test
+    public void overrideConfigurationNotAllValuesProvided_shouldUseDefaultValue() {
+        WaiterConfiguration waiterConfiguration = new WaiterConfiguration(WaiterOverrideConfiguration.builder()
+                                                                                                     .backoffStrategy(BackoffStrategy.none())
+                                                                                                     .build());
+
+        assertThat(waiterConfiguration.backoffStrategy())
+            .isEqualTo(BackoffStrategy.none());
+        assertThat(waiterConfiguration.maxAttempts()).isEqualTo(3);
+        assertThat(waiterConfiguration.waitTimeout()).isNull();
+    }
+
+    @Test
+    public void overrideConfigurationProvided_shouldTakesPrecedence() {
+        WaiterConfiguration waiterConfiguration =
+            new WaiterConfiguration(WaiterOverrideConfiguration.builder()
+                                                               .backoffStrategy(BackoffStrategy.none())
+                                                               .maxAttempts(10)
+                                                               .waitTimeout(Duration.ofMinutes(3))
+                                                               .build());
+
+        assertThat(waiterConfiguration.backoffStrategy())
+            .isEqualTo(BackoffStrategy.none());
+        assertThat(waiterConfiguration.maxAttempts()).isEqualTo(10);
+        assertThat(waiterConfiguration.waitTimeout()).isEqualTo(Duration.ofMinutes(3));
+    }
+
+
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/waiters/AsyncWaiterTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/waiters/AsyncWaiterTest.java
@@ -31,7 +31,7 @@ public class AsyncWaiterTest extends BaseWaiterTest {
     @Override
     public BiFunction<Integer, TestWaiterConfiguration, WaiterResponse<String>> successOnResponseWaiterOperation() {
         return (count, waiterConfiguration) -> AsyncWaiter.builder(String.class)
-                                                          .pollingStrategy(waiterConfiguration.getPollingStrategy())
+                                                          .overrideConfiguration(waiterConfiguration.getPollingStrategy())
                                                           .acceptors(waiterConfiguration.getWaiterAcceptors())
                                                           .scheduledExecutorService(executorService)
                                                           .build()
@@ -41,7 +41,7 @@ public class AsyncWaiterTest extends BaseWaiterTest {
     @Override
     public BiFunction<Integer, TestWaiterConfiguration, WaiterResponse<String>> successOnExceptionWaiterOperation() {
         return (count, waiterConfiguration) -> AsyncWaiter.builder(String.class)
-                                                          .pollingStrategy(waiterConfiguration.getPollingStrategy())
+                                                          .overrideConfiguration(waiterConfiguration.getPollingStrategy())
                                                           .acceptors(waiterConfiguration.getWaiterAcceptors())
                                                           .scheduledExecutorService(executorService)
                                                           .build()
@@ -51,7 +51,7 @@ public class AsyncWaiterTest extends BaseWaiterTest {
     @Test
     public void missingScheduledExecutor_shouldThrowException() {
         assertThatThrownBy(() -> AsyncWaiter.builder(String.class)
-                                            .pollingStrategy(p -> p.maxAttempts(3).backoffStrategy(BackoffStrategy.none()))
+                                            .overrideConfiguration(p -> p.maxAttempts(3).backoffStrategy(BackoffStrategy.none()))
                                             .build()
                                             .runAsync(() -> null))
             .hasMessageContaining("executorService");
@@ -60,7 +60,7 @@ public class AsyncWaiterTest extends BaseWaiterTest {
     @Test
     public void concurrentWaiterOperations_shouldBeThreadSafe() {
         AsyncWaiter<String> waiter = AsyncWaiter.builder(String.class)
-                                                .pollingStrategy(p -> p.maxAttempts(4).backoffStrategy(BackoffStrategy.none()))
+                                                .overrideConfiguration(p -> p.maxAttempts(4).backoffStrategy(BackoffStrategy.none()))
                                                 .addAcceptor(WaiterAcceptor.successOnResponseAcceptor(s -> s.equals(SUCCESS_STATE_MESSAGE)))
                                                 .addAcceptor(WaiterAcceptor.retryOnResponseAcceptor(i -> true))
                                                 .scheduledExecutorService(executorService)

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/waiters/WaiterOverrideConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/waiters/WaiterOverrideConfigurationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.waiters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.Test;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+
+public class WaiterOverrideConfigurationTest {
+
+    @Test
+    public void valuesProvided_shouldReturnOptionalValues() {
+        WaiterOverrideConfiguration configuration = WaiterOverrideConfiguration.builder()
+                                                                               .maxAttempts(10)
+                                                                               .backoffStrategy(BackoffStrategy.none())
+                                                                               .waitTimeout(Duration.ofSeconds(1))
+                                                                               .build();
+        assertThat(configuration.backoffStrategy()).contains(BackoffStrategy.none());
+        assertThat(configuration.maxAttempts()).contains(10);
+        assertThat(configuration.waitTimeout()).contains(Duration.ofSeconds(1));
+    }
+
+    @Test
+    public void valuesNotProvided_shouldReturnEmptyOptionalValues() {
+        WaiterOverrideConfiguration configuration = WaiterOverrideConfiguration.builder().build();
+        assertThat(configuration.backoffStrategy()).isEmpty();
+        assertThat(configuration.maxAttempts()).isEmpty();
+        assertThat(configuration.waitTimeout()).isEmpty();
+    }
+
+    @Test
+    public void nonPositiveMaxWaitTime_shouldThrowException() {
+        assertThatThrownBy(() -> WaiterOverrideConfiguration.builder()
+                                                            .waitTimeout(Duration.ZERO)
+                                                            .build()).hasMessageContaining("must be positive");
+    }
+
+    @Test
+    public void nonPositiveMaxAttempts_shouldThrowException() {
+        assertThatThrownBy(() -> WaiterOverrideConfiguration.builder()
+                                                            .maxAttempts(-10)
+                                                            .build()).hasMessageContaining("must be positive");
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/waiters/WaiterTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/waiters/WaiterTest.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.core.waiters;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -41,21 +40,21 @@ public class WaiterTest extends BaseWaiterTest {
     @Override
     public BiFunction<Integer, TestWaiterConfiguration, WaiterResponse<String>> successOnResponseWaiterOperation() {
         return (count, waiterConfiguration) -> Waiter.builder(String.class)
-                                                     .pollingStrategy(waiterConfiguration.getPollingStrategy())
+                                                     .overrideConfiguration(waiterConfiguration.getPollingStrategy())
                                                      .acceptors(waiterConfiguration.getWaiterAcceptors()).build().run(new ReturnResponseResource(count));
     }
 
     @Override
     public BiFunction<Integer, TestWaiterConfiguration, WaiterResponse<String>> successOnExceptionWaiterOperation() {
         return (count, waiterConfiguration) -> Waiter.builder(String.class)
-                                                     .pollingStrategy(waiterConfiguration.getPollingStrategy())
+                                                     .overrideConfiguration(waiterConfiguration.getPollingStrategy())
                                                      .acceptors(waiterConfiguration.getWaiterAcceptors()).build().run(new ThrowExceptionResource(count));
     }
 
     @Test
     public void concurrentWaiterOperations_shouldBeThreadSafe() {
         Waiter<String> waiter = Waiter.builder(String.class)
-                                      .pollingStrategy(p -> p.maxAttempts(4).backoffStrategy(BackoffStrategy.none()))
+                                      .overrideConfiguration(p -> p.maxAttempts(4).backoffStrategy(BackoffStrategy.none()))
                                       .addAcceptor(WaiterAcceptor.successOnResponseAcceptor(s -> s.equals(SUCCESS_STATE_MESSAGE)))
                                       .addAcceptor(WaiterAcceptor.retryOnResponseAcceptor(i -> true))
                                       .build();

--- a/services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/waiters/AutoScalingWaiterTest.java
+++ b/services/autoscaling/src/it/java/software/amazon/awssdk/services/autoscaling/waiters/AutoScalingWaiterTest.java
@@ -25,7 +25,7 @@ import static software.amazon.awssdk.services.autoscaling.model.LifecycleState.P
 import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.services.autoscaling.AutoScalingClient;
 import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
@@ -72,15 +72,15 @@ public class AutoScalingWaiterTest {
         when(client.describeAutoScalingGroups(any(DescribeAutoScalingGroupsRequest.class))).thenReturn(response1, response2);
 
         AutoScalingWaiter waiter = AutoScalingWaiter.builder()
-                                                    .pollingStrategy(PollingStrategy.builder()
-                                                                                    .maxAttempts(3)
-                                                                                    .backoffStrategy(BackoffStrategy.none())
-                                                                                    .build())
+                                                    .overrideConfiguration(WaiterOverrideConfiguration.builder()
+                                                                                                      .maxAttempts(3)
+                                                                                                      .backoffStrategy(BackoffStrategy.none())
+                                                                                                      .build())
                                                     .client(client)
                                                     .build();
 
         WaiterResponse<DescribeAutoScalingGroupsResponse> response = waiter.waitUntilGroupInService(request);
         assertThat(response.attemptsExecuted()).isEqualTo(2);
-        assertThat(response.responseOrException().response()).hasValueSatisfying(r -> assertThat(r).isEqualTo(response2));
+        assertThat(response.matched().response()).hasValueSatisfying(r -> assertThat(r).isEqualTo(response2));
     }
 }

--- a/services/ecs/src/it/java/software/amazon/awssdk/services/ecs/waiters/EcsWaiterTest.java
+++ b/services/ecs/src/it/java/software/amazon/awssdk/services/ecs/waiters/EcsWaiterTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
-import software.amazon.awssdk.core.waiters.PollingStrategy;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.ecs.model.Deployment;
@@ -61,15 +61,15 @@ public class EcsWaiterTest {
         when(client.describeServices(any(DescribeServicesRequest.class))).thenReturn(response1, response2);
 
         EcsWaiter waiter = EcsWaiter.builder()
-                                    .pollingStrategy(PollingStrategy.builder()
-                                                                    .maxAttempts(3)
-                                                                    .backoffStrategy(BackoffStrategy.none())
-                                                                    .build())
+                                    .overrideConfiguration(WaiterOverrideConfiguration.builder()
+                                                                                .maxAttempts(3)
+                                                                                .backoffStrategy(BackoffStrategy.none())
+                                                                                .build())
                                     .client(client)
                                     .build();
 
         WaiterResponse<DescribeServicesResponse> response = waiter.waitUntilServicesStable(request);
         assertThat(response.attemptsExecuted()).isEqualTo(2);
-        assertThat(response.responseOrException().response()).hasValueSatisfying(r -> assertThat(r).isEqualTo(response2));
+        assertThat(response.matched().response()).hasValueSatisfying(r -> assertThat(r).isEqualTo(response2));
     }
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/waiters/WaiterResourceTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/waiters/WaiterResourceTest.java
@@ -51,7 +51,7 @@ public class WaiterResourceTest {
     public void closeAsyncWaiter_customizedClientAndExecutorServiceProvided_shouldNotClose() {
         RestJsonWithWaitersAsyncWaiter waiter = RestJsonWithWaitersAsyncWaiter.builder()
                                                                               .client(asyncClient)
-                                                                              .executorService(executorService)
+                                                                              .scheduledExecutorService(executorService)
                                                                               .build();
 
         waiter.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- rename `{Service}Waiter.Builder#executorService` -> `{Service}Waiter.Builder#scheduledExecutorService` 
- rename `PollingStratege` -> `WaiterOverrideConfiguration` and `Waiter.Builder#pollingStrategy` -> `Waiter.Builder#overrideConfiguration`
- rename `WaiterResponse#responseOrExecption` -> `WaiterResponse#matched`
- provide default values for `waiterOverrideConfiguration`
- rename `maxWaitTime` -> `waitTimeout`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
