### PR TITLE
Reverting #1971 as it was causing latency issues in test canaries

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-da92594.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-da92594.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Reverting synchronization of eventsToDeliver Object in onComplete() [PR#1971](https://github.com/aws/aws-sdk-java-v2/pull/1971) since it was causing latency."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamAsyncResponseTransformer.java
@@ -394,9 +394,7 @@ public final class EventStreamAsyncResponseTransformer<ResponseT, EventT>
         @Override
         public void onComplete() {
             // Add the special on complete event to signal drainEvents to complete the subscriber
-            synchronized (eventsToDeliver) {
-                eventsToDeliver.add(ON_COMPLETE_EVENT);
-            }
+            eventsToDeliver.add(ON_COMPLETE_EVENT);
             drainEventsIfNotAlready();
             transformFuture.complete(null);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reverting  #1971 as after this fix there was latency seen in test canaries.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

- Checked the thread dump saw lot of instances when the isCompletedOrDeliverEvent and onNext are waiting as onComplete has already acquired the lock.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  Tested on Canaries and saw that latency disappeared after the fix was reverted.

## Screenshots (if appropriate)

```
"aws-java-sdk-NettyEventLoop-1-9" #46 daemon prio=5 os_prio=0 tid=0x00007f3f5003f800 nid=0x2998 runnable [0x00007f3fcc77e000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.Thread.setPriority0(Native Method)
	at java.lang.Thread.setPriority(Thread.java:1099)
	at java.lang.Thread.init(Thread.java:418)
	at java.lang.Thread.init(Thread.java:350)
	at java.lang.Thread.<init>(Thread.java:679)
	at java.util.concurrent.Executors$DefaultThreadFactory.newThread(Executors.java:613)
	at software.amazon.awssdk.utils.NamedThreadFactory.newThread(NamedThreadFactory.java:38)
	at software.amazon.awssdk.utils.DaemonThreadFactory.newThread(DaemonThreadFactory.java:34)
	at java.util.concurrent.ThreadPoolExecutor$Worker.<init>(ThreadPoolExecutor.java:619)
	at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:932)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1367)
	at java.util.concurrent.CompletableFuture.asyncRunStage(CompletableFuture.java:1654)
	at java.util.concurrent.CompletableFuture.runAsync(CompletableFuture.java:1871)
	at software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer.isCompletedOrDeliverEvent(EventStreamAsyncResponseTransformer.java:510)
	- locked <0x00000000c492a728> (a java.util.LinkedList)
	at software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer.drainEvents(EventStreamAsyncResponseTransformer.java:483)
	at software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer.drainEventsIfNotAlready(EventStreamAsyncResponseTransformer.java:469)
	at software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer.access$600(EventStreamAsyncResponseTransformer.java:65)
	at software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer$ByteSubscriber.onNext(EventStreamAsyncResponseTransformer.java:378)
	- locked <0x00000000c492a728> (a java.util.LinkedList)
	at software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer$ByteSubscriber.onNext(EventStreamAsyncResponseTransformer.java:350)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.lambda$onNext$2(ResponseHandler.java:270)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1$$Lambda$348/159224483.run(Unknown Source)
	at software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch(ExceptionHandlingUtils.java:40)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onNext(ResponseHandler.java:270)
	at software.amazon.awssdk.http.nio.netty.internal.ResponseHandler$PublisherAdapter$1.onNext(ResponseHandler.java:221)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.publishMessage(HandlerPublisher.java:407)
	at software.amazon.awssdk.http.nio.netty.internal.nrs.HandlerPublisher.channelRead(HandlerPublisher.java:383)
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
