### PR TITLE
Fix for Issue #1684 Changes in handleTimeoutCausedException in Timeou…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-b5a2807.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-b5a2807.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix for [#1684](https://github.com/aws/aws-sdk-java-v2/issues/1684) Some of the Retry attempts which failed due to the API TimeOuts did not successfully retried but ended up with AbortedException."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/TimeoutExceptionHandlingStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/TimeoutExceptionHandlingStage.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkInterruptedException;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
@@ -90,7 +91,8 @@ public final class TimeoutExceptionHandlingStage<OutputT> implements RequestToRe
      */
     private Exception translatePipelineException(RequestExecutionContext context, Exception e) {
         if (e instanceof InterruptedException || e instanceof IOException ||
-            e instanceof AbortedException || Thread.currentThread().isInterrupted()) {
+                e instanceof AbortedException || Thread.currentThread().isInterrupted()
+                || (e instanceof SdkClientException && isCausedByApiCallAttemptTimeout(context))) {
             return handleTimeoutCausedException(context, e);
         }
         return e;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/TimeoutExceptionHandlingStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/TimeoutExceptionHandlingStageTest.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.core.SdkRequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.NoopTestRequest;
 import software.amazon.awssdk.core.internal.http.HttpClientDependencies;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
@@ -163,6 +164,33 @@ public class TimeoutExceptionHandlingStageTest {
         verifyExceptionThrown(InterruptedException.class);
         verifyInterruptStatusPreserved();
     }
+
+    @Test
+    public void apiCallAttemptTimeoutException_causedBySdkClientException_as_apiCallAttemptTimeoutTask_Caused_SdkClientException() throws Exception {
+        when(apiCallTimeoutTask.hasExecuted()).thenReturn(false);
+        when(apiCallAttemptTimeoutTask.hasExecuted()).thenReturn(true);
+        when(requestPipeline.execute(any(), any())).thenThrow(SdkClientException.create(""));
+        verifyExceptionThrown(ApiCallAttemptTimeoutException.class);
+    }
+
+    @Test
+    public void interruptedException_causedByApiCallAttemptTimeoutTask() throws Exception {
+        when(apiCallTimeoutTask.hasExecuted()).thenReturn(true);
+        when(apiCallAttemptTimeoutTask.hasExecuted()).thenReturn(true);
+        when(requestPipeline.execute(any(), any())).thenThrow(SdkClientException.class);
+        verifyExceptionThrown(InterruptedException.class);
+    }
+
+
+    @Test
+    public void abortedException_causedByApiCallAttemptTimeoutTask_shouldNotPropagate() throws Exception {
+        when(apiCallTimeoutTask.hasExecuted()).thenReturn(false);
+        when(apiCallAttemptTimeoutTask.hasExecuted()).thenReturn(true);
+        when(requestPipeline.execute(any(), any())).thenThrow(AbortedException.class);
+        verifyExceptionThrown(ApiCallAttemptTimeoutException.class);
+    }
+
+
 
 
     private void verifyInterruptStatusPreserved() {

--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoDbJavaClientRetryOnTimeoutIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoDbJavaClientRetryOnTimeoutIntegrationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.dynamodb;
+
+import org.junit.Test;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
+import software.amazon.awssdk.testutils.service.AwsTestBase;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Simple test to check all the retries are made when all the API calls timeouts.
+ */
+public class DynamoDbJavaClientRetryOnTimeoutIntegrationTest extends AwsTestBase {
+
+    private static DynamoDbClient ddb;
+    private final Integer RETRY_ATTEMPTS = 3;
+
+    public static void setupWithRetryPolicy(RetryPolicy retryPolicy, Integer attemptTimeOutMillis) throws Exception {
+        ddb = DynamoDbClient.builder()
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .retryPolicy(retryPolicy)
+                        .apiCallAttemptTimeout(Duration.ofMillis(attemptTimeOutMillis)) //forces really quick api call timeout
+                        .build())
+                .build();
+
+    }
+
+    public static RetryPolicy createRetryPolicyWithCounter(AtomicInteger counter, Integer numOfAttempts) {
+        final RetryPolicy retryPolicy = RetryPolicy.defaultRetryPolicy().toBuilder()
+                .numRetries(numOfAttempts)
+                .retryCondition(OrRetryCondition.create(
+                        context -> {
+                            counter.incrementAndGet();
+                            return false;
+                        }, RetryCondition.defaultRetryCondition())).build();
+
+        return retryPolicy;
+
+    }
+
+    @Test
+    public void testRetryAttemptsOnTimeOut() throws Exception {
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        Boolean apiTimeOutExceptionOccurred = Boolean.FALSE;
+        setupWithRetryPolicy(createRetryPolicyWithCounter(atomicInteger, RETRY_ATTEMPTS), 2);
+        try {
+
+            ddb.listTables();
+        } catch (ApiCallAttemptTimeoutException e) {
+            apiTimeOutExceptionOccurred = true;
+        }
+        assertEquals(RETRY_ATTEMPTS.intValue(), atomicInteger.get());
+        assertTrue(apiTimeOutExceptionOccurred);
+    }
+
+}


### PR DESCRIPTION
…tExceptionHandlingStage

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some of the Retry attempts which failed due to the API TimeOuts did not successfully retried but ended up with AbortedException.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Refer [Issue 1684](https://github.com/aws/aws-sdk-java-v2/issues/1684)

### Root Cause
- This is intermittent timing issue.
-Occurs in below scenario
1. ApiCallTimeoutTrackingStage Times out as its not getting the response. This Interrupts the thread.
2. Request is still in progress but in some places we check the Thread interrupt status it then fails because the Thread is interrupted and throws Aborted Exception which is then thrown with SDKCLient Exception
3. Now ApiCallTimeoutTrackingStage's handleInterruptedException resets the interrupt flag.
4. And when the TimeoutExceptionHandlingStage resumes and tries to translatePipelineException() it fails to handle the exception because thread Interrupt is RESET and its SdkClientException (Hadled ones are InterruptedException, AbortedException, IOException)
5. Thus fails to handle the Exception

### Fix Options

1. Do changes in ApiCallTimeoutTrackingStage's handleInterruptedException() not to clear the interrupt .
Cons :- However this fix doesnot looks feasible since as per ApiCallTimeoutTrackingStage it rightly resets the Interrupt of the current Thread as part of had handleInterruptedException

2. translatePipelineException  of TimeoutExceptionHandlingStage should check (e.getCause instance of AbortedException)
Cons :- We are getting too specifics to AbortedException and assuming that all the APIs fail with AbortedException whenever the request is aborted due to TimeOuts. So this looks we might miss some other exceptions or new exception added in future/

3. In translatePipelineException check if the isCausedByApiCallAttemptTimeout and its SdkClientException
Pros : This handles all the cases also in handleTimeoutCausedException we have if clauses which does the filtering.
Cons : not aware.



## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits
- Integ Test added and Integ Testing done

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
