### PR TITLE
Fix eventstream legacy generation

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamVisitorBuilderImplSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamVisitorBuilderImplSpec.java
@@ -46,7 +46,7 @@ public class EventStreamVisitorBuilderImplSpec extends EventStreamVisitorBuilder
     private final EventStreamSpecHelper eventStreamSpecHelper;
 
     public EventStreamVisitorBuilderImplSpec(GeneratorTaskParams params, OperationModel operationModel) {
-        super(params.getPoetExtensions(), operationModel);
+        super(params.getPoetExtensions(), params.getModel(), operationModel);
         this.intermediateModel = params.getModel();
         this.poetExt = params.getPoetExtensions();
         this.opModel = operationModel;
@@ -108,7 +108,7 @@ public class EventStreamVisitorBuilderImplSpec extends EventStreamVisitorBuilder
                                                                         MemberModel event) {
             ClassName eventSubType = poetExt.getModelClass(event.getShape().getShapeName());
             TypeName eventConsumerType = consumerType(eventSubType);
-            FieldSpec consumerField = FieldSpec.builder(eventConsumerType, eventConsumerName(event))
+            FieldSpec consumerField = FieldSpec.builder(eventConsumerType, eventStreamSpecHelper.eventConsumerName(event))
                                                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
                                                .build();
             typeBuilder.addField(consumerField);
@@ -138,7 +138,7 @@ public class EventStreamVisitorBuilderImplSpec extends EventStreamVisitorBuilder
                                                                  MemberModel event) {
         ClassName eventSubType = poetExt.getModelClass(event.getShape().getShapeName());
         TypeName eventConsumerType = consumerType(eventSubType);
-        FieldSpec consumerField = FieldSpec.builder(eventConsumerType, eventConsumerName(event))
+        FieldSpec consumerField = FieldSpec.builder(eventConsumerType, eventStreamSpecHelper.eventConsumerName(event))
                                            .addModifiers(Modifier.PRIVATE)
                                            .build();
         typeBuilder.addField(consumerField);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamVisitorInterfaceSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamVisitorInterfaceSpec.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
  */
 class EventStreamVisitorInterfaceSpec implements ClassSpec {
     private final PoetExtensions poetExt;
+    private final IntermediateModel intermediateModel;
     private final OperationModel operationModel;
     private final ShapeModel eventStreamShape;
     private final ClassName eventStreamBaseClass;
@@ -42,6 +43,7 @@ class EventStreamVisitorInterfaceSpec implements ClassSpec {
 
     EventStreamVisitorInterfaceSpec(IntermediateModel intermediateModel, PoetExtensions poetExt, OperationModel operationModel) {
         this.poetExt = poetExt;
+        this.intermediateModel = intermediateModel;
         this.operationModel = operationModel;
         this.eventStreamShape = EventStreamUtils.getEventStreamInResponse(operationModel.getOutputShape());
         this.eventStreamBaseClass = poetExt.getModelClassFromShape(eventStreamShape);
@@ -72,7 +74,8 @@ class EventStreamVisitorInterfaceSpec implements ClassSpec {
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                         .addJavadoc("Visitor for subtypes of {@link $T}.", eventStreamBaseClass)
                         .addMethod(createBuilderMethodSpec())
-                        .addType(new EventStreamVisitorBuilderInterfaceSpec(poetExt, operationModel).poetSpec());
+                        .addType(new EventStreamVisitorBuilderInterfaceSpec(poetExt, intermediateModel, operationModel)
+                                .poetSpec());
     }
 
     protected TypeSpec.Builder finalizeTypeSpec(TypeSpec.Builder builder) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/EventStreamSpecHelper.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/EventStreamSpecHelper.java
@@ -96,4 +96,11 @@ public final class EventStreamSpecHelper {
     public String eventBuilderMethodName(MemberModel eventModel) {
         return String.format("%sBuilder", StringUtils.uncapitalize(eventModel.getName()));
     }
+
+    public String eventConsumerName(MemberModel eventModel) {
+        if (useLegacyGenerationScheme(eventModel)) {
+            return "on" + eventModel.getShape().getShapeName();
+        }
+        return "on" + eventModel.getName();
+    }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -15,6 +15,6 @@
     "createMethodParams": ["param1", "param2", "param3"]
   },
   "useLegacyEventGenerationScheme": {
-    "EventStream": ["EventOne", "event-two"]
+    "EventStream": ["EventOne", "event-two", "eventThree"]
   }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
@@ -417,6 +417,10 @@
         },
         "secondEventOne": {
           "shape": "EventOne"
+        },
+        // Legacy generation uses shape name == event name
+        "eventThree": {
+          "shape": "LegacyEventThree"
         }
       },
       "eventstream": true
@@ -434,6 +438,15 @@
       "type": "structure",
       "members": {
         "Bar": {
+          "shape": "String"
+        }
+      },
+      "event": true
+    },
+    "LegacyEventThree": {
+      "type": "structure",
+      "members": {
+        "Baz": {
           "shape": "String"
         }
       },

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-async-client-class.java
@@ -305,6 +305,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventStream::eventOneBuilder)
                             .putSdkPojoSupplier("EventTheSecond", EventStream::eventTheSecondBuilder)
                             .putSdkPojoSupplier("secondEventOne", EventStream::secondEventOneBuilder)
+                            .putSdkPojoSupplier("eventThree", EventStream::eventThreeBuilder)
                             .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
@@ -468,6 +469,7 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                     EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventStream::eventOneBuilder)
                             .putSdkPojoSupplier("EventTheSecond", EventStream::eventTheSecondBuilder)
                             .putSdkPojoSupplier("secondEventOne", EventStream::secondEventOneBuilder)
