### PR TITLE
Correctly select the cipher suites based on the HTTP protocol

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-dd43cf4.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-dd43cf4.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Use `SystemPropretyTlsKeyManagersProvider` if no `KeyManger` is provided."
+}

--- a/.changes/next-release/feature-NettyNIOHTTPClient-e7d2844.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-e7d2844.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "contributor": "", 
+    "type": "bugfix",
+    "description": "Correctly select the cipher suites based on the HTTP protocol. See [#2159](https://github.com/aws/aws-sdk-java-v2/issues/2159)"
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -90,6 +91,7 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
     private final SslProvider sslProvider;
     private final ProxyConfiguration proxyConfiguration;
     private final BootstrapProvider bootstrapProvider;
+    private final SslContextProvider sslContextProvider;
 
     private AwaitCloseChannelPoolMap(Builder builder, Function<Builder, BootstrapProvider> createBootStrapProvider) {
         this.configuration = builder.configuration;
@@ -100,6 +102,7 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         this.sslProvider = builder.sslProvider;
         this.proxyConfiguration = builder.proxyConfiguration;
         this.bootstrapProvider = createBootStrapProvider.apply(builder);
+        this.sslContextProvider = new SslContextProvider(configuration, protocol, sslProvider);
     }
 
     private AwaitCloseChannelPoolMap(Builder builder) {
@@ -123,8 +126,11 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
 
     @Override
     protected SimpleChannelPoolAwareChannelPool newPool(URI key) {
-        SslContext sslContext = sslContext(key);
-        
+        SslContext sslContext = null;
+        if (needSslContext(key)) {
+            sslContext = sslContextProvider.sslContext();
+        }
+
         Bootstrap bootstrap = createBootstrap(key);
 
         AtomicReference<ChannelPool> channelPoolRef = new AtomicReference<>();
@@ -259,53 +265,12 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         return sdkChannelPool;
     }
 
-    private SslContext sslContext(URI targetAddress) {
+    private boolean needSslContext(URI targetAddress) {
         URI proxyAddress = proxyAddress(targetAddress);
-
         boolean needContext = targetAddress.getScheme().equalsIgnoreCase("https")
-                || proxyAddress != null && proxyAddress.getScheme().equalsIgnoreCase("https");
+                              || proxyAddress != null && proxyAddress.getScheme().equalsIgnoreCase("https");
 
-        if (!needContext) {
-            return null;
-        }
-
-        try {
-            return SslContextBuilder.forClient()
-                                    .sslProvider(sslProvider)
-                                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-                                    .trustManager(getTrustManager())
-                                    .keyManager(getKeyManager())
-                                    .build();
-        } catch (SSLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private TrustManagerFactory getTrustManager() {
-        Validate.isTrue(configuration.tlsTrustManagersProvider() == null || !configuration.trustAllCertificates(),
-                        "A TlsTrustManagerProvider can't be provided if TrustAllCertificates is also set");
-
-        if (configuration.tlsTrustManagersProvider() != null) {
-            return StaticTrustManagerFactory.create(configuration.tlsTrustManagersProvider().trustManagers());
-        }
-
-        if (configuration.trustAllCertificates()) {
-            log.warn(() -> "SSL Certificate verification is disabled. This is not a safe setting and should only be "
-                           + "used for testing.");
-            return InsecureTrustManagerFactory.INSTANCE;
-        }
-
-        return null;
-    }
-
-    private KeyManagerFactory getKeyManager() {
-        if (configuration.tlsKeyManagersProvider() != null) {
-            KeyManager[] keyManagers = configuration.tlsKeyManagersProvider().keyManagers();
-            if (keyManagers != null) {
-                return StaticKeyManagerFactory.create(keyManagers);
-            }
-        }
-        return null;
+        return needContext;
     }
 
     public static class Builder {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
@@ -21,17 +21,12 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.ChannelPoolHandler;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,10 +35,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManagerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.http.Protocol;
@@ -51,7 +42,6 @@ import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
 import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
 import software.amazon.awssdk.http.nio.netty.internal.http2.HttpOrHttp2ChannelPool;
 import software.amazon.awssdk.utils.Logger;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * Implementation of {@link SdkChannelPoolMap} that awaits channel pools to be closed upon closing.
@@ -126,10 +116,7 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
 
     @Override
     protected SimpleChannelPoolAwareChannelPool newPool(URI key) {
-        SslContext sslContext = null;
-        if (needSslContext(key)) {
-            sslContext = sslContextProvider.sslContext();
-        }
+        SslContext sslContext = needSslContext(key) ? sslContextProvider.sslContext() : null;
 
         Bootstrap bootstrap = createBootstrap(key);
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProvider.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public final class SslContextProvider {
+    private static final Logger log = Logger.loggerFor(SslContextProvider.class);
+    private final Protocol protocol;
+    private final SslProvider sslProvider;
+    private final TrustManagerFactory trustManagerFactory;
+    private final KeyManagerFactory keyManagerFactory;
+
+    public SslContextProvider(NettyConfiguration configuration, Protocol protocol, SslProvider sslProvider) {
+        this.protocol = protocol;
+        this.sslProvider = sslProvider;
+        this.trustManagerFactory = getTrustManager(configuration);
+        this.keyManagerFactory = getKeyManager(configuration);
+    }
+
+    public SslContext sslContext() {
+        try {
+            return SslContextBuilder.forClient()
+                                    .sslProvider(sslProvider)
+                                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                                    .trustManager(trustManagerFactory)
+                                    .keyManager(keyManagerFactory)
+                                    .build();
+        } catch (SSLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private TrustManagerFactory getTrustManager(NettyConfiguration configuration) {
+        Validate.isTrue(configuration.tlsTrustManagersProvider() == null || !configuration.trustAllCertificates(),
+                        "A TlsTrustManagerProvider can't be provided if TrustAllCertificates is also set");
+
+        if (configuration.tlsTrustManagersProvider() != null) {
+            return StaticTrustManagerFactory.create(configuration.tlsTrustManagersProvider().trustManagers());
+        }
+
+        if (configuration.trustAllCertificates()) {
+            log.warn(() -> "SSL Certificate verification is disabled. This is not a safe setting and should only be "
+                           + "used for testing.");
+            return InsecureTrustManagerFactory.INSTANCE;
+        }
+
+        return null;
+    }
+
+    private KeyManagerFactory getKeyManager(NettyConfiguration configuration) {
+        if (configuration.tlsKeyManagersProvider() != null) {
+            KeyManager[] keyManagers = configuration.tlsKeyManagersProvider().keyManagers();
+            if (keyManagers != null) {
+                return StaticKeyManagerFactory.create(keyManagers);
+            }
+        }
+        return null;
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProvider.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProvider.java
@@ -21,12 +21,15 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.util.List;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SystemPropertyTlsKeyManagersProvider;
+import software.amazon.awssdk.http.TlsTrustManagersProvider;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
@@ -49,7 +52,7 @@ public final class SslContextProvider {
         try {
             return SslContextBuilder.forClient()
                                     .sslProvider(sslProvider)
-                                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                                    .ciphers(getCiphers(), SupportedCipherSuiteFilter.INSTANCE)
                                     .trustManager(trustManagerFactory)
                                     .keyManager(keyManagerFactory)
                                     .build();
@@ -58,12 +61,25 @@ public final class SslContextProvider {
         }
     }
 
+    /**
+     * HTTP/2: per Rfc7540, there is a blocked list of cipher suites for HTTP/2, so setting
+     * the recommended cipher suites directly here
+     *
+     * HTTP/1.1: return null so that the default ciphers suites will be used
+     * https://github.com/netty/netty/blob/0dc246eb129796313b58c1dbdd674aa289f72cad/handler/src/main/java/io/netty/handler/ssl
+     * /SslUtils.java
+     */
+    private List<String> getCiphers() {
+        return protocol.equals(Protocol.HTTP2) ? Http2SecurityUtil.CIPHERS : null;
+    }
+
     private TrustManagerFactory getTrustManager(NettyConfiguration configuration) {
-        Validate.isTrue(configuration.tlsTrustManagersProvider() == null || !configuration.trustAllCertificates(),
+        TlsTrustManagersProvider tlsTrustManagersProvider = configuration.tlsTrustManagersProvider();
+        Validate.isTrue(tlsTrustManagersProvider == null || !configuration.trustAllCertificates(),
                         "A TlsTrustManagerProvider can't be provided if TrustAllCertificates is also set");
 
-        if (configuration.tlsTrustManagersProvider() != null) {
-            return StaticTrustManagerFactory.create(configuration.tlsTrustManagersProvider().trustManagers());
+        if (tlsTrustManagersProvider != null) {
+            return StaticTrustManagerFactory.create(tlsTrustManagersProvider.trustManagers());
         }
 
         if (configuration.trustAllCertificates()) {
@@ -72,6 +88,7 @@ public final class SslContextProvider {
             return InsecureTrustManagerFactory.INSTANCE;
         }
 
+        // return null so that the system default trust manager will be used
         return null;
     }
 
@@ -82,6 +99,8 @@ public final class SslContextProvider {
                 return StaticKeyManagerFactory.create(keyManagers);
             }
         }
-        return null;
+
+        KeyManager[] systemPropertyKeyManagers = SystemPropertyTlsKeyManagersProvider.create().keyManagers();
+        return systemPropertyKeyManagers == null ? null : StaticKeyManagerFactory.create(systemPropertyKeyManagers);
     }
 }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
@@ -224,10 +224,11 @@ public class AwaitCloseChannelPoolMapTest {
                 .build();
 
         channelPoolMap = AwaitCloseChannelPoolMap.builder()
-                .sdkChannelOptions(new SdkChannelOptions())
-                .sdkEventLoopGroup(SdkEventLoopGroup.builder().build())
-                .configuration(new NettyConfiguration(config.merge(GLOBAL_HTTP_DEFAULTS)))
-                .build();
+                                                 .sdkChannelOptions(new SdkChannelOptions())
+                                                 .sdkEventLoopGroup(SdkEventLoopGroup.builder().build())
+                                                 .protocol(Protocol.HTTP1_1)
+                                                 .configuration(new NettyConfiguration(config.merge(GLOBAL_HTTP_DEFAULTS)))
+                                                 .build();
 
         ChannelPool channelPool = channelPoolMap.newPool(URI.create("https://localhost:" + mockProxy.port()));
         channelPool.acquire().awaitUninterruptibly();

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProviderTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProviderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TLS_KEY_MANAGERS_PROVIDER;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TLS_TRUST_MANAGERS_PROVIDER;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.SslProvider;
+import javax.net.ssl.TrustManager;
+import org.junit.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.TlsKeyManagersProvider;
+import software.amazon.awssdk.http.TlsTrustManagersProvider;
+import software.amazon.awssdk.utils.AttributeMap;
+
+public class SslContextProviderTest {
+
+    @Test
+    public void sslContext_h2WithJdk_h2CiphersShouldBeUsed() {
+        SslContextProvider sslContextProvider = new SslContextProvider(new NettyConfiguration(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS),
+                                                                       Protocol.HTTP2,
+                                                                       SslProvider.JDK);
+
+        assertThat(sslContextProvider.sslContext().cipherSuites()).isSubsetOf(Http2SecurityUtil.CIPHERS);
+    }
+
+    @Test
+    public void sslContext_h2WithOpenSsl_h2CiphersShouldBeUsed() {
+        SslContextProvider sslContextProvider = new SslContextProvider(new NettyConfiguration(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS),
+                                                                       Protocol.HTTP2,
+                                                                       SslProvider.OPENSSL);
+
+        assertThat(sslContextProvider.sslContext().cipherSuites()).isSubsetOf(Http2SecurityUtil.CIPHERS);
+    }
+
+    @Test
+    public void sslContext_h1_defaultCipherShouldBeUsed() {
+        SslContextProvider sslContextProvider = new SslContextProvider(new NettyConfiguration(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS),
+                                                                       Protocol.HTTP1_1,
+                                                                       SslProvider.JDK);
+
+        assertThat(sslContextProvider.sslContext().cipherSuites()).isNotIn(Http2SecurityUtil.CIPHERS);
+    }
+
+    @Test
+    public void customizedKeyManagerPresent_shouldUseCustomized() {
+        TlsKeyManagersProvider mockProvider = Mockito.mock(TlsKeyManagersProvider.class);
+        SslContextProvider sslContextProvider = new SslContextProvider(new NettyConfiguration(AttributeMap.builder()
+                                                                                                          .put(TRUST_ALL_CERTIFICATES, false)
+                                                                                                          .put(TLS_KEY_MANAGERS_PROVIDER, mockProvider)
+                                                                                                          .build()),
+                                                                       Protocol.HTTP1_1,
+                                                                       SslProvider.JDK);
+
+        sslContextProvider.sslContext();
+        Mockito.verify(mockProvider).keyManagers();
+    }
+
+    @Test
+    public void customizedTrustManagerPresent_shouldUseCustomized() {
+        TlsTrustManagersProvider mockProvider = Mockito.mock(TlsTrustManagersProvider.class);
+        TrustManager mockTrustManager = Mockito.mock(TrustManager.class);
+        Mockito.when(mockProvider.trustManagers()).thenReturn(new TrustManager[] {mockTrustManager});
+        SslContextProvider sslContextProvider = new SslContextProvider(new NettyConfiguration(AttributeMap.builder()
+                                                                                                          .put(TRUST_ALL_CERTIFICATES, false)
+                                                                                                          .put(TLS_TRUST_MANAGERS_PROVIDER, mockProvider)
+                                                                                                          .build()),
+                                                                       Protocol.HTTP1_1,
+                                                                       SslProvider.JDK);
+
+        sslContextProvider.sslContext();
+        Mockito.verify(mockProvider).trustManagers();
+    }
+
+    @Test
+    public void TlsTrustManagerAndTrustAllCertificates_shouldThrowException() {
+        TlsTrustManagersProvider mockProvider = Mockito.mock(TlsTrustManagersProvider.class);
+        assertThatThrownBy(() -> new SslContextProvider(new NettyConfiguration(AttributeMap.builder()
+                                                                                           .put(TRUST_ALL_CERTIFICATES, true)
+                                                                                           .put(TLS_TRUST_MANAGERS_PROVIDER,
+                                                                                                mockProvider)
+                                                                                           .build()),
+                                                        Protocol.HTTP1_1,
+                                                        SslProvider.JDK)).isInstanceOf(IllegalArgumentException.class)
+                                                                         .hasMessageContaining("A TlsTrustManagerProvider can't"
+                                                                                               + " be provided if "
+                                                                                               + "TrustAllCertificates is also "
+                                                                                               + "set");
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- 4a18e52 Refactor: extract sslContext logic to a separate class.
- f063861 Correctly select the cipher suites based on the HTTP protocol. 


### Before the change
All requests use Http2SecurityUtil.CIPHERS cipher suites

###  After the change
`HTTP/2`: [Http2SecurityUtil.CIPHERS](https://github.com/netty/netty/blob/0dc246eb129796313b58c1dbdd674aa289f72cad/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java)
`HTTP/1.1`: the [default cipher suites](https://github.com/netty/netty/blob/0dc246eb129796313b58c1dbdd674aa289f72cad/handler/src/main/java/io/netty/handler/ssl/SslUtils.java#L115-L141) provided by netty 

## Motivation and Context
#2159 

## Testing
Added unit tests
Integration tests and stability tests passed

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
