### PR TITLE
Adding more tests to show how a string marked with the jsonvalue trai…

### DIFF
--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/HeaderUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/HeaderUnmarshaller.java
@@ -43,6 +43,9 @@ final class HeaderUnmarshaller {
 
     /**
      * Unmarshalls a string header, taking into account whether it's a Base 64 encoded JSON value.
+     * <p>
+     * <em>Note:</em> This code does no attempt to validate whether the unmarshalled string does, in fact, represent valid
+     * JSON values. The string value is returned as-is, and it's up to the user to validate the results.
      *
      * @param value Value to unmarshall
      * @param field {@link SdkField} containing metadata about member being unmarshalled.

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-output.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-output.json
@@ -38,7 +38,7 @@
     }
   },
   {
-    "description": "Base 64 string header with JSON trait is decoded",
+    "description": "Base 64 string header with JSON trait is decoded, unquoted string preserved (invalid json)",
     "given": {
       "response": {
         "status_code": 200,
@@ -55,6 +55,50 @@
     "then": {
       "deserializedAs": {
         "JsonValueHeaderMember": "toDecode",
+        "JsonValueMember": "dontDecode"
+      }
+    }
+  },
+  {
+    "description": "Base 64 string header with JSON trait is decoded, quoted string preserved (valid json)",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "headers": {
+          "Encoded-Header": "InRvRGVjb2RlIg=="
+        },
+        "body": "{\"JsonValueMember\":\"dontDecode\"}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "JsonValuesOperation"
+    },
+    "then": {
+      "deserializedAs": {
+        "JsonValueHeaderMember": "\"toDecode\"",
+        "JsonValueMember": "dontDecode"
+      }
+    }
+  },
+  {
+    "description": "Base 64 string header with JSON trait is decoded, quoted json object preserved",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "headers": {
+          "Encoded-Header": "IntcImxpc3RcIjpbMSwyLDNdLFwibWFwXCI6e1wiZmlyc3RcIjpcInZhbHVlMVwiLFwic2Vjb25kXCI6XCJ2YWx1ZTJcIn19Ig=="
+        },
+        "body": "{\"JsonValueMember\":\"dontDecode\"}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "JsonValuesOperation"
+    },
+    "then": {
+      "deserializedAs": {
+        "JsonValueHeaderMember": "\"{\\\"list\\\":[1,2,3],\\\"map\\\":{\\\"first\\\":\\\"value1\\\",\\\"second\\\":\\\"value2\\\"}}\"",
         "JsonValueMember": "dontDecode"
       }
     }


### PR DESCRIPTION
…t and encoded as a base64 header should be decoded

## Description
API request/response fields marked as "jsonvalue" located in the header are base64 encoded, and when unmarshalled are returned as-is; the string values aren't validating whether the original value is valid json or not. This is up to the user.  

## Motivation and Context
Because some SDKs returned a parsed JSON object for these fields, the tests add clarification to the Java SDK behavior. 

## Testing
Unit testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
