### PR TITLE
Add japicmp plugin to validate source and binary compatibility

### DIFF
--- a/buildspecs/release-to-maven.yml
+++ b/buildspecs/release-to-maven.yml
@@ -20,7 +20,7 @@ phases:
       if ! curl -f --head $SONATYPE_URL; then
         mkdir -p $CREDENTIALS
         aws s3 cp s3://aws-java-sdk-release-credentials/ $CREDENTIALS/ --recursive
-        mvn clean deploy -B -s $SETTINGS_XML -Dgpg.homedir=$GPG_HOME -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30
+        mvn clean deploy -B -s $SETTINGS_XML -Dgpg.homedir=$GPG_HOME -Ppublishing -DperformRelease -Dspotbugs.skip -DskipTests -Dcheckstyle.skip -Djapicmp.skip -Ddoclint=none -pl !:protocol-tests,!:protocol-tests-core,!:codegen-generated-classes-test,!:sdk-benchmarks,!:module-path-tests,!:tests-coverage-reporting,!:stability-tests -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30
       else
         echo "This version was already released."
       fi

--- a/buildspecs/update-master-from-release.yml
+++ b/buildspecs/update-master-from-release.yml
@@ -27,12 +27,14 @@ phases:
     - POINT=$(echo $RELEASE_VERSION | cut -d'.' -f3)
     - NEW_VERSION_SNAPSHOT="$MAJOR.$MINOR.$((POINT + 1))-SNAPSHOT"
     - echo "New shapshot version - $NEW_VERSION_SNAPSHOT"
+    - PREVIOUS_RELEASE_VERSION="$MAJOR.$MINOR.$((POINT - 1))"
     -
     - git checkout master
     - git merge public/release --no-edit
     -
     - mvn versions:set -DnewVersion=$NEW_VERSION_SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true
     - sed -i -E "s/(<version>).+(<\/version>)/\1$RELEASE_VERSION\2/" README.md
+    - sed -i -E "s/(<awsjavasdk.previous.version>).+(<awsjavasdk.previous.version>)/\1$PREVIOUS_RELEASE_VERSION\2/" pom.xml
     -
     - 'git commit -am "Update to next snapshot version: $NEW_VERSION_SNAPSHOT"'
     -

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     </scm>
     <properties>
         <awsjavasdk.version>${project.version}</awsjavasdk.version>
+        <awsjavasdk.previous.version>2.15.51</awsjavasdk.previous.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jacksonjr.version>2.11.2</jacksonjr.version>
@@ -143,6 +144,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+        <japicmp-maven-plugin.version>0.14.4</japicmp-maven-plugin.version>
 
         <!-- These properties are used by Step functions for its dependencies -->
         <json-path.version>2.4.0</json-path.version>
@@ -487,6 +489,74 @@
                 <version>${spotbugs.version}</version>
             </plugin>
 
+            <!-- https://siom79.github.io/japicmp/MavenPlugin.html -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <version>${japicmp-maven-plugin.version}</version>
+                <configuration>
+                    <oldVersion>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>${awsjavasdk.previous.version}</version>
+                            <type>jar</type>
+                        </dependency>
+                    </oldVersion>
+                    <newVersion>
+                        <file>
+                            <path>${project.build.directory}/aws-sdk-java-${project.artifactId}-${project.version}.${project.packaging}</path>
+                        </file>
+                    </newVersion>
+                    <parameter>
+                        <onlyModified>true</onlyModified>
+                        <excludes>
+                            <exclude>*.internal.*</exclude>
+                        </excludes>
+                        <excludeModules>
+                            <excludeModule>codegen-lite-maven-plugin</excludeModule>
+                            <excludeModule>codegen-maven-plugin</excludeModule>
+                            <excludeModule>codegen</excludeModule>
+                            <excludeModule>codegen-lite</excludeModule>
+                            <excludeModule>.*tests*</excludeModule>
+                            <excludeModule>.*test*</excludeModule>
+                            <excludeModule>protocol-tests-core</excludeModule>
+                            <excludeModule>tests-coverage-reporting</excludeModule>
+                            <excludeModule>aws-sdk-java</excludeModule>
+                            <excludModeule>archetype-lambda</excludModeule>
+                            <excludeModule>sdk-benchmarks</excludeModule>
+                            <excludeModule>bundle</excludeModule>
+                            <excludeModule>transcribestreaming</excludeModule>
+                            <!-- ignore crt because it's in preview TODO: remove this when CRT is GA -->
+                            <excludModeule>aws-crt-client</excludModeule>
+                        </excludeModules>
+                        <ignoreMissingNewVersion>true</ignoreMissingNewVersion>
+                        <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                        <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+                        <overrideCompatibilityChangeParameters>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                            </overrideCompatibilityChangeParameter>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>METHOD_ADDED_TO_INTERFACE</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                            </overrideCompatibilityChangeParameter>
+                        </overrideCompatibilityChangeParameters>
+                    </parameter>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -497,6 +567,7 @@
                 <checkstyle.skip>true</checkstyle.skip>
                 <spotbugs.skip>true</spotbugs.skip>
                 <mdep.analyze.skip>true</mdep.analyze.skip>
+                <japicmp.skip>true</japicmp.skip>
             </properties>
         </profile>
 
@@ -549,6 +620,7 @@
                 <spotbugs.skip>true</spotbugs.skip>
                 <skip.unit.tests>true</skip.unit.tests>
                 <mdep.analyze.skip>true</mdep.analyze.skip>
+                <japicmp.skip>true</japicmp.skip>
             </properties>
         </profile>
 
@@ -564,6 +636,7 @@
                 <spotbugs.skip>true</spotbugs.skip>
                 <skip.unit.tests>true</skip.unit.tests>
                 <mdep.analyze.skip>true</mdep.analyze.skip>
+                <japicmp.skip>true</japicmp.skip>
             </properties>
             <build>
                 <plugins>
@@ -612,6 +685,7 @@
                 <spotbugs.skip>true</spotbugs.skip>
                 <skip.unit.tests>true</skip.unit.tests>
                 <mdep.analyze.skip>true</mdep.analyze.skip>
+                <japicmp.skip>true</japicmp.skip>
             </properties>
             <build>
                 <plugins>
@@ -654,6 +728,7 @@
                 <spotbugs.skip>true</spotbugs.skip>
                 <skip.unit.tests>true</skip.unit.tests>
                 <mdep.analyze.skip>true</mdep.analyze.skip>
+                <japicmp.skip>true</japicmp.skip>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add japicmp plugin to validate source and binary compatibility

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
Made a couple of breaking changes to public APIs locally and verified that the build failed.
Also verified the build did not fail when the changes were in internal APIs


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
