### PR TITLE
Add support for SSO credentials provider

### DIFF
--- a/.changes/next-release/feature-AWSSingleSignon-9e785be.json
+++ b/.changes/next-release/feature-AWSSingleSignon-9e785be.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS Single Sign-on", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Added support for retrieving SSO credentials: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html."
+}

--- a/core/annotations/src/main/java/software/amazon/awssdk/annotations/SdkInternalApi.java
+++ b/core/annotations/src/main/java/software/amazon/awssdk/annotations/SdkInternalApi.java
@@ -19,7 +19,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 /**
- * Marker interface for 'internal' APIs that should not be used outside the core module. Breaking
+ * Marker interface for 'internal' APIs that should not be used outside the same module. Breaking
  * changes can and will be introduced to elements marked as {@link SdkInternalApi}. Users of the SDK
  * and the generated clients themselves should not depend on any packages, types, fields,
  * constructors, or methods with this annotation.

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderFactory.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProfileCredentialsProviderFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.profiles.Profile;
+
+/**
+ * A factory for {@link AwsCredentialsProvider}s, which can be used to create different credentials providers with
+ * different Profile properties.
+ */
+@FunctionalInterface
+@SdkProtectedApi
+public interface ProfileCredentialsProviderFactory {
+    AwsCredentialsProvider create(Profile profile);
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/ProfileCredentialsUtils.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProcessCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProviderFactory;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
 import software.amazon.awssdk.core.internal.util.ClassLoaderHelper;
@@ -50,6 +51,8 @@ import software.amazon.awssdk.utils.Validate;
 public final class ProfileCredentialsUtils {
     private static final String STS_PROFILE_CREDENTIALS_PROVIDER_FACTORY =
         "software.amazon.awssdk.services.sts.internal.StsProfileCredentialsProviderFactory";
+    private static final String SSO_PROFILE_CREDENTIALS_PROVIDER_FACTORY =
+        "software.amazon.awssdk.services.sso.auth.SsoProfileCredentialsProviderFactory";
 
     private final Profile profile;
 
@@ -95,18 +98,21 @@ public final class ProfileCredentialsUtils {
      * @param children The child profiles that source credentials from this profile.
      */
     private Optional<AwsCredentialsProvider> credentialsProvider(Set<String> children) {
+        if (properties.containsKey(ProfileProperty.ROLE_ARN) && properties.containsKey(ProfileProperty.WEB_IDENTITY_TOKEN_FILE)) {
+            return Optional.ofNullable(roleAndWebIdentityTokenProfileCredentialsProvider());
+        }
+
+        if (properties.containsKey(ProfileProperty.SSO_ROLE_NAME) || properties.containsKey(ProfileProperty.SSO_ACCOUNT_ID)
+            || properties.containsKey(ProfileProperty.SSO_REGION) || properties.containsKey(ProfileProperty.SSO_START_URL)) {
+            return Optional.ofNullable(ssoProfileCredentialsProvider());
+        }
+
         if (properties.containsKey(ProfileProperty.ROLE_ARN)) {
             boolean hasSourceProfile = properties.containsKey(ProfileProperty.SOURCE_PROFILE);
             boolean hasCredentialSource = properties.containsKey(ProfileProperty.CREDENTIAL_SOURCE);
-            boolean hasWebIdentityTokenFile = properties.containsKey(ProfileProperty.WEB_IDENTITY_TOKEN_FILE);
-            boolean hasRoleArn = properties.containsKey(ProfileProperty.ROLE_ARN);
             Validate.validState(!(hasSourceProfile && hasCredentialSource),
                                 "Invalid profile file: profile has both %s and %s.",
                                 ProfileProperty.SOURCE_PROFILE, ProfileProperty.CREDENTIAL_SOURCE);
-
-            if (hasWebIdentityTokenFile && hasRoleArn) {
-                return Optional.ofNullable(roleAndWebIdentityTokenProfileCredentialsProvider());
-            }
 
             if (hasSourceProfile) {
                 return Optional.ofNullable(roleAndSourceProfileBasedProfileCredentialsProvider(children));
@@ -162,6 +168,17 @@ public final class ProfileCredentialsUtils {
         return ProcessCredentialsProvider.builder()
                                          .command(properties.get(ProfileProperty.CREDENTIAL_PROCESS))
                                          .build();
+    }
+
+    /**
+     * Create the SSO credentials provider based on the related profile properties.
+     */
+    private AwsCredentialsProvider ssoProfileCredentialsProvider() {
+        requireProperties(ProfileProperty.SSO_ACCOUNT_ID,
+                          ProfileProperty.SSO_REGION,
+                          ProfileProperty.SSO_ROLE_NAME,
+                          ProfileProperty.SSO_START_URL);
+        return ssoCredentialsProviderFactory().create(profile);
     }
 
     private AwsCredentialsProvider roleAndWebIdentityTokenProfileCredentialsProvider() {
@@ -259,6 +276,22 @@ public final class ProfileCredentialsUtils {
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("To use assumed roles in the '" + name + "' profile, the 'sts' service module must "
                                             + "be on the class path.", e);
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            throw new IllegalStateException("Failed to create the '" + name + "' profile credentials provider.", e);
+        }
+    }
+
+    /**
+     * Load the factory that can be used to create the SSO credentials provider, assuming it is on the classpath.
+     */
+    private ProfileCredentialsProviderFactory ssoCredentialsProviderFactory() {
+        try {
+            Class<?> ssoProfileCredentialsProviderFactory = ClassLoaderHelper.loadClass(SSO_PROFILE_CREDENTIALS_PROVIDER_FACTORY,
+                                                                                 getClass());
+            return (ProfileCredentialsProviderFactory) ssoProfileCredentialsProviderFactory.getConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("To use Sso related properties in the '" + name + "' profile, the 'sso' service "
+                                            + "module must be on the class path.", e);
         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
             throw new IllegalStateException("Failed to create the '" + name + "' profile credentials provider.", e);
         }

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileLocation.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileLocation.java
@@ -15,16 +15,15 @@
 
 package software.amazon.awssdk.profiles;
 
+import static software.amazon.awssdk.utils.UserHomeDirectoryUtils.userHomeDirectory;
+
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.utils.JavaSystemSetting;
-import software.amazon.awssdk.utils.StringUtils;
 
 /**
  * A collection of static methods for loading the location for configuration and credentials files.
@@ -46,7 +45,7 @@ public final class ProfileFileLocation {
     public static Path configurationFilePath() {
         return resolveProfileFilePath(
             ProfileFileSystemSetting.AWS_CONFIG_FILE.getStringValue()
-                                                    .orElse(Paths.get(ProfileFileLocation.userHomeDirectory(),
+                                                    .orElse(Paths.get(userHomeDirectory(),
                                                                       ".aws", "config").toString()));
     }
 
@@ -76,43 +75,6 @@ public final class ProfileFileLocation {
      */
     public static Optional<Path> credentialsFileLocation() {
         return resolveIfExists(credentialsFilePath());
-    }
-
-    /**
-     * Load the home directory that should be used for the profile file. This will check the same environment variables as the CLI
-     * to identify the location of home, before falling back to java-specific resolution.
-     */
-    @SdkInternalApi
-    static String userHomeDirectory() {
-        boolean isWindows = JavaSystemSetting.OS_NAME.getStringValue()
-                                                     .map(s -> StringUtils.lowerCase(s).startsWith("windows"))
-                                                     .orElse(false);
-
-        // To match the logic of the CLI we have to consult environment variables directly.
-        // CHECKSTYLE:OFF
-        String home = System.getenv("HOME");
-
-        if (home != null) {
-            return home;
-        }
-
-        if (isWindows) {
-            String userProfile = System.getenv("USERPROFILE");
-
-            if (userProfile != null) {
-                return userProfile;
-            }
-
-            String homeDrive = System.getenv("HOMEDRIVE");
-            String homePath = System.getenv("HOMEPATH");
-
-            if (homeDrive != null && homePath != null) {
-                return homeDrive + homePath;
-            }
-        }
-
-        return JavaSystemSetting.USER_HOME.getStringValueOrThrow();
-        // CHECKSTYLE:ON
     }
 
     private static Path resolveProfileFilePath(String path) {

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -99,6 +99,28 @@ public final class ProfileProperty {
      */
     public static final String RETRY_MODE = "retry_mode";
 
+    /**
+     * Aws region where the SSO directory for the given 'sso_start_url' is hosted. This is independent of the general 'region'.
+     */
+    public static final String SSO_REGION = "sso_region";
+
+    /**
+     * The corresponding IAM role in the AWS account that temporary AWS credentials will be resolved for.
+     */
+    public static final String SSO_ROLE_NAME = "sso_role_name";
+
+    /**
+     * AWS account ID that temporary AWS credentials will be resolved for.
+     */
+    public static final String SSO_ACCOUNT_ID = "sso_account_id";
+
+    /**
+     * Start url provided by the SSO service via the console. It's the main URL used for login to the SSO directory.
+     * This is also referred to as the "User Portal URL" and can also be used to login to the SSO web interface for AWS
+     * console access.
+     */
+    public static final String SSO_START_URL = "sso_start_url";
+
     private ProfileProperty() {
     }
 }

--- a/services/sso/pom.xml
+++ b/services/sso/pom.xml
@@ -56,5 +56,23 @@
             <artifactId>aws-json-protocol</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/ExpiredTokenException.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/ExpiredTokenException.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.auth;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+/**
+ * <p>
+ * The session token that was passed is expired or is not valid.
+ * </p>
+ */
+@SdkPublicApi
+public final class ExpiredTokenException extends SdkClientException {
+
+    private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList());
+
+    private ExpiredTokenException(Builder b) {
+        super(b);
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder extends SdkPojo, SdkClientException.Builder {
+        @Override
+        Builder message(String message);
+
+        @Override
+        Builder cause(Throwable cause);
+
+        @Override
+        ExpiredTokenException build();
+    }
+
+    static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(ExpiredTokenException model) {
+            super(model);
+        }
+
+        @Override
+        public BuilderImpl message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public BuilderImpl cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public ExpiredTokenException build() {
+            return new ExpiredTokenException(this);
+        }
+
+        @Override
+        public List<SdkField<?>> sdkFields() {
+            return SDK_FIELDS;
+        }
+    }
+}

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.auth;
+
+import static software.amazon.awssdk.utils.Validate.notNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sso.SsoClient;
+import software.amazon.awssdk.services.sso.internal.SessionCredentialsHolder;
+import software.amazon.awssdk.services.sso.model.GetRoleCredentialsRequest;
+import software.amazon.awssdk.services.sso.model.RoleCredentials;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.cache.CachedSupplier;
+import software.amazon.awssdk.utils.cache.NonBlocking;
+import software.amazon.awssdk.utils.cache.RefreshResult;
+
+/**
+ * <p>
+ * An implementation of {@link AwsCredentialsProvider} that is extended within this package to provide support for
+ * periodically updating session credentials. This credential provider maintains a {@link Supplier<GetRoleCredentialsRequest>}
+ * for a {@link SsoClient#getRoleCredentials(Consumer)} call to retrieve the credentials needed.
+ * </p>
+ *
+ * <p>
+ * While creating the {@link GetRoleCredentialsRequest}, an access token is needed to be resolved from a token file.
+ * In default, the token is assumed unexpired, and if it's expired then an {@link ExpiredTokenException} will be thrown.
+ * If the users want to change the behavior of this, please implement your own token resolving logic and override the
+ * {@link Builder#refreshRequest).
+ * </p>
+ *
+ * <p>
+ * When credentials get close to expiration, this class will attempt to update them asynchronously. If the credentials
+ * end up expiring, this class will block all calls to {@link #resolveCredentials()} until the credentials can be updated.
+ * </p>
+ */
+@SdkPublicApi
+public final class SsoCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
+
+    private static final Duration DEFAULT_STALE_TIME = Duration.ofMinutes(1);
+    private static final Duration DEFAULT_PREFETCH_TIME = Duration.ofMinutes(5);
+
+    private static final String ASYNC_THREAD_NAME = "sdk-sso-credentials-provider";
+
+    private final Supplier<GetRoleCredentialsRequest> getRoleCredentialsRequestSupplier;
+
+    private final SsoClient ssoClient;
+    private final Duration staleTime;
+    private final Duration prefetchTime;
+
+    private final CachedSupplier<SessionCredentialsHolder> credentialCache;
+
+    /**
+     * @see #builder()
+     */
+    private SsoCredentialsProvider(BuilderImpl builder) {
+        this.ssoClient = notNull(builder.ssoClient, "SSO client must not be null.");
+        this.getRoleCredentialsRequestSupplier = builder.getRoleCredentialsRequestSupplier;
+
+        this.staleTime = Optional.ofNullable(builder.staleTime).orElse(DEFAULT_STALE_TIME);
+        this.prefetchTime = Optional.ofNullable(builder.prefetchTime).orElse(DEFAULT_PREFETCH_TIME);
+
+        CachedSupplier.Builder<SessionCredentialsHolder> cacheBuilder = CachedSupplier.builder(this::updateSsoCredentials);
+        if (builder.asyncCredentialUpdateEnabled) {
+            cacheBuilder.prefetchStrategy(new NonBlocking(ASYNC_THREAD_NAME));
+        }
+
+        this.credentialCache = cacheBuilder.build();
+    }
+
+    /**
+     * Update the expiring session SSO credentials by calling SSO. Invoked by {@link CachedSupplier} when the credentials
+     * are close to expiring.
+     */
+    private RefreshResult<SessionCredentialsHolder> updateSsoCredentials() {
+        SessionCredentialsHolder credentials = getUpdatedCredentials(ssoClient);
+        Instant acutalTokenExpiration = credentials.sessionCredentialsExpiration();
+
+        return RefreshResult.builder(credentials)
+                            .staleTime(acutalTokenExpiration.minus(staleTime))
+                            .prefetchTime(acutalTokenExpiration.minus(prefetchTime))
+                            .build();
+    }
+
+    private SessionCredentialsHolder getUpdatedCredentials(SsoClient ssoClient) {
+        GetRoleCredentialsRequest request = getRoleCredentialsRequestSupplier.get();
+        notNull(request, "GetRoleCredentialsRequest can't be null.");
+        RoleCredentials roleCredentials = ssoClient.getRoleCredentials(request).roleCredentials();
+        AwsSessionCredentials sessionCredentials = AwsSessionCredentials.create(roleCredentials.accessKeyId(),
+                                                                                roleCredentials.secretAccessKey(),
+                                                                                roleCredentials.sessionToken());
+        return new SessionCredentialsHolder(sessionCredentials, Instant.ofEpochMilli(roleCredentials.expiration()));
+    }
+
+    /**
+     * The amount of time, relative to session token expiration, that the cached credentials are considered stale and
+     * should no longer be used. All threads will block until the value is updated.
+     */
+    public Duration staleTime() {
+        return staleTime;
+    }
+
+    /**
+     * The amount of time, relative to session token expiration, that the cached credentials are considered close to stale
+     * and should be updated.
+     */
+    public Duration prefetchTime() {
+        return prefetchTime;
+    }
+
+    /**
+     * Get a builder for creating a custom {@link SsoCredentialsProvider}.
+     */
+    public static BuilderImpl builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        return credentialCache.get().sessionCredentials();
+    }
+
+    @Override
+    public void close() {
+        credentialCache.close();
+    }
+
+    /**
+     * A builder for creating a custom {@link SsoCredentialsProvider}.
+     */
+    public interface Builder {
+
+        /**
+         * Configure the {@link SsoClient} to use when calling SSO to update the session. This client should not be shut
+         * down as long as this credentials provider is in use.
+         */
+        Builder ssoClient(SsoClient ssoclient);
+
+        /**
+         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
+         * threads are less likely to block when credentials are loaded, but addtiional resources are used to maintian
+         * the provider.
+         *
+         * <p>By default, this is disabled.</p>
+         */
+        Builder asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled);
+
+        /**
+         * Configure the amount of time, relative to SSO session token expiration, that the cached credentials are considered
+         * stale and should no longer be used. All threads will block until the value is updated.
+         *
+         * <p>By default, this is 1 minute.</p>
+         */
+        Builder staleTime(Duration staleTime);
+
+        /**
+         * Configure the amount of time, relative to SSO session token expiration, that the cached credentials are considered
+         * close to stale and should be updated. See {@link #asyncCredentialUpdateEnabled}.
+         *
+         * <p>By default, this is 5 minutes.</p>
+         */
+        Builder prefetchTime(Duration prefetchTime);
+
+        /**
+         * Configure the {@link GetRoleCredentialsRequest} that should be periodically sent to the SSO service to update the
+         * credentials.
+         */
+        Builder refreshRequest(GetRoleCredentialsRequest getRoleCredentialsRequest);
+
+        /**
+         * Similar to {@link #refreshRequest(GetRoleCredentialsRequest)}, but takes a {@link Supplier} to supply the request to
+         * SSO.
+         */
+        Builder refreshRequest(Supplier<GetRoleCredentialsRequest> getRoleCredentialsRequestSupplier);
+
+        /**
+         * Create a {@link SsoCredentialsProvider} using the configuration applied to this builder.
+         * @return
+         */
+        SsoCredentialsProvider build();
+
+    }
+
+    protected static final class BuilderImpl implements Builder {
+        private Boolean asyncCredentialUpdateEnabled = false;
+        private SsoClient ssoClient;
+        private Duration staleTime;
+        private Duration prefetchTime;
+        private Supplier<GetRoleCredentialsRequest> getRoleCredentialsRequestSupplier;
+
+        BuilderImpl() {
+
+        }
+
+        @Override
+        public Builder ssoClient(SsoClient ssoClient) {
+            this.ssoClient = ssoClient;
+            return this;
+        }
+
+        @Override
+        public Builder asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled) {
+            this.asyncCredentialUpdateEnabled = asyncCredentialUpdateEnabled;
+            return this;
+        }
+
+        @Override
+        public Builder staleTime(Duration staleTime) {
+            this.staleTime = staleTime;
+            return this;
+        }
+
+        @Override
+        public Builder prefetchTime(Duration prefetchTime) {
+            this.prefetchTime = prefetchTime;
+            return this;
+        }
+
+        @Override
+        public Builder refreshRequest(GetRoleCredentialsRequest getRoleCredentialsRequest) {
+            return refreshRequest(() -> getRoleCredentialsRequest);
+        }
+
+        @Override
+        public Builder refreshRequest(Supplier<GetRoleCredentialsRequest> getRoleCredentialsRequestSupplier) {
+            this.getRoleCredentialsRequestSupplier = getRoleCredentialsRequestSupplier;
+            return this;
+        }
+
+        @Override
+        public SsoCredentialsProvider build() {
+            return new SsoCredentialsProvider(this);
+        }
+
+    }
+}

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoProfileCredentialsProviderFactory.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoProfileCredentialsProviderFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.auth;
+
+import static software.amazon.awssdk.services.sso.internal.SsoTokenFileUtils.generateCachedTokenPath;
+import static software.amazon.awssdk.utils.UserHomeDirectoryUtils.userHomeDirectory;
+
+import java.nio.file.Paths;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProviderFactory;
+import software.amazon.awssdk.profiles.Profile;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sso.SsoClient;
+import software.amazon.awssdk.services.sso.internal.SsoAccessTokenProvider;
+import software.amazon.awssdk.services.sso.model.GetRoleCredentialsRequest;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
+/**
+ * An implementation of {@link ProfileCredentialsProviderFactory} that allows users to get SSO role credentials using the startUrl
+ * specified in either a {@link Profile} or environment variables.
+ */
+@SdkProtectedApi
+public class SsoProfileCredentialsProviderFactory implements ProfileCredentialsProviderFactory {
+
+    private static final String TOKEN_DIRECTORY = Paths.get(userHomeDirectory(), ".aws", "sso", "cache").toString();
+
+    /**
+     * Default method to create the {@link SsoProfileCredentialsProvider} with a {@link SsoAccessTokenProvider}
+     * object created with the start url from {@link Profile} or environment variables and the default token file directory.
+     */
+    public AwsCredentialsProvider create(Profile profile) {
+        return create(profile, new SsoAccessTokenProvider(
+            generateCachedTokenPath(profile.properties().get(ProfileProperty.SSO_START_URL), TOKEN_DIRECTORY)));
+    }
+
+    /**
+     * Alternative method to create the {@link SsoProfileCredentialsProvider} with a customized
+     * {@link SsoAccessTokenProvider}. This method is only used for testing.
+     */
+    @SdkTestInternalApi
+    public AwsCredentialsProvider create(Profile profile,
+                                         SsoAccessTokenProvider tokenProvider) {
+        return new SsoProfileCredentialsProvider(profile, tokenProvider);
+    }
+
+    /**
+     * A wrapper for a {@link SsoCredentialsProvider} that is returned by this factory when {@link #create(Profile)} or
+     * {@link #create(Profile, SsoAccessTokenProvider)} is invoked. This wrapper is important because it ensures the parent
+     * credentials provider is closed when the sso credentials provider is no longer needed.
+     */
+    private static final class SsoProfileCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
+        private final SsoClient ssoClient;
+        private final SsoCredentialsProvider credentialsProvider;
+
+        private SsoProfileCredentialsProvider(Profile profile,
+                                              SsoAccessTokenProvider tokenProvider) {
+            String ssoAccountId = profile.properties().get(ProfileProperty.SSO_ACCOUNT_ID);
+            String ssoRoleName = profile.properties().get(ProfileProperty.SSO_ROLE_NAME);
+            String ssoRegion = profile.properties().get(ProfileProperty.SSO_REGION);
+
+            this.ssoClient = SsoClient.builder()
+                                      .credentialsProvider(AnonymousCredentialsProvider.create())
+                                      .region(Region.of(ssoRegion))
+                                      .build();
+
+            GetRoleCredentialsRequest request = GetRoleCredentialsRequest.builder()
+                                                                         .accountId(ssoAccountId)
+                                                                         .roleName(ssoRoleName)
+                                                                         .build();
+
+            Supplier<GetRoleCredentialsRequest> supplier = () -> request.toBuilder()
+                                                                        .accessToken(tokenProvider.resolveAccessToken()).build();
+
+
+            this.credentialsProvider = SsoCredentialsProvider.builder()
+                                                             .ssoClient(ssoClient)
+                                                             .refreshRequest(supplier)
+                                                             .build();
+        }
+
+        @Override
+        public AwsCredentials resolveCredentials() {
+            return this.credentialsProvider.resolveCredentials();
+        }
+
+        @Override
+        public void close() {
+            IoUtils.closeQuietly(credentialsProvider, null);
+            IoUtils.closeQuietly(ssoClient, null);
+        }
+    }
+}

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/internal/SessionCredentialsHolder.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/internal/SessionCredentialsHolder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.internal;
+
+import java.time.Instant;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+/**
+ * Holder class used to atomically store a session with its expiration time.
+ */
+@SdkInternalApi
+@ThreadSafe
+public final class SessionCredentialsHolder {
+
+    private final AwsSessionCredentials sessionCredentials;
+    private final Instant sessionCredentialsExpiration;
+
+    public SessionCredentialsHolder(AwsSessionCredentials credentials, Instant expiration) {
+        this.sessionCredentials = credentials;
+        this.sessionCredentialsExpiration = expiration;
+    }
+
+    public AwsSessionCredentials sessionCredentials() {
+        return sessionCredentials;
+    }
+
+    public Instant sessionCredentialsExpiration() {
+        return sessionCredentialsExpiration;
+    }
+}

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/internal/SsoAccessTokenProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/internal/SsoAccessTokenProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.internal;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.util.json.JacksonUtils;
+import software.amazon.awssdk.services.sso.auth.ExpiredTokenException;
+import software.amazon.awssdk.services.sso.auth.SsoCredentialsProvider;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Resolve the access token from the cached token file. If the token has expired then throw out an exception to ask the users to
+ * update the token. This provider can also be replaced by any other implementation of resolving the access token. The users can
+ * resolve the access token in their own way and add it to the {@link SsoCredentialsProvider.Builder#refreshRequest}.
+ */
+@SdkInternalApi
+public final class SsoAccessTokenProvider {
+
+    private Path cachedTokenFilePath;
+
+    public SsoAccessTokenProvider(Path cachedTokenFilePath) {
+        this.cachedTokenFilePath = cachedTokenFilePath;
+    }
+
+    public String resolveAccessToken() {
+        try (InputStream cachedTokenStream = Files.newInputStream(cachedTokenFilePath)) {
+            return getTokenFromJson(IoUtils.toUtf8String(cachedTokenStream));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private String getTokenFromJson(String json) {
+        JsonNode jsonNode = JacksonUtils.sensitiveJsonNodeOf(json);
+
+        if (validateToken(jsonNode.get("expiresAt").asText())) {
+            throw ExpiredTokenException.builder().message("The SSO session associated with this profile has expired or is"
+                                                          + " otherwise invalid. To refresh this SSO session run aws sso"
+                                                          + " login with the corresponding profile.").build();
+        }
+
+        return jsonNode.get("accessToken").asText();
+    }
+
+    private boolean validateToken(String expirationTime) {
+        return Instant.now().isAfter(Instant.parse(expirationTime).minus(15, MINUTES));
+    }
+
+}

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/internal/SsoTokenFileUtils.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/internal/SsoTokenFileUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.internal;
+
+import static software.amazon.awssdk.utils.UserHomeDirectoryUtils.userHomeDirectory;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.regex.Pattern;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A tool class helps generating the path of cached token file.
+ */
+@SdkInternalApi
+public class SsoTokenFileUtils {
+
+    private static final Pattern HOME_DIRECTORY_PATTERN =
+        Pattern.compile("^~(/|" + Pattern.quote(FileSystems.getDefault().getSeparator()) + ").*$");
+
+    private SsoTokenFileUtils() {
+
+    }
+
+    /**
+     * Generate the cached file name by generating the SHA1 Hex Digest of the UTF-8 encoded start url bytes.
+     */
+    public static Path generateCachedTokenPath(String startUrl, String tokenDirectory) {
+        Validate.notNull(startUrl, "The start url shouldn't be null.");
+        byte[] startUrlBytes = startUrl.getBytes(StandardCharsets.UTF_8);
+        String encodedUrl = new String(startUrlBytes, StandardCharsets.UTF_8);
+        return resolveProfileFilePath(Paths.get(tokenDirectory, sha1Hex(encodedUrl) + ".json").toString());
+    }
+
+    /**
+     * Use {@link MessageDigest} instance to encrypt the input String.
+     */
+    private static String sha1Hex(String input) {
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-1");
+            md.update(input.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw SdkClientException.builder().message("Unable to use \"SHA-1\" algorithm.").cause(e).build();
+        }
+
+        return BinaryUtils.toHex(md.digest());
+    }
+
+    private static Path resolveProfileFilePath(String path) {
+        // Resolve ~ using the CLI's logic, not whatever Java decides to do with it.
+        if (HOME_DIRECTORY_PATTERN.matcher(path).matches()) {
+            path = userHomeDirectory() + path.substring(1);
+        }
+
+        return Paths.get(path);
+    }
+}

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProviderTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProviderTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sso.SsoClient;
+import software.amazon.awssdk.services.sso.auth.SsoCredentialsProvider;
+import software.amazon.awssdk.services.sso.model.GetRoleCredentialsRequest;
+import software.amazon.awssdk.services.sso.model.GetRoleCredentialsResponse;
+import software.amazon.awssdk.services.sso.model.RoleCredentials;
+
+/**
+ * Validates the functionality of {@link SsoCredentialsProvider}.
+ */
+public class SsoCredentialsProviderTest {
+
+    private SsoClient ssoClient;
+
+    @Test
+    public void cachingDoesNotApplyToExpiredSession() {
+        callClientWithCredentialsProvider(Instant.now().minus(Duration.ofSeconds(5)), 2, false);
+        callClient(verify(ssoClient, times(2)), Mockito.any());
+    }
+
+    @Test
+    public void cachingDoesNotApplyToExpiredSession_OverridePrefetchAndStaleTimes() {
+        callClientWithCredentialsProvider(Instant.now().minus(Duration.ofSeconds(5)), 2, true);
+        callClient(verify(ssoClient, times(2)), Mockito.any());
+    }
+
+    @Test
+    public void cachingAppliesToNonExpiredSession() {
+        callClientWithCredentialsProvider(Instant.now().plus(Duration.ofHours(5)), 2, false);
+        callClient(verify(ssoClient, times(1)), Mockito.any());
+    }
+
+    @Test
+    public void cachingAppliesToNonExpiredSession_OverridePrefetchAndStaleTimes() {
+        callClientWithCredentialsProvider(Instant.now().plus(Duration.ofHours(5)), 2, true);
+        callClient(verify(ssoClient, times(1)), Mockito.any());
+    }
+
+    @Test
+    public void distantExpiringCredentialsUpdatedInBackground() throws InterruptedException {
+        callClientWithCredentialsProvider(Instant.now().plusSeconds(90), 2, false);
+
+        Instant endCheckTime = Instant.now().plus(Duration.ofSeconds(5));
+        while (Mockito.mockingDetails(ssoClient).getInvocations().size() < 2 && endCheckTime.isAfter(Instant.now())) {
+            Thread.sleep(100);
+        }
+
+        callClient(verify(ssoClient, times(2)), Mockito.any());
+    }
+
+    @Test
+    public void distantExpiringCredentialsUpdatedInBackground_OverridePrefetchAndStaleTimes() throws InterruptedException {
+        callClientWithCredentialsProvider(Instant.now().plusSeconds(90), 2, true);
+
+        Instant endCheckTime = Instant.now().plus(Duration.ofSeconds(5));
+        while (Mockito.mockingDetails(ssoClient).getInvocations().size() < 2 && endCheckTime.isAfter(Instant.now())) {
+            Thread.sleep(100);
+        }
+
+        callClient(verify(ssoClient, times(2)), Mockito.any());
+    }
+
+
+
+    private GetRoleCredentialsRequestSupplier getRequestSupplier() {
+        return new GetRoleCredentialsRequestSupplier(GetRoleCredentialsRequest.builder().build(), "cachedToken");
+    }
+
+    private GetRoleCredentialsResponse getResponse(RoleCredentials roleCredentials) {
+        return GetRoleCredentialsResponse.builder().roleCredentials(roleCredentials).build();
+    }
+
+    private GetRoleCredentialsResponse callClient(SsoClient ssoClient, GetRoleCredentialsRequest request) {
+        return ssoClient.getRoleCredentials(request);
+    }
+
+    private void callClientWithCredentialsProvider(Instant credentialsExpirationDate, int numTimesInvokeCredentialsProvider,
+                                                   boolean overrideStaleAndPrefetchTimes) {
+        ssoClient = mock(SsoClient.class);
+        RoleCredentials credentials = RoleCredentials.builder().accessKeyId("a").secretAccessKey("b").sessionToken("c")
+                                                     .expiration(credentialsExpirationDate.toEpochMilli()).build();
+
+        Supplier<GetRoleCredentialsRequest> supplier = getRequestSupplier();
+        GetRoleCredentialsResponse response = getResponse(credentials);
+
+        when(ssoClient.getRoleCredentials(supplier.get())).thenReturn(response);
+
+        SsoCredentialsProvider.Builder ssoCredentialsProviderBuilder = SsoCredentialsProvider.builder().refreshRequest(supplier);
+
+        if(overrideStaleAndPrefetchTimes) {
+            ssoCredentialsProviderBuilder.staleTime(Duration.ofMinutes(2));
+            ssoCredentialsProviderBuilder.prefetchTime(Duration.ofMinutes(4));
+        }
+
+        try (SsoCredentialsProvider credentialsProvider = ssoCredentialsProviderBuilder.ssoClient(ssoClient).build()) {
+            if(overrideStaleAndPrefetchTimes) {
+                assertThat(credentialsProvider.staleTime()).as("stale time").isEqualTo(Duration.ofMinutes(2));
+                assertThat(credentialsProvider.prefetchTime()).as("prefetch time").isEqualTo(Duration.ofMinutes(4));
+            } else {
+                assertThat(credentialsProvider.staleTime()).as("stale time").isEqualTo(Duration.ofMinutes(1));
+                assertThat(credentialsProvider.prefetchTime()).as("prefetch time").isEqualTo(Duration.ofMinutes(5));
+            }
+
+            for (int i = 0; i < numTimesInvokeCredentialsProvider; ++i) {
+                AwsSessionCredentials actualCredentials = (AwsSessionCredentials) credentialsProvider.resolveCredentials();
+                assertThat(actualCredentials.accessKeyId()).isEqualTo("a");
+                assertThat(actualCredentials.secretAccessKey()).isEqualTo("b");
+                assertThat(actualCredentials.sessionToken()).isEqualTo("c");
+            }
+        }
+
+    }
+
+    private static final class GetRoleCredentialsRequestSupplier implements Supplier {
+        private final GetRoleCredentialsRequest request;
+        private final String cachedToken;
+
+        GetRoleCredentialsRequestSupplier(GetRoleCredentialsRequest request,
+                                          String cachedToken) {
+            this.request = request;
+            this.cachedToken = cachedToken;
+        }
+
+        @Override
+        public Object get() {
+            return request.toBuilder().accessToken(cachedToken).build();
+        }
+
+    }
+
+}

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoProfileCredentialsProviderFactoryTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoProfileCredentialsProviderFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.profiles.Profile;
+import software.amazon.awssdk.services.sso.internal.SsoAccessTokenProvider;
+
+/**
+ * Validate the code path of creating the {@link SsoCredentialsProvider} with {@link SsoProfileCredentialsProviderFactory}.
+ */
+public class SsoProfileCredentialsProviderFactoryTest {
+
+    @Test
+    public void createSsoCredentialsProviderWithFactorySucceed() throws IOException {
+        String startUrl = "https//d-abc123.awsapps.com/start";
+        String generatedTokenFileName = "6a888bdb653a4ba345dd68f21b896ec2e218c6f4.json";
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("sso_account_id", "accountId");
+        properties.put("sso_region", "region");
+        properties.put("sso_role_name", "roleName");
+        properties.put("sso_start_url", "https//d-abc123.awsapps.com/start");
+        Profile profile = Profile.builder().name("foo").properties(properties).build();
+
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"expiresAt\": \"2090-01-01T00:00:00Z\",\n" +
+                           "\"region\": \"us-west-2\", \n" +
+                           "\"startUrl\": \""+ startUrl +"\"\n" +
+                           "}";
+        SsoAccessTokenProvider tokenProvider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, generatedTokenFileName));
+
+        SsoProfileCredentialsProviderFactory factory = new SsoProfileCredentialsProviderFactory();
+        assertThat(factory.create(profile, tokenProvider)).isInstanceOf(AwsCredentialsProvider.class);
+    }
+
+    private Path prepareTestCachedTokenFile(String tokenFileContent, String generatedTokenFileName) throws IOException {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        Path fileDirectory = fs.getPath("./foo");
+
+        Files.createDirectory(fileDirectory);
+        Path cachedTokenFilePath = fileDirectory.resolve(generatedTokenFileName);
+        Files.write(cachedTokenFilePath, ImmutableList.of(tokenFileContent), StandardCharsets.UTF_8);
+
+        return cachedTokenFilePath;
+    }
+}

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoProfileTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/auth/SsoProfileTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.internal.ProfileCredentialsUtils;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.utils.StringInputStream;
+
+/**
+ * Validate the completeness of sso profile properties consumed by the {@link ProfileCredentialsUtils}.
+ */
+public class SsoProfileTest {
+
+    @Test
+    public void createSsoCredentialsProvider_SsoAccountIdMissing_throwException() {
+        String profileContent = "[profile foo]\n" +
+                                "sso_region=us-east-1\n" +
+                                "sso_role_name=SampleRole\n" +
+                                "sso_start_url=https://d-abc123.awsapps.com/start-beta\n";
+        ProfileFile profiles = ProfileFile.builder()
+                                          .content(new StringInputStream(profileContent))
+                                          .type(ProfileFile.Type.CONFIGURATION)
+                                          .build();
+        assertThat(profiles.profile("foo")).hasValueSatisfying(profile -> {
+            assertThatThrownBy(() -> new ProfileCredentialsUtils(profile, profiles::profile).credentialsProvider())
+                .hasMessageContaining("Profile property 'sso_account_id' was not configured");
+        });
+    }
+
+    @Test
+    public void createSsoCredentialsProvider_SsoRegionMissing_throwException() {
+        String profileContent = "[profile foo]\n" +
+                                "sso_account_id=012345678901\n" +
+                                "sso_role_name=SampleRole\n" +
+                                "sso_start_url=https://d-abc123.awsapps.com/start-beta\n";
+        ProfileFile profiles = ProfileFile.builder()
+                                          .content(new StringInputStream(profileContent))
+                                          .type(ProfileFile.Type.CONFIGURATION)
+                                          .build();
+        assertThat(profiles.profile("foo")).hasValueSatisfying(profile -> {
+            assertThatThrownBy(() -> new ProfileCredentialsUtils(profile, profiles::profile).credentialsProvider())
+                .hasMessageContaining("Profile property 'sso_region' was not configured");
+        });
+    }
+
+    @Test
+    public void createSsoCredentialsProvider_SsoRoleNameMissing_throwException() {
+        String profileContent = "[profile foo]\n" +
+                                "sso_account_id=012345678901\n" +
+                                "sso_region=us-east-1\n" +
+                                "sso_start_url=https://d-abc123.awsapps.com/start-beta\n";
+        ProfileFile profiles = ProfileFile.builder()
+                                          .content(new StringInputStream(profileContent))
+                                          .type(ProfileFile.Type.CONFIGURATION)
+                                          .build();
+        assertThat(profiles.profile("foo")).hasValueSatisfying(profile -> {
+            assertThatThrownBy(() -> new ProfileCredentialsUtils(profile, profiles::profile).credentialsProvider())
+                .hasMessageContaining("Profile property 'sso_role_name' was not configured");
+        });
+    }
+
+    @Test
+    public void createSsoCredentialsProvider_SsoStartUrlMissing_throwException() {
+        String profileContent = "[profile foo]\n" +
+                                "sso_account_id=012345678901\n" +
+                                "sso_region=us-east-1\n" +
+                                "sso_role_name=SampleRole\n";
+        ProfileFile profiles = ProfileFile.builder()
+                                          .content(new StringInputStream(profileContent))
+                                          .type(ProfileFile.Type.CONFIGURATION)
+                                          .build();
+        assertThat(profiles.profile("foo")).hasValueSatisfying(profile -> {
+            assertThatThrownBy(() -> new ProfileCredentialsUtils(profile, profiles::profile).credentialsProvider())
+                .hasMessageContaining("Profile property 'sso_start_url' was not configured");
+        });
+    }
+}

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/internal/SsoAccessTokenProviderTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/internal/SsoAccessTokenProviderTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+/**
+ * Check if the behavior of {@link SsoAccessTokenProvider} is correct while consuming different formats of cached token
+ * file.
+ */
+public class SsoAccessTokenProviderTest {
+
+    private static final String START_URL = "https//d-abc123.awsapps.com/start";
+    private static final String GENERATED_TOKEN_FILE_NAME = "6a888bdb653a4ba345dd68f21b896ec2e218c6f4.json";
+    private static final String WRONG_TOKEN_FILE_NAME = "wrong-token-file.json";
+
+    @Test
+    public void cachedTokenFile_correctFormat_resolveAccessTokenCorrectly() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"expiresAt\": \"2090-01-01T00:00:00Z\",\n" +
+                           "\"region\": \"us-west-2\", \n" +
+                           "\"startUrl\": \""+ START_URL +"\"\n" +
+                           "}";
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, GENERATED_TOKEN_FILE_NAME));
+        assertThat(provider.resolveAccessToken()).isEqualTo("base64string");
+    }
+
+    @Test
+    public void cachedTokenFile_accessTokenMissing_throwNullPointerException() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"expiresAt\": \"2090-01-01T00:00:00Z\",\n" +
+                           "\"region\": \"us-west-2\", \n" +
+                           "\"startUrl\": \""+ START_URL +"\"\n" +
+                           "}";
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, GENERATED_TOKEN_FILE_NAME));
+        assertThatThrownBy(provider::resolveAccessToken).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void cachedTokenFile_expiresAtMissing_throwNullPointerException() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"region\": \"us-west-2\", \n" +
+                           "\"startUrl\": \""+ START_URL +"\"\n" +
+                           "}";
+
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, GENERATED_TOKEN_FILE_NAME));
+        assertThatThrownBy(provider::resolveAccessToken).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void cachedTokenFile_optionalRegionMissing_resolveAccessTokenCorrectly() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"expiresAt\": \"2090-01-01T00:00:00Z\",\n" +
+                           "\"startUrl\": \""+ START_URL +"\"\n" +
+                           "}";
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, GENERATED_TOKEN_FILE_NAME));
+        assertThat(provider.resolveAccessToken()).isEqualTo("base64string");
+    }
+
+    @Test
+    public void cachedTokenFile_optionalStartUrlMissing_resolveAccessTokenCorrectly() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"expiresAt\": \"2090-01-01T00:00:00Z\",\n" +
+                           "\"region\": \"us-west-2\"\n" +
+                           "}";
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, GENERATED_TOKEN_FILE_NAME));
+        assertThat(provider.resolveAccessToken()).isEqualTo("base64string");
+    }
+
+    @Test
+    public void cachedTokenFile_alreadyExpired_resolveAccessTokenCorrectly() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"expiresAt\": \"2019-01-01T00:00:00Z\",\n" +
+                           "\"region\": \"us-west-2\"\n" +
+                           "}";
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(
+            prepareTestCachedTokenFile(tokenFile, GENERATED_TOKEN_FILE_NAME));
+        assertThatThrownBy(provider::resolveAccessToken).hasMessageContaining("The SSO session associated with this profile "
+                                                                              + "has expired or is otherwise invalid.");
+    }
+
+    @Test
+    public void cachedTokenFile_tokenFileNotExist_throwNullPointerException() throws IOException {
+        String tokenFile = "{\n" +
+                           "\"accessToken\": \"base64string\",\n" +
+                           "\"expiresAt\": \"2019-01-01T00:00:00Z\",\n" +
+                           "\"region\": \"us-west-2\"\n" +
+                           "}";
+        prepareTestCachedTokenFile(tokenFile, WRONG_TOKEN_FILE_NAME);
+        SsoAccessTokenProvider provider = new SsoAccessTokenProvider(createTestCachedTokenFilePath(
+            Jimfs.newFileSystem(Configuration.unix()).getPath("./foo"), GENERATED_TOKEN_FILE_NAME));
+        assertThatThrownBy(provider::resolveAccessToken).isInstanceOf(UncheckedIOException.class);
+    }
+
+    private Path prepareTestCachedTokenFile(String tokenFileContent, String generatedTokenFileName) throws IOException {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        Path fileDirectory = fs.getPath("./foo");
+
+        Files.createDirectory(fileDirectory);
+        Path cachedTokenFilePath = createTestCachedTokenFilePath(fileDirectory, generatedTokenFileName);
+        Files.write(cachedTokenFilePath, ImmutableList.of(tokenFileContent), StandardCharsets.UTF_8);
+
+        return cachedTokenFilePath;
+    }
+
+    private Path createTestCachedTokenFilePath(Path directory, String tokenFileName) {
+        return directory.resolve(tokenFileName);
+    }
+
+}