+                            .putSdkPojoSupplier("eventThree", EventStream::eventThreeBuilder)
                             .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
 
             HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-response-handler.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-response-handler.java
@@ -108,6 +108,17 @@ public interface EventStreamOperationResponseHandler extends
         }
 
         /**
+         * Invoked when a {@link LegacyEventThree} is encountered. If this is not overridden, the event will be given to
+         * {@link #visitDefault(EventStream)}.
+         *
+         * @param event
+         *        Event being visited
+         */
+        default void visit(LegacyEventThree event) {
+            visitDefault(event);
+        }
+
+        /**
          * Builder for {@link Visitor}. The {@link Visitor} class may also be extended for a more traditional style but
          * this builder allows for a more functional way of creating a visitor will callback methods.
          */
@@ -153,6 +164,15 @@ public interface EventStreamOperationResponseHandler extends
              * @return This builder for method chaining.
              */
             Builder onSecondEventOne(Consumer<EventOne> c);
+
+            /**
+             * Callback to invoke when a {@link LegacyEventThree} is visited.
+             *
+             * @param c
+             *        Callback to process the event.
+             * @return This builder for method chaining.
+             */
+            Builder onLegacyEventThree(Consumer<LegacyEventThree> c);
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-visitor-builder.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/eventstream/test-visitor-builder.java
@@ -15,6 +15,8 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
 
     private Consumer<EventOne> onSecondEventOne;
 
+    private Consumer<LegacyEventThree> onLegacyEventThree;
+
     @Override
     public EventStreamOperationResponseHandler.Visitor.Builder onDefault(Consumer<EventStream> c) {
         this.onDefault = c;
@@ -44,6 +46,12 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
         return this;
     }
 
