### PR TITLE
  Event transformation based on type

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AwsServiceModel.java
@@ -699,9 +699,7 @@ public class AwsServiceModel implements ClassSpec {
             returnType = baseClass.nestedClass("Builder");
         }
 
-        String eventClass = intermediateModel.getNamingStrategy().getShapeClassName(event.getName());
-        String methodName = String.format("%sBuilder", StringUtils.uncapitalize(eventClass));
-
+        String methodName = specHelper.eventBuilderMethodName(event);
         return MethodSpec.methodBuilder(methodName)
                 .addModifiers(PUBLIC, Modifier.STATIC)
                 .returns(returnType)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/EventStreamSpecHelper.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/EventStreamSpecHelper.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.naming.NamingStrategy;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.codegen.poet.eventstream.EventTypeEnumSpec;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
 
 public final class EventStreamSpecHelper {
@@ -90,5 +91,9 @@ public final class EventStreamSpecHelper {
     public String eventTypeEnumValue(MemberModel eventModel) {
         NamingStrategy namingStrategy = intermediateModel.getNamingStrategy();
         return namingStrategy.getEnumValueName(eventModel.getName());
+    }
+
+    public String eventBuilderMethodName(MemberModel eventModel) {
+        return String.format("%sBuilder", StringUtils.uncapitalize(eventModel.getName()));
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
@@ -22,7 +22,6 @@ import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
-import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.protocols.core.OperationInfo;
@@ -35,11 +34,8 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
-    private final IntermediateModel intermediateModel;
-
     public EventStreamJsonMarshallerSpec(IntermediateModel model, ShapeModel shapeModel) {
         super(shapeModel);
-        this.intermediateModel = model;
     }
 
     @Override
@@ -50,8 +46,8 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
                      .addStatement("$T<$T> protocolMarshaller = protocolFactory.createProtocolMarshaller(SDK_OPERATION_BINDING)",
                                    ProtocolMarshaller.class, SdkHttpFullRequest.class)
                      .add("return protocolMarshaller.marshall($L).toBuilder()", variableName)
-                     .add(".putHeader(\":message-type\", \"event\")")
-                     .add(".putHeader(\":event-type\", \"$L\")", getMemberNameFromEventStream());
+                     .add(".putHeader($S, $S)", ":message-type", "event")
+                     .add(".putHeader($S, $N.sdkEventType().toString())", ":event-type", variableName);
 
         // Add :content-type header only if payload is present
         if (!shapeModel.hasNoEventPayload()) {
@@ -81,18 +77,6 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
                         .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.STATIC)
                         .initializer(builder.build())
                         .build();
-    }
-
-    private String getMemberNameFromEventStream() {
-        ShapeModel eventStream = EventStreamUtils.getBaseEventStreamShape(intermediateModel, shapeModel)
-            .orElseThrow(() -> new IllegalStateException("Could not find associated event stream spec for "
-                                                         + shapeModel.getC2jName()));
-        return eventStream.getMembers().stream()
-                          .filter(memberModel -> memberModel.getShape().equals(shapeModel))
-                          .findAny()
-                          .map(MemberModel::getC2jName)
-                          .orElseThrow(() -> new IllegalStateException(
-                              String.format("Unable to find %s from its parent event stream", shapeModel.getC2jName())));
     }
 
     private String determinePayloadContentType() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -57,7 +57,6 @@ import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest;
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputResponse;
-import software.amazon.awssdk.services.json.model.EventOne;
 import software.amazon.awssdk.services.json.model.EventStream;
 import software.amazon.awssdk.services.json.model.EventStreamOperationRequest;
 import software.amazon.awssdk.services.json.model.EventStreamOperationResponse;
@@ -67,7 +66,6 @@ import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyIn
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputRequest;
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponse;
 import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponseHandler;
-import software.amazon.awssdk.services.json.model.EventTwo;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
 import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
 import software.amazon.awssdk.services.json.model.InputEvent;
@@ -304,9 +302,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             HttpResponseHandler<? extends EventStream> eventResponseHandler = protocolFactory.createResponseHandler(
                     JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
-                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
-                            .putSdkPojoSupplier("EventTheSecond", EventTwo::builder)
-                            .putSdkPojoSupplier("secondEventOne", EventOne::builder)
+                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventStream::eventOneBuilder)
+                            .putSdkPojoSupplier("EventTheSecond", EventStream::eventTheSecondBuilder)
+                            .putSdkPojoSupplier("secondEventOne", EventStream::secondEventOneBuilder)
                             .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
@@ -467,9 +465,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
             HttpResponseHandler<? extends EventStream> eventResponseHandler = protocolFactory.createResponseHandler(
                     JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
-                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventOne::builder)
-                            .putSdkPojoSupplier("EventTheSecond", EventTwo::builder)
-                            .putSdkPojoSupplier("secondEventOne", EventOne::builder)
+                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventStream::eventOneBuilder)
+                            .putSdkPojoSupplier("EventTheSecond", EventStream::eventTheSecondBuilder)
+                            .putSdkPojoSupplier("secondEventOne", EventStream::secondEventOneBuilder)
                             .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventOneMarshaller implements Marshaller<EventOne> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -32,11 +32,13 @@ public class EventOneMarshaller implements Marshaller<EventOne> {
         Validate.paramNotNull(eventOne, "eventOne");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventOne).toBuilder().putHeader(":message-type", "event")
-                                     .putHeader(":event-type", "EventOne").putHeader(":content-type", "application/json").build();
+                    .putHeader(":event-type", eventOne.sdkEventType().toString()).putHeader(":content-type", "application/json")
+                    .build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
+

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
@@ -19,7 +19,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventThreeMarshaller implements Marshaller<EventThree> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
     public EventThreeMarshaller(BaseAwsJsonProtocolFactory protocolFactory) {
@@ -33,7 +34,8 @@ public class EventThreeMarshaller implements Marshaller<EventThree> {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventThree).toBuilder().putHeader(":message-type", "event")
-                    .putHeader(":event-type", "EventThree").putHeader(":content-type", "application/json").build();
+                    .putHeader(":event-type", eventThree.sdkEventType().toString())
+                    .putHeader(":content-type", "application/json").build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventTwoMarshaller implements Marshaller<EventTwo> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -32,11 +32,13 @@ public class EventTwoMarshaller implements Marshaller<EventTwo> {
         Validate.paramNotNull(eventTwo, "eventTwo");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventTwo).toBuilder().putHeader(":message-type", "event")
-                                     .putHeader(":event-type", "EventTwo").putHeader(":content-type", "application/json").build();
+                    .putHeader(":event-type", eventTwo.sdkEventType().toString()).putHeader(":content-type", "application/json")
+                    .build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
+

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventmarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class InputEventMarshaller implements Marshaller<InputEvent> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(true)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -32,11 +32,13 @@ public class InputEventMarshaller implements Marshaller<InputEvent> {
         Validate.paramNotNull(inputEvent, "inputEvent");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(inputEvent).toBuilder().putHeader(":message-type", "event")
-                                     .putHeader(":event-type", "InputEvent").putHeader(":content-type", "application/octet-stream").build();
+                    .putHeader(":event-type", inputEvent.sdkEventType().toString())
+                    .putHeader(":content-type", "application/octet-stream").build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
+

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class InputEventTwoMarshaller implements Marshaller<InputEventTwo> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -32,11 +32,13 @@ public class InputEventTwoMarshaller implements Marshaller<InputEventTwo> {
         Validate.paramNotNull(inputEventTwo, "inputEventTwo");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(inputEventTwo).toBuilder().putHeader(":message-type", "event")
-                                     .putHeader(":event-type", "InputEventTwo").putHeader(":content-type", "application/json").build();
+                    .putHeader(":event-type", inputEventTwo.sdkEventType().toString())
+                    .putHeader(":content-type", "application/json").build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
+


### PR DESCRIPTION
## Description
Fixes event marshalling and unmarshalling:

 - Fix unmarshalling by mapping event type to the correct builder static
   constructor on the eventstream interface.

 - Fix marshalling by retrieving the value for the :event-type header from the
   event using getSdkEventType()

Builds off #2176.

## Motivation and Context
Bug fix.

## Testing

Updated `codegen` reference files.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
