### PR TITLE
Remove openjdk11 because the build exceeds the allowed time limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - openjdk8
-  - openjdk11
 sudo: true
 dist: xenial
 install: /bin/true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove openjdk11 because the openjdk11 job took longer than 50 mins, which is a hard limit on Travis for public repos.

```
The job exceeded the maximum time limit for jobs, and has been terminated.
```

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
