### PR TITLE
Include event type in visitor name

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
@@ -33,7 +33,8 @@ public final class DefaultCustomizationProcessor {
                 new ShapeModifiersProcessor(config.getShapeModifiers()),
                 new ShapeSubstitutionsProcessor(config.getShapeSubstitutions()),
                 new OperationModifiersProcessor(config.getOperationModifiers()),
-                new RemoveExceptionMessagePropertyProcessor()
+                new RemoveExceptionMessagePropertyProcessor(),
+                new ExcludeEventNameFromVisitMethodProcessor()
         );
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ExcludeEventNameFromVisitMethodProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ExcludeEventNameFromVisitMethodProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.customization.processors;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.codegen.customization.CodegenCustomizationProcessor;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+
+/**
+ * This process enforces constraints placed on the "excludeEventNameFromVisitMethod"; i.e. that no two members
+ * of the same event stream sharing the same shape have this customization enabled for them. This processor does not
+ * modify the the service or intermediate model.
+ */
+public class ExcludeEventNameFromVisitMethodProcessor implements CodegenCustomizationProcessor {
+    private static final String CUSTOMIZATION_NAME = "ExcludeEventNameFromVisitMethod";
+    private static final Logger log = LoggerFactory.getLogger(ExcludeEventNameFromVisitMethodProcessor.class);
+
+    @Override
+    public void preprocess(ServiceModel serviceModel) {
+        // no-op
+    }
+
+    @Override
+    public void postprocess(IntermediateModel intermediateModel) {
+        Map<String, List<String>> excludeEventNameFromVisitMethod = intermediateModel.getCustomizationConfig()
+                .getExcludeEventNameFromVisitMethod();
+
+        excludeEventNameFromVisitMethod.forEach((eventStream, members) -> {
+            ShapeModel shapeModel = getShapeByC2jName(intermediateModel, eventStream);
+
+            if (shapeModel == null || !shapeModel.isEventStream()) {
+                log.warn("Encountered " + CUSTOMIZATION_NAME + " for unrecognized eventstream " + eventStream);
+                return;
+            }
+
+            Map<String, Integer> shapeToEventCount = new HashMap<>();
+
+            members.forEach(m -> {
+                MemberModel event = shapeModel.getMemberByC2jName(m);
+
+                if (event != null) {
+                    String shapeName = event.getC2jShape();
+                    int count = shapeToEventCount.getOrDefault(shapeName, 0);
+                    shapeToEventCount.put(shapeName, ++count);
+                } else {
+                    String msg = String.format("Encountered %s customization for unrecognized eventstream member %s#%s",
+                            CUSTOMIZATION_NAME, eventStream, m);
+                    log.warn(msg);
+                }
+            });
+
+            shapeToEventCount.forEach((shape, count) -> {
+                if (count > 1) {
+                    throw new IllegalArgumentException(CUSTOMIZATION_NAME + " customization declared for "
+                            + eventStream + ", but more than it targets more than one member with the shape " + shape);
+                }
+            });
+        });
+    }
+
+    private ShapeModel getShapeByC2jName(IntermediateModel intermediateModel, String c2jName) {
+        return intermediateModel.getShapes().values().stream()
+                .filter(s -> s.getC2jName().equals(c2jName))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -176,6 +176,16 @@ public class CustomizationConfig {
      */
     private boolean allowEndpointOverrideForEndpointDiscoveryRequiredOperations = false;
 
+    /**
+     * Customization to instruct the code generator *not* to include the event's name in the {@code Visitor#visit*()}
+     * method; i.e. the signature of the method will be {@code void visit(<Event Shape type>)}.
+     * <p>
+     * <b>NOTE</b>This customization is primarily here to preserve backwards compatibility with existing code before the
+     * generation scheme for the visitor methods was changed. There should be no good reason to use this customization
+     * for any other purpose.
+     */
+    private Map<String, List<String>> excludeEventNameFromVisitMethod = new HashMap<>();
+
     private CustomizationConfig() {
     }
 
@@ -453,5 +463,13 @@ public class CustomizationConfig {
         boolean allowEndpointOverrideForEndpointDiscoveryRequiredOperations) {
         this.allowEndpointOverrideForEndpointDiscoveryRequiredOperations =
             allowEndpointOverrideForEndpointDiscoveryRequiredOperations;
+    }
+
+    public Map<String, List<String>> getExcludeEventNameFromVisitMethod() {
+        return excludeEventNameFromVisitMethod;
+    }
+
+    public void setExcludeEventNameFromVisitMethod(Map<String, List<String>> excludeEventNameFromVisitMethod) {
+        this.excludeEventNameFromVisitMethod = excludeEventNameFromVisitMethod;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamResponseHandlerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamResponseHandlerSpec.java
@@ -23,6 +23,7 @@ import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.eventstream.EventStreamResponseHandler;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
@@ -33,6 +34,7 @@ import software.amazon.awssdk.codegen.poet.PoetUtils;
  */
 public class EventStreamResponseHandlerSpec implements ClassSpec {
 
+    private final IntermediateModel intermediateModel;
     private final PoetExtensions poetExt;
     private final OperationModel operationModel;
     private final String apiName;
@@ -41,6 +43,7 @@ public class EventStreamResponseHandlerSpec implements ClassSpec {
     private final ClassName eventStreamBaseClass;
 
     public EventStreamResponseHandlerSpec(GeneratorTaskParams params, OperationModel operationModel) {
+        this.intermediateModel = params.getModel();
         this.poetExt = params.getPoetExtensions();
         this.operationModel = operationModel;
         this.apiName = poetExt.getApiName(operationModel);
@@ -61,7 +64,7 @@ public class EventStreamResponseHandlerSpec implements ClassSpec {
                         .addJavadoc("Response handler for the $L API.", apiName)
                         .addMethod(builderMethodSpec())
                         .addType(new EventStreamResponseHandlerBuilderInterfaceSpec(poetExt, operationModel).poetSpec())
-                        .addType(new EventStreamVisitorInterfaceSpec(poetExt, operationModel).poetSpec())
+                        .addType(new EventStreamVisitorInterfaceSpec(intermediateModel, poetExt, operationModel).poetSpec())
                         .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamUtils.java
@@ -96,11 +96,11 @@ public class EventStreamUtils {
     }
 
     /**
-     * Returns the stream of event member shapes ('event: true') excluding exceptions
+     * Returns the stream of event members ('event: true') excluding exceptions
      * from the input event stream shape ('eventstream: true').
      */
-    public static Stream<ShapeModel> getEvents(ShapeModel eventStreamShape) {
-        return getEventMembers(eventStreamShape).map(MemberModel::getShape);
+    public static Stream<MemberModel> getEvents(ShapeModel eventStreamShape) {
+        return getEventMembers(eventStreamShape);
     }
 
     /**

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/customization/processors/ExcludeEventNameFromVisitMethodProcessorTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/customization/processors/ExcludeEventNameFromVisitMethodProcessorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.customization.processors;
+
+
+import java.io.File;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.codegen.C2jModels;
+import software.amazon.awssdk.codegen.IntermediateModelBuilder;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
+
+/**
+ * Tests for {@link ExcludeEventNameFromVisitMethodProcessor}
+ */
+public class ExcludeEventNameFromVisitMethodProcessorTest {
+    private static final String RESOURCE_ROOT = "/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor";
+
+    private static final ExcludeEventNameFromVisitMethodProcessor processor = new ExcludeEventNameFromVisitMethodProcessor();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private static ServiceModel serviceModel;
+
+
+    @BeforeClass
+    public static void setup() {
+        String c2jFilePath = ExcludeEventNameFromVisitMethodProcessorTest.class.getResource(RESOURCE_ROOT + "/service-2.json").getFile();
+        File c2jFile = new File(c2jFilePath);
+
+        serviceModel = ModelLoaderUtils.loadModel(ServiceModel.class, c2jFile);
+    }
+
+    @Test
+    public void testPostProcess_customizationDeclaredForMultipleMembersWithSameShape_throws() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("targets more than one member with the shape");
+
+        IntermediateModel intermediateModel = intermediateModelWithConfig("multiple-event-types-same-shape.config");
+
+        processor.postprocess(intermediateModel);
+    }
+
+    @Test
+    public void testPostProcess_customizationIsValid_succeeds() {
+        IntermediateModel intermediateModel = intermediateModelWithConfig("happy-case-customization.config");
+        processor.postprocess(intermediateModel);
+    }
+
+
+    private static IntermediateModel intermediateModelWithConfig(String configName) {
+        IntermediateModel intermediateModel = new IntermediateModelBuilder(C2jModels.builder()
+                .serviceModel(serviceModel)
+                .customizationConfig(CustomizationConfig.create())
+                .build())
+                .build();
+
+        intermediateModel.setCustomizationConfig(loadCustomizationConfig(configName));
+
+        return intermediateModel;
+    }
+
+    private static CustomizationConfig loadCustomizationConfig(String configName) {
+        String c2jFilePath = ExcludeEventNameFromVisitMethodProcessorTest.class.getResource(RESOURCE_ROOT + "/" + configName).getFile();
+        File file = new File(c2jFilePath);
+        return ModelLoaderUtils.loadModel(CustomizationConfig.class, file);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor/happy-case-customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor/happy-case-customization.config
@@ -1,0 +1,5 @@
+{
+    "excludeEventNameFromVisitMethod": {
+        "EventStream": ["EventOne"]
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor/multiple-event-types-same-shape.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor/multiple-event-types-same-shape.config
@@ -1,0 +1,5 @@
+{
+    "excludeEventNameFromVisitMethod": {
+        "EventStream": ["EventOne", "secondEventOne"]
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/emitters/customizations/processors/excludeventnamefromvisitor/service-2.json
@@ -412,6 +412,9 @@
         },
         "second-event-two": {
           "shape": "EventTwo"
+        },
+        "third-event-two-customizedVisitMethod": {
+          "shape": "EventTwo"
         }
       },
       "eventstream": true

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -13,5 +13,8 @@
   "utilitiesMethod": {
     "returnType": "software.amazon.awssdk.services.json.JsonUtilities",
     "createMethodParams": ["param1", "param2", "param3"]
+  },
+  "excludeEventNameFromVisitMethod": {
+    "EventStream": ["EventOne", "event-two"]
   }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -301,6 +301,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
                     EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
                             .putSdkPojoSupplier("event-two", EventTwo::builder)
+                            .putSdkPojoSupplier("secondEventOne", EventOne::builder)
+                            .putSdkPojoSupplier("second-event-two", EventTwo::builder)
                             .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
@@ -463,6 +465,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
                     EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
                             .putSdkPojoSupplier("event-two", EventTwo::builder)
+                            .putSdkPojoSupplier("secondEventOne", EventOne::builder)
+                            .putSdkPojoSupplier("second-event-two", EventTwo::builder)
                             .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-response-handler.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-response-handler.java
@@ -97,6 +97,28 @@ public interface EventStreamOperationResponseHandler extends
         }
 
         /**
+         * Invoked when a {@link EventOne} is encountered. If this is not overridden, the event will be given to
+         * {@link #visitDefault(EventStream)}.
+         *
+         * @param event
+         *        Event being visited
+         */
+        default void visitSecondEventOne(EventOne event) {
+            visitDefault(event);
+        }
+
+        /**
+         * Invoked when a {@link EventTwo} is encountered. If this is not overridden, the event will be given to
+         * {@link #visitDefault(EventStream)}.
+         *
+         * @param event
+         *        Event being visited
+         */
+        default void visitSecondEventTwo(EventTwo event) {
+            visitDefault(event);
+        }
+
+        /**
          * Builder for {@link Visitor}. The {@link Visitor} class may also be extended for a more traditional style but
          * this builder allows for a more functional way of creating a visitor will callback methods.
          */
@@ -133,6 +155,25 @@ public interface EventStreamOperationResponseHandler extends
              * @return This builder for method chaining.
              */
             Builder onEventTwo(Consumer<EventTwo> c);
+
+            /**
+             * Callback to invoke when a {@link EventOne} is visited.
+             *
+             * @param c
+             *        Callback to process the event.
+             * @return This builder for method chaining.
+             */
+            Builder onSecondEventOne(Consumer<EventOne> c);
+
+            /**
+             * Callback to invoke when a {@link EventTwo} is visited.
+             *
+             * @param c
+             *        Callback to process the event.
+             * @return This builder for method chaining.
+             */
+            Builder onSecondEventTwo(Consumer<EventTwo> c);
         }
     }
 }
+

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-visitor-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-visitor-builder.java
@@ -13,6 +13,10 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
 
     private Consumer<EventTwo> onEventTwo;
 
+    private Consumer<EventOne> onSecondEventOne;
+
+    private Consumer<EventTwo> onSecondEventTwo;
+
     @Override
     public EventStreamOperationResponseHandler.Visitor.Builder onDefault(Consumer<EventStream> c) {
         this.onDefault = c;
@@ -36,6 +40,18 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
         return this;
     }
 
+    @Override
+    public EventStreamOperationResponseHandler.Visitor.Builder onSecondEventOne(Consumer<EventOne> c) {
+        this.onSecondEventOne = c;
+        return this;
+    }
+
+    @Override
+    public EventStreamOperationResponseHandler.Visitor.Builder onSecondEventTwo(Consumer<EventTwo> c) {
+        this.onSecondEventTwo = c;
+        return this;
+    }
+
     @Generated("software.amazon.awssdk:codegen")
     static class VisitorFromBuilder implements EventStreamOperationResponseHandler.Visitor {
         private final Consumer<EventStream> onDefault;
@@ -44,12 +60,20 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
 
         private final Consumer<EventTwo> onEventTwo;
 
+        private final Consumer<EventOne> onSecondEventOne;
+
+        private final Consumer<EventTwo> onSecondEventTwo;
+
         VisitorFromBuilder(DefaultEventStreamOperationVisitorBuilder builder) {
             this.onDefault = builder.onDefault != null ? builder.onDefault
                     : EventStreamOperationResponseHandler.Visitor.super::visitDefault;
             this.onEventOne = builder.onEventOne != null ? builder.onEventOne
                     : EventStreamOperationResponseHandler.Visitor.super::visit;
             this.onEventTwo = builder.onEventTwo != null ? builder.onEventTwo
+                    : EventStreamOperationResponseHandler.Visitor.super::visit;
+            this.onSecondEventOne = builder.onSecondEventOne != null ? builder.onSecondEventOne
+                    : EventStreamOperationResponseHandler.Visitor.super::visit;
+            this.onSecondEventTwo = builder.onSecondEventTwo != null ? builder.onSecondEventTwo
                     : EventStreamOperationResponseHandler.Visitor.super::visit;
         }
 
@@ -67,5 +91,16 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
         public void visit(EventTwo event) {
             onEventTwo.accept(event);
         }
+
+        @Override
+        public void visitSecondEventOne(EventOne event) {
+            onSecondEventOne.accept(event);
+        }
+
+        @Override
+        public void visitSecondEventTwo(EventTwo event) {
+            onSecondEventTwo.accept(event);
+        }
     }
 }
+

--- a/services/kinesis/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesis/src/main/resources/codegen-resources/customization.config
@@ -15,5 +15,8 @@
   "customResponseMetadata": {
     "EXTENDED_REQUEST_ID": "x-amz-id-2"
   },
-  "serviceSpecificHttpConfig": "software.amazon.awssdk.services.kinesis.internal.KinesisHttpConfigurationOptions"
+  "serviceSpecificHttpConfig": "software.amazon.awssdk.services.kinesis.internal.KinesisHttpConfigurationOptions",
+  "excludeEventNameFromVisitMethod": {
+      "SubscribeToShardEventStream": ["SubscribeToShardEvent"]
+    }
 }

--- a/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,7 @@
 {
     "serviceSpecificHttpConfig": "software.amazon.awssdk.services.transcribestreaming.internal.DefaultHttpConfigurationOptions",
-    "skipSyncClientGeneration": true
+    "skipSyncClientGeneration": true,
+    "excludeEventNameFromVisitMethod": {
+        "TranscriptResultStream": ["TranscriptEvent"]
+      }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit fixes event visitor method generation by including the *event type*
in the visitor name. Note that event type here is actually the member name in
the encompassing eventstream structure, *not* the Java class of the event.

For example, in the example below, "Foo" is the event type.

```json
"MyEventStream": {
   "type": "structure",
   "eventstream": true,
   "members": {
       "Foo": {
           "shape": "Bar"
       }
   }
}
```

To ensure that this change is backwards compatible with existing services that
have event streams (Transcribe Streaming and Kinesis), we also include a
customization to supress this behavior keep the method name as "visit".

Note that by sheer luck, the existing consumer method setters, e.g.

```java
Builder onSubscribeToShardEvent(Consumer<SubscribeToShardEvent>);
```

are unaffected by this change. See an example [here](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/kinesis/model/SubscribeToShardResponseHandler.Visitor.Builder.html#onSubscribeToShardEvent-java.util.function.Consumer-).
The previous generation scheme for these methods is "on{Generation Java class
name for event shape}"; now it's "on{event type}".  However, both Transcribe and
Kinesis use the shape name as the member name (or vise versa?) in their current
iteration of their event streams.


For example, in Kinesis, SubscribeToShard's output stream is defined as

```json
"SubscribeToShardEventStream":{
  "type":"structure",
  "required":["SubscribeToShardEvent"],
  "members":{
    "SubscribeToShardEvent":{"shape":"SubscribeToShardEvent"},

    ...
    },
  "eventstream":true
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
