### PR TITLE
Use virtual host style on customizing endpoint

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtils.java
@@ -124,12 +124,14 @@ public final class S3EndpointUtils {
      * @param bucketName     Bucket name for this particular operation.
      */
     public static void changeToDnsEndpoint(SdkHttpRequest.Builder mutableRequest, String bucketName) {
+        String newHost;
         if (mutableRequest.host().startsWith("s3")) {
-            String newHost = mutableRequest.host().replaceFirst("s3", bucketName + "." + "s3");
-            String newPath = mutableRequest.encodedPath().replaceFirst("/" + bucketName, "");
-
-            mutableRequest.host(newHost).encodedPath(newPath);
+            newHost = mutableRequest.host().replaceFirst("s3", bucketName + "." + "s3");
+        } else {
+            newHost = bucketName + "." + mutableRequest.host();
         }
+        String newPath = mutableRequest.encodedPath().replaceFirst("/" + bucketName, "");
+        mutableRequest.host(newHost).encodedPath(newPath);
     }
 
     public static boolean isArn(String s) {


### PR DESCRIPTION

## Description
 choose virtual host style when customize endpoint

## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/2317

## Testing
Built locally

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
