### PR TITLE
Fix wrongly replaced double slash in Apache Http Client

### DIFF
--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
@@ -71,7 +71,8 @@ public class ApacheHttpRequestFactory {
      */
     private String sanitizeUri(URI uri) {
         String newPath = uri.getPath().replace("//", "/%2F");
-        return uri.toString().replace(uri.getPath(), newPath);
+        String baseUri = uri.toString();
+        return baseUri.substring(0, baseUri.length() - uri.getPath().length()) + newPath;
     }
 
     private void addRequestConfig(final HttpRequestBase base,

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
@@ -17,6 +17,8 @@ package software.amazon.awssdk.http.apache.internal.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -91,4 +93,32 @@ public class ApacheHttpRequestFactoryTest {
         assertEquals(1, hostHeaders.length);
         assertEquals("localhost", hostHeaders[0].getValue());
     }
+
+    @Test
+    public void sanitizeUriTest_slashPathInUriWillBeReplaced() {
+        assertTrue(sanitizeUriTestHelper("/").endsWith("/%2F"));
+    }
+
+    @Test
+    public void sanitizeUriTest_multipleConsecutiveSlashesPathInUriWillBeReplaced() {
+        assertTrue(sanitizeUriTestHelper("//").endsWith("/%2F/"));
+    }
+
+    @Test
+    public void sanitizeUriTest_normalPathInUriReturnOriginalpath() {
+        assertTrue(sanitizeUriTestHelper("path").endsWith("/path"));
+    }
+
+    private String sanitizeUriTestHelper(String path) {
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                                                  .uri(URI.create("http://localhost:80/" + path))
+                                                  .method(SdkHttpMethod.HEAD)
+                                                  .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(sdkRequest)
+                                                       .build();
+
+        return instance.create(request, requestConfig).getURI().toString();
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The `sanitizeUri` method in Apache Http Client is wrongly replacing all the double slash charSet in the Uri with `"%2F"` when the path in Uri is `"//"`. This pr will fix this issue and only replace the `"//"` at the end of the Uri.

For the condition of multiple consecutive slashes path, for instance an Uri ending with `"///"`, only the first `"//"` will be replaced with `"/%2F"`. That is, `"http://localhost:80///" -> "http://localhost:80/%2F/"`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