--- a/services/sso/src/test/java/software/amazon/awssdk/services/sso/internal/SsoTokenFileUtilsTest.java
+++ b/services/sso/src/test/java/software/amazon/awssdk/services/sso/internal/SsoTokenFileUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sso.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.services.sso.internal.SsoTokenFileUtils.generateCachedTokenPath;
+import static software.amazon.awssdk.utils.UserHomeDirectoryUtils.userHomeDirectory;
+
+import org.junit.Test;
+
+public class SsoTokenFileUtilsTest {
+
+    @Test
+    public void generateTheCorrectPathTest() {
+        String startUrl = "https//d-abc123.awsapps.com/start";
+        String directory = "~/.aws/sso/cache";
+        assertThat(generateCachedTokenPath(startUrl, directory).toString())
+            .isEqualTo(userHomeDirectory() + "/.aws/sso/cache/6a888bdb653a4ba345dd68f21b896ec2e218c6f4.json");
+    }
+
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/UserHomeDirectoryUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/UserHomeDirectoryUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Load the home directory that should be used for the stored file. This will check the same environment variables as the CLI
+ * to identify the location of home, before falling back to java-specific resolution.
+ */
+@SdkProtectedApi
+public final class UserHomeDirectoryUtils {
+
+    private UserHomeDirectoryUtils() {
+
+    }
+
+    public static String userHomeDirectory() {
+        // To match the logic of the CLI we have to consult environment variables directly.
+        // CHECKSTYLE:OFF
+        String home = System.getenv("HOME");
+
+        if (home != null) {
+            return home;
+        }
+
+        boolean isWindows = JavaSystemSetting.OS_NAME.getStringValue()
+                                                     .map(s -> StringUtils.lowerCase(s).startsWith("windows"))
+                                                     .orElse(false);
+
+        if (isWindows) {
+            String userProfile = System.getenv("USERPROFILE");
+
+            if (userProfile != null) {
+                return userProfile;
+            }
+
+            String homeDrive = System.getenv("HOMEDRIVE");
+            String homePath = System.getenv("HOMEPATH");
+
+            if (homeDrive != null && homePath != null) {
+                return homeDrive + homePath;
+            }
+        }
+
+        return JavaSystemSetting.USER_HOME.getStringValueOrThrow();
+        // CHECKSTYLE:ON
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/testutils/EnvironmentVariableHelper.java
+++ b/utils/src/test/java/software/amazon/awssdk/testutils/EnvironmentVariableHelper.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.testutils;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.junit.rules.ExternalResource;
+import software.amazon.awssdk.utils.SystemSetting;
+
+/**
+ * A utility that can temporarily forcibly set environment variables and
+ * then allows resetting them to the original values.
+ */
+public class EnvironmentVariableHelper extends ExternalResource {
+
+    private final Map<String, String> originalEnvironmentVariables;
+    private final Map<String, String> modifiableMap;
+    private volatile boolean mutated = false;
+
+    public EnvironmentVariableHelper() {
+        // CHECKSTYLE:OFF - This is a specific utility around system environment variables
+        originalEnvironmentVariables = new HashMap<>(System.getenv());
+        modifiableMap = Optional.ofNullable(processEnv()).orElse(envMap());
+        // CHECKSTYLE:ON
+    }
+
+    public void remove(SystemSetting setting) {
+        remove(setting.environmentVariable());
+    }
+
+    public void remove(String key) {
+        mutated = true;
+        modifiableMap.remove(key);
+    }
+
+    public void set(SystemSetting setting, String value) {
+        set(setting.environmentVariable(), value);
+    }
+
+    public void set(String key, String value) {
+        mutated = true;
+        modifiableMap.put(key, value);
+    }
+
+    public void reset() {
+        if (mutated) {
+            synchronized (this) {
+                if (mutated) {
+                    modifiableMap.clear();
+                    modifiableMap.putAll(originalEnvironmentVariables);
+                    mutated = false;
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void after() {
+        reset();
+    }
+
+    private PrivilegedExceptionAction<Void> setAccessible(Field f) {
+        return () -> {
+            f.setAccessible(true);
+            return null;
+        };
+    }
+
+    /**
+     * Static run method that allows for "single-use" environment variable modification.
+     *
+     * Example use:
+     * <pre>
+     * {@code
+     * EnvironmentVariableHelper.run(helper -> {
+     *    helper.set("variable", "value");
+     *    //run some test that uses "variable"
+     * });
+     * }
+     * </pre>
+     *
+     * Will call {@link #reset} at the end of the block (even if the block exits exceptionally).
+     *
+     * @param helperConsumer a code block to run that gets an {@link EnvironmentVariableHelper} as an argument
+     */
+    public static void run(Consumer<EnvironmentVariableHelper> helperConsumer) {
+        EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
+        try {
+            helperConsumer.accept(helper);
+        } finally {
+            helper.reset();
+        }
+    }
+
+    private Map<String, String> envMap() {
+        // CHECKSTYLE:OFF - This is a specific utility around system environment variables
+        return getField(System.getenv().getClass(), System.getenv(), "m");
+        // CHECKSTYLE:ON
+    }
+
+    /**
+     * Windows is using a different process environment.
+     *
+     * See http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/windows/classes/java/lang/ProcessEnvironment.java#l235
+     */
+    private Map<String, String> processEnv() {
+        Class<?> processEnvironment;
+        try {
+            processEnvironment = Class.forName("java.lang.ProcessEnvironment");
+            return getField(processEnvironment, null, "theCaseInsensitiveEnvironment");
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> getField(Class<?> processEnvironment, Object obj, String fieldName) {
+        try {
+            Field declaredField = processEnvironment.getDeclaredField(fieldName);
+            AccessController.doPrivileged(setAccessible(declaredField));
+
+            return (Map<String, String>) declaredField.get(obj);
+        } catch (IllegalAccessException | NoSuchFieldException | PrivilegedActionException e) {
+            return null;
+        }
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/UserHomeDirectoryUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/UserHomeDirectoryUtilsTest.java
@@ -13,9 +13,10 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.profiles;
+package software.amazon.awssdk.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.utils.UserHomeDirectoryUtils.userHomeDirectory;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -24,13 +25,10 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import software.amazon.awssdk.profiles.ProfileFileLocation;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
-/**
- * Verify the functionality of {@link ProfileFileLocation}.
- */
-public class ProfileFileLocationTest {
+public class UserHomeDirectoryUtilsTest {
+
     private final Map<String, String> savedEnvironmentVariableValues = new HashMap<>();
 
     private static final List<String> SAVED_ENVIRONMENT_VARIABLES = Arrays.asList("HOME",
@@ -46,11 +44,10 @@ public class ProfileFileLocationTest {
      */
     @Before
     public void saveEnvironment() throws Exception {
-        // The tests in this file change the os.home for testing windows vs non-windows loading, and the static constructor for
-        // ProfileFileLocation currently loads the file system separator based on the os.home. We need to call the static
-        // constructor for ProfileFileLocation before changing the os.home so that it doesn't try to load the file system
-        // separator during the test. If we don't, it'll complain that it doesn't recognize the file system.
-        ProfileFileLocation.userHomeDirectory();
+        // The tests in this file change the os.home for testing windows vs non-windows loading. We need to load the home
+        // directory that should be used for the stored file before changing the os.home so that it doesn't try to load
+        // the file system separator during the test. If we don't, it'll complain that it doesn't recognize the file system.
+        userHomeDirectory();
 
         for (String variable : SAVED_ENVIRONMENT_VARIABLES) {
             savedEnvironmentVariableValues.put(variable, System.getenv(variable));
@@ -84,18 +81,18 @@ public class ProfileFileLocationTest {
             ENVIRONMENT_VARIABLE_HELPER.set("HOMEDRIVE", "homedrive");
             ENVIRONMENT_VARIABLE_HELPER.set("HOMEPATH", "homepath");
 
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo("home");
+            assertThat(userHomeDirectory()).isEqualTo("home");
 
             ENVIRONMENT_VARIABLE_HELPER.remove("HOME");
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo("userprofile");
+            assertThat(userHomeDirectory()).isEqualTo("userprofile");
 
             ENVIRONMENT_VARIABLE_HELPER.remove("USERPROFILE");
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo("homedrivehomepath");
+            assertThat(userHomeDirectory()).isEqualTo("homedrivehomepath");
 
             ENVIRONMENT_VARIABLE_HELPER.remove("HOMEDRIVE");
             ENVIRONMENT_VARIABLE_HELPER.remove("HOMEPATH");
 
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
+            assertThat(userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
         } finally {
             System.setProperty("os.name", osName);
         }
@@ -112,18 +109,18 @@ public class ProfileFileLocationTest {
             ENVIRONMENT_VARIABLE_HELPER.set("HOMEDRIVE", "homedrive");
             ENVIRONMENT_VARIABLE_HELPER.set("HOMEPATH", "homepath");
 
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo("home");
+            assertThat(userHomeDirectory()).isEqualTo("home");
 
             ENVIRONMENT_VARIABLE_HELPER.remove("HOME");
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
+            assertThat(userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
 
             ENVIRONMENT_VARIABLE_HELPER.remove("USERPROFILE");
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
+            assertThat(userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
 
             ENVIRONMENT_VARIABLE_HELPER.remove("HOMEDRIVE");
             ENVIRONMENT_VARIABLE_HELPER.remove("HOMEPATH");
 
-            assertThat(ProfileFileLocation.userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
+            assertThat(userHomeDirectory()).isEqualTo(System.getProperty("user.home"));
         } finally {
             System.setProperty("os.name", osName);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add support for SSO Credentials Provider.

## Description
<!--- Describe your changes in detail -->
In this pr, a credential provider that exchanges a resolved SSO login token for temporary AWS credentials is added. Besides, several new classes and tests are added to enable this credentials provider.

Main Updates since the first review:
1. Merged the `SsoCredentialsProvider` into part of the `ProfileCredentialsProvider` so the profile addressing part can be better taken care of;
2. Separate the generation of cached token path and resolution of access token to make it more flexible;
3. Updated all the tests to make them match the current code and achieve better coverage;

Besides the main changes for SSO, there are also some small changes to the code:
1. Corrected the javadocs of annotation `SdkInternalApi` to make it more accurate;
2. Moved the `userHomeDirectory`method out of `ProfileFileLocation` and put it in the `utils` module, thus it can be used by the other modules;

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently, SSO provides customers an interface where customers can copy-paste snippests to set the environment variables to temporary credentials that they generate.
While the interface is good for console access and fine for occasional API use, it is painful for repeated API use as customers have to go back to the SSO page every hour to get new credentials. Allowing customers to use their existing login username and password to fetch temporart AWS credentials without having to go to an external site is a much more seamless experience.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since this credentials provider include interaction with SSO service and it relies on another SSO login flow, so there isn’t integration tests added here. However, to make sure the functionality is sound, multiple unit tests and functional tests are added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license