### PR TITLE
Add support for event stream requests over RPC

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -232,6 +232,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                .add(".withMarshaller($L)\n", asyncMarshaller(model, opModel, marshaller, protocolFactory))
                .add(asyncRequestBody(opModel))
                .add(fullDuplex(opModel))
+               .add(hasInitialRequestEvent(opModel, isRestJson))
                .add(".withResponseHandler($L)\n", responseHandlerName(opModel, isRestJson))
                .add(".withErrorResponseHandler(errorResponseHandler)\n")
                .add(".withMetricCollector(apiCallMetricCollector)\n")
@@ -269,6 +270,11 @@ public class JsonProtocolSpec implements ProtocolSpec {
     private CodeBlock fullDuplex(OperationModel opModel) {
         return opModel.hasEventStreamInput() && opModel.hasEventStreamOutput() ? CodeBlock.of(".withFullDuplex(true)")
                                                                                : CodeBlock.of("");
+    }
+
+    private CodeBlock hasInitialRequestEvent(OperationModel opModel, boolean isRestJson) {
+        return opModel.hasEventStreamInput() && !isRestJson ? CodeBlock.of(".withInitialRequestEvent(true)")
+                                                            : CodeBlock.of("");
     }
 
     private CodeBlock asyncRequestBody(OperationModel opModel) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
@@ -32,8 +32,6 @@ import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
  */
 public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
 
-    private static final String JSON_CONTENT_TYPE = "application/json";
-
     public EventStreamJsonMarshallerSpec(IntermediateModel model, ShapeModel shapeModel) {
         super(shapeModel);
     }
@@ -51,7 +49,7 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
 
         // Add :content-type header only if payload is present
         if (!shapeModel.hasNoEventPayload()) {
-            builder.add(".putHeader(\":content-type\", \"$L\")", determinePayloadContentType());
+            builder.add(".putHeader(\":content-type\", $L)", determinePayloadContentType());
         }
 
         builder.add(".build();");
@@ -85,12 +83,12 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
             return getPayloadContentType(explicitEventPayload);
         }
 
