### PR TITLE
Removing transcribestreaming and iotwireless from japicmp excluded mo…

### DIFF
--- a/buildspecs/update-master-from-release.yml
+++ b/buildspecs/update-master-from-release.yml
@@ -27,14 +27,13 @@ phases:
     - POINT=$(echo $RELEASE_VERSION | cut -d'.' -f3)
     - NEW_VERSION_SNAPSHOT="$MAJOR.$MINOR.$((POINT + 1))-SNAPSHOT"
     - echo "New shapshot version - $NEW_VERSION_SNAPSHOT"
-    - PREVIOUS_RELEASE_VERSION="$MAJOR.$MINOR.$((POINT - 1))"
     -
     - git checkout master
     - git merge public/release --no-edit
     -
     - mvn versions:set -DnewVersion=$NEW_VERSION_SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true
     - sed -i -E "s/(<version>).+(<\/version>)/\1$RELEASE_VERSION\2/" README.md
-    - sed -i -E "s/(<awsjavasdk.previous.version>).+(<awsjavasdk.previous.version>)/\1$PREVIOUS_RELEASE_VERSION\2/" pom.xml
+    - sed -i -E "s/(<awsjavasdk.previous.version>).+(<\/awsjavasdk.previous.version>)/\1$RELEASE_VERSION\2/" pom.xml
     -
     - 'git commit -am "Update to next snapshot version: $NEW_VERSION_SNAPSHOT"'
     -

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </scm>
     <properties>
         <awsjavasdk.version>${project.version}</awsjavasdk.version>
-        <awsjavasdk.previous.version>2.15.51</awsjavasdk.previous.version>
+        <awsjavasdk.previous.version>2.15.57</awsjavasdk.previous.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jacksonjr.version>2.11.2</jacksonjr.version>
@@ -525,13 +525,11 @@
                             <excludeModule>aws-sdk-java</excludeModule>
                             <excludModeule>archetype-lambda</excludModeule>
                             <excludeModule>sdk-benchmarks</excludeModule>
-                            <excludeModule>iotwireless</excludeModule>
                             <excludeModule>bundle</excludeModule>
-                            <excludeModule>transcribestreaming</excludeModule>
                             <!-- ignore crt because it's in preview TODO: remove this when CRT is GA -->
                             <excludModeule>aws-crt-client</excludModeule>
                         </excludeModules>
-                        <ignoreMissingNewVersion>true</ignoreMissingNewVersion>
+                        <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                         <overrideCompatibilityChangeParameters>

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/SignersIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/SignersIntegrationTest.java
@@ -197,7 +197,8 @@ public class SignersIntegrationTest extends DynamoDBTestBase {
                + "      \"" + HASH_KEY_NAME + "\":{  \n"
                + "         \"S\":\"" + HASH_KEY_VALUE + "\"\n"
                + "      }\n"
-               + "   }\n"
+               + "   },\n"
+               + "   \"ConsistentRead\": true"
                + "}".trim();
     }
 
@@ -221,6 +222,7 @@ public class SignersIntegrationTest extends DynamoDBTestBase {
         Map<String, AttributeValue> item =
             client.getItem(GetItemRequest.builder()
                                          .tableName(TABLE_NAME)
+                                         .consistentRead(true)
                                          .key(Collections.singletonMap(HASH_KEY_NAME, AttributeValue.builder()
                                                                                                     .s(HASH_KEY_VALUE)
                                                                                                     .build()))


### PR DESCRIPTION
…dule lists and fix the test

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removing transcribestreaming and iotwireless from japicmp excluded module lists
- adding a sleep after we write data to the ddb table in the integ test
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
