### PR TITLE
Adding Crosslink redirect for API reference document

### DIFF
--- a/buildspecs/release-javadoc.yml
+++ b/buildspecs/release-javadoc.yml
@@ -22,3 +22,5 @@ phases:
     - aws s3 sync $DOC_PATH/$RELEASE_VERSION/ $DOC_PATH/latest/ --acl=public-read --delete
     - jar cf aws-java-sdk-v2-docs.jar -C target/site/apidocs .
     - aws s3 cp aws-java-sdk-v2-docs.jar $DOC_PATH/ --acl="public-read"
+    - python ./scripts/doc_crosslinks/generate_cross_link_data.py --apiDefinitionsBasePath ./services/ --apiDefinitionsRelativeFilePath src/main/resources/codegen-resources/service-2.json  --templateFilePath ./scripts/doc_crosslinks/crosslink_redirect.html --outputFilePath ./scripts/crosslink_redirect.html
+    - aws s3 cp ./scripts/crosslink_redirect.html $DOC_PATH/latest/ --acl="public-read"

--- a/scripts/doc_crosslinks/crosslink_redirect.html
+++ b/scripts/doc_crosslinks/crosslink_redirect.html
@@ -1,0 +1,68 @@
+<DOCTYPE HTML>
+    <html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <script type="text/javascript">
+
+            var uidServiceData = '${UID_SERVICE_MAPPING}';
+            var uidToServiceName = JSON.parse(uidServiceData);
+            var uidClientNameData = '${UID_CLIENT_CLASS_MAPPING}';
+            var uidToClientName = JSON.parse(uidClientNameData);
+            var baseUri = window.location.href;
+            var serviceFolderPath = "software/amazon/awssdk/services/";
+
+            function getQueryStringParameter(name, url) {
+
+                var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)");
+                name = name.replace(/[\[\]]/g, "\\$&");
+                results = regex.exec(url);
+                if (!results) return null;
+                if (!results[2]) return '';
+                return decodeURIComponent(results[2].replace(/\+/g, " "));
+            }
+
+            function camelize(str) {
+                return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function(word, index) {
+                    return index === 0 ? word.toLowerCase() : word.toUpperCase();
+                }).replace(/\s+/g, '');
+            }
+
+            function checkResourceExists(url) {
+                try {
+                    var xmlHttp = new XMLHttpRequest();
+                    xmlHttp.open( "GET", url, false );
+                    xmlHttp.send( null );
+                    return xmlHttp.status == 200;
+                }
+                catch(err) {
+                    return false;
+                }
+            }
+
+            var typeName = getQueryStringParameter("type", window.location.href);
+            var operation = getQueryStringParameter("operation", window.location.href);
+            var uid = getQueryStringParameter("uid", window.location.href);
+            var clientObjectName =  uidToClientName[uid];
+            var serviceName =  uidToServiceName[uid];
+            var redirectSuffixLink = "index.html"
+
+            if(clientObjectName != null && serviceName != null) {
+                redirectServiceSuffixLink = serviceFolderPath + serviceName + "/model/" + typeName + ".html" ;
+                if(checkResourceExists( baseUri.replace(/crosslink_redirect.*/gi, redirectServiceSuffixLink) )) {
+                    redirectSuffixLink =  redirectServiceSuffixLink;
+                }
+                else
+                {
+                    redirectServiceSuffixLink =  serviceFolderPath + serviceName + "/" + clientObjectName + ".html" ;
+                    if(typeName != null)
+                        redirectServiceSuffixLink  = redirectServiceSuffixLink + "#" + camelize(typeName) + "--";
+                    if(checkResourceExists( baseUri.replace(/crosslink_redirect.*/gi, redirectServiceSuffixLink) ))
+                        redirectSuffixLink =  redirectServiceSuffixLink;
+                }
+            }
+            window.location.href = redirectSuffixLink ;
+        </script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/scripts/doc_crosslinks/generate_cross_link_data.py
+++ b/scripts/doc_crosslinks/generate_cross_link_data.py
@@ -1,0 +1,120 @@
+import os
+import argparse
+import io
+import codecs
+import json
+import re
+# import requests
+from os import listdir
+from os.path import isdir, exists, join
+from re import split
+
+sdks = {}
+clientClass = {}
+
+def generateDocsMap(apiDefinitionsPath, apiDefinitionsRelativeFilePath):
+
+    filesInDir = [f for f in listdir(apiDefinitionsPath) if isdir(join(apiDefinitionsPath, f))]
+    for file in filesInDir :
+        serviceJsonFileName = join(apiDefinitionsPath, join(file, apiDefinitionsRelativeFilePath))
+
+        if(exists(serviceJsonFileName)) :
+            with codecs.open(serviceJsonFileName, 'rb', 'utf-8') as api_definition:
+                api_content = json.loads(api_definition.read())
+                if "uid" in api_content["metadata"].keys():
+                    sdks[api_content["metadata"]["uid"]] = file
+                clientClass[api_content["metadata"]["uid"]] = getClientClassNameFromMetadata(api_content["metadata"])
+
+#                 # Below  code can be used for debugging  failing clients
+#                 str  = "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/"+ file +"/"+getClientClassNameFromMetadata(api_content["metadata"])+".html"+"#validateTemplate--"
+#                 ret = requests.head(str)
+#                 if( ret.status_code != 200 ):
+#                     print(str)
+
+    return sdks
+
+def splitOnWordBoundaries(toSplit) :
+    result = toSplit
+    result = re.sub(r'[^A-Za-z0-9]+', " ", result)
+    result = re.sub(r'([^a-z]{2,})v([0-9]+)', r'\g<1> v\g<2>' , result)
+    result = re.sub(r'([^A-Z]{2,})V([0-9]+)', r'\g<1> V\g<2>', result)
+    result = re.sub(r'(?<=[a-z])(?=[A-Z]([a-zA-Z]|[0-9]))', r' ', result)
+    result = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\g<1> \g<2>', result)
+    result = re.sub(r'([0-9])([a-zA-Z])', r'\g<1> \g<2>', result)
+    result = re.sub(r' +', ' ', result)
+    return result.split(" ");
+
+
+def capitalize(str):
+    if(str is None or len(str) == 0):
+        return str
+    strFirstCaps = str[0].title() + str[1:]
+    return strFirstCaps
+
+
+def lowerCase(str):
+    if(str is None or len(str) == 0):
+        return str
+    return str.lower()
+
+def pascalCase(str):
+    splits = splitOnWordBoundaries(str)
+    modifiedStr = ""
+    for i in range(0, len(splits)) :
+        modifiedStr += capitalize(lowerCase(splits[i]))
+    return modifiedStr
+
+def getClientClassNameFromMetadata(metadataNode):
+    toSanitize = ""
+    if "serviceId" in metadataNode.keys():
+        toSanitize = metadataNode["serviceId"]
+    clientName = pascalCase(toSanitize)
+    clientName =  removeLeading(clientName , "Amazon")
+    clientName =  removeLeading(clientName, "Aws")
+    clientName = removeTrailing(clientName, "Service" )
+    return   clientName + "Client"
+
+
+def removeLeading(str, toRemove) :
+    if(str is None) :
+        return str
+    if(str.startswith(toRemove)):
+        return str.replace(toRemove, "")
+    return str
+
+def removeTrailing(str, toRemove) :
+    if(str is None) :
+        return str
+    if(str.endswith(toRemove)):
+        return str.replace(toRemove, "")
+    return str
+
+def insertDocsMapToRedirect(apiDefinitionsBasePath, apiDefinitionsRelativeFilePath, templateFilePath, outputFilePath):
+    generateDocsMap(apiDefinitionsBasePath, apiDefinitionsRelativeFilePath)
+    output = ""
+    with codecs.open(templateFilePath, 'rb', 'utf-8') as redirect_template:
+        current_template = redirect_template.read();
+        output = current_template.replace("${UID_SERVICE_MAPPING}", json.dumps(sdks, ensure_ascii=False))
+        output = output.replace("${UID_CLIENT_CLASS_MAPPING}", json.dumps(clientClass, ensure_ascii=False))
+    with open(outputFilePath, 'w') as redirect_output:
+        redirect_output.write(output)
+
+def Main():
+    parser = argparse.ArgumentParser(description="Generates a Cross-link redirect file.")
+    parser.add_argument("--apiDefinitionsBasePath", action="store")
+    parser.add_argument("--apiDefinitionsRelativeFilePath", action="store")
+    parser.add_argument("--templateFilePath", action="store")
+    parser.add_argument("--outputFilePath", action="store")
+    
+    args = vars( parser.parse_args() )
+    argMap = {}
+    argMap[ "apiDefinitionsBasePath" ] = args[ "apiDefinitionsBasePath" ] or "./../services/"
+    argMap[ "apiDefinitionsRelativeFilePath" ] = args[ "apiDefinitionsRelativeFilePath" ] or "/src/main/resources/codegen-resources/service-2.json"
+    argMap[ "templateFilePath" ] = args[ "templateFilePath" ] or "./scripts/crosslink_redirect.html"
+    argMap[ "outputFilePath" ] = args[ "outputFilePath" ] or "./crosslink_redirect.html"
+    
+    insertDocsMapToRedirect(argMap["apiDefinitionsBasePath"], argMap["apiDefinitionsRelativeFilePath"], argMap["templateFilePath"], argMap["outputFilePath"])
+    print("Generated Cross link at " + argMap["outputFilePath"])
+    
+Main()    
+            


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adding Crosslink redirect for API reference document
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- As of now we donot have Links to Java Doc link for API reference
- This PR will will create a static page which will extract the ClientName and service name from the API refenence and redirect to the s3 location where we have Java V2 docs,


### generate_cross_link_data.py 
-  this loops through all the services service-2.json  and gets the service name and client name
- The python code is same as Java code where we generate the [DefaultNamingStrategy-Link](https://github.com/aws/aws-sdk-java-v2/blob/35c5f89ae29b3e5bbf3ab711c1b7b7024b76bd97/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultNamingStrategy.java#L116-L130)

### crosslink_redirect.html
- This will redirect the SPI refernced link via Java Scripts the maps are populated during publish java docs from above python scripts.

### release-javadoc.yml
- This will create the static redirect html  in the S3 Java while releasing Java docs.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested end to end by running publish-javadoc builds
- Tested error cases when incorrect redirect in this case it will land to index.html



## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