-        return JSON_CONTENT_TYPE;
+        return "protocolFactory.getContentType()";
     }
 
     private String getPayloadContentType(MemberModel memberModel) {
-        String blobContentType = "application/octet-stream";
-        String stringContentType = "text/plain";
+        String blobContentType = "\"application/octet-stream\"";
+        String stringContentType = "\"text/plain\"";
         String variableType = memberModel.getVariable().getVariableType();
 
         if ("software.amazon.awssdk.core.SdkBytes".equals(variableType)) {
@@ -99,6 +97,6 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
             return stringContentType;
         }
 
-        return JSON_CONTENT_TYPE;
+        return "protocolFactory.getContentType()";
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.codegen.poet;
 
 import java.io.File;
+
+import org.eclipse.core.runtime.internal.adaptor.IModel;
 import software.amazon.awssdk.codegen.C2jModels;
 import software.amazon.awssdk.codegen.IntermediateModelBuilder;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
@@ -31,7 +33,20 @@ import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
 public class ClientTestModels {
     private ClientTestModels() {}
 
-    public static IntermediateModel jsonServiceModels() {
+    public static IntermediateModel awsJsonServiceModels() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/json/service-2.json").getFile());
+        File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/json/customization.config").getFile());
+        File paginatorsModel = new File(ClientTestModels.class.getResource("client/c2j/json/paginators.json").getFile());
+        C2jModels models = C2jModels.builder()
+            .serviceModel(getServiceModel(serviceModel))
+            .customizationConfig(getCustomizationConfig(customizationModel))
+            .paginatorsModel(getPaginatorsModel(paginatorsModel))
+            .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
+    public static IntermediateModel restJsonServiceModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/rest-json/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/rest-json/customization.config").getFile());
         File paginatorsModel = new File(ClientTestModels.class.getResource("client/c2j/rest-json/paginators.json").getFile());

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/builder/BuilderClassTest.java
@@ -69,7 +69,7 @@ public class BuilderClassTest {
     }
 
     private void validateGeneration(Function<IntermediateModel, ClassSpec> generatorConstructor, String expectedClassName) {
-        assertThat(generatorConstructor.apply(ClientTestModels.jsonServiceModels()), generatesTo(expectedClassName));
+        assertThat(generatorConstructor.apply(ClientTestModels.restJsonServiceModels()), generatesTo(expectedClassName));
     }
 
     private void validateQueryGeneration(Function<IntermediateModel, ClassSpec> generatorConstructor, String expectedClassName) {

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
@@ -28,27 +28,26 @@ public class PoetClientFunctionalTests {
 
     @Test
     public void asyncClientClass() throws Exception {
-        AsyncClientClass asyncClientClass = new AsyncClientClass(
-                GeneratorTaskParams.create(ClientTestModels.jsonServiceModels(), "sources/", "tests/"));
+        AsyncClientClass asyncClientClass = createAsyncClientClass(ClientTestModels.restJsonServiceModels());
         assertThat(asyncClientClass, generatesTo("test-async-client-class.java"));
     }
 
     @Test
     public void asyncClientInterface() throws Exception {
-        ClassSpec asyncClientInterface = new AsyncClientInterface(ClientTestModels.jsonServiceModels());
+        ClassSpec asyncClientInterface = new AsyncClientInterface(ClientTestModels.restJsonServiceModels());
         assertThat(asyncClientInterface, generatesTo("test-json-async-client-interface.java"));
     }
 
     @Test
     public void simpleMethodsIntegClass() throws Exception {
         ClientSimpleMethodsIntegrationTests simpleMethodsClass = new ClientSimpleMethodsIntegrationTests(
-                ClientTestModels.jsonServiceModels());
+                ClientTestModels.restJsonServiceModels());
         assertThat(simpleMethodsClass, generatesTo("test-simple-methods-integ-class.java"));
     }
 
     @Test
-    public void syncClientClassJson() throws Exception {
-        SyncClientClass syncClientClass = createSyncClientClass(ClientTestModels.jsonServiceModels());
+    public void syncClientClassRestJson() throws Exception {
+        SyncClientClass syncClientClass = createSyncClientClass(ClientTestModels.restJsonServiceModels());
         assertThat(syncClientClass, generatesTo("test-json-client-class.java"));
     }
 
@@ -58,6 +57,11 @@ public class PoetClientFunctionalTests {
         assertThat(syncClientClass, generatesTo("test-query-client-class.java"));
     }
 
+    @Test
+    public void asyncClientClassAwsJson() throws Exception {
+        AsyncClientClass asyncClientClass = createAsyncClientClass(ClientTestModels.awsJsonServiceModels());
+        assertThat(asyncClientClass, generatesTo("test-aws-json-async-client-class.java"));
+    }
 
     @Test
     public void asyncClientClassQuery() throws Exception {
@@ -70,7 +74,6 @@ public class PoetClientFunctionalTests {
         SyncClientClass syncClientClass = createSyncClientClass(ClientTestModels.xmlServiceModels());
         assertThat(syncClientClass, generatesTo("test-xml-client-class.java"));
     }
-
 
     @Test
     public void asyncClientClassXml() throws Exception {
@@ -88,7 +91,7 @@ public class PoetClientFunctionalTests {
 
     @Test
     public void syncClientInterface() throws Exception {
-        ClassSpec syncClientInterface = new SyncClientInterface(ClientTestModels.jsonServiceModels());
+        ClassSpec syncClientInterface = new SyncClientInterface(ClientTestModels.restJsonServiceModels());
         assertThat(syncClientInterface, generatesTo("test-json-client-interface.java"));
     }
 

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamFunctionalTests.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/eventstream/EventStreamFunctionalTests.java
@@ -45,7 +45,7 @@ public class EventStreamFunctionalTests {
 
     private void runTest(BiFunction<GeneratorTaskParams, OperationModel, ClassSpec> specFactory,
                          String expectedTestFile) {
-        IntermediateModel model = ClientTestModels.jsonServiceModels();
+        IntermediateModel model = ClientTestModels.restJsonServiceModels();
         GeneratorTaskParams dependencies = GeneratorTaskParams.create(model, "sources/", "tests/");
         ClassSpec classSpec = specFactory.apply(dependencies, model.getOperation("EventStreamOperation"));
         assertThat(classSpec, generatesTo(expectedTestFile));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -1,0 +1,20 @@
+{
+    "authPolicyActions" : {
+        "skip" : true
+    },
+    "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
+    "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
+    "serviceSpecificClientConfigClass": "ServiceConfiguration",
+    "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
+    "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
+    "blacklistedSimpleMethods" : [
+        "eventStreamOperation"
+    ],
+  "utilitiesMethod": {
+    "returnType": "software.amazon.awssdk.services.json.JsonUtilities",
+    "createMethodParams": ["param1", "param2", "param3"]
+  },
+  "useLegacyEventGenerationScheme": {
+    "EventStream": ["EventOne", "event-two", "eventThree"]
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/paginators.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/paginators.json
@@ -1,0 +1,15 @@
+{
+  "pagination": {
+    "PaginatedOperationWithResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Items"
+    },
+    "PaginatedOperationWithoutResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
@@ -1,0 +1,498 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2010-05-08",
+    "endpointPrefix": "json-service-endpoint",
+    "globalEndpoint": "json-service.amazonaws.com",
+    "protocol": "json",
+    "serviceAbbreviation": "Json Service",
+    "serviceFullName": "Some Service That Uses AWS Json Protocol",
+    "serviceId": "Json Service",
+    "signingName": "json-service",
+    "signatureVersion": "v4",
+    "uid": "json-service-2010-05-08",
+    "xmlNamespace": "https://json-service.amazonaws.com/doc/2010-05-08/"
+  },
+  "operations": {
+    "OperationWithChecksumRequired": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "httpChecksumRequired": true
+    },
+    "APostOperation": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "endpoint": {
+        "hostPrefix": "{StringMember}-foo."
+      },
+      "input": {
+        "shape": "APostOperationRequest"
+      },
+      "errors": [
+        {
+          "shape": "InvalidInputException"
+        }
+      ],
+      "documentation": "<p>Performs a post operation to the query service and has no output</p>"
+    },
+    "GetWithoutRequiredMembers": {
+      "name": "GetWithoutRequiredMembers",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "GetWithoutRequiredMembersRequest"
+      },
+      "errors": [
+        {
+          "shape": "InvalidInputException"
+        }
+      ],
+      "documentation": "<p>Performs a post operation to the query service and has no output</p>"
+    },
+    "APostOperationWithOutput": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "APostOperationWithOutputRequest"
+      },
+      "output": {
+        "shape": "APostOperationWithOutputResponse",
+        "resultWrapper": "APostOperationWithOutputResult"
+      },
+      "errors": [
+        {
+          "shape": "InvalidInputException"
+        }
+      ],
+      "documentation": "<p>Performs a post operation to the query service and has modelled output</p>"
+    },
+    "StreamingInputOperation": {
+      "name": "StreamingInputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingInputOperation"
+      },
+      "input": {
+        "shape": "StructureWithStreamingMember"
+      },
+      "documentation": "Some operation with a streaming input"
+    },
+    "StreamingOutputOperation": {
+      "name": "StreamingOutputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingOutputOperation"
+      },
+      "output": {
+        "shape": "StructureWithStreamingMember"
+      },
+      "documentation": "Some operation with a streaming output"
+    },
+    "StreamingInputOutputOperation": {
+      "name": "StreamingInputOutputOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/streamingInputOutputOperation"
+      },
+      "input": {
+        "shape": "StructureWithStreamingMember"
+      },
+      "output": {
+        "shape": "StructureWithStreamingMember"
+      },
+      "documentation": "Some operation with streaming input and streaming output",
+      "authtype":"v4-unsigned-body"
+    },
+    "PaginatedOperationWithResultKey": {
+      "name": "PaginatedOperationWithResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithResultKeyResponse",
+        "resultWrapper": "PaginatedOperationWithResultKeyResult"
+      },
+      "documentation": "Some paginated operation with result_key in paginators.json file"
+    },
+    "PaginatedOperationWithoutResultKey": {
+      "name": "PaginatedOperationWithoutResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithoutResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithoutResultKeyResponse",
+        "resultWrapper": "PaginatedOperationWithoutResultKeyResult"
+      },
+      "documentation": "Some paginated operation without result_key in paginators.json file"
+    },
+    "EventStreamOperation": {
+      "name": "EventStreamOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/eventStreamOperation"
+      },
+      "input": {
+        "shape": "EventStreamOperationRequest"
+      },
+      "output": {
+        "shape": "EventStreamOutput"
+      }
+    },
+    "EventStreamOperationWithOnlyInput": {
+      "name": "EventStreamOperationWithOnlyInput",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/EventStreamOperationWithOnlyInput"
+      },
+      "input": {
+        "shape": "EventStreamOperationWithOnlyInputRequest"
+      }
+    },
+    "EventStreamOperationWithOnlyOutput": {
+      "name": "EventStreamOperationWithOnlyOutput",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2016-03-11/EventStreamOperationWithOnlyOutput"
+      },
+      "output": {
+        "shape": "EventStreamOutput"
+      }
+    }
+  },
+  "shapes": {
+    "APostOperationRequest": {
+      "type": "structure",
+      "required": [
+        "SomeNestedMember",
+        "StringMember"
+      ],
+      "members": {
+        "SomeNestedMember": {
+          "shape": "nestedMember",
+          "documentation": "<p>a member that has nested members</p>"
+        },
+        "OptionalMember": {
+          "shape": "dateType",
+          "documentation": "<p>An optional member</p>"
+        },
+        "StringMember": {
+          "shape": "String",
+          "hostLabel": true,
+          "documentation": "<p>Member to compute the endpoint host</p>"
+        }
+      }
+    },
+    "GetWithoutRequiredMembersRequest": {
+      "type": "structure",
+      "members": {
+        "SomeNestedMember": {
+          "shape": "nestedMember",
+          "documentation": "<p>a member that has nested members</p>"
+        },
+        "OptionalMember": {
+          "shape": "dateType",
+          "documentation": "<p>An optional member</p>"
+        }
+      }
+    },
+    "APostOperationWithOutputRequest": {
+      "type": "structure",
+      "required": [
+        "SomeNestedMember"
+      ],
+      "members": {
+        "SomeNestedMember": {
+          "shape": "nestedMember",
+          "documentation": "<p>a member that has nested members</p>"
+        },
+        "OptionalMember": {
+          "shape": "dateType",
+          "documentation": "<p>An optional member</p>"
+        }
+      }
+    },
+    "APostOperationWithOutputResponse": {
+      "type": "structure",
+      "required": [
+        "NestedMember"
+      ],
+      "members": {
+        "NestedMember": {
+          "shape": "nestedMember",
+          "documentation": "<p>A structure containing nested members</p>"
+        }
+      },
+      "documentation": "<p>Contains the response to a successful <a>APostOperationWithOutput</a> request. </p>"
+    },
+    "InvalidInputException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "invalidInputMessage"
+        }
+      },
+      "documentation": "<p>The request was rejected because an invalid or out-of-range value was supplied for an input parameter.</p>",
+      "error": {
+        "code": "InvalidInput",
+        "httpStatusCode": 400,
+        "senderFault": true
+      },
+      "exception": true
+    },
+    "nestedMember": {
+      "type": "structure",
+      "required": [
+        "SubMember",
+        "CreateDate"
+      ],
+      "members": {
+        "SubMember": {
+          "shape": "subMember",
+          "documentation": "<p>A sub-member</p>"
+        },
+        "CreateDate": {
+          "shape": "dateType",
+          "documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time format</a>, when the member was created.</p>"
+        }
+      },
+      "documentation": "<p>A shape with nested sub-members"
+    },
+    "subMember": {
+      "type": "string",
+      "max": 63,
+      "min": 3,
+      "pattern": "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$"
+    },
+    "dateType": {
+      "type": "timestamp"
+    },
+    "String": {
+      "type": "string"
+    },
+    "invalidInputMessage": {
+      "type": "string"
+    },
+    "StreamType": {
+      "type": "blob",
+      "streaming": true
+    },
+    "StructureWithStreamingMember": {
+      "type": "structure",
+      "members": {
+        "StreamingMember": {
+          "shape": "StreamType",
+          "documentation": "This be a stream"
+        }
+      },
+      "payload": "StreamingMember"
+    },
+    "PaginatedOperationWithResultKeyRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "subMember",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "Items": {
+          "shape": "ItemsList",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
+    },
+    "ItemsList": {
+      "type": "list",
+      "member": {
+        "shape": "subMember"
+      }
+    },
+    "PaginatedOperationWithoutResultKeyRequest": {
+      "type": "structure",
+      "required": [
+        "NextToken"
+      ],
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "subMember",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithoutResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "subMember",
+          "documentation": "<p>Token for the next set of results</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
+    },
+    "EventStreamOperationRequest": {
+      "type": "structure",
+      "required": [
+        "InputEventStream"
+      ],
+      "members": {
+        "InputEventStream": {
+          "shape": "InputEventStream"
+        }
+      },
+      "payload":"InputEventStream"
+    },
+    "EventStreamOutput": {
+      "type": "structure",
+      "required": [
+        "EventStream"
+      ],
+      "members": {
+        "EventStream": {
+          "shape": "EventStream"
+        }
+      }
+    },
+    "InputEventStream": {
+      "type": "structure",
+      "members": {
+        "InputEvent": {
+          "shape": "InputEvent"
+        }
+      },
+      "eventstream": true
+    },
+    "InputEvent": {
+      "type": "structure",
+      "members": {
+        "ExplicitPayloadMember": {
+          "shape":"ExplicitPayloadMember",
+          "eventpayload":true
+        }
+      },
+      "event": true
+    },
+    "ExplicitPayloadMember":{"type":"blob"},
+    "EventStream": {
+      "type": "structure",
+      "members": {
+        "EventOne": {
+          "shape": "EventOne"
+        },
+        "EventTheSecond": {
+          "shape": "EventTwo"
+        },
+        "secondEventOne": {
+          "shape": "EventOne"
+        },
+        // Legacy generation uses shape name == event name
+        "eventThree": {
+          "shape": "LegacyEventThree"
+        }
+      },
+      "eventstream": true
+    },
+    "EventOne": {
+      "type": "structure",
+      "members": {
+        "Foo": {
+          "shape": "String"
+        }
+      },
+      "event": true
+    },
+    "EventTwo": {
+      "type": "structure",
+      "members": {
+        "Bar": {
+          "shape": "String"
+        }
+      },
+      "event": true
+    },
+    "LegacyEventThree": {
+      "type": "structure",
+      "members": {
+        "Baz": {
+          "shape": "String"
+        }
+      },
+      "event": true
+    },
+    "EventStreamOperationWithOnlyInputRequest": {
+      "type": "structure",
+      "required": [
+        "InputEventStreamTwo"
+      ],
+      "members": {
+        "InputEventStreamTwo": {
+          "shape": "InputEventStreamTwo"
+        }
+      }
+    },
+    "InputEventStreamTwo": {
+      "type": "structure",
+      "members": {
+        "InputEventOne": {
+          "shape": "InputEvent"
+        },
+        "InputEventTwo": {
+          "shape": "InputEventTwo"
+        }
+      },
+      "eventstream": true
+    },
+    "InputEventTwo": {
+      "type": "structure",
+      "members": {
+        "ImplicitPayloadMemberOne": {
+          "shape": "ImplicitPayloadMemberOne"
+        },
+        "ImplicitPayloadMemberTwo": {
+          "shape": "String"
+        },
+        "EventHeaderMember": {
+          "shape":"String",
+          "eventheader":true
+        }
+      },
+      "event": true
+    },
+    "ImplicitPayloadMemberOne":{"type":"blob"}
+  },
+  "documentation": "A service that is implemented using the query protocol"
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -1,0 +1,1189 @@
+package software.amazon.awssdk.services.json;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.signer.AsyncAws4Signer;
+import software.amazon.awssdk.auth.signer.Aws4UnsignedPayloadSigner;
+import software.amazon.awssdk.auth.signer.EventStreamAws4Signer;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
+import software.amazon.awssdk.awscore.client.handler.AwsClientHandlerUtils;
+import software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransformer;
+import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionJsonMarshaller;
+import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionPojoSupplier;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ApiName;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.SdkPojoBuilder;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.client.handler.AttachHttpMetadataResponseHandler;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.core.protocol.VoidSdkResponse;
+import software.amazon.awssdk.core.runtime.transform.AsyncStreamingRequestMarshaller;
+import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.core.util.VersionInfo;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.protocols.core.ExceptionMetadata;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.services.json.model.APostOperationRequest;
+import software.amazon.awssdk.services.json.model.APostOperationResponse;
+import software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest;
+import software.amazon.awssdk.services.json.model.APostOperationWithOutputResponse;
+import software.amazon.awssdk.services.json.model.EventStream;
+import software.amazon.awssdk.services.json.model.EventStreamOperationRequest;
+import software.amazon.awssdk.services.json.model.EventStreamOperationResponse;
+import software.amazon.awssdk.services.json.model.EventStreamOperationResponseHandler;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputRequest;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyInputResponse;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputRequest;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponse;
+import software.amazon.awssdk.services.json.model.EventStreamOperationWithOnlyOutputResponseHandler;
+import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersRequest;
+import software.amazon.awssdk.services.json.model.GetWithoutRequiredMembersResponse;
+import software.amazon.awssdk.services.json.model.InputEventStream;
+import software.amazon.awssdk.services.json.model.InputEventStreamTwo;
+import software.amazon.awssdk.services.json.model.InvalidInputException;
+import software.amazon.awssdk.services.json.model.JsonException;
+import software.amazon.awssdk.services.json.model.JsonRequest;
+import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
+import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
+import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse;
+import software.amazon.awssdk.services.json.model.StreamingInputOperationRequest;
+import software.amazon.awssdk.services.json.model.StreamingInputOperationResponse;
+import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationRequest;
+import software.amazon.awssdk.services.json.model.StreamingInputOutputOperationResponse;
+import software.amazon.awssdk.services.json.model.StreamingOutputOperationRequest;
+import software.amazon.awssdk.services.json.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.services.json.model.inputeventstream.DefaultInputEvent;
+import software.amazon.awssdk.services.json.model.inputeventstreamtwo.DefaultInputEventOne;
+import software.amazon.awssdk.services.json.model.inputeventstreamtwo.DefaultInputEventTwo;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher;
+import software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher;
+import software.amazon.awssdk.services.json.transform.APostOperationRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.APostOperationWithOutputRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.EventStreamOperationRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.EventStreamOperationWithOnlyInputRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.EventStreamOperationWithOnlyOutputRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.InputEventMarshaller;
+import software.amazon.awssdk.services.json.transform.InputEventTwoMarshaller;
+import software.amazon.awssdk.services.json.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.StreamingInputOperationRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.StreamingInputOutputOperationRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.StreamingOutputOperationRequestMarshaller;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+import software.amazon.awssdk.utils.HostnameValidator;
+
+/**
+ * Internal implementation of {@link JsonAsyncClient}.
+ *
+ * @see JsonAsyncClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultJsonAsyncClient implements JsonAsyncClient {
+    private static final Logger log = LoggerFactory.getLogger(DefaultJsonAsyncClient.class);
+
+    private final AsyncClientHandler clientHandler;
+
+    private final AwsJsonProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    private final Executor executor;
+
+    protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration;
+        this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+        this.executor = clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    /**
+     * <p>
+     * Performs a post operation to the query service and has no output
+     * </p>
+     *
+     * @param aPostOperationRequest
+     * @return A Java Future containing the result of the APostOperation operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>InvalidInputException The request was rejected because an invalid or out-of-range value was supplied
+     *         for an input parameter.</li>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.APostOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
+     *      API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<APostOperationResponse> aPostOperation(APostOperationRequest aPostOperationRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, aPostOperationRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "APostOperation");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<APostOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, APostOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+            String hostPrefix = "{StringMember}-foo.";
+            HostnameValidator.validateHostnameCompliant(aPostOperationRequest.stringMember(), "StringMember",
+                    "aPostOperationRequest");
+            String resolvedHostExpression = String.format("%s-foo.", aPostOperationRequest.stringMember());
+
+            CompletableFuture<APostOperationResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<APostOperationRequest, APostOperationResponse>()
+                            .withOperationName("APostOperation")
+                            .withMarshaller(new APostOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).hostPrefixExpression(resolvedHostExpression)
+                            .withInput(aPostOperationRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = aPostOperationRequest.overrideConfiguration().orElse(null);
+            CompletableFuture<APostOperationResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * <p>
+     * Performs a post operation to the query service and has modelled output
+     * </p>
+     *
+     * @param aPostOperationWithOutputRequest
+     * @return A Java Future containing the result of the APostOperationWithOutput operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>InvalidInputException The request was rejected because an invalid or out-of-range value was supplied
+     *         for an input parameter.</li>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.APostOperationWithOutput
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperationWithOutput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<APostOperationWithOutputResponse> aPostOperationWithOutput(
+            APostOperationWithOutputRequest aPostOperationWithOutputRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, aPostOperationWithOutputRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "APostOperationWithOutput");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<APostOperationWithOutputResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, APostOperationWithOutputResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<APostOperationWithOutputResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<APostOperationWithOutputRequest, APostOperationWithOutputResponse>()
+                            .withOperationName("APostOperationWithOutput")
+                            .withMarshaller(new APostOperationWithOutputRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(aPostOperationWithOutputRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = aPostOperationWithOutputRequest.overrideConfiguration()
+                    .orElse(null);
+            CompletableFuture<APostOperationWithOutputResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the EventStreamOperation operation asynchronously.
+     *
+     * @param eventStreamOperationRequest
+     * @return A Java Future containing the result of the EventStreamOperation operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.EventStreamOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/EventStreamOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<Void> eventStreamOperation(EventStreamOperationRequest eventStreamOperationRequest,
+            Publisher<InputEventStream> requestStream, EventStreamOperationResponseHandler asyncResponseHandler) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, eventStreamOperationRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "EventStreamOperation");
+            eventStreamOperationRequest = applySignerOverride(eventStreamOperationRequest, EventStreamAws4Signer.create());
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<EventStreamOperationResponse> responseHandler = new AttachHttpMetadataResponseHandler(
+                    protocolFactory.createResponseHandler(operationMetadata, EventStreamOperationResponse::builder));
+
+            HttpResponseHandler<SdkResponse> voidResponseHandler = protocolFactory.createResponseHandler(JsonOperationMetadata
+                    .builder().isPayloadJson(false).hasStreamingSuccessResponse(true).build(), VoidSdkResponse::builder);
+
+            HttpResponseHandler<? extends EventStream> eventResponseHandler = protocolFactory.createResponseHandler(
+                    JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
+                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventStream::eventOneBuilder)
+                            .putSdkPojoSupplier("EventTheSecond", EventStream::eventTheSecondBuilder)
+                            .putSdkPojoSupplier("secondEventOne", EventStream::secondEventOneBuilder)
+                            .putSdkPojoSupplier("eventThree", EventStream::eventThreeBuilder)
+                            .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+            EventStreamTaggedUnionJsonMarshaller eventMarshaller = EventStreamTaggedUnionJsonMarshaller.builder()
+                    .putMarshaller(DefaultInputEvent.class, new InputEventMarshaller(protocolFactory)).build();
+            SdkPublisher<InputEventStream> eventPublisher = SdkPublisher.adapt(requestStream);
+            Publisher<ByteBuffer> adapted = eventPublisher.map(event -> eventMarshaller.marshall(event)).map(
+                    AwsClientHandlerUtils::encodeEventStreamRequestToByteBuffer);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            EventStreamAsyncResponseTransformer<EventStreamOperationResponse, EventStream> asyncResponseTransformer = EventStreamAsyncResponseTransformer
+                    .<EventStreamOperationResponse, EventStream> builder().eventStreamResponseHandler(asyncResponseHandler)
+                    .eventResponseHandler(eventResponseHandler).initialResponseHandler(responseHandler)
+                    .exceptionResponseHandler(errorResponseHandler).future(future).executor(executor).serviceName(serviceName())
+                    .build();
+
+            CompletableFuture<Void> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<EventStreamOperationRequest, SdkResponse>()
+                            .withOperationName("EventStreamOperation")
+                            .withMarshaller(new EventStreamOperationRequestMarshaller(protocolFactory))
+                            .withAsyncRequestBody(AsyncRequestBody.fromPublisher(adapted)).withFullDuplex(true)
+                            .withInitialRequestEvent(true).withResponseHandler(voidResponseHandler)
+                            .withErrorResponseHandler(errorResponseHandler).withMetricCollector(apiCallMetricCollector)
+                            .withInput(eventStreamOperationRequest), asyncResponseTransformer);
+            AwsRequestOverrideConfiguration requestOverrideConfig = eventStreamOperationRequest.overrideConfiguration().orElse(
+                    null);
+            CompletableFuture<Void> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    try {
+                        asyncResponseHandler.exceptionOccurred(e);
+                    } finally {
+                        future.completeExceptionally(e);
+                    }
+                }
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);
+        } catch (Throwable t) {
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                    () -> asyncResponseHandler.exceptionOccurred(t));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the EventStreamOperationWithOnlyInput operation asynchronously.
+     *
+     * @param eventStreamOperationWithOnlyInputRequest
+     * @return A Java Future containing the result of the EventStreamOperationWithOnlyInput operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.EventStreamOperationWithOnlyInput
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/EventStreamOperationWithOnlyInput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<EventStreamOperationWithOnlyInputResponse> eventStreamOperationWithOnlyInput(
+            EventStreamOperationWithOnlyInputRequest eventStreamOperationWithOnlyInputRequest,
+            Publisher<InputEventStreamTwo> requestStream) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                eventStreamOperationWithOnlyInputRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "EventStreamOperationWithOnlyInput");
+            eventStreamOperationWithOnlyInputRequest = applySignerOverride(eventStreamOperationWithOnlyInputRequest,
+                    EventStreamAws4Signer.create());
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<EventStreamOperationWithOnlyInputResponse> responseHandler = protocolFactory
+                    .createResponseHandler(operationMetadata, EventStreamOperationWithOnlyInputResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+            EventStreamTaggedUnionJsonMarshaller eventMarshaller = EventStreamTaggedUnionJsonMarshaller.builder()
+                    .putMarshaller(DefaultInputEventOne.class, new InputEventMarshaller(protocolFactory))
+                    .putMarshaller(DefaultInputEventTwo.class, new InputEventTwoMarshaller(protocolFactory)).build();
+            SdkPublisher<InputEventStreamTwo> eventPublisher = SdkPublisher.adapt(requestStream);
+            Publisher<ByteBuffer> adapted = eventPublisher.map(event -> eventMarshaller.marshall(event)).map(
+                    AwsClientHandlerUtils::encodeEventStreamRequestToByteBuffer);
+
+            CompletableFuture<EventStreamOperationWithOnlyInputResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<EventStreamOperationWithOnlyInputRequest, EventStreamOperationWithOnlyInputResponse>()
+                            .withOperationName("EventStreamOperationWithOnlyInput")
+                            .withMarshaller(new EventStreamOperationWithOnlyInputRequestMarshaller(protocolFactory))
+                            .withAsyncRequestBody(AsyncRequestBody.fromPublisher(adapted)).withInitialRequestEvent(true)
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(eventStreamOperationWithOnlyInputRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = eventStreamOperationWithOnlyInputRequest
+                    .overrideConfiguration().orElse(null);
+            CompletableFuture<EventStreamOperationWithOnlyInputResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the EventStreamOperationWithOnlyOutput operation asynchronously.
+     *
+     * @param eventStreamOperationWithOnlyOutputRequest
+     * @return A Java Future containing the result of the EventStreamOperationWithOnlyOutput operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.EventStreamOperationWithOnlyOutput
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/EventStreamOperationWithOnlyOutput"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<Void> eventStreamOperationWithOnlyOutput(
+            EventStreamOperationWithOnlyOutputRequest eventStreamOperationWithOnlyOutputRequest,
+            EventStreamOperationWithOnlyOutputResponseHandler asyncResponseHandler) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                eventStreamOperationWithOnlyOutputRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "EventStreamOperationWithOnlyOutput");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<EventStreamOperationWithOnlyOutputResponse> responseHandler = new AttachHttpMetadataResponseHandler(
+                    protocolFactory.createResponseHandler(operationMetadata, EventStreamOperationWithOnlyOutputResponse::builder));
+
+            HttpResponseHandler<SdkResponse> voidResponseHandler = protocolFactory.createResponseHandler(JsonOperationMetadata
+                    .builder().isPayloadJson(false).hasStreamingSuccessResponse(true).build(), VoidSdkResponse::builder);
+
+            HttpResponseHandler<? extends EventStream> eventResponseHandler = protocolFactory.createResponseHandler(
+                    JsonOperationMetadata.builder().isPayloadJson(true).hasStreamingSuccessResponse(false).build(),
+                    EventStreamTaggedUnionPojoSupplier.builder().putSdkPojoSupplier("EventOne", EventStream::eventOneBuilder)
+                            .putSdkPojoSupplier("EventTheSecond", EventStream::eventTheSecondBuilder)
+                            .putSdkPojoSupplier("secondEventOne", EventStream::secondEventOneBuilder)
+                            .putSdkPojoSupplier("eventThree", EventStream::eventThreeBuilder)
+                            .defaultSdkPojoSupplier(() -> new SdkPojoBuilder(EventStream.UNKNOWN)).build());
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            EventStreamAsyncResponseTransformer<EventStreamOperationWithOnlyOutputResponse, EventStream> asyncResponseTransformer = EventStreamAsyncResponseTransformer
+                    .<EventStreamOperationWithOnlyOutputResponse, EventStream> builder()
+                    .eventStreamResponseHandler(asyncResponseHandler).eventResponseHandler(eventResponseHandler)
+                    .initialResponseHandler(responseHandler).exceptionResponseHandler(errorResponseHandler).future(future)
+                    .executor(executor).serviceName(serviceName()).build();
+
+            CompletableFuture<Void> executeFuture = clientHandler
+                    .execute(
+                            new ClientExecutionParams<EventStreamOperationWithOnlyOutputRequest, SdkResponse>()
+                                    .withOperationName("EventStreamOperationWithOnlyOutput")
+                                    .withMarshaller(new EventStreamOperationWithOnlyOutputRequestMarshaller(protocolFactory))
+                                    .withResponseHandler(voidResponseHandler).withErrorResponseHandler(errorResponseHandler)
+                                    .withMetricCollector(apiCallMetricCollector)
+                                    .withInput(eventStreamOperationWithOnlyOutputRequest),
+                            asyncResponseTransformer);
+            AwsRequestOverrideConfiguration requestOverrideConfig = eventStreamOperationWithOnlyOutputRequest
+                    .overrideConfiguration().orElse(null);
+            CompletableFuture<Void> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    try {
+                        asyncResponseHandler.exceptionOccurred(e);
+                    } finally {
+                        future.completeExceptionally(e);
+                    }
+                }
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return CompletableFutureUtils.forwardExceptionTo(future, executeFuture);
+        } catch (Throwable t) {
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                    () -> asyncResponseHandler.exceptionOccurred(t));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * <p>
+     * Performs a post operation to the query service and has no output
+     * </p>
+     *
+     * @param getWithoutRequiredMembersRequest
+     * @return A Java Future containing the result of the GetWithoutRequiredMembers operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>InvalidInputException The request was rejected because an invalid or out-of-range value was supplied
+     *         for an input parameter.</li>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.GetWithoutRequiredMembers
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/GetWithoutRequiredMembers"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<GetWithoutRequiredMembersResponse> getWithoutRequiredMembers(
+            GetWithoutRequiredMembersRequest getWithoutRequiredMembersRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, getWithoutRequiredMembersRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "GetWithoutRequiredMembers");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<GetWithoutRequiredMembersResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, GetWithoutRequiredMembersResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<GetWithoutRequiredMembersResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<GetWithoutRequiredMembersRequest, GetWithoutRequiredMembersResponse>()
+                            .withOperationName("GetWithoutRequiredMembers")
+                            .withMarshaller(new GetWithoutRequiredMembersRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(getWithoutRequiredMembersRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = getWithoutRequiredMembersRequest.overrideConfiguration()
+                    .orElse(null);
+            CompletableFuture<GetWithoutRequiredMembersResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithChecksumRequired operation asynchronously.
+     *
+     * @param operationWithChecksumRequiredRequest
+     * @return A Java Future containing the result of the OperationWithChecksumRequired operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithChecksumRequired
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithChecksumRequired"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithChecksumRequiredResponse> operationWithChecksumRequired(
+            OperationWithChecksumRequiredRequest operationWithChecksumRequiredRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                operationWithChecksumRequiredRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithChecksumRequired");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<OperationWithChecksumRequiredResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, OperationWithChecksumRequiredResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<OperationWithChecksumRequiredResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<OperationWithChecksumRequiredRequest, OperationWithChecksumRequiredResponse>()
+                            .withOperationName("OperationWithChecksumRequired")
+                            .withMarshaller(new OperationWithChecksumRequiredRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler)
+                            .withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector)
+                            .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
+                                    HttpChecksumRequired.create()).withInput(operationWithChecksumRequiredRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = operationWithChecksumRequiredRequest.overrideConfiguration()
+                    .orElse(null);
+            CompletableFuture<OperationWithChecksumRequiredResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return A Java Future containing the result of the PaginatedOperationWithResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<PaginatedOperationWithResultKeyResponse> paginatedOperationWithResultKey(
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                paginatedOperationWithResultKeyRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "PaginatedOperationWithResultKey");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<PaginatedOperationWithResultKeyResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, PaginatedOperationWithResultKeyResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<PaginatedOperationWithResultKeyResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<PaginatedOperationWithResultKeyRequest, PaginatedOperationWithResultKeyResponse>()
+                            .withOperationName("PaginatedOperationWithResultKey")
+                            .withMarshaller(new PaginatedOperationWithResultKeyRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(paginatedOperationWithResultKeyRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = paginatedOperationWithResultKeyRequest
+                    .overrideConfiguration().orElse(null);
+            CompletableFuture<PaginatedOperationWithResultKeyResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some paginated operation with result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
+     * SDK will internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
+     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
+     * failures only after you start streaming the data. The subscribe method should be called as a request to start
+     * streaming data. For more info, see
+     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
+     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
+     * starting request.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to use the response class:
+     * </p>
+     * 1) Using the subscribe helper method
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
+     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
+     * future.get();
+     * }
+     * </pre>
+     *
+     * 2) Using a custom subscriber
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithResultKeyPublisher publisher = client.paginatedOperationWithResultKeyPaginator(request);
+     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse>() {
+     *
+     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
+     *
+     *
+     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse response) { //... };
+     * });}
+     * </pre>
+     *
+     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
+     * <p>
+     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
+     * paginator. It only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithResultKeyRequest
+     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithResultKey
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    public PaginatedOperationWithResultKeyPublisher paginatedOperationWithResultKeyPaginator(
+            PaginatedOperationWithResultKeyRequest paginatedOperationWithResultKeyRequest) {
+        return new PaginatedOperationWithResultKeyPublisher(this, applyPaginatorUserAgent(paginatedOperationWithResultKeyRequest));
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return A Java Future containing the result of the PaginatedOperationWithoutResultKey operation returned by the
+     *         service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<PaginatedOperationWithoutResultKeyResponse> paginatedOperationWithoutResultKey(
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                paginatedOperationWithoutResultKeyRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "PaginatedOperationWithoutResultKey");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<PaginatedOperationWithoutResultKeyResponse> responseHandler = protocolFactory
+                    .createResponseHandler(operationMetadata, PaginatedOperationWithoutResultKeyResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<PaginatedOperationWithoutResultKeyResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<PaginatedOperationWithoutResultKeyRequest, PaginatedOperationWithoutResultKeyResponse>()
+                            .withOperationName("PaginatedOperationWithoutResultKey")
+                            .withMarshaller(new PaginatedOperationWithoutResultKeyRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(paginatedOperationWithoutResultKeyRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = paginatedOperationWithoutResultKeyRequest
+                    .overrideConfiguration().orElse(null);
+            CompletableFuture<PaginatedOperationWithoutResultKeyResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some paginated operation without result_key in paginators.json file<br/>
+     * <p>
+     * This is a variant of
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation. The return type is a custom publisher that can be subscribed to request a stream of response pages.
+     * SDK will internally handle making service calls for you.
+     * </p>
+     * <p>
+     * When the operation is called, an instance of this class is returned. At this point, no service calls are made yet
+     * and so there is no guarantee that the request is valid. If there are errors in your request, you will see the
+     * failures only after you start streaming the data. The subscribe method should be called as a request to start
+     * streaming data. For more info, see
+     * {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)}. Each call to the subscribe
+     * method will result in a new {@link org.reactivestreams.Subscription} i.e., a new contract to stream data from the
+     * starting request.
+     * </p>
+     *
+     * <p>
+     * The following are few ways to use the response class:
+     * </p>
+     * 1) Using the subscribe helper method
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
+     * CompletableFuture<Void> future = publisher.subscribe(res -> { // Do something with the response });
+     * future.get();
+     * }
+     * </pre>
+     *
+     * 2) Using a custom subscriber
+     *
+     * <pre>
+     * {@code
+     * software.amazon.awssdk.services.json.paginators.PaginatedOperationWithoutResultKeyPublisher publisher = client.paginatedOperationWithoutResultKeyPaginator(request);
+     * publisher.subscribe(new Subscriber<software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse>() {
+     *
+     * public void onSubscribe(org.reactivestreams.Subscriber subscription) { //... };
+     *
+     *
+     * public void onNext(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyResponse response) { //... };
+     * });}
+     * </pre>
+     *
+     * As the response is a publisher, it can work well with third party reactive streams implementations like RxJava2.
+     * <p>
+     * <b>Please notice that the configuration of MaxResults won't limit the number of results you get with the
+     * paginator. It only limits the number of results in each page.</b>
+     * </p>
+     * <p>
+     * <b>Note: If you prefer to have control on service calls, use the
+     * {@link #paginatedOperationWithoutResultKey(software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest)}
+     * operation.</b>
+     * </p>
+     *
+     * @param paginatedOperationWithoutResultKeyRequest
+     * @return A custom publisher that can be subscribed to request a stream of response pages.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.PaginatedOperationWithoutResultKey
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/PaginatedOperationWithoutResultKey"
+     *      target="_top">AWS API Documentation</a>
+     */
+    public PaginatedOperationWithoutResultKeyPublisher paginatedOperationWithoutResultKeyPaginator(
+            PaginatedOperationWithoutResultKeyRequest paginatedOperationWithoutResultKeyRequest) {
+        return new PaginatedOperationWithoutResultKeyPublisher(this,
+                applyPaginatorUserAgent(paginatedOperationWithoutResultKeyRequest));
+    }
+
+    /**
+     * Some operation with a streaming input
+     *
+     * @param streamingInputOperationRequest
+     * @param requestBody
+     *        Functional interface that can be implemented to produce the request content in a non-blocking manner. The
+     *        size of the content is expected to be known up front. See {@link AsyncRequestBody} for specific details on
+     *        implementing this interface as well as links to precanned implementations for common scenarios like
+     *        uploading from a file. The service documentation for the request content is as follows 'This be a stream'
+     * @return A Java Future containing the result of the StreamingInputOperation operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.StreamingInputOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<StreamingInputOperationResponse> streamingInputOperation(
+            StreamingInputOperationRequest streamingInputOperationRequest, AsyncRequestBody requestBody) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, streamingInputOperationRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "StreamingInputOperation");
+            if (!isSignerOverridden(clientConfiguration)) {
+                streamingInputOperationRequest = applySignerOverride(streamingInputOperationRequest, AsyncAws4Signer.create());
+            }
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<StreamingInputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, StreamingInputOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<StreamingInputOperationResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<StreamingInputOperationRequest, StreamingInputOperationResponse>()
+                            .withOperationName("StreamingInputOperation")
+                            .withMarshaller(
+                                    AsyncStreamingRequestMarshaller.builder()
+                                            .delegateMarshaller(new StreamingInputOperationRequestMarshaller(protocolFactory))
+                                            .asyncRequestBody(requestBody).build()).withResponseHandler(responseHandler)
+                            .withErrorResponseHandler(errorResponseHandler).withMetricCollector(apiCallMetricCollector)
+                            .withAsyncRequestBody(requestBody).withInput(streamingInputOperationRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = streamingInputOperationRequest.overrideConfiguration()
+                    .orElse(null);
+            CompletableFuture<StreamingInputOperationResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some operation with streaming input and streaming output
+     *
+     * @param streamingInputOutputOperationRequest
+     * @param requestBody
+     *        Functional interface that can be implemented to produce the request content in a non-blocking manner. The
+     *        size of the content is expected to be known up front. See {@link AsyncRequestBody} for specific details on
+     *        implementing this interface as well as links to precanned implementations for common scenarios like
+     *        uploading from a file. The service documentation for the request content is as follows 'This be a stream'
+     * @param asyncResponseTransformer
+     *        The response transformer for processing the streaming response in a non-blocking manner. See
+     *        {@link AsyncResponseTransformer} for details on how this callback should be implemented and for links to
+     *        precanned implementations for common scenarios like downloading to a file. The service documentation for
+     *        the response content is as follows 'This be a stream'.
+     * @return A future to the transformed result of the AsyncResponseTransformer.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.StreamingInputOutputOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingInputOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public <ReturnT> CompletableFuture<ReturnT> streamingInputOutputOperation(
+            StreamingInputOutputOperationRequest streamingInputOutputOperationRequest, AsyncRequestBody requestBody,
+            AsyncResponseTransformer<StreamingInputOutputOperationResponse, ReturnT> asyncResponseTransformer) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration,
+                streamingInputOutputOperationRequest.overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "StreamingInputOutputOperation");
+            streamingInputOutputOperationRequest = applySignerOverride(streamingInputOutputOperationRequest,
+                    Aws4UnsignedPayloadSigner.create());
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
+                    .isPayloadJson(false).build();
+
+            HttpResponseHandler<StreamingInputOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, StreamingInputOutputOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<StreamingInputOutputOperationRequest, StreamingInputOutputOperationResponse>()
+                            .withOperationName("StreamingInputOutputOperation")
+                            .withMarshaller(
+                                    AsyncStreamingRequestMarshaller
+                                            .builder()
+                                            .delegateMarshaller(
+                                                    new StreamingInputOutputOperationRequestMarshaller(protocolFactory))
+                                            .asyncRequestBody(requestBody).transferEncoding(true).build())
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withAsyncRequestBody(requestBody)
+                            .withInput(streamingInputOutputOperationRequest), asyncResponseTransformer);
+            AwsRequestOverrideConfiguration requestOverrideConfig = streamingInputOutputOperationRequest.overrideConfiguration()
+                    .orElse(null);
+            CompletableFuture<ReturnT> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                            () -> asyncResponseTransformer.exceptionOccurred(e));
+                }
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                    () -> asyncResponseTransformer.exceptionOccurred(t));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Some operation with a streaming output
+     *
+     * @param streamingOutputOperationRequest
+     * @param asyncResponseTransformer
+     *        The response transformer for processing the streaming response in a non-blocking manner. See
+     *        {@link AsyncResponseTransformer} for details on how this callback should be implemented and for links to
+     *        precanned implementations for common scenarios like downloading to a file. The service documentation for
+     *        the response content is as follows 'This be a stream'.
+     * @return A future to the transformed result of the AsyncResponseTransformer.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.StreamingOutputOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/StreamingOutputOperation"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public <ReturnT> CompletableFuture<ReturnT> streamingOutputOperation(
+            StreamingOutputOperationRequest streamingOutputOperationRequest,
+            AsyncResponseTransformer<StreamingOutputOperationResponse, ReturnT> asyncResponseTransformer) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, streamingOutputOperationRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "StreamingOutputOperation");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(true)
+                    .isPayloadJson(false).build();
+
+            HttpResponseHandler<StreamingOutputOperationResponse> responseHandler = protocolFactory.createResponseHandler(
+                    operationMetadata, StreamingOutputOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<ReturnT> executeFuture = clientHandler.execute(
+                    new ClientExecutionParams<StreamingOutputOperationRequest, StreamingOutputOperationResponse>()
+                            .withOperationName("StreamingOutputOperation")
+                            .withMarshaller(new StreamingOutputOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(streamingOutputOperationRequest),
+                    asyncResponseTransformer);
+            AwsRequestOverrideConfiguration requestOverrideConfig = streamingOutputOperationRequest.overrideConfiguration()
+                    .orElse(null);
+            CompletableFuture<ReturnT> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                if (e != null) {
+                    runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                            () -> asyncResponseTransformer.exceptionOccurred(e));
+                }
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            runAndLogError(log, "Exception thrown in exceptionOccurred callback, ignoring",
+                    () -> asyncResponseTransformer.exceptionOccurred(t));
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+
+    private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
+        return builder
+                .clientConfiguration(clientConfiguration)
+                .defaultServiceExceptionSupplier(JsonException::builder)
+                .protocol(AwsJsonProtocol.AWS_JSON)
+                .protocolVersion("1.1")
+                .registerModeledException(
+                        ExceptionMetadata.builder().errorCode("InvalidInput")
+                                .exceptionBuilderSupplier(InvalidInputException::builder).httpStatusCode(400).build());
+    }
+
+    private static List<MetricPublisher> resolveMetricPublishers(SdkClientConfiguration clientConfiguration,
+            RequestOverrideConfiguration requestOverrideConfiguration) {
+        List<MetricPublisher> publishers = null;
+        if (requestOverrideConfiguration != null) {
+            publishers = requestOverrideConfiguration.metricPublishers();
+        }
+        if (publishers == null || publishers.isEmpty()) {
+            publishers = clientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS);
+        }
+        if (publishers == null) {
+            publishers = Collections.emptyList();
+        }
+        return publishers;
+    }
+
+    private <T extends JsonRequest> T applyPaginatorUserAgent(T request) {
+        Consumer<AwsRequestOverrideConfiguration.Builder> userAgentApplier = b -> b.addApiName(ApiName.builder()
+                .version(VersionInfo.SDK_VERSION).name("PAGINATED").build());
+        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
+                .map(c -> c.toBuilder().applyMutation(userAgentApplier).build())
+                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(userAgentApplier).build()));
+        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
+    }
+
+    private <T extends JsonRequest> T applySignerOverride(T request, Signer signer) {
+        if (request.overrideConfiguration().flatMap(c -> c.signer()).isPresent()) {
+            return request;
+        }
+        Consumer<AwsRequestOverrideConfiguration.Builder> signerOverride = b -> b.signer(signer).build();
+        AwsRequestOverrideConfiguration overrideConfiguration = request.overrideConfiguration()
+                .map(c -> c.toBuilder().applyMutation(signerOverride).build())
+                .orElse((AwsRequestOverrideConfiguration.builder().applyMutation(signerOverride).build()));
+        return (T) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
+    }
+
+    private static boolean isSignerOverridden(SdkClientConfiguration clientConfiguration) {
+        return Boolean.TRUE.equals(clientConfiguration.option(SdkClientOption.SIGNER_OVERRIDDEN));
+    }
+
+    @Override
+    public JsonUtilities utilities() {
+        return JsonUtilities.create(param1, param2, param3);
+    }
+
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
+            JsonOperationMetadata operationMetadata) {
+        return protocolFactory.createErrorResponseHandler(operationMetadata);
+    }
+}
+

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
@@ -34,7 +34,7 @@ public class EventOneMarshaller implements Marshaller<EventOne> {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventOne).toBuilder().putHeader(":message-type", "event")
-                    .putHeader(":event-type", eventOne.sdkEventType().toString()).putHeader(":content-type", "application/json")
+                    .putHeader(":event-type", eventOne.sdkEventType().toString()).putHeader(":content-type", protocolFactory.getContentType())
                     .build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
@@ -35,7 +35,7 @@ public class EventThreeMarshaller implements Marshaller<EventThree> {
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventThree).toBuilder().putHeader(":message-type", "event")
                     .putHeader(":event-type", eventThree.sdkEventType().toString())
-                    .putHeader(":content-type", "application/json").build();
+                    .putHeader(":content-type", protocolFactory.getContentType()).build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
@@ -34,7 +34,7 @@ public class EventTwoMarshaller implements Marshaller<EventTwo> {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventTwo).toBuilder().putHeader(":message-type", "event")
-                    .putHeader(":event-type", eventTwo.sdkEventType().toString()).putHeader(":content-type", "application/json")
+                    .putHeader(":event-type", eventTwo.sdkEventType().toString()).putHeader(":content-type", protocolFactory.getContentType())
                     .build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
@@ -35,7 +35,7 @@ public class InputEventTwoMarshaller implements Marshaller<InputEventTwo> {
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(inputEventTwo).toBuilder().putHeader(":message-type", "event")
                     .putHeader(":event-type", inputEventTwo.sdkEventType().toString())
-                    .putHeader(":content-type", "application/json").build();
+                    .putHeader(":content-type", protocolFactory.getContentType()).build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsClientHandlerUtils.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsClientHandlerUtils.java
@@ -92,6 +92,7 @@ public final class AwsClientHandlerUtils {
             .putAttribute(AwsExecutionAttribute.ENDPOINT_PREFIX, clientConfig.option(AwsClientOption.ENDPOINT_PREFIX))
             .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, clientConfig.option(AwsClientOption.SIGNING_REGION))
             .putAttribute(SdkInternalExecutionAttribute.IS_FULL_DUPLEX, executionParams.isFullDuplex())
+            .putAttribute(SdkInternalExecutionAttribute.HAS_INITIAL_REQUEST_EVENT, executionParams.hasInitialRequestEvent())
             .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, clientConfig.option(SdkClientOption.CLIENT_TYPE))
             .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfig.option(SdkClientOption.SERVICE_NAME))
             .putAttribute(SdkExecutionAttribute.OPERATION_NAME, executionParams.getOperationName())

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamInitialRequestInterceptor.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/eventstream/EventStreamInitialRequestInterceptor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.eventstream;
+
+import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.HAS_INITIAL_REQUEST_EVENT;
+import static software.amazon.awssdk.core.internal.util.Mimetype.MIMETYPE_EVENT_STREAM;
+import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.interceptor.Context.ModifyHttpRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.internal.async.AsyncStreamPrepender;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.eventstream.HeaderValue;
+import software.amazon.eventstream.Message;
+
+/**
+ * An interceptor for event stream requests sent over RPC. This interceptor will prepend the initial request (i.e. the
+ * serialized request POJO) to the stream of events supplied by the caller.
+ */
+@SdkProtectedApi
+public class EventStreamInitialRequestInterceptor implements ExecutionInterceptor {
+    @Override
+    public SdkHttpRequest modifyHttpRequest(
+        ModifyHttpRequest context, ExecutionAttributes executionAttributes
+    ) {
+        if (!Boolean.TRUE.equals(executionAttributes.getAttribute(HAS_INITIAL_REQUEST_EVENT))) {
+            return context.httpRequest();
+        }
+
+        return context.httpRequest().toBuilder()
+            .removeHeader(CONTENT_TYPE)
+            .putHeader(CONTENT_TYPE, MIMETYPE_EVENT_STREAM)
+            .build();
+    }
+
+    @Override
+    public Optional<AsyncRequestBody> modifyAsyncHttpContent(
+        ModifyHttpRequest context, ExecutionAttributes executionAttributes
+    ) {
+        if (!Boolean.TRUE.equals(executionAttributes.getAttribute(HAS_INITIAL_REQUEST_EVENT))) {
+            return context.asyncRequestBody();
+        }
+
+        /*
+         * At this point in the request execution, the requestBody contains the serialized initial request,
+         * and the asyncRequestBody contains the event stream proper. We will prepend the former to the
+         * latter.
+         */
+        byte[] payload = getInitialRequestPayload(context);
+        String contentType = context.httpRequest().headers().get(CONTENT_TYPE).get(0);
+
+        Map<String, HeaderValue> initialRequestEventHeaders = new HashMap<>();
+        initialRequestEventHeaders.put(":message-type", HeaderValue.fromString("event"));
+        initialRequestEventHeaders.put(":event-type", HeaderValue.fromString("initial-request"));
+        initialRequestEventHeaders.put(":content-type", HeaderValue.fromString(contentType));
+
+        ByteBuffer initialRequest = new Message(initialRequestEventHeaders, payload).toByteBuffer();
+
+        Publisher<ByteBuffer> asyncRequestBody = context.asyncRequestBody()
+            .orElseThrow(() -> new IllegalStateException("This request is an event streaming request and thus "
+                        + "should have an asyncRequestBody"));
+        Publisher<ByteBuffer> withInitialRequest = new AsyncStreamPrepender<>(asyncRequestBody, initialRequest);
+        return Optional.of(AsyncRequestBody.fromPublisher(withInitialRequest));
+    }
+
+    private byte[] getInitialRequestPayload(ModifyHttpRequest context) {
+        RequestBody requestBody = context.requestBody()
+            .orElseThrow(() -> new IllegalStateException("This request should have a requestBody"));
+        byte[] payload;
+        try {
+            try (InputStream inputStream = requestBody.contentStreamProvider().newStream()) {
+                payload = new byte[inputStream.available()];
+                int bytesRead = inputStream.read(payload);
+                if (bytesRead != payload.length) {
+                    throw new IllegalStateException("Expected " + payload.length + " bytes, but only got " +
+                            bytesRead + " bytes");
+                }
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to read serialized request payload", ex);
+        }
+        return payload;
+    }
+}

--- a/core/aws-core/src/main/resources/META-INF/native-image/software.amazon.awssdk/aws-core/reflect-config.json
+++ b/core/aws-core/src/main/resources/META-INF/native-image/software.amazon.awssdk/aws-core/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "software.amazon.awssdk.awscore.eventstream.EventStreamInitialRequestInterceptor",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/core/aws-core/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/core/aws-core/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,0 +1,1 @@
+software.amazon.awssdk.awscore.eventstream.EventStreamInitialRequestInterceptor

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/eventstream/EventStreamInitialRequestInterceptorTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/eventstream/EventStreamInitialRequestInterceptorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.eventstream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.HAS_INITIAL_REQUEST_EVENT;
+import static software.amazon.awssdk.core.internal.util.Mimetype.MIMETYPE_EVENT_STREAM;
+import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
+
+import io.reactivex.Flowable;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.interceptor.Context.ModifyHttpRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.eventstream.HeaderValue;
+import software.amazon.eventstream.Message;
+
+public class EventStreamInitialRequestInterceptorTest {
+    static final String RPC_CONTENT_TYPE = "rpc-format";
+    Message eventMessage = getEventMessage();
+    Flowable<ByteBuffer> bytePublisher = Flowable.just(eventMessage.toByteBuffer(), eventMessage.toByteBuffer());
+    byte[] payload = "initial request payload".getBytes(StandardCharsets.UTF_8);
+    ExecutionAttributes attr = new ExecutionAttributes().putAttribute(HAS_INITIAL_REQUEST_EVENT, true);
+    EventStreamInitialRequestInterceptor interceptor = new EventStreamInitialRequestInterceptor();
+
+    @Test
+    public void testHttpHeaderModification() {
+        ModifyHttpRequest context = buildContext(bytePublisher, payload);
+
+        SdkHttpRequest modifiedRequest = interceptor.modifyHttpRequest(context, attr);
+
+        List<String> contentType = modifiedRequest.headers().get(CONTENT_TYPE);
+        assertEquals(1, contentType.size());
+        assertEquals(MIMETYPE_EVENT_STREAM, contentType.get(0));
+    }
+
+    @Test
+    public void testInitialRequestEvent() {
+        ModifyHttpRequest context = buildContext(bytePublisher, payload);
+
+        Optional<AsyncRequestBody> modifiedBody = interceptor.modifyAsyncHttpContent(context, attr);
+
+        List<Message> messages = Flowable.fromPublisher(modifiedBody.get()).map(Message::decode).toList().blockingGet();
+        Message initialRequestEvent = messages.get(0);
+        assertArrayEquals(payload, initialRequestEvent.getPayload());
+        assertEquals(RPC_CONTENT_TYPE, initialRequestEvent.getHeaders().get(":content-type").getString());
+    }
+
+    @Test
+    public void testPrepending() {
+        ModifyHttpRequest context = buildContext(bytePublisher, payload);
+
+        Optional<AsyncRequestBody> modifiedBody = interceptor.modifyAsyncHttpContent(context, attr);
+
+        List<Message> messages = Flowable.fromPublisher(modifiedBody.get()).map(Message::decode).toList().blockingGet();
+        assertEquals(3, messages.size());
+        assertEquals(eventMessage, messages.get(1));
+        assertEquals(eventMessage, messages.get(2));
+    }
+
+    @Test
+    public void testDisabled() {
+        ModifyHttpRequest context = buildContext(bytePublisher, payload);
+        attr.putAttribute(HAS_INITIAL_REQUEST_EVENT, false);
+
+        assertSame(context.httpRequest(), interceptor.modifyHttpRequest(context, attr));
+        assertSame(context.asyncRequestBody(), interceptor.modifyAsyncHttpContent(context, attr));
+    }
+
+    private ModifyHttpRequest buildContext(Flowable<ByteBuffer> bytePublisher, byte[] payload) {
+        SdkHttpFullRequest request = buildRequest();
+        ModifyHttpRequest context = Mockito.mock(ModifyHttpRequest.class);
+        when(context.httpRequest()).thenReturn(request);
+        when(context.asyncRequestBody()).thenReturn(Optional.of(AsyncRequestBody.fromPublisher(bytePublisher)));
+        when(context.requestBody()).thenReturn(Optional.of(RequestBody.fromByteBuffer(ByteBuffer.wrap(payload))));
+        return context;
+    }
+
+    private SdkHttpFullRequest buildRequest() {
+        return SdkHttpFullRequest.builder()
+            .method(SdkHttpMethod.POST)
+            .uri(URI.create("https://example.com/"))
+            .putHeader(CONTENT_TYPE, RPC_CONTENT_TYPE)
+            .build();
+    }
+
+    private Message getEventMessage() {
+        Map<String, HeaderValue> headers = ImmutableMap.of(":message-type", HeaderValue.fromString("event"),
+            ":event-type", HeaderValue.fromString("foo"));
+        return new Message(headers, new byte[0]);
+    }
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -145,8 +146,8 @@ public abstract class BaseAwsJsonProtocolFactory {
         return getSdkFactory().createWriter(getContentType());
     }
 
-    @SdkTestInternalApi
-    protected final String getContentType() {
+    @SdkInternalApi
+    public final String getContentType() {
         return getContentTypeResolver().resolveContentType(protocolMetadata);
     }
 
@@ -182,6 +183,7 @@ public abstract class BaseAwsJsonProtocolFactory {
                                             .contentType(getContentType())
                                             .operationInfo(operationInfo)
                                             .sendExplicitNullForPayload(false)
+                                            .protocolMetadata(protocolMetadata)
                                             .build();
     }
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -16,8 +16,10 @@
 package software.amazon.awssdk.protocols.json.internal.marshall;
 
 import static software.amazon.awssdk.core.internal.util.Mimetype.MIMETYPE_EVENT_STREAM;
+import static software.amazon.awssdk.http.Header.CHUNKED;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
+import static software.amazon.awssdk.http.Header.TRANSFER_ENCODING;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -39,6 +41,8 @@ import software.amazon.awssdk.protocols.core.OperationInfo;
 import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
 import software.amazon.awssdk.protocols.core.ProtocolUtils;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter.ValueToString;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolMetadata;
 import software.amazon.awssdk.protocols.json.StructuredJsonGenerator;
 
 /**
@@ -56,6 +60,7 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
     private final StructuredJsonGenerator jsonGenerator;
     private final SdkHttpFullRequest.Builder request;
     private final String contentType;
+    private final AwsJsonProtocolMetadata protocolMetadata;
     private final boolean hasExplicitPayloadMember;
     private final boolean hasStreamingInput;
 
@@ -66,10 +71,12 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
     JsonProtocolMarshaller(URI endpoint,
                            StructuredJsonGenerator jsonGenerator,
                            String contentType,
-                           OperationInfo operationInfo) {
+                           OperationInfo operationInfo,
+                           AwsJsonProtocolMetadata protocolMetadata) {
         this.endpoint = endpoint;
         this.jsonGenerator = jsonGenerator;
         this.contentType = contentType;
+        this.protocolMetadata = protocolMetadata;
         this.hasExplicitPayloadMember = operationInfo.hasExplicitPayloadMember();
         this.hasStreamingInput = operationInfo.hasStreamingInput();
         this.hasEventStreamingInput = operationInfo.hasEventStreamingInput();
@@ -220,7 +227,17 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
         // and not from the original request
         if (!request.headers().containsKey(CONTENT_TYPE) && !hasEvent) {
             if (hasEventStreamingInput) {
-                request.putHeader(CONTENT_TYPE, MIMETYPE_EVENT_STREAM);
+                AwsJsonProtocol protocol = protocolMetadata.protocol();
+                if (protocol == AwsJsonProtocol.AWS_JSON) {
+                    // For RPC formats, this content type will later be pushed down into the `initial-event` in the body
+                    request.putHeader(CONTENT_TYPE, contentType);
+                } else if (protocol == AwsJsonProtocol.REST_JSON) {
+                    request.putHeader(CONTENT_TYPE, MIMETYPE_EVENT_STREAM);
+                } else {
+                    throw new IllegalArgumentException("Unknown AwsJsonProtocol: " + protocol);
+                }
+                request.removeHeader(CONTENT_LENGTH);
+                request.putHeader(TRANSFER_ENCODING, CHUNKED);
             } else if (contentType != null && !hasStreamingInput && request.contentStreamProvider() != null) {
                 request.putHeader(CONTENT_TYPE, contentType);
             }

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshallerBuilder.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshallerBuilder.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.protocols.core.OperationInfo;
 import software.amazon.awssdk.protocols.core.ProtocolMarshaller;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolMetadata;
 import software.amazon.awssdk.protocols.json.StructuredJsonGenerator;
 
 /**
@@ -33,6 +34,7 @@ public final class JsonProtocolMarshallerBuilder {
     private String contentType;
     private OperationInfo operationInfo;
     private boolean sendExplicitNullForPayload;
+    private AwsJsonProtocolMetadata protocolMetadata;
 
     private JsonProtocolMarshallerBuilder() {
     }
@@ -93,6 +95,14 @@ public final class JsonProtocolMarshallerBuilder {
     }
 
     /**
+     * @param protocolMetadata
+     */
+    public JsonProtocolMarshallerBuilder protocolMetadata(AwsJsonProtocolMetadata protocolMetadata) {
+        this.protocolMetadata = protocolMetadata;
+        return this;
+    }
+
+    /**
      * @return New instance of {@link ProtocolMarshaller}. If {@link #sendExplicitNullForPayload} is true then the marshaller
      * will be wrapped with {@link NullAsEmptyBodyProtocolRequestMarshaller}.
      */
@@ -100,7 +110,8 @@ public final class JsonProtocolMarshallerBuilder {
         ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = new JsonProtocolMarshaller(endpoint,
                                                                                                jsonGenerator,
                                                                                                contentType,
-                                                                                               operationInfo);
+                                                                                               operationInfo,
+                                                                                               protocolMetadata);
         return sendExplicitNullForPayload ? protocolMarshaller
                                           : new NullAsEmptyBodyProtocolRequestMarshaller(protocolMarshaller);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/handler/ClientExecutionParams.java
@@ -47,6 +47,7 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
     private HttpResponseHandler<? extends SdkException> errorResponseHandler;
     private HttpResponseHandler<Response<OutputT>> combinedResponseHandler;
     private boolean fullDuplex;
+    private boolean hasInitialRequestEvent;
     private String hostPrefixExpression;
     private String operationName;
     private URI discoveredEndpoint;
@@ -135,6 +136,18 @@ public final class ClientExecutionParams<InputT extends SdkRequest, OutputT> {
      */
     public ClientExecutionParams<InputT, OutputT> withFullDuplex(boolean fullDuplex) {
         this.fullDuplex = fullDuplex;
+        return this;
+    }
+
+    public boolean hasInitialRequestEvent() {
+        return hasInitialRequestEvent;
+    }
+
+    /**
+     * Sets whether this is an event streaming request over RPC.
+     */
+    public ClientExecutionParams<InputT, OutputT> withInitialRequestEvent(boolean hasInitialRequestEvent) {
+        this.hasInitialRequestEvent = hasInitialRequestEvent;
         return this;
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -30,6 +30,13 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<Boolean> IS_FULL_DUPLEX = new ExecutionAttribute<>("IsFullDuplex");
 
+    /**
+     * If true, indicates that this is an event streaming request being sent over RPC, and therefore the serialized
+     * request object is encapsulated as an event of type {@code initial-request}.
+     */
+    public static final ExecutionAttribute<Boolean> HAS_INITIAL_REQUEST_EVENT = new ExecutionAttribute<>(
+        "HasInitialRequestEvent");
+
     public static final ExecutionAttribute<HttpChecksumRequired> HTTP_CHECKSUM_REQUIRED =
         new ExecutionAttribute<>("HttpChecksumRequired");
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/AsyncStreamPrepender.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/AsyncStreamPrepender.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+@SdkInternalApi
+public class AsyncStreamPrepender<T> implements Publisher<T> {
+    private final Publisher<T> delegate;
+    private final T firstItem;
+    private Subscriber<? super T> subscriber;
+    private volatile boolean complete = false;
+    private volatile boolean firstRequest = true;
+
+    public AsyncStreamPrepender(Publisher<T> delegate, T firstItem) {
+        this.delegate = delegate;
+        this.firstItem = firstItem;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        subscriber = s;
+        delegate.subscribe(new DelegateSubscriber());
+    }
+
+    private class DelegateSubscriber implements Subscriber<T> {
+        @Override
+        public void onSubscribe(Subscription subscription) {
+            subscriber.onSubscribe(new Subscription() {
+                private final AtomicLong requests = new AtomicLong(0L);
+                private volatile boolean cancelled = false;
+                private volatile boolean isOutermostCall = true;
+
+                @Override
+                public void request(long n) {
+                    if (cancelled) {
+                        return;
+                    }
+                    if (n <= 0) {
+                        subscription.cancel();
+                        subscriber.onError(new IllegalArgumentException("Requested " + n + " items"));
+                    }
+
+                    if (firstRequest) {
+                        firstRequest = false;
+                        if (n - 1 > 0) {
+                            requests.addAndGet(n - 1);
+                        }
+                        isOutermostCall = false;
+                        subscriber.onNext(firstItem);
+                        isOutermostCall = true;
+                        if (complete) {
+                            subscriber.onComplete();
+                            return;
+                        }
+                    } else {
+                        requests.addAndGet(n);
+                    }
+                    if (isOutermostCall) {
+                        try {
+                            isOutermostCall = false;
+                            long l;
+                            while ((l = requests.getAndSet(0L)) > 0) {
+                                subscription.request(l);
+                            }
+                        } finally {
+                            isOutermostCall = true;
+                        }
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    cancelled = true;
+                    subscription.cancel();
+                    subscriber = null;
+                }
+            });
+        }
+
+        @Override
+        public void onNext(T item) {
+            subscriber.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            subscriber.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            complete = true;
+            if (!firstRequest) {
+                subscriber.onComplete();
+            }
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/AsyncStreamPrependerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/AsyncStreamPrependerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import io.reactivex.Flowable;
+import org.junit.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.testng.Assert;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static io.reactivex.Flowable.fromPublisher;
+import static io.reactivex.Flowable.just;
+import static io.reactivex.Flowable.rangeLong;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class AsyncStreamPrependerTest {
+    @Test
+    public void empty() {
+        Flowable<Long> prepender = fromPublisher(new AsyncStreamPrepender<>(Flowable.empty(), 0L));
+
+        List<Long> actual = prepender.toList().blockingGet();
+
+        assertEquals(singletonList(0L), actual);
+    }
+
+    @Test
+    public void single() {
+        Flowable<Long> prepender = fromPublisher(new AsyncStreamPrepender<>(just(1L), 0L));
+
+        List<Long> actual = prepender.toList().blockingGet();
+
+        assertEquals(asList(0L, 1L), actual);
+    }
+
+    @Test
+    public void sequence() {
+        Flowable<Long> prepender = fromPublisher(new AsyncStreamPrepender<>(rangeLong(1L, 5L), 0L));
+
+        Iterator<Long> iterator = prepender.blockingIterable(1).iterator();
+
+        for (long i = 0; i <= 5; i++) {
+            assertEquals(i, iterator.next().longValue());
+        }
+    }
+
+    @Test
+    public void error() {
+        Flowable<Long> error = Flowable.error(IllegalStateException::new);
+        Flowable<Long> prepender = fromPublisher(new AsyncStreamPrepender<>(error, 0L));
+        Iterator<Long> iterator = prepender.blockingNext().iterator();
+
+        assertThrows(IllegalStateException.class, iterator::next);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeRequest() {
+        Flowable<Long> prepender = fromPublisher(new AsyncStreamPrepender<>(rangeLong(1L, 5L), 0L));
+
+        prepender.blockingSubscribe(new Subscriber<Long>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(-1L);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                if (throwable instanceof RuntimeException) {
+                    throw (RuntimeException) throwable;
+                }
+            }
+
+            @Override
+            public void onNext(Long aLong) {}
+
+            @Override
+            public void onComplete() {}
+        });
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/AyncStreamPrependerTckTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/AyncStreamPrependerTckTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+import io.reactivex.Flowable;
+
+public class AyncStreamPrependerTckTest extends PublisherVerification<Long> {
+    public AyncStreamPrependerTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<Long> createPublisher(long l) {
+        if (l == 0) {
+            return Flowable.empty();
+        } else {
+            Flowable<Long> delegate = Flowable.rangeLong(1, l - 1);
+            return new AsyncStreamPrepender<>(delegate, 0L);
+        }
+    }
+
+    @Override
+    public Publisher<Long> createFailedPublisher() {
+        return new AsyncStreamPrepender<>(Flowable.error(new NullPointerException()), 0L);
+    }
+}


### PR DESCRIPTION
This commit adds support for RPC services that use client->server or
bidirectional event streaming. In the RPC formats (i.e. AWS JSON), the
marshalled request and response objects are sent as the first event in
the request and response stream respectively. This is different from the
REST formats, such as REST JSON, which bind the request and response
fields to non-payload positions (headers, URI, method, status code,
query string) when event streaming is used.

The implementation of this feature is mainly performed by a new global
interceptor, `EventStreamInitialRequestInterceptor`. The interceptor
detects when an `initial-request` event needs to be sent and transforms
the async response body by constructing the `initial-request` message
and prepending it to the event stream. Due to the high precedence of
global interceptors, any subsequent service or override interceptors
that run on the body will see the transformed version. This also applies
to the `EventStreamAws4Signer`, which will produce a signature over the
`initial-request` event.

I confirm that this pull request can be released under the Apache 2 license.