+    @Override
+    public EventStreamOperationResponseHandler.Visitor.Builder onLegacyEventThree(Consumer<LegacyEventThree> c) {
+        this.onLegacyEventThree = c;
+        return this;
+    }
+
     @Generated("software.amazon.awssdk:codegen")
     static class VisitorFromBuilder implements EventStreamOperationResponseHandler.Visitor {
         private final Consumer<EventStream> onDefault;
@@ -54,6 +62,8 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
 
         private final Consumer<EventOne> onSecondEventOne;
 
+        private final Consumer<LegacyEventThree> onLegacyEventThree;
+
         VisitorFromBuilder(DefaultEventStreamOperationVisitorBuilder builder) {
             this.onDefault = builder.onDefault != null ? builder.onDefault
                     : EventStreamOperationResponseHandler.Visitor.super::visitDefault;
@@ -63,6 +73,8 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
                     : EventStreamOperationResponseHandler.Visitor.super::visitEventTheSecond;
             this.onSecondEventOne = builder.onSecondEventOne != null ? builder.onSecondEventOne
                     : EventStreamOperationResponseHandler.Visitor.super::visitSecondEventOne;
+            this.onLegacyEventThree = builder.onLegacyEventThree != null ? builder.onLegacyEventThree
+                    : EventStreamOperationResponseHandler.Visitor.super::visit;
         }
 
         @Override
@@ -83,6 +95,11 @@ final class DefaultEventStreamOperationVisitorBuilder implements EventStreamOper
         @Override
         public void visitSecondEventOne(EventOne event) {
             onSecondEventOne.accept(event);
+        }
+
+        @Override
+        public void visit(LegacyEventThree event) {
+            onLegacyEventThree.accept(event);
         }
     }
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/eventstreams/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/eventstreams/service-2.json
@@ -75,7 +75,7 @@
     "EventStream": {
       "type": "structure",
       "members": {
-        "EventOne": {
+        "TheEventOne": {
           "shape": "EventOne"
         },
         "LegacyGeneratedEvent": {

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/eventstreams/EventDispatchTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/eventstreams/EventDispatchTest.java
@@ -47,7 +47,7 @@ public class EventDispatchTest {
     private Consumer<EventStream> onDefaultConsumer;
 
     @Mock
-    private Consumer<EventOne> eventOneConsumer;
+    private Consumer<EventOne> theEventOneConsumer;
 
     @Mock
     private Consumer<EventOne> legacyGeneratedEventConsumer;
@@ -62,28 +62,28 @@ public class EventDispatchTest {
     public ExpectedException expected = ExpectedException.none();
 
     @Test
-    public void test_acceptEventOne_correctVisitorMethodCalled() {
-        EventStream eventStream = EventStream.eventOneBuilder().build();
+    public void test_acceptTheEventOne_correctVisitorMethodCalled() {
+        EventStream eventStream = EventStream.theEventOneBuilder().build();
         eventStream.accept(visitor);
 
-        verify(visitor).visitEventOne(Mockito.eq((EventOne) eventStream));
+        verify(visitor).visitTheEventOne(Mockito.eq((EventOne) eventStream));
         verifyNoMoreInteractions(visitor);
     }
 
     @Test
-    public void test_acceptEventOne_visitorBuiltWithBuilder_correctVisitorMethodCalled() {
+    public void test_acceptTheEventOne_visitorBuiltWithBuilder_correctVisitorMethodCalled() {
         EventStreamOperationResponseHandler.Visitor visitor = visitorBuiltWithBuilder();
-        EventStream eventStream = EventStream.eventOneBuilder().build();
+        EventStream eventStream = EventStream.theEventOneBuilder().build();
 
         eventStream.accept(visitor);
 
-        verify(eventOneConsumer).accept(eq((EventOne) eventStream));
+        verify(theEventOneConsumer).accept(eq((EventOne) eventStream));
         verifyNoMoreConsumerInteractions();
     }
 
     @Test
     public void test_acceptLegacyGeneratedEvent_correctVisitorMethodCalled() {
-        EventStream eventStream = EventStream.legacyGeneratedEventBuilder().build();
+        EventStream eventStream = EventOne.builder().build();
         eventStream.accept(visitor);
 
         // Note: notice the visit() method rather than visitLegacyGeneratedEvent()
@@ -94,7 +94,7 @@ public class EventDispatchTest {
     @Test
     public void test_acceptLegacyGeneratedEvent_visitorBuiltWithBuilder_correctVisitorMethodCalled() {
         EventStreamOperationResponseHandler.Visitor visitor = visitorBuiltWithBuilder();
-        EventStream eventStream = EventStream.legacyGeneratedEventBuilder().build();
+        EventStream eventStream = EventOne.builder().build();
 
         eventStream.accept(visitor);
 
@@ -155,15 +155,15 @@ public class EventDispatchTest {
     private EventStreamOperationResponseHandler.Visitor visitorBuiltWithBuilder() {
         return EventStreamOperationResponseHandler.Visitor.builder()
                 .onDefault(onDefaultConsumer)
-                .onEventOne(eventOneConsumer)
+                .onTheEventOne(theEventOneConsumer)
                 .onEventTwo(eventTwoConsumer)
-                .onLegacyGeneratedEvent(legacyGeneratedEventConsumer)
+                .onEventOne(legacyGeneratedEventConsumer)
                 .onSecondEventTwo(secondEventTwoConsumer)
                 .build();
     }
 
     private void verifyNoMoreConsumerInteractions() {
-        verifyNoMoreInteractions(onDefaultConsumer, eventOneConsumer, eventTwoConsumer, legacyGeneratedEventConsumer,
+        verifyNoMoreInteractions(onDefaultConsumer, theEventOneConsumer, eventTwoConsumer, legacyGeneratedEventConsumer,
                 secondEventTwoConsumer);
     }
 }


### PR DESCRIPTION
## Description
Legacy generation uses the shape name as the event name. Transcribe Streaming
has a member event named "TranscriptEvent", but its shape is
"MedicalTranscriptEvent". This only affected interfaces, marshalling/marshalling
is okay.

## Motivation and Context
Bug fix.

## Testing
Added a new test.

Checked the diffs:

 - Transcribe Streaming diff with `2.15.51`: https://gist.github.com/dagnir/8a7578648433595ede76d998081ad749#file-transcribestreaming-diff-with-2-15-51-diff
 - Transcribe Streaming diff with `2.15.35`. This is the first time `MedicalTransciptEvent` is introduced: https://gist.github.com/dagnir/8a7578648433595ede76d998081ad749#file-transcribestreaming-diff-with-2-15-35-diff
 - Kinesis diff with `2.15.51`: https://gist.github.com/dagnir/8a7578648433595ede76d998081ad749#file-kinesis-diff-with-2-15-51-diff

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
