### PR TITLE
Add validation for new streams

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/DefaultCustomizationProcessor.java
@@ -34,7 +34,8 @@ public final class DefaultCustomizationProcessor {
                 new ShapeSubstitutionsProcessor(config.getShapeSubstitutions()),
                 new OperationModifiersProcessor(config.getOperationModifiers()),
                 new RemoveExceptionMessagePropertyProcessor(),
-                new UseLegacyEventGenerationSchemeProcessor()
+                new UseLegacyEventGenerationSchemeProcessor(),
+                new NewAndLegacyEventStreamProcessor()
         );
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/NewAndLegacyEventStreamProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/NewAndLegacyEventStreamProcessor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.customization.processors;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.codegen.customization.CodegenCustomizationProcessor;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.service.ServiceModel;
+
+/**
+ * Services that have "legacy" streams, Kinesis and Transcribe Streaming builds should fail if there is a new
+ * evenstream added, that codegen doesn't know about. This is so we can decide if we want to generate the new stream in
+ * the legacy style so they look like the existing streams, or if we use the new style (e.g. because it won't work with
+ * the old style).
+ */
+public final class NewAndLegacyEventStreamProcessor implements CodegenCustomizationProcessor {
+    // Map from service ID -> list of event streams we know about and approve
+    private static final Map<String, Set<String>> APPROVED_EVENT_STREAMS;
+
+    static {
+        Map<String, Set<String>> approvedEventStreams = new HashMap<>();
+
+        approvedEventStreams.put("Kinesis", new HashSet<>(Arrays.asList("SubscribeToShardEventStream")));
+        approvedEventStreams.put("Transcribe Streaming",
+                new HashSet<>(Arrays.asList("AudioStream", "TranscriptResultStream", "MedicalTranscriptResultStream")));
+
+        APPROVED_EVENT_STREAMS = Collections.unmodifiableMap(approvedEventStreams);
+    }
+
+
+    @Override
+    public void preprocess(ServiceModel serviceModel) {
+        String serviceId = serviceModel.getMetadata().getServiceId();
+        if (!APPROVED_EVENT_STREAMS.containsKey(serviceId)) {
+            return;
+        }
+
+        Set<String> approvedStreams = APPROVED_EVENT_STREAMS.get(serviceId);
+
+        serviceModel.getShapes().entrySet().stream()
+                .filter(e -> e.getValue().isEventstream())
+                .forEach(e -> {
+                    String name = e.getKey();
+                    if (!approvedStreams.contains(name)) {
+                        throw unknownStreamError(serviceId, name);
+                    }
+                });
+    }
+
+    @Override
+    public void postprocess(IntermediateModel intermediateModel) {
+        // no-op
+    }
+
+    private static RuntimeException unknownStreamError(String serviceId, String evenstreamName) {
+        String msg = String.format("Encountered a new eventstream for service %s: %s. This service contains " +
+                "evenstreams that are code generated using an older style that requires a customization. Please " +
+                "contact the Java SDK maintainers for assistance.", serviceId, evenstreamName);
+
+        return new RuntimeException(msg);
+    }
+}


### PR DESCRIPTION
## Description
Validation is only for Kinesis, Transcribe Streaming, since they have existing
streams generated with the old style.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Remove streams from the Kinesis and Transcribe Stream mappings and attempt to generate.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
