### PR TITLE
Added null protection for streamFuture after we saw a NPE in AsyncResponseHandler.onError()

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/AsyncResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/AsyncResponseHandler.java
@@ -73,7 +73,9 @@ public final class AsyncResponseHandler<T> implements TransformingAsyncResponseH
 
     @Override
     public void onError(Throwable err) {
-        streamFuture.completeExceptionally(err);
+        if (streamFuture != null) {
+            streamFuture.completeExceptionally(err);
+        }
     }
 
     @Override


### PR DESCRIPTION
Seems like there is a way for `onError()` to be called before `prepare()` where `streamFuture` is initialized.

## Description
Added a null check around the use of `streamFuture`.  Here's the full exception stack.  This is from code from an earlier version.

```
java.lang.NullPointerException
 	at software.amazon.awssdk.core.internal.http.async.AsyncResponseHandler.onError(AsyncResponseHandler.java:76)
 	at software.amazon.awssdk.core.internal.http.async.CombinedResponseAsyncHttpResponseHandler.onError(CombinedResponseAsyncHttpResponseHandler.java:70)
 	at software.amazon.awssdk.core.internal.handler.BaseAsyncClientHandler.lambda$doExecute$3(BaseAsyncClientHandler.java:223)
 	at software.amazon.awssdk.utils.FunctionalUtils.runAndLogError(FunctionalUtils.java:40)
 	at software.amazon.awssdk.core.internal.handler.BaseAsyncClientHandler.doExecute(BaseAsyncClientHandler.java:220)
 	at software.amazon.awssdk.core.internal.handler.BaseAsyncClientHandler.execute(BaseAsyncClientHandler.java:86)
 	at software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler.execute(AwsAsyncClientHandler.java:52)
 	at software.amazon.awssdk.services.sqs.DefaultSqsAsyncClient.receiveMessage(DefaultSqsAsyncClient.java:1149)

```
## Motivation and Context
We saw a NPE on that line.

## Testing
Don't see the need for testing this sort of change.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
