### PR TITLE
Fix the bug of client endpoint override being ignored

### DIFF
--- a/.changes/next-release/bugfix-AWSS3-3df5a2e.json
+++ b/.changes/next-release/bugfix-AWSS3-3df5a2e.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS S3", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix the bug that getUrl in S3Utilities ignores the overriding endpoint in the client."
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3UtilitiesTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3UtilitiesTest.java
@@ -131,6 +131,20 @@ public class S3UtilitiesTest {
     }
 
     @Test
+    public void test_EndpointOverrideOnClientWorks() {
+        S3Utilities customizeUtilities = S3Client.builder()
+                                                 .endpointOverride(URI.create("https://s3.custom.host"))
+                                                 .build()
+                                                 .utilities();
+        assertThat(customizeUtilities.getUrl(GetUrlRequest.builder()
+                                                          .bucket("foo-bucket")
+                                                          .key("key-without-spaces")
+                                                          .build())
+                                     .toExternalForm())
+            .isEqualTo("https://foo-bucket.s3.custom.host/key-without-spaces");
+    }
+
+    @Test
     public void testWithAccelerateAndDualStackEnabled() throws MalformedURLException {
         S3Utilities utilities = S3Client.builder()
                                         .credentialsProvider(dummyCreds())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pr is to fix #2266.
Fix the bug that `getUrl` method in `S3Utilities` ignores the client level override endpoint.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test testing when there is the client level overriding endpoint but no request level overriding endpoint, the client level overriding endpoint would be used for the `getUrl` method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
