### PR TITLE
 XML entity encoding for carriage return and line feed

### DIFF
--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlWriter.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlWriter.java
@@ -193,6 +193,8 @@ final class XmlWriter {
             s = s.replace("&apos;", "'");
             s = s.replace("&lt;", "<");
             s = s.replace("&gt;", ">");
+            s = s.replace("&#x0D;", "\r");
+            s = s.replace("&#x0A;", "\n");
             // Ampersands should always be the last to unescape
             s = s.replace("&amp;", "&");
         }
@@ -202,6 +204,8 @@ final class XmlWriter {
         s = s.replace("'", "&apos;");
         s = s.replace("<", "&lt;");
         s = s.replace(">", "&gt;");
+        s = s.replace("\r", "&#x0D;");
+        s = s.replace("\n", "&#x0A;");
         return s;
     }
 

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-xml-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-xml-input.json
@@ -39,6 +39,26 @@
     }
   },
   {
+    "description": "Escape Characters are marshalled correctly as XML in the payload",
+    "given": {
+
+      "input": {
+        "stringMember": "\"'<\r\nNormalCharacters\"'>\r\n"
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "serializedAs": {
+        "body": {
+          "xmlEquals": "<AllTypesRequest xmlns=\"https://restxml/\"><stringMember>&quot;&apos;&lt;&#x0D;&#x0A;NormalCharacters&quot;&apos;&gt;&#x0D;&#x0A;</stringMember></AllTypesRequest>"
+        }
+      }
+    }
+  },
+  {
     "description": "Boolean member with value true is marshalled correctly as XML",
     "given": {
       "input": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 XML entity encoding for carriage return and line feed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The \r and \n didnot have xml encoding.


## Testing
- Added protocol test cases
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
