### PR TITLE
Change STANDARD mode retry count for DynamoDB to match LEGACY as V1

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e6a3a04.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e6a3a04.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon DynamoDB",
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Change STANDARD mode retry count which was 2 for DynamoDB to match LEGACY retry count which is 8."
+}

--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/DynamoDbRetryPolicyTest.java
@@ -1,0 +1,35 @@
+package software.amazon.awssdk.services.dynamodb;
+
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DynamoDbRetryPolicyTest {
+
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+    @Test
+    public void test_numRetries_with_standardRetryPolicy() {
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_RETRY_MODE.environmentVariable(), "standard");
+        System.setProperty(ProfileFileSystemSetting.AWS_PROFILE.property(), "default");
+        final SdkClientConfiguration sdkClientConfiguration = SdkClientConfiguration.builder().build();
+        final RetryPolicy retryPolicy = DynamoDbRetryPolicy.resolveRetryPolicy(sdkClientConfiguration);
+        assertThat(retryPolicy.numRetries()).isEqualTo(8);
+    }
+
+    @Test
+    public void test_numRetries_with_legacyRetryPolicy() {
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_RETRY_MODE.environmentVariable(), "legacy");
+        System.setProperty(ProfileFileSystemSetting.AWS_PROFILE.property(), "default");
+        final SdkClientConfiguration sdkClientConfiguration = SdkClientConfiguration.builder().build();
+        final RetryPolicy retryPolicy = DynamoDbRetryPolicy.resolveRetryPolicy(sdkClientConfiguration);
+        assertThat(retryPolicy.numRetries()).isEqualTo(8);
+    }
+
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change STANDARD mode retry count for DynamoDB to match LEGACY same as in V1



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- DynamoDB is concerned of the lower  value in STANDARD  which was a lower value (2 in case of V2) and asked to set it to higher value as legacy mode.
- In-order to keep this consistent with V1 setting the retry count to 8 same as LEGACY_RETRY_COUNT.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
