### PR TITLE
Remove flaky integ test

### DIFF
--- a/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3ControlIntegrationTest.java
+++ b/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3ControlIntegrationTest.java
@@ -103,16 +103,6 @@ public class S3ControlIntegrationTest extends AwsIntegrationTestBase {
     }
 
     @Test
-    public void getPublicAccessBlock_NoSuchConfig() {
-        try {
-            client.getPublicAccessBlock(r -> r.accountId(accountId));
-            fail("Expected exception");
-        } catch (NoSuchPublicAccessBlockConfigurationException e) {
-            assertNotNull(e.requestId());
-        }
-    }
-
-    @Test
     public void deletePublicAccessBlock_NoSuchAccount() {
         try {
             client.deletePublicAccessBlock(r -> r.accountId(INVALID_ACCOUNT_ID));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove flaky integ test that is testing service and not the SDK

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
