### PR TITLE
Fix archetype-lambda

### DIFF
--- a/.changes/next-release/bugfix-AWSLambdaMavenArchetype-9037fcf.json
+++ b/.changes/next-release/bugfix-AWSLambdaMavenArchetype-9037fcf.json
@@ -1,0 +1,5 @@
+{
+    "category": "AWS Lambda Maven Archetype", 
+    "type": "bugfix", 
+    "description": "Fixed an issue where archetype generation failed with latest maven-archetype-plugin. See [#1981](https://github.com/aws/aws-sdk-java-v2/issues/1981)"
+}

--- a/archetypes/archetype-lambda/pom.xml
+++ b/archetypes/archetype-lambda/pom.xml
@@ -31,7 +31,8 @@
     </description>
 
     <properties>
-        <maven.archetype.version>3.1.2</maven.archetype.version>
+        <maven.archetype.version>3.2.0</maven.archetype.version>
+        <maven.resource.plugin.version>3.2.0</maven.resource.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     </properties>
 
@@ -117,6 +118,56 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+
+            <!-- workaround to copy the global.vm and serviceMapping.vm to the sub folders
+                 because gloabl.vm is not so global any more
+                 see https://github.com/aws/aws-sdk-java-v2/issues/1981 -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven.resource.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes/archetype-resources</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/target/classes/</directory>
+                                    <includes>
+                                        <include>global.vm</include>
+                                        <include>serviceMapping.vm</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-resources-to-sub-folder</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes/archetype-resources/src/main/java</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/target/classes/</directory>
+                                    <includes>
+                                        <include>global.vm</include>
+                                        <include>serviceMapping.vm</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an issue where archetype generation failed with latest maven-archetype-plugin by
copying the global.vm to archetype resources folder because it's no longer global any more ¯\_(ツ)_/¯

I tried other ways such as using relative path and none of them worked. 

## Motivation and Context
#1981 

## Testing
Unit tests passed.
Tried using both new version of old version of archetype plugin to generate a new project and both worked.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
