### PR TITLE
Fix slash path parameter in apache http client

### DIFF
--- a/.changes/next-release/bugfix-ApacheHTTPClient-3ccb50d.json
+++ b/.changes/next-release/bugfix-ApacheHTTPClient-3ccb50d.json
@@ -1,0 +1,5 @@
+{
+    "category": "Apache HTTP Client", 
+    "type": "bugfix", 
+    "description": "Fixed an issue in Apache HTTP client where a request with path parameter as a single slash threw invalid host name error."
+}

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactory.java
@@ -47,14 +47,10 @@ import software.amazon.awssdk.utils.http.SdkHttpUtils;
 @SdkInternalApi
 public class ApacheHttpRequestFactory {
 
-    private static final String DEFAULT_ENCODING = "UTF-8";
-
     private static final List<String> IGNORE_HEADERS = Arrays.asList(HttpHeaders.CONTENT_LENGTH, HttpHeaders.HOST);
 
     public HttpRequestBase create(final HttpExecuteRequest request, final ApacheHttpRequestConfig requestConfig) {
-        URI uri = request.httpRequest().getUri();
-
-        HttpRequestBase base = createApacheRequest(request, sanitizeUri(uri));
+        HttpRequestBase base = createApacheRequest(request, sanitizeUri(request.httpRequest()));
         addHeadersToRequest(base, request.httpRequest());
         addRequestConfig(base, request.httpRequest(), requestConfig);
 
@@ -66,12 +62,28 @@ public class ApacheHttpRequestFactory {
      * and other AWS services, this is allowed and required. This methods replaces
      * any occurrence of "//" in the URI path with "/%2F".
      *
-     * @param uri The existing URI with double slashes not sanitized for Apache.
+     * @see SdkHttpRequest#getUri()
+     * @param request The existing request
      * @return a new String containing the modified URI
      */
-    private String sanitizeUri(URI uri) {
-        String newPath = uri.getPath().replace("//", "/%2F");
-        return uri.toString().replace(uri.getPath(), newPath);
+    private String sanitizeUri(SdkHttpRequest request) {
+        String path = request.encodedPath();
+        if (path.contains("//")) {
+            int port = request.port();
+            String protocol = request.protocol();
+            String newPath = path.replace("//", "/%2F");
+            String encodedQueryString = SdkHttpUtils.encodeAndFlattenQueryParameters(request.rawQueryParameters())
+                                                    .map(value -> "?" + value)
+                                                    .orElse("");
+
+            // Do not include the port in the URI when using the default port for the protocol.
+            String portString = SdkHttpUtils.isUsingStandardPort(protocol, port) ?
+                                "" : ":" + port;
+
+            return URI.create(protocol + "://" + request.host() + portString + newPath + encodedQueryString).toString();
+        }
+
+        return request.getUri().toString();
     }
 
     private void addRequestConfig(final HttpRequestBase base,

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/impl/ApacheHttpRequestFactoryTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.apache.internal.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -90,5 +91,38 @@ public class ApacheHttpRequestFactoryTest {
         assertNotNull(hostHeaders);
         assertEquals(1, hostHeaders.length);
         assertEquals("localhost", hostHeaders[0].getValue());
+    }
+
+    @Test
+    public void pathWithLeadingSlash_shouldEncode() {
+        assertThat(sanitizedUri("/foobar")).isEqualTo("http://localhost/%2Ffoobar");
+    }
+
+    @Test
+    public void pathWithOnlySlash_shouldEncode() {
+        assertThat(sanitizedUri("/")).isEqualTo("http://localhost/%2F");
+    }
+
+    @Test
+    public void pathWithoutSlash_shouldReturnSameUri() {
+        assertThat(sanitizedUri("path")).isEqualTo("http://localhost/path");
+    }
+
+    @Test
+    public void pathWithSpecialChars_shouldPreserveEncoding() {
+        assertThat(sanitizedUri("/special-chars-%40%24%25")).isEqualTo("http://localhost/%2Fspecial-chars-%40%24%25");
+    }
+
+    private String sanitizedUri(String path) {
+        SdkHttpRequest sdkRequest = SdkHttpRequest.builder()
+                                                  .uri(URI.create("http://localhost:80"))
+                                                  .encodedPath("/" + path)
+                                                  .method(SdkHttpMethod.HEAD)
+                                                  .build();
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(sdkRequest)
+                                                       .build();
+
+        return instance.create(request, requestConfig).getURI().toString();
     }
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/KeysWithLeadingSlashIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/KeysWithLeadingSlashIntegrationTest.java
@@ -26,7 +26,9 @@ import software.amazon.awssdk.core.sync.RequestBody;
 public class KeysWithLeadingSlashIntegrationTest extends S3IntegrationTestBase {
 
     private static final String BUCKET = temporaryBucketName(KeysWithLeadingSlashIntegrationTest.class);
-    private static final String KEY = "/stupidkeywithillegalleadingslashthatsucks";
+    private static final String KEY = "/keyWithLeadingSlash";
+    private static final String SLASH_KEY = "/";
+    private static final String KEY_WITH_SLASH_AND_SPECIAL_CHARS = "/special-chars-@$%";
     private static final byte[] CONTENT = "Hello".getBytes(StandardCharsets.UTF_8);
 
     @BeforeClass
@@ -42,9 +44,26 @@ public class KeysWithLeadingSlashIntegrationTest extends S3IntegrationTestBase {
 
     @Test
     public void putObject_KeyWithLeadingSlash_Succeeds() {
-        s3.putObject(r -> r.bucket(BUCKET).key(KEY), RequestBody.fromBytes(CONTENT));
+        verify(KEY);
+    }
+
+    @Test
+    public void slashKey_shouldSucceed() {
+        verify(SLASH_KEY);
+    }
+
+    @Test
+    public void slashKeyWithSpecialChar_shouldSucceed() {
+        verify(KEY_WITH_SLASH_AND_SPECIAL_CHARS);
+    }
+
+    private void verify(String key) {
+        s3.putObject(r -> r.bucket(BUCKET).key(key), RequestBody.fromBytes(CONTENT));
+
+        assertThat(s3.getObjectAsBytes(r -> r.bucket(BUCKET).key(key)).asByteArray()).isEqualTo(CONTENT);
+
         String retrievedKey = s3.listObjects(r -> r.bucket(BUCKET)).contents().get(0).key();
 
-        assertThat(retrievedKey).isEqualTo(KEY);
+        assertThat(retrievedKey).isEqualTo(key);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue in Apache HTTP client where a request with path parameter as a single slash threw invalid host name error.

**Root case:**
In previous implementation, all occurrences of `//` were replaced with `/%2F`, including the one right after the http scheme, causing `http://localhost/%2F` -> `http:/%2Flocalhost/%2F`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Added integ tests and unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
