### PR TITLE
Add support for adapting the sdk configurations to crt configurations.

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/DefaultS3CrtAsyncClient.java
@@ -16,8 +16,11 @@
 package software.amazon.awssdk.services.s3.internal;
 
 
+import static software.amazon.awssdk.services.s3.internal.S3CrtUtils.createCrtCredentialsProvider;
+
 import com.amazonaws.s3.S3NativeClient;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClient;
 
 @SdkInternalApi
@@ -25,11 +28,17 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
     private final S3NativeClient s3NativeClient;
     private final S3NativeClientConfiguration configuration;
 
-    public DefaultS3CrtAsyncClient(DefaultS3CrtClientBuilder builder) {
+    private final CredentialsProvider credentialsProvider;
 
-        // TODO: adapt SDK Configurations to CRT configurations
+
+    public DefaultS3CrtAsyncClient(DefaultS3CrtClientBuilder builder) {
+        this.credentialsProvider = createCrtCredentialsProvider(builder.credentialsProvider());
+
         this.configuration = S3NativeClientConfiguration.builder()
+                                                        .credentialsProvider(credentialsProvider)
                                                         .signingRegion(builder.region().id())
+                                                        .partSizeBytes(builder.partSizeBytes())
+                                                        .maxThroughputGbps(builder.maxThroughputGbps())
                                                         .build();
 
         this.s3NativeClient = new S3NativeClient(configuration.signingRegion(),
@@ -38,6 +47,8 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
                                                  configuration.partSizeBytes(),
                                                  configuration.maxThroughputGbps());
     }
+
+
 
     @Override
     public String serviceName() {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/DefaultS3CrtClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/DefaultS3CrtClientBuilder.java
@@ -28,8 +28,8 @@ import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 public final class DefaultS3CrtClientBuilder implements S3CrtAsyncClientBuilder {
     private AwsCredentialsProvider credentialsProvider;
     private Region region;
-    private ClientOverrideConfiguration clientOverrideConfiguration;
-    private URI endpointOverride;
+    private long partSizeBytes;
+    private double maxThroughputGbps;
 
     public AwsCredentialsProvider credentialsProvider() {
         return credentialsProvider;
@@ -39,12 +39,12 @@ public final class DefaultS3CrtClientBuilder implements S3CrtAsyncClientBuilder 
         return region;
     }
 
-    public ClientOverrideConfiguration clientOverrideConfiguration() {
-        return clientOverrideConfiguration;
+    public long partSizeBytes() {
+        return partSizeBytes;
     }
 
-    public URI endpointOverride() {
-        return endpointOverride;
+    public double maxThroughputGbps() {
+        return maxThroughputGbps;
     }
 
     @Override
@@ -53,27 +53,37 @@ public final class DefaultS3CrtClientBuilder implements S3CrtAsyncClientBuilder 
         return this;
     }
 
-    @Override
+
     public S3CrtAsyncClientBuilder region(Region region) {
         this.region = region;
         return this;
     }
 
+    // TODO: Add support for this configuration
     @Override
     public S3CrtAsyncClientBuilder overrideConfiguration(ClientOverrideConfiguration overrideConfiguration) {
-        this.clientOverrideConfiguration = overrideConfiguration;
-        return this;
+        throw new UnsupportedOperationException();
     }
 
+    // TODO: Add support for this configuration
     @Override
     public S3CrtAsyncClientBuilder overrideConfiguration(Consumer<ClientOverrideConfiguration.Builder> overrideConfiguration) {
-        this.clientOverrideConfiguration = ClientOverrideConfiguration.builder().applyMutation(overrideConfiguration).build();
+        throw new UnsupportedOperationException();
+    }
+
+    // TODO: Add support for this configuration
+    @Override
+    public S3CrtAsyncClientBuilder endpointOverride(URI endpointOverride) {
+        throw new UnsupportedOperationException();
+    }
+
+    public S3CrtAsyncClientBuilder partSizeBytes(long partSizeBytes) {
+        this.partSizeBytes = partSizeBytes;
         return this;
     }
 
-    @Override
-    public S3CrtAsyncClientBuilder endpointOverride(URI endpointOverride) {
-        this.endpointOverride = endpointOverride;
+    public S3CrtAsyncClientBuilder maxThroughputGbps(double maxThroughputGbps) {
+        this.maxThroughputGbps = maxThroughputGbps;
         return this;
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/S3CrtUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/S3CrtUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
+import software.amazon.awssdk.crt.auth.credentials.StaticCredentialsProvider;
+
+@SdkInternalApi
+public final class S3CrtUtils {
+
+    private S3CrtUtils() {
+    }
+
+    // TODO: Add more adapters if there are any new crt credentials providers.
+    /**
+     * Adapter between the sdk credentials provider and the crt credentials provider.
+     */
+    public static CredentialsProvider createCrtCredentialsProvider(AwsCredentialsProvider awsCredentialsProvider) {
+        AwsCredentials sdkCredentials = awsCredentialsProvider.resolveCredentials();
+        StaticCredentialsProvider.StaticCredentialsProviderBuilder builder =
+            new StaticCredentialsProvider.StaticCredentialsProviderBuilder();
+
+        if (sdkCredentials instanceof AwsSessionCredentials) {
+            builder.withSessionToken(((AwsSessionCredentials) sdkCredentials).sessionToken().getBytes());
+        }
+
+        return builder.withAccessKeyId(sdkCredentials.accessKeyId().getBytes())
+                      .withSecretAccessKey(sdkCredentials.secretAccessKey().getBytes())
+                      .build();
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/S3CrtUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/S3CrtUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.crt.auth.credentials.Credentials;
+import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
+
+public class S3CrtUtilsTest {
+
+    private final String ACCESS_KEY = "accessKey";
+    private final String SECRET_ACCESS_KEY = "secretAccessKey";
+    private final String SESSION_TOKEN = "sessionToken";
+
+    @Test
+    public void createCrtCredentialsProviderTest() throws ExecutionException, InterruptedException {
+        AwsCredentialsProvider awsCredentialsProvider = StaticCredentialsProvider
+            .create(AwsSessionCredentials.create(ACCESS_KEY, SECRET_ACCESS_KEY, SESSION_TOKEN));
+        CredentialsProvider crtCredentialsProvider = S3CrtUtils.createCrtCredentialsProvider(awsCredentialsProvider);
+
+        Credentials credentials = crtCredentialsProvider.getCredentials().get();
+
+        assertThat(ACCESS_KEY, equalTo(new String(credentials.getAccessKeyId(), StandardCharsets.UTF_8)));
+        assertThat(SECRET_ACCESS_KEY, equalTo(new String(credentials.getSecretAccessKey(), StandardCharsets.UTF_8)));
+        assertThat(SESSION_TOKEN, equalTo(new String(credentials.getSessionToken(), StandardCharsets.UTF_8)));
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add support for adapting the sdk configurations to crt configurations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The java sdk configurations are not exactly the same as the crt configurations, so we need to adapt the sdk configurations to the crt configurations.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test testing if the crt credentials provider can be created correctly is added in this pr.
