### PR TITLE
Rewrote generated copiers to support builders for arbitrarily nested containers.

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-a0ae32a.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-a0ae32a.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon DynamoDB", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed bean-based marshalling for model builder types containing complex collections."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.codegen.internal.TypeUtils;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
@@ -615,15 +616,26 @@ public class MemberModel extends DocumentationModel {
     }
 
     @JsonIgnore
-    public boolean isCollectionWithBuilderMember() {
-        return (isList() && getListModel().getListMemberModel() != null && getListModel().getListMemberModel().hasBuilder()) ||
-               (isMap() && getMapModel().getValueModel() != null && getMapModel().getValueModel().hasBuilder());
+    public boolean containsBuildable() {
+        return containsBuildable(true);
     }
 
-    @JsonIgnore
-    public boolean isCollectionWithNestedBuilderMember() {
-        return isList() && getListModel().getListMemberModel() != null && getListModel().isMap() &&
-               getListModel().getListMemberModel().getMapModel().getValueModel().hasBuilder();
+    private boolean containsBuildable(boolean root) {
+        if (!root && hasBuilder()) {
+            return true;
+        }
+
+        if (isList()) {
+            return getListModel().getListMemberModel().containsBuildable(false);
+        }
+
+        if (isMap()) {
+            MapModel mapModel = getMapModel();
+            return mapModel.getKeyModel().containsBuildable(false) ||
+                   mapModel.getValueModel().containsBuildable(false);
+        }
+
+        return false;
     }
 
     @JsonIgnore

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AccessorsFactory.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AccessorsFactory.java
@@ -39,7 +39,7 @@ class AccessorsFactory {
         this.shapeModel = shapeModel;
         this.typeProvider = typeProvider;
         this.intermediateModel = intermediateModel;
-        this.getterHelper = new BeanGetterHelper(poetExtensions, typeProvider);
+        this.getterHelper = new BeanGetterHelper(poetExtensions, new ServiceModelCopiers(intermediateModel), typeProvider);
     }
 
     public MethodSpec beanStyleGetter(MemberModel memberModel) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ListSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ListSetters.java
@@ -120,12 +120,7 @@ class ListSetters extends AbstractMemberSetters {
     @Override
     public List<MethodSpec> beanStyle() {
         MethodSpec.Builder builder = beanStyleSetterBuilder();
-        if (memberModel().isCollectionWithBuilderMember()) {
-            builder.addCode(copySetterBuilderBody());
-        } else {
-            builder.addCode(beanCopySetterBody());
-        }
-
+        builder.addCode(beanCopySetterBody());
         return Collections.singletonList(builder.build());
 
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MapSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/MapSetters.java
@@ -77,9 +77,8 @@ class MapSetters extends AbstractMemberSetters {
 
     @Override
     public List<MethodSpec> beanStyle() {
-        MethodSpec.Builder builder = beanStyleSetterBuilder()
-                .addCode(memberModel().isCollectionWithBuilderMember() ? copySetterBuilderBody() : beanCopySetterBody());
-
+        MethodSpec.Builder builder = beanStyleSetterBuilder();
+        builder.addCode(beanCopySetterBody());
         return Collections.singletonList(builder.build());
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceModelCopiers.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ServiceModelCopiers.java
@@ -22,11 +22,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
-import software.amazon.awssdk.codegen.model.intermediate.MapModel;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 
 public class ServiceModelCopiers {
     private final IntermediateModel intermediateModel;
@@ -42,35 +40,16 @@ public class ServiceModelCopiers {
     public Collection<ClassSpec> copierSpecs() {
         Map<ClassName, ClassSpec> memberSpecs = new HashMap<>();
         allShapeMembers().values().stream()
-                .filter(m -> !(canCopyReference(m) || canUseStandardCopier(m)))
+                .filter(m -> !canCopyReference(m))
                 .map(m -> new MemberCopierSpec(m, this, typeProvider, poetExtensions))
                 .forEach(spec -> memberSpecs.put(spec.className(), spec));
 
         return memberSpecs.values();
     }
 
-    public boolean requiresBuilderCopier(MemberModel memberModel) {
-        if (memberModel.isCollectionWithNestedBuilderMember()) {
-            return true;
-        }
-        if (memberModel.isList()) {
-            MemberModel type = memberModel.getListModel().getListMemberModel();
-            return type != null && type.hasBuilder();
-        }
-        if (memberModel.isMap()) {
-            MemberModel valueType = memberModel.getMapModel().getValueModel();
-            return valueType != null && valueType.hasBuilder();
-        }
-        return false;
-    }
-
     public Optional<ClassName> copierClassFor(MemberModel memberModel) {
         if (canCopyReference(memberModel)) {
             return Optional.empty();
-        }
-
-        if (canUseStandardCopier(memberModel)) {
-            return Optional.of(ClassName.get(StandardMemberCopier.class));
         }
 
         // FIXME: Some services (Health) have shapes with names
@@ -96,8 +75,12 @@ public class ServiceModelCopiers {
         return "copyStringToEnum";
     }
 
-    public String builderCopyMethodName() {
+    public String copyFromBuilderMethodName() {
         return "copyFromBuilder";
+    }
+
+    public String copyToBuilderMethodName() {
+        return "copyToBuilder";
     }
 
     private Map<String, MemberModel> allShapeMembers() {
@@ -105,58 +88,10 @@ public class ServiceModelCopiers {
         intermediateModel.getShapes().values().stream()
                 .flatMap(s -> s.getMembersAsMap().values().stream())
                 .forEach(m -> shapeMembers.put(m.getC2jShape(), m));
-
-        // Step above only gives us the top level shape members.
-        // List and Map members have members of their own, so find those too.
-        Map<String, MemberModel> allMembers = new HashMap<>(shapeMembers);
-
-        shapeMembers.values().forEach(m -> putMembersOfMember(m, allMembers));
-
-        return allMembers;
-    }
-
-    private void putMembersOfMember(MemberModel memberModel, Map<String, MemberModel> allMembers) {
-        if (memberModel.isList()) {
-            MemberModel listMember = memberModel.getListModel().getListMemberModel();
-            allMembers.put(listMember.getC2jShape(), listMember);
-            putMembersOfMember(listMember, allMembers);
-        } else if (memberModel.isMap()) {
-            MapModel mapModel = memberModel.getMapModel();
-            // NOTE: keys are always simple, so don't bother checking
-            if (!mapModel.getValueModel().isSimple()) {
-                MemberModel valueMember = mapModel.getValueModel();
-                allMembers.put(valueMember.getC2jShape(), valueMember);
-                putMembersOfMember(valueMember, allMembers);
-            }
-        }
-    }
-
-    private boolean canUseStandardCopier(MemberModel m) {
-        if (m.isList() || m.isMap() || !m.isSimple()) {
-            return false;
-        }
-
-        String simpleType = m.getVariable().getSimpleType();
-
-        return "Date".equals(simpleType) || "SdkBytes".equals(simpleType);
+        return shapeMembers;
     }
 
     private boolean canCopyReference(MemberModel m) {
-        if (m.isList() || m.isMap()) {
-            return false;
-        }
-
-        if (m.isSimple()) {
-            String simpleType = m.getVariable().getSimpleType();
-            switch (simpleType) {
-                case "Date":
-                case "SdkBytes":
-                    return false;
-                default:
-                    return true;
-            }
-        }
-
-        return true;
+        return !m.isList() && !m.isMap();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -19,7 +19,6 @@ import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
@@ -29,7 +28,6 @@ import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
-import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -64,9 +62,9 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
 
     private static final SdkField<Short> SHORT_MEMBER_FIELD = SdkField.<Short> builder(MarshallingType.SHORT)
-            .memberName("ShortMember").getter(getter(AllTypesRequest::shortMember)).setter(setter(Builder::shortMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ShortMember").build()).build();
-    
+                                                                      .memberName("ShortMember").getter(getter(AllTypesRequest::shortMember)).setter(setter(Builder::shortMember))
+                                                                      .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ShortMember").build()).build();
+
     private static final SdkField<List<String>> SIMPLE_LIST_FIELD = SdkField
         .<List<String>> builder(MarshallingType.LIST)
         .memberName("SimpleList")
@@ -594,7 +592,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
     /**
      * Returns the value of the ShortMember property for this object.
-     * 
+     *
      * @return The value of the ShortMember property for this object.
      */
     public final Short shortMember() {
@@ -1299,9 +1297,8 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         return Objects.equals(stringMember(), other.stringMember()) && Objects.equals(integerMember(), other.integerMember())
                && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
                && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
-               && Objects.equals(shortMember(), other.shortMember()) 
-               && hasSimpleList() == other.hasSimpleList() && Objects.equals(simpleList(), other.simpleList())
-               && hasListOfEnums() == other.hasListOfEnums()
+               && Objects.equals(shortMember(), other.shortMember()) && hasSimpleList() == other.hasSimpleList()
+               && Objects.equals(simpleList(), other.simpleList()) && hasListOfEnums() == other.hasListOfEnums()
                && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
                && hasListOfMaps() == other.hasListOfMaps() && Objects.equals(listOfMaps(), other.listOfMaps())
                && hasListOfStructs() == other.hasListOfStructs() && Objects.equals(listOfStructs(), other.listOfStructs())
@@ -1796,7 +1793,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the MapOfEnumToMapOfStringToEnum property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder mapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum);
+        Builder mapOfEnumToMapOfStringToEnumWithStrings(Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum);
 
         /**
          * Sets the value of the MapOfEnumToMapOfStringToEnum property for this object.
@@ -1805,7 +1802,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
          *        The new value for the MapOfEnumToMapOfStringToEnum property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder mapOfEnumToMapOfStringToEnum(Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum);
+        Builder mapOfEnumToMapOfStringToEnum(Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum);
 
         /**
          * Sets the value of the TimestampMember property for this object.
@@ -2334,12 +2331,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.listOfMaps = ListOfMapStringToStringCopier.copy(listOfMaps);
         }
 
-        public final Collection<SimpleStruct.Builder> getListOfStructs() {
-            if (listOfStructs instanceof SdkAutoConstructList) {
+        public final List<SimpleStruct.Builder> getListOfStructs() {
+            List<SimpleStruct.Builder> result = ListOfSimpleStructsCopier.copyToBuilder(this.listOfStructs);
+            if (result instanceof SdkAutoConstructList) {
                 return null;
             }
-            return listOfStructs != null ? listOfStructs.stream().map(SimpleStruct::toBuilder).collect(Collectors.toList())
-                                         : null;
+            return result;
         }
 
         @Override
@@ -2391,15 +2388,13 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
         }
 
-        public final Collection<Map<String, SimpleStruct.Builder>> getListOfMapOfStringToStruct() {
-            if (listOfMapOfStringToStruct instanceof SdkAutoConstructList) {
+        public final List<Map<String, SimpleStruct.Builder>> getListOfMapOfStringToStruct() {
+            List<Map<String, SimpleStruct.Builder>> result = ListOfMapOfStringToStructCopier
+                .copyToBuilder(this.listOfMapOfStringToStruct);
+            if (result instanceof SdkAutoConstructList) {
                 return null;
             }
-            return listOfMapOfStringToStruct != null ? listOfMapOfStringToStruct
-                .stream()
-                .map(m -> m.entrySet().stream()
-                           .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue().toBuilder())))
-                .collect(Collectors.toList()) : null;
+            return result;
         }
 
         @Override
@@ -2415,7 +2410,8 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             return this;
         }
 
-        public final void setListOfMapOfStringToStruct(Collection<Map<String, SimpleStruct.BuilderImpl>> listOfMapOfStringToStruct) {
+        public final void setListOfMapOfStringToStruct(
+            Collection<? extends Map<String, SimpleStruct.BuilderImpl>> listOfMapOfStringToStruct) {
             this.listOfMapOfStringToStruct = ListOfMapOfStringToStructCopier.copyFromBuilder(listOfMapOfStringToStruct);
         }
 
@@ -2454,11 +2450,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
-            if (mapOfStringToSimpleStruct instanceof SdkAutoConstructMap) {
+            Map<String, SimpleStruct.Builder> result = MapOfStringToSimpleStructCopier
+                .copyToBuilder(this.mapOfStringToSimpleStruct);
+            if (result instanceof SdkAutoConstructMap) {
                 return null;
             }
-            return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
-                                                                                 SimpleStruct::toBuilder) : null;
+            return result;
         }
 
         @Override
@@ -2541,11 +2538,11 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
-            if (mapOfEnumToSimpleStruct instanceof SdkAutoConstructMap) {
+            Map<String, SimpleStruct.Builder> result = MapOfEnumToSimpleStructCopier.copyToBuilder(this.mapOfEnumToSimpleStruct);
+            if (result instanceof SdkAutoConstructMap) {
                 return null;
             }
-            return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
-                                                   : null;
+            return result;
         }
 
         @Override
@@ -2587,7 +2584,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
         }
 
-        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
+        public final Map<String, ? extends Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
             if (mapOfEnumToMapOfStringToEnum instanceof SdkAutoConstructMap) {
                 return null;
             }
@@ -2595,18 +2592,20 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        public final Builder mapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final Builder mapOfEnumToMapOfStringToEnumWithStrings(
+            Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
             return this;
         }
 
         @Override
-        public final Builder mapOfEnumToMapOfStringToEnum(Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
+        public final Builder mapOfEnumToMapOfStringToEnum(
+            Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copyEnumToString(mapOfEnumToMapOfStringToEnum);
             return this;
         }
 
-        public final void setMapOfEnumToMapOfStringToEnum(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final void setMapOfEnumToMapOfStringToEnum(Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
         }
 
@@ -2645,7 +2644,7 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
 
         @Override
         public final Builder blobArg(SdkBytes blobArg) {
-            this.blobArg = StandardMemberCopier.copy(blobArg);
+            this.blobArg = blobArg;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
@@ -28,7 +27,6 @@ import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
-import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -63,8 +61,8 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("LongMember").build()).build();
 
     private static final SdkField<Short> SHORT_MEMBER_FIELD = SdkField.<Short> builder(MarshallingType.SHORT)
-            .memberName("ShortMember").getter(getter(AllTypesResponse::shortMember)).setter(setter(Builder::shortMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ShortMember").build()).build();
+                                                                      .memberName("ShortMember").getter(getter(AllTypesResponse::shortMember)).setter(setter(Builder::shortMember))
+                                                                      .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ShortMember").build()).build();
 
     private static final SdkField<List<String>> SIMPLE_LIST_FIELD = SdkField
         .<List<String>> builder(MarshallingType.LIST)
@@ -593,7 +591,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
     /**
      * Returns the value of the ShortMember property for this object.
-     * 
+     *
      * @return The value of the ShortMember property for this object.
      */
     public final Short shortMember() {
@@ -1298,9 +1296,8 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         return Objects.equals(stringMember(), other.stringMember()) && Objects.equals(integerMember(), other.integerMember())
                && Objects.equals(booleanMember(), other.booleanMember()) && Objects.equals(floatMember(), other.floatMember())
                && Objects.equals(doubleMember(), other.doubleMember()) && Objects.equals(longMember(), other.longMember())
-               && Objects.equals(shortMember(), other.shortMember())
-               && hasSimpleList() == other.hasSimpleList() && Objects.equals(simpleList(), other.simpleList())
-               && hasListOfEnums() == other.hasListOfEnums()
+               && Objects.equals(shortMember(), other.shortMember()) && hasSimpleList() == other.hasSimpleList()
+               && Objects.equals(simpleList(), other.simpleList()) && hasListOfEnums() == other.hasListOfEnums()
                && Objects.equals(listOfEnumsAsStrings(), other.listOfEnumsAsStrings())
                && hasListOfMaps() == other.hasListOfMaps() && Objects.equals(listOfMaps(), other.listOfMaps())
                && hasListOfStructs() == other.hasListOfStructs() && Objects.equals(listOfStructs(), other.listOfStructs())
@@ -1795,7 +1792,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the MapOfEnumToMapOfStringToEnum property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder mapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum);
+        Builder mapOfEnumToMapOfStringToEnumWithStrings(Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum);
 
         /**
          * Sets the value of the MapOfEnumToMapOfStringToEnum property for this object.
@@ -1804,7 +1801,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
          *        The new value for the MapOfEnumToMapOfStringToEnum property for this object.
          * @return Returns a reference to this object so that method calls can be chained together.
          */
-        Builder mapOfEnumToMapOfStringToEnum(Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum);
+        Builder mapOfEnumToMapOfStringToEnum(Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum);
 
         /**
          * Sets the value of the TimestampMember property for this object.
@@ -2327,12 +2324,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.listOfMaps = ListOfMapStringToStringCopier.copy(listOfMaps);
         }
 
-        public final Collection<SimpleStruct.Builder> getListOfStructs() {
-            if (listOfStructs instanceof SdkAutoConstructList) {
+        public final List<SimpleStruct.Builder> getListOfStructs() {
+            List<SimpleStruct.Builder> result = ListOfSimpleStructsCopier.copyToBuilder(this.listOfStructs);
+            if (result instanceof SdkAutoConstructList) {
                 return null;
             }
-            return listOfStructs != null ? listOfStructs.stream().map(SimpleStruct::toBuilder).collect(Collectors.toList())
-                                         : null;
+            return result;
         }
 
         @Override
@@ -2384,15 +2381,13 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
         }
 
-        public final Collection<Map<String, SimpleStruct.Builder>> getListOfMapOfStringToStruct() {
-            if (listOfMapOfStringToStruct instanceof SdkAutoConstructList) {
+        public final List<Map<String, SimpleStruct.Builder>> getListOfMapOfStringToStruct() {
+            List<Map<String, SimpleStruct.Builder>> result = ListOfMapOfStringToStructCopier
+                .copyToBuilder(this.listOfMapOfStringToStruct);
+            if (result instanceof SdkAutoConstructList) {
                 return null;
             }
-            return listOfMapOfStringToStruct != null ? listOfMapOfStringToStruct
-                .stream()
-                .map(m -> m.entrySet().stream()
-                           .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue().toBuilder())))
-                .collect(Collectors.toList()) : null;
+            return result;
         }
 
         @Override
@@ -2408,7 +2403,8 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             return this;
         }
 
-        public final void setListOfMapOfStringToStruct(Collection<Map<String, SimpleStruct.BuilderImpl>> listOfMapOfStringToStruct) {
+        public final void setListOfMapOfStringToStruct(
+            Collection<? extends Map<String, SimpleStruct.BuilderImpl>> listOfMapOfStringToStruct) {
             this.listOfMapOfStringToStruct = ListOfMapOfStringToStructCopier.copyFromBuilder(listOfMapOfStringToStruct);
         }
 
@@ -2447,11 +2443,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         public final Map<String, SimpleStruct.Builder> getMapOfStringToSimpleStruct() {
-            if (mapOfStringToSimpleStruct instanceof SdkAutoConstructMap) {
+            Map<String, SimpleStruct.Builder> result = MapOfStringToSimpleStructCopier
+                .copyToBuilder(this.mapOfStringToSimpleStruct);
+            if (result instanceof SdkAutoConstructMap) {
                 return null;
             }
-            return mapOfStringToSimpleStruct != null ? CollectionUtils.mapValues(mapOfStringToSimpleStruct,
-                                                                                 SimpleStruct::toBuilder) : null;
+            return result;
         }
 
         @Override
@@ -2534,11 +2531,11 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         public final Map<String, SimpleStruct.Builder> getMapOfEnumToSimpleStruct() {
-            if (mapOfEnumToSimpleStruct instanceof SdkAutoConstructMap) {
+            Map<String, SimpleStruct.Builder> result = MapOfEnumToSimpleStructCopier.copyToBuilder(this.mapOfEnumToSimpleStruct);
+            if (result instanceof SdkAutoConstructMap) {
                 return null;
             }
-            return mapOfEnumToSimpleStruct != null ? CollectionUtils.mapValues(mapOfEnumToSimpleStruct, SimpleStruct::toBuilder)
-                                                   : null;
+            return result;
         }
 
         @Override
@@ -2580,7 +2577,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
         }
 
-        public final Map<String, Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
+        public final Map<String, ? extends Map<String, String>> getMapOfEnumToMapOfStringToEnum() {
             if (mapOfEnumToMapOfStringToEnum instanceof SdkAutoConstructMap) {
                 return null;
             }
@@ -2588,18 +2585,20 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        public final Builder mapOfEnumToMapOfStringToEnumWithStrings(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final Builder mapOfEnumToMapOfStringToEnumWithStrings(
+            Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
             return this;
         }
 
         @Override
-        public final Builder mapOfEnumToMapOfStringToEnum(Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
+        public final Builder mapOfEnumToMapOfStringToEnum(
+            Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copyEnumToString(mapOfEnumToMapOfStringToEnum);
             return this;
         }
 
-        public final void setMapOfEnumToMapOfStringToEnum(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnum) {
+        public final void setMapOfEnumToMapOfStringToEnum(Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
         }
 
@@ -2638,7 +2637,7 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
 
         @Override
         public final Builder blobArg(SdkBytes blobArg) {
-            this.blobArg = StandardMemberCopier.copy(blobArg);
+            this.blobArg = blobArg;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/blobmaptypecopier.java
@@ -3,22 +3,26 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class BlobMapTypeCopier {
     static Map<String, SdkBytes> copy(Map<String, SdkBytes> blobMapTypeParam) {
+        Map<String, SdkBytes> map;
         if (blobMapTypeParam == null || blobMapTypeParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SdkBytes> modifiableMap = new LinkedHashMap<>();
+            blobMapTypeParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, SdkBytes> blobMapTypeParamCopy = blobMapTypeParam.entrySet().stream()
-            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), StandardMemberCopier.copy(e.getValue())), HashMap::putAll);
-        return Collections.unmodifiableMap(blobMapTypeParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.LocationTrait;
@@ -28,15 +27,15 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 @Generated("software.amazon.awssdk:codegen")
 public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<InputEvent.Builder, InputEvent>, InputEventStream {
     private static final SdkField<SdkBytes> EXPLICIT_PAYLOAD_MEMBER_FIELD = SdkField
-            .<SdkBytes> builder(MarshallingType.SDK_BYTES)
-            .memberName("ExplicitPayloadMember")
-            .getter(getter(InputEvent::explicitPayloadMember))
-            .setter(setter(Builder::explicitPayloadMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ExplicitPayloadMember").build(),
-                    PayloadTrait.create()).build();
+        .<SdkBytes> builder(MarshallingType.SDK_BYTES)
+        .memberName("ExplicitPayloadMember")
+        .getter(getter(InputEvent::explicitPayloadMember))
+        .setter(setter(Builder::explicitPayloadMember))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ExplicitPayloadMember").build(),
+                PayloadTrait.create()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections
-            .unmodifiableList(Arrays.asList(EXPLICIT_PAYLOAD_MEMBER_FIELD));
+        .unmodifiableList(Arrays.asList(EXPLICIT_PAYLOAD_MEMBER_FIELD));
 
     private static final long serialVersionUID = 1L;
 
@@ -48,7 +47,7 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
 
     /**
      * Returns the value of the ExplicitPayloadMember property for this object.
-     * 
+     *
      * @return The value of the ExplicitPayloadMember property for this object.
      */
     public final SdkBytes explicitPayloadMember() {
@@ -106,10 +105,10 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
 
     public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "ExplicitPayloadMember":
-            return Optional.ofNullable(clazz.cast(explicitPayloadMember()));
-        default:
-            return Optional.empty();
+            case "ExplicitPayloadMember":
+                return Optional.ofNullable(clazz.cast(explicitPayloadMember()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -158,7 +157,7 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
 
         @Override
         public final Builder explicitPayloadMember(SdkBytes explicitPayloadMember) {
-            this.explicitPayloadMember = StandardMemberCopier.copy(explicitPayloadMember);
+            this.explicitPayloadMember = explicitPayloadMember;
             return this;
         }
 
@@ -177,4 +176,3 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.LocationTrait;
@@ -26,26 +25,26 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<InputEventTwo.Builder, InputEventTwo>,
-        InputEventStreamTwo {
+                                      InputEventStreamTwo {
     private static final SdkField<SdkBytes> IMPLICIT_PAYLOAD_MEMBER_ONE_FIELD = SdkField
-            .<SdkBytes> builder(MarshallingType.SDK_BYTES).memberName("ImplicitPayloadMemberOne")
-            .getter(getter(InputEventTwo::implicitPayloadMemberOne)).setter(setter(Builder::implicitPayloadMemberOne))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ImplicitPayloadMemberOne").build())
-            .build();
+        .<SdkBytes> builder(MarshallingType.SDK_BYTES).memberName("ImplicitPayloadMemberOne")
+        .getter(getter(InputEventTwo::implicitPayloadMemberOne)).setter(setter(Builder::implicitPayloadMemberOne))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ImplicitPayloadMemberOne").build())
+        .build();
 
     private static final SdkField<String> IMPLICIT_PAYLOAD_MEMBER_TWO_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .memberName("ImplicitPayloadMemberTwo").getter(getter(InputEventTwo::implicitPayloadMemberTwo))
-            .setter(setter(Builder::implicitPayloadMemberTwo))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ImplicitPayloadMemberTwo").build())
-            .build();
+                                                                                      .memberName("ImplicitPayloadMemberTwo").getter(getter(InputEventTwo::implicitPayloadMemberTwo))
+                                                                                      .setter(setter(Builder::implicitPayloadMemberTwo))
+                                                                                      .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("ImplicitPayloadMemberTwo").build())
+                                                                                      .build();
 
     private static final SdkField<String> EVENT_HEADER_MEMBER_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .memberName("EventHeaderMember").getter(getter(InputEventTwo::eventHeaderMember))
-            .setter(setter(Builder::eventHeaderMember))
-            .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("EventHeaderMember").build()).build();
+                                                                              .memberName("EventHeaderMember").getter(getter(InputEventTwo::eventHeaderMember))
+                                                                              .setter(setter(Builder::eventHeaderMember))
+                                                                              .traits(LocationTrait.builder().location(MarshallLocation.HEADER).locationName("EventHeaderMember").build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(
-            IMPLICIT_PAYLOAD_MEMBER_ONE_FIELD, IMPLICIT_PAYLOAD_MEMBER_TWO_FIELD, EVENT_HEADER_MEMBER_FIELD));
+        IMPLICIT_PAYLOAD_MEMBER_ONE_FIELD, IMPLICIT_PAYLOAD_MEMBER_TWO_FIELD, EVENT_HEADER_MEMBER_FIELD));
 
     private static final long serialVersionUID = 1L;
 
@@ -63,7 +62,7 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
 
     /**
      * Returns the value of the ImplicitPayloadMemberOne property for this object.
-     * 
+     *
      * @return The value of the ImplicitPayloadMemberOne property for this object.
      */
     public final SdkBytes implicitPayloadMemberOne() {
@@ -72,7 +71,7 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
 
     /**
      * Returns the value of the ImplicitPayloadMemberTwo property for this object.
-     * 
+     *
      * @return The value of the ImplicitPayloadMemberTwo property for this object.
      */
     public final String implicitPayloadMemberTwo() {
@@ -81,7 +80,7 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
 
     /**
      * Returns the value of the EventHeaderMember property for this object.
-     * 
+     *
      * @return The value of the EventHeaderMember property for this object.
      */
     public final String eventHeaderMember() {
@@ -128,8 +127,8 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
         }
         InputEventTwo other = (InputEventTwo) obj;
         return Objects.equals(implicitPayloadMemberOne(), other.implicitPayloadMemberOne())
-                && Objects.equals(implicitPayloadMemberTwo(), other.implicitPayloadMemberTwo())
-                && Objects.equals(eventHeaderMember(), other.eventHeaderMember());
+               && Objects.equals(implicitPayloadMemberTwo(), other.implicitPayloadMemberTwo())
+               && Objects.equals(eventHeaderMember(), other.eventHeaderMember());
     }
 
     /**
@@ -139,20 +138,20 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
     @Override
     public final String toString() {
         return ToString.builder("InputEventTwo").add("ImplicitPayloadMemberOne", implicitPayloadMemberOne())
-                .add("ImplicitPayloadMemberTwo", implicitPayloadMemberTwo()).add("EventHeaderMember", eventHeaderMember())
-                .build();
+                       .add("ImplicitPayloadMemberTwo", implicitPayloadMemberTwo()).add("EventHeaderMember", eventHeaderMember())
+                       .build();
     }
 
     public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "ImplicitPayloadMemberOne":
-            return Optional.ofNullable(clazz.cast(implicitPayloadMemberOne()));
-        case "ImplicitPayloadMemberTwo":
-            return Optional.ofNullable(clazz.cast(implicitPayloadMemberTwo()));
-        case "EventHeaderMember":
-            return Optional.ofNullable(clazz.cast(eventHeaderMember()));
-        default:
-            return Optional.empty();
+            case "ImplicitPayloadMemberOne":
+                return Optional.ofNullable(clazz.cast(implicitPayloadMemberOne()));
+            case "ImplicitPayloadMemberTwo":
+                return Optional.ofNullable(clazz.cast(implicitPayloadMemberTwo()));
+            case "EventHeaderMember":
+                return Optional.ofNullable(clazz.cast(eventHeaderMember()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -225,7 +224,7 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
 
         @Override
         public final Builder implicitPayloadMemberOne(SdkBytes implicitPayloadMemberOne) {
-            this.implicitPayloadMemberOne = StandardMemberCopier.copy(implicitPayloadMemberOne);
+            this.implicitPayloadMemberOne = implicitPayloadMemberOne;
             return this;
         }
 
@@ -272,4 +271,3 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofblobstypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofblobstypecopier.java
@@ -2,22 +2,28 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfBlobsTypeCopier {
     static List<SdkBytes> copy(Collection<SdkBytes> listOfBlobsTypeParam) {
+        List<SdkBytes> list;
         if (listOfBlobsTypeParam == null || listOfBlobsTypeParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<SdkBytes> modifiableList = new ArrayList<>();
+            listOfBlobsTypeParam.forEach(entry -> {
+                modifiableList.add(entry);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<SdkBytes> listOfBlobsTypeParamCopy = listOfBlobsTypeParam.stream().map(StandardMemberCopier::copy).collect(toList());
-        return Collections.unmodifiableList(listOfBlobsTypeParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofenumscopier.java
@@ -13,26 +13,46 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfEnumsCopier {
     static List<String> copy(Collection<String> listOfEnumsParam) {
+        List<String> list;
         if (listOfEnumsParam == null || listOfEnumsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<String> modifiableList = new ArrayList<>();
+            listOfEnumsParam.forEach(entry -> {
+                modifiableList.add(entry);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<String> listOfEnumsParamCopy = new ArrayList<>(listOfEnumsParam);
-        return Collections.unmodifiableList(listOfEnumsParamCopy);
+        return list;
     }
 
     static List<String> copyEnumToString(Collection<EnumType> listOfEnumsParam) {
+        List<String> list;
         if (listOfEnumsParam == null || listOfEnumsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<String> modifiableList = new ArrayList<>();
+            listOfEnumsParam.forEach(entry -> {
+                String result = entry.toString();
+                modifiableList.add(result);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<String> listOfEnumsParamCopy = listOfEnumsParam.stream().map(Object::toString).collect(toList());
-        return Collections.unmodifiableList(listOfEnumsParamCopy);
+        return list;
     }
 
     static List<EnumType> copyStringToEnum(Collection<String> listOfEnumsParam) {
+        List<EnumType> list;
         if (listOfEnumsParam == null || listOfEnumsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<EnumType> modifiableList = new ArrayList<>();
+            listOfEnumsParam.forEach(entry -> {
+                EnumType result = EnumType.fromValue(entry);
+                modifiableList.add(result);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<EnumType> listOfEnumsParamCopy = listOfEnumsParam.stream().map(EnumType::fromValue).collect(toList());
-        return Collections.unmodifiableList(listOfEnumsParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofintegerscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofintegerscopier.java
@@ -13,10 +13,16 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfIntegersCopier {
     static List<Integer> copy(Collection<Integer> listOfIntegersParam) {
+        List<Integer> list;
         if (listOfIntegersParam == null || listOfIntegersParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Integer> modifiableList = new ArrayList<>();
+            listOfIntegersParam.forEach(entry -> {
+                modifiableList.add(entry);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<Integer> listOfIntegersParamCopy = new ArrayList<>(listOfIntegersParam);
-        return Collections.unmodifiableList(listOfIntegersParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistoflistofstringscopier.java
@@ -2,6 +2,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -12,12 +13,37 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfListOfListOfStringsCopier {
     static List<List<List<String>>> copy(
-            Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStringsParam) {
+        Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStringsParam) {
+        List<List<List<String>>> list;
         if (listOfListOfListOfStringsParam == null || listOfListOfListOfStringsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<List<List<String>>> modifiableList = new ArrayList<>();
+            listOfListOfListOfStringsParam.forEach(entry -> {
+                List<List<String>> list1;
+                if (entry == null || entry instanceof SdkAutoConstructList) {
+                    list1 = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<List<String>> modifiableList1 = new ArrayList<>();
+                    entry.forEach(entry1 -> {
+                        List<String> list2;
+                        if (entry1 == null || entry1 instanceof SdkAutoConstructList) {
+                            list2 = DefaultSdkAutoConstructList.getInstance();
+                        } else {
+                            List<String> modifiableList2 = new ArrayList<>();
+                            entry1.forEach(entry2 -> {
+                                modifiableList2.add(entry2);
+                            });
+                            list2 = Collections.unmodifiableList(modifiableList2);
+                        }
+                        modifiableList1.add(list2);
+                    });
+                    list1 = Collections.unmodifiableList(modifiableList1);
+                }
+                modifiableList.add(list1);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<List<List<String>>> listOfListOfListOfStringsParamCopy = listOfListOfListOfStringsParam.stream()
-                .map(ListOfListOfStringsCopier::copy).collect(toList());
-        return Collections.unmodifiableList(listOfListOfListOfStringsParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listoflistofstringscopier.java
@@ -2,6 +2,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -12,11 +13,26 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfListOfStringsCopier {
     static List<List<String>> copy(Collection<? extends Collection<String>> listOfListOfStringsParam) {
+        List<List<String>> list;
         if (listOfListOfStringsParam == null || listOfListOfStringsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<List<String>> modifiableList = new ArrayList<>();
+            listOfListOfStringsParam.forEach(entry -> {
+                List<String> list1;
+                if (entry == null || entry instanceof SdkAutoConstructList) {
+                    list1 = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<String> modifiableList1 = new ArrayList<>();
+                    entry.forEach(entry1 -> {
+                        modifiableList1.add(entry1);
+                    });
+                    list1 = Collections.unmodifiableList(modifiableList1);
+                }
+                modifiableList.add(list1);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<List<String>> listOfListOfStringsParamCopy = listOfListOfStringsParam.stream().map(ListOfStringsCopier::copy)
-                .collect(toList());
-        return Collections.unmodifiableList(listOfListOfStringsParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofenumtostringcopier.java
@@ -2,40 +2,93 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfMapOfEnumToStringCopier {
     static List<Map<String, String>> copy(Collection<? extends Map<String, String>> listOfMapOfEnumToStringParam) {
+        List<Map<String, String>> list;
         if (listOfMapOfEnumToStringParam == null || listOfMapOfEnumToStringParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<String, String>> modifiableList = new ArrayList<>();
+            listOfMapOfEnumToStringParam.forEach(entry -> {
+                Map<String, String> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, String> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        modifiableMap.put(key, value);
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<Map<String, String>> listOfMapOfEnumToStringParamCopy = listOfMapOfEnumToStringParam.stream()
-                .map(MapOfEnumToStringCopier::copy).collect(toList());
-        return Collections.unmodifiableList(listOfMapOfEnumToStringParamCopy);
+        return list;
     }
 
     static List<Map<String, String>> copyEnumToString(Collection<? extends Map<EnumType, String>> listOfMapOfEnumToStringParam) {
+        List<Map<String, String>> list;
         if (listOfMapOfEnumToStringParam == null || listOfMapOfEnumToStringParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<String, String>> modifiableList = new ArrayList<>();
+            listOfMapOfEnumToStringParam.forEach(entry -> {
+                Map<String, String> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, String> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        String result = key.toString();
+                        modifiableMap.put(result, value);
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<Map<String, String>> listOfMapOfEnumToStringParamCopy = listOfMapOfEnumToStringParam.stream()
-                .map(MapOfEnumToStringCopier::copyEnumToString).collect(toList());
-        return Collections.unmodifiableList(listOfMapOfEnumToStringParamCopy);
+        return list;
     }
 
     static List<Map<EnumType, String>> copyStringToEnum(Collection<? extends Map<String, String>> listOfMapOfEnumToStringParam) {
+        List<Map<EnumType, String>> list;
         if (listOfMapOfEnumToStringParam == null || listOfMapOfEnumToStringParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<EnumType, String>> modifiableList = new ArrayList<>();
+            listOfMapOfEnumToStringParam.forEach(entry -> {
+                Map<EnumType, String> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<EnumType, String> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        EnumType result = EnumType.fromValue(key);
+                        if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {
+                            modifiableMap.put(result, value);
+                        }
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<Map<EnumType, String>> listOfMapOfEnumToStringParamCopy = listOfMapOfEnumToStringParam.stream()
-                .map(MapOfEnumToStringCopier::copyStringToEnum).collect(toList());
-        return Collections.unmodifiableList(listOfMapOfEnumToStringParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofstringtostructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapofstringtostructcopier.java
@@ -2,30 +2,94 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfMapOfStringToStructCopier {
-    static List<Map<String, SimpleStruct>> copy(Collection<? extends Map<String, SimpleStruct>> listOfMapOfStringToStructParam) {
+    static List<Map<String, SimpleStruct>> copy(
+        Collection<? extends Map<String, ? extends SimpleStruct>> listOfMapOfStringToStructParam) {
+        List<Map<String, SimpleStruct>> list;
         if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<String, SimpleStruct>> modifiableList = new ArrayList<>();
+            listOfMapOfStringToStructParam.forEach(entry -> {
+                Map<String, SimpleStruct> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        modifiableMap.put(key, value);
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<Map<String, SimpleStruct>> listOfMapOfStringToStructParamCopy = listOfMapOfStringToStructParam.stream()
-                                                                                                           .map(MapOfStringToSimpleStructCopier::copy).collect(toList());
-        return Collections.unmodifiableList(listOfMapOfStringToStructParamCopy);
+        return list;
     }
 
     static List<Map<String, SimpleStruct>> copyFromBuilder(
         Collection<? extends Map<String, ? extends SimpleStruct.Builder>> listOfMapOfStringToStructParam) {
-        if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof DefaultSdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+        List<Map<String, SimpleStruct>> list;
+        if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof SdkAutoConstructList) {
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<String, SimpleStruct>> modifiableList = new ArrayList<>();
+            listOfMapOfStringToStructParam.forEach(entry -> {
+                Map<String, SimpleStruct> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        SimpleStruct member = value.build();
+                        modifiableMap.put(key, member);
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        return copy(listOfMapOfStringToStructParam.stream().map(MapOfStringToSimpleStructCopier::copyFromBuilder).collect(toList()));
+        return list;
+    }
+
+    static List<Map<String, SimpleStruct.Builder>> copyToBuilder(
+        Collection<? extends Map<String, ? extends SimpleStruct>> listOfMapOfStringToStructParam) {
+        List<Map<String, SimpleStruct.Builder>> list;
+        if (listOfMapOfStringToStructParam == null || listOfMapOfStringToStructParam instanceof SdkAutoConstructList) {
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<String, SimpleStruct.Builder>> modifiableList = new ArrayList<>();
+            listOfMapOfStringToStructParam.forEach(entry -> {
+                Map<String, SimpleStruct.Builder> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        SimpleStruct.Builder member = value.toBuilder();
+                        modifiableMap.put(key, member);
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
+        }
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofmapstringtostringcopier.java
@@ -2,22 +2,41 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
+import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfMapStringToStringCopier {
     static List<Map<String, String>> copy(Collection<? extends Map<String, String>> listOfMapStringToStringParam) {
+        List<Map<String, String>> list;
         if (listOfMapStringToStringParam == null || listOfMapStringToStringParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<Map<String, String>> modifiableList = new ArrayList<>();
+            listOfMapStringToStringParam.forEach(entry -> {
+                Map<String, String> map;
+                if (entry == null || entry instanceof SdkAutoConstructMap) {
+                    map = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, String> modifiableMap = new LinkedHashMap<>();
+                    entry.forEach((key, value) -> {
+                        modifiableMap.put(key, value);
+                    });
+                    map = Collections.unmodifiableMap(modifiableMap);
+                }
+                modifiableList.add(map);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<Map<String, String>> listOfMapStringToStringParamCopy = listOfMapStringToStringParam.stream()
-                .map(MapOfStringToStringCopier::copy).collect(toList());
-        return Collections.unmodifiableList(listOfMapStringToStringParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofsimplestructscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofsimplestructscopier.java
@@ -12,18 +12,47 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfSimpleStructsCopier {
-    static List<SimpleStruct> copy(Collection<SimpleStruct> listOfSimpleStructsParam) {
+    static List<SimpleStruct> copy(Collection<? extends SimpleStruct> listOfSimpleStructsParam) {
+        List<SimpleStruct> list;
         if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<SimpleStruct> modifiableList = new ArrayList<>();
+            listOfSimpleStructsParam.forEach(entry -> {
+                modifiableList.add(entry);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<SimpleStruct> listOfSimpleStructsParamCopy = new ArrayList<>(listOfSimpleStructsParam);
-        return Collections.unmodifiableList(listOfSimpleStructsParamCopy);
+        return list;
     }
 
     static List<SimpleStruct> copyFromBuilder(Collection<? extends SimpleStruct.Builder> listOfSimpleStructsParam) {
-        if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof DefaultSdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+        List<SimpleStruct> list;
+        if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof SdkAutoConstructList) {
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<SimpleStruct> modifiableList = new ArrayList<>();
+            listOfSimpleStructsParam.forEach(entry -> {
+                SimpleStruct member = entry.build();
+                modifiableList.add(member);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        return copy(listOfSimpleStructsParam.stream().map(SimpleStruct.Builder::build).collect(toList()));
+        return list;
+    }
+
+    static List<SimpleStruct.Builder> copyToBuilder(Collection<? extends SimpleStruct> listOfSimpleStructsParam) {
+        List<SimpleStruct.Builder> list;
+        if (listOfSimpleStructsParam == null || listOfSimpleStructsParam instanceof SdkAutoConstructList) {
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<SimpleStruct.Builder> modifiableList = new ArrayList<>();
+            listOfSimpleStructsParam.forEach(entry -> {
+                SimpleStruct.Builder member = entry.toBuilder();
+                modifiableList.add(member);
+            });
+            list = Collections.unmodifiableList(modifiableList);
+        }
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/listofstringscopier.java
@@ -13,10 +13,16 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 @Generated("software.amazon.awssdk:codegen")
 final class ListOfStringsCopier {
     static List<String> copy(Collection<String> listOfStringsParam) {
+        List<String> list;
         if (listOfStringsParam == null || listOfStringsParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<String> modifiableList = new ArrayList<>();
+            listOfStringsParam.forEach(entry -> {
+                modifiableList.add(entry);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<String> listOfStringsParamCopy = new ArrayList<>(listOfStringsParam);
-        return Collections.unmodifiableList(listOfStringsParamCopy);
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtoenumcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -12,34 +12,50 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfEnumToEnumCopier {
     static Map<String, String> copy(Map<String, String> mapOfEnumToEnumParam) {
+        Map<String, String> map;
         if (mapOfEnumToEnumParam == null || mapOfEnumToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToEnumParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
+        return map;
     }
 
     static Map<String, String> copyEnumToString(Map<EnumType, EnumType> mapOfEnumToEnumParam) {
+        Map<String, String> map;
         if (mapOfEnumToEnumParam == null || mapOfEnumToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToEnumParam.forEach((key, value) -> {
+                String result = key.toString();
+                String result1 = value.toString();
+                modifiableMap.put(result, result1);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue().toString()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
+        return map;
     }
 
     static Map<EnumType, EnumType> copyStringToEnum(Map<String, String> mapOfEnumToEnumParam) {
+        Map<EnumType, EnumType> map;
         if (mapOfEnumToEnumParam == null || mapOfEnumToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<EnumType, EnumType> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToEnumParam.forEach((key, value) -> {
+                EnumType result = EnumType.fromValue(key);
+                EnumType result1 = EnumType.fromValue(value);
+                if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {
+                    modifiableMap.put(result, result1);
+                }
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<EnumType, EnumType> mapOfEnumToEnumParamCopy = mapOfEnumToEnumParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> {
-                    EnumType keyAsEnum = EnumType.fromValue(e.getKey());
-                    if (keyAsEnum != EnumType.UNKNOWN_TO_SDK_VERSION) {
-                        m.put(keyAsEnum, EnumType.fromValue(e.getValue()));
-                    }
-                }, HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToEnumParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtolistofenumscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtolistofenumscopier.java
@@ -2,50 +2,95 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfEnumToListOfEnumsCopier {
     static Map<String, List<String>> copy(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnumsParam) {
+        Map<String, List<String>> map;
         if (mapOfEnumToListOfEnumsParam == null || mapOfEnumToListOfEnumsParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, List<String>> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
+                List<String> list;
+                if (value == null || value instanceof SdkAutoConstructList) {
+                    list = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<String> modifiableList = new ArrayList<>();
+                    value.forEach(entry -> {
+                        modifiableList.add(entry);
+                    });
+                    list = Collections.unmodifiableList(modifiableList);
+                }
+                modifiableMap.put(key, list);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, List<String>> mapOfEnumToListOfEnumsParamCopy = mapOfEnumToListOfEnumsParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfEnumsCopier.copy(e.getValue())), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToListOfEnumsParamCopy);
+        return map;
     }
 
     static Map<String, List<String>> copyEnumToString(Map<EnumType, ? extends Collection<EnumType>> mapOfEnumToListOfEnumsParam) {
+        Map<String, List<String>> map;
         if (mapOfEnumToListOfEnumsParam == null || mapOfEnumToListOfEnumsParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, List<String>> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
+                String result = key.toString();
+                List<String> list;
+                if (value == null || value instanceof SdkAutoConstructList) {
+                    list = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<String> modifiableList = new ArrayList<>();
+                    value.forEach(entry -> {
+                        String result1 = entry.toString();
+                        modifiableList.add(result1);
+                    });
+                    list = Collections.unmodifiableList(modifiableList);
+                }
+                modifiableMap.put(result, list);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, List<String>> mapOfEnumToListOfEnumsParamCopy = mapOfEnumToListOfEnumsParam
-                .entrySet()
-                .stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), ListOfEnumsCopier.copyEnumToString(e.getValue())),
-                        HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToListOfEnumsParamCopy);
+        return map;
     }
 
     static Map<EnumType, List<EnumType>> copyStringToEnum(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnumsParam) {
+        Map<EnumType, List<EnumType>> map;
         if (mapOfEnumToListOfEnumsParam == null || mapOfEnumToListOfEnumsParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<EnumType, List<EnumType>> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToListOfEnumsParam.forEach((key, value) -> {
+                EnumType result = EnumType.fromValue(key);
+                List<EnumType> list;
+                if (value == null || value instanceof SdkAutoConstructList) {
+                    list = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<EnumType> modifiableList = new ArrayList<>();
+                    value.forEach(entry -> {
+                        EnumType result1 = EnumType.fromValue(entry);
+                        modifiableList.add(result1);
+                    });
+                    list = Collections.unmodifiableList(modifiableList);
+                }
+                if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {
+                    modifiableMap.put(result, list);
+                }
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<EnumType, List<EnumType>> mapOfEnumToListOfEnumsParamCopy = mapOfEnumToListOfEnumsParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> {
-                    EnumType keyAsEnum = EnumType.fromValue(e.getKey());
-                    if (keyAsEnum != EnumType.UNKNOWN_TO_SDK_VERSION) {
-                        m.put(keyAsEnum, ListOfEnumsCopier.copyStringToEnum(e.getValue()));
-                    }
-                }, HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToListOfEnumsParamCopy);
+        return map;
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtomapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtomapofstringtoenumcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -11,42 +11,83 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfEnumToMapOfStringToEnumCopier {
-    static Map<String, Map<String, String>> copy(Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumParam) {
+    static Map<String, Map<String, String>> copy(Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnumParam) {
+        Map<String, Map<String, String>> map;
         if (mapOfEnumToMapOfStringToEnumParam == null || mapOfEnumToMapOfStringToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
+                Map<String, String> map1;
+                if (value == null || value instanceof SdkAutoConstructMap) {
+                    map1 = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, String> modifiableMap1 = new LinkedHashMap<>();
+                    value.forEach((key1, value1) -> {
+                        modifiableMap1.put(key1, value1);
+                    });
+                    map1 = Collections.unmodifiableMap(modifiableMap1);
+                }
+                modifiableMap.put(key, map1);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumParamCopy = mapOfEnumToMapOfStringToEnumParam.entrySet()
-                .stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), MapOfStringToEnumCopier.copy(e.getValue())), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToMapOfStringToEnumParamCopy);
+        return map;
     }
 
     static Map<String, Map<String, String>> copyEnumToString(
-            Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnumParam) {
+        Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnumParam) {
+        Map<String, Map<String, String>> map;
         if (mapOfEnumToMapOfStringToEnumParam == null || mapOfEnumToMapOfStringToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, Map<String, String>> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
+                String result = key.toString();
+                Map<String, String> map1;
+                if (value == null || value instanceof SdkAutoConstructMap) {
+                    map1 = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, String> modifiableMap1 = new LinkedHashMap<>();
+                    value.forEach((key1, value1) -> {
+                        String result1 = value1.toString();
+                        modifiableMap1.put(key1, result1);
+                    });
+                    map1 = Collections.unmodifiableMap(modifiableMap1);
+                }
+                modifiableMap.put(result, map1);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumParamCopy = mapOfEnumToMapOfStringToEnumParam
-                .entrySet()
-                .stream()
-                .collect(HashMap::new,
-                        (m, e) -> m.put(e.getKey().toString(), MapOfStringToEnumCopier.copyEnumToString(e.getValue())),
-                        HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToMapOfStringToEnumParamCopy);
+        return map;
     }
 
     static Map<EnumType, Map<String, EnumType>> copyStringToEnum(
-            Map<String, Map<String, String>> mapOfEnumToMapOfStringToEnumParam) {
+        Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnumParam) {
+        Map<EnumType, Map<String, EnumType>> map;
         if (mapOfEnumToMapOfStringToEnumParam == null || mapOfEnumToMapOfStringToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<EnumType, Map<String, EnumType>> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToMapOfStringToEnumParam.forEach((key, value) -> {
+                EnumType result = EnumType.fromValue(key);
+                Map<String, EnumType> map1;
+                if (value == null || value instanceof SdkAutoConstructMap) {
+                    map1 = DefaultSdkAutoConstructMap.getInstance();
+                } else {
+                    Map<String, EnumType> modifiableMap1 = new LinkedHashMap<>();
+                    value.forEach((key1, value1) -> {
+                        EnumType result1 = EnumType.fromValue(value1);
+                        modifiableMap1.put(key1, result1);
+                    });
+                    map1 = Collections.unmodifiableMap(modifiableMap1);
+                }
+                if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {
+                    modifiableMap.put(result, map1);
+                }
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<EnumType, Map<String, EnumType>> mapOfEnumToMapOfStringToEnumParamCopy = mapOfEnumToMapOfStringToEnumParam.entrySet()
-                .stream().collect(HashMap::new, (m, e) -> {
-                    EnumType keyAsEnum = EnumType.fromValue(e.getKey());
-                    if (keyAsEnum != EnumType.UNKNOWN_TO_SDK_VERSION) {
-                        m.put(keyAsEnum, MapOfStringToEnumCopier.copyStringToEnum(e.getValue()));
-                    }
-                }, HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToMapOfStringToEnumParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtosimplestructcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -11,42 +11,79 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfEnumToSimpleStructCopier {
-    static Map<String, SimpleStruct> copy(Map<String, SimpleStruct> mapOfEnumToSimpleStructParam) {
+    static Map<String, SimpleStruct> copy(Map<String, ? extends SimpleStruct> mapOfEnumToSimpleStructParam) {
+        Map<String, SimpleStruct> map;
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToSimpleStructParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                                                                                                 .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
+        return map;
     }
 
     static Map<String, SimpleStruct> copyFromBuilder(Map<String, ? extends SimpleStruct.Builder> mapOfEnumToSimpleStructParam) {
-        if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof DefaultSdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+        Map<String, SimpleStruct> map;
+        if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToSimpleStructParam.forEach((key, value) -> {
+                SimpleStruct member = value.build();
+                modifiableMap.put(key, member);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        return copy(mapOfEnumToSimpleStructParam.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+        return map;
     }
 
-    static Map<String, SimpleStruct> copyEnumToString(Map<EnumType, SimpleStruct> mapOfEnumToSimpleStructParam) {
+    static Map<String, SimpleStruct.Builder> copyToBuilder(Map<String, ? extends SimpleStruct> mapOfEnumToSimpleStructParam) {
+        Map<String, SimpleStruct.Builder> map;
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToSimpleStructParam.forEach((key, value) -> {
+                SimpleStruct.Builder member = value.toBuilder();
+                modifiableMap.put(key, member);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                                                                                                 .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
+        return map;
     }
 
-    static Map<EnumType, SimpleStruct> copyStringToEnum(Map<String, SimpleStruct> mapOfEnumToSimpleStructParam) {
+    static Map<String, SimpleStruct> copyEnumToString(Map<EnumType, ? extends SimpleStruct> mapOfEnumToSimpleStructParam) {
+        Map<String, SimpleStruct> map;
         if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToSimpleStructParam.forEach((key, value) -> {
+                String result = key.toString();
+                modifiableMap.put(result, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<EnumType, SimpleStruct> mapOfEnumToSimpleStructParamCopy = mapOfEnumToSimpleStructParam.entrySet().stream()
-                                                                                                   .collect(HashMap::new, (m, e) -> {
-                                                                                                       EnumType keyAsEnum = EnumType.fromValue(e.getKey());
-                                                                                                       if (keyAsEnum != EnumType.UNKNOWN_TO_SDK_VERSION) {
-                                                                                                           m.put(keyAsEnum, e.getValue());
-                                                                                                       }
-                                                                                                   }, HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToSimpleStructParamCopy);
+        return map;
+    }
+
+    static Map<EnumType, SimpleStruct> copyStringToEnum(Map<String, ? extends SimpleStruct> mapOfEnumToSimpleStructParam) {
+        Map<EnumType, SimpleStruct> map;
+        if (mapOfEnumToSimpleStructParam == null || mapOfEnumToSimpleStructParam instanceof SdkAutoConstructMap) {
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<EnumType, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToSimpleStructParam.forEach((key, value) -> {
+                EnumType result = EnumType.fromValue(key);
+                if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {
+                    modifiableMap.put(result, value);
+                }
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
+        }
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofenumtostringcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -12,34 +12,48 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfEnumToStringCopier {
     static Map<String, String> copy(Map<String, String> mapOfEnumToStringParam) {
+        Map<String, String> map;
         if (mapOfEnumToStringParam == null || mapOfEnumToStringParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToStringParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
+        return map;
     }
 
     static Map<String, String> copyEnumToString(Map<EnumType, String> mapOfEnumToStringParam) {
+        Map<String, String> map;
         if (mapOfEnumToStringParam == null || mapOfEnumToStringParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToStringParam.forEach((key, value) -> {
+                String result = key.toString();
+                modifiableMap.put(result, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey().toString(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
+        return map;
     }
 
     static Map<EnumType, String> copyStringToEnum(Map<String, String> mapOfEnumToStringParam) {
+        Map<EnumType, String> map;
         if (mapOfEnumToStringParam == null || mapOfEnumToStringParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<EnumType, String> modifiableMap = new LinkedHashMap<>();
+            mapOfEnumToStringParam.forEach((key, value) -> {
+                EnumType result = EnumType.fromValue(key);
+                if (result != EnumType.UNKNOWN_TO_SDK_VERSION) {
+                    modifiableMap.put(result, value);
+                }
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<EnumType, String> mapOfEnumToStringParamCopy = mapOfEnumToStringParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> {
-                    EnumType keyAsEnum = EnumType.fromValue(e.getKey());
-                    if (keyAsEnum != EnumType.UNKNOWN_TO_SDK_VERSION) {
-                        m.put(keyAsEnum, e.getValue());
-                    }
-                }, HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfEnumToStringParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtoenumcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -12,29 +12,46 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToEnumCopier {
     static Map<String, String> copy(Map<String, String> mapOfStringToEnumParam) {
+        Map<String, String> map;
         if (mapOfStringToEnumParam == null || mapOfStringToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToEnumParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
+        return map;
     }
 
     static Map<String, String> copyEnumToString(Map<String, EnumType> mapOfStringToEnumParam) {
+        Map<String, String> map;
         if (mapOfStringToEnumParam == null || mapOfStringToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToEnumParam.forEach((key, value) -> {
+                String result = value.toString();
+                modifiableMap.put(key, result);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue().toString()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
+        return map;
     }
 
     static Map<String, EnumType> copyStringToEnum(Map<String, String> mapOfStringToEnumParam) {
+        Map<String, EnumType> map;
         if (mapOfStringToEnumParam == null || mapOfStringToEnumParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, EnumType> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToEnumParam.forEach((key, value) -> {
+                EnumType result = EnumType.fromValue(value);
+                modifiableMap.put(key, result);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, EnumType> mapOfStringToEnumParamCopy = mapOfStringToEnumParam.entrySet().stream()
-                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), EnumType.fromValue(e.getValue())), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToEnumParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtointegerlistcopier.java
@@ -2,23 +2,41 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToIntegerListCopier {
     static Map<String, List<Integer>> copy(Map<String, ? extends Collection<Integer>> mapOfStringToIntegerListParam) {
+        Map<String, List<Integer>> map;
         if (mapOfStringToIntegerListParam == null || mapOfStringToIntegerListParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, List<Integer>> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToIntegerListParam.forEach((key, value) -> {
+                List<Integer> list;
+                if (value == null || value instanceof SdkAutoConstructList) {
+                    list = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<Integer> modifiableList = new ArrayList<>();
+                    value.forEach(entry -> {
+                        modifiableList.add(entry);
+                    });
+                    list = Collections.unmodifiableList(modifiableList);
+                }
+                modifiableMap.put(key, list);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, List<Integer>> mapOfStringToIntegerListParamCopy = mapOfStringToIntegerListParam.entrySet().stream()
-            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfIntegersCopier.copy(e.getValue())), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToIntegerListParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtolistoflistofstringscopier.java
@@ -2,26 +2,52 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
+import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToListOfListOfStringsCopier {
     static Map<String, List<List<String>>> copy(
         Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStringsParam) {
+        Map<String, List<List<String>>> map;
         if (mapOfStringToListOfListOfStringsParam == null || mapOfStringToListOfListOfStringsParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, List<List<String>>> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToListOfListOfStringsParam.forEach((key, value) -> {
+                List<List<String>> list;
+                if (value == null || value instanceof SdkAutoConstructList) {
+                    list = DefaultSdkAutoConstructList.getInstance();
+                } else {
+                    List<List<String>> modifiableList = new ArrayList<>();
+                    value.forEach(entry -> {
+                        List<String> list1;
+                        if (entry == null || entry instanceof SdkAutoConstructList) {
+                            list1 = DefaultSdkAutoConstructList.getInstance();
+                        } else {
+                            List<String> modifiableList1 = new ArrayList<>();
+                            entry.forEach(entry1 -> {
+                                modifiableList1.add(entry1);
+                            });
+                            list1 = Collections.unmodifiableList(modifiableList1);
+                        }
+                        modifiableList.add(list1);
+                    });
+                    list = Collections.unmodifiableList(modifiableList);
+                }
+                modifiableMap.put(key, list);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, List<List<String>>> mapOfStringToListOfListOfStringsParamCopy = mapOfStringToListOfListOfStringsParam
-            .entrySet()
-            .stream()
-            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), ListOfListOfStringsCopier.copy(e.getValue())), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToListOfListOfStringsParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtosimplestructcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -11,20 +11,47 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToSimpleStructCopier {
-    static Map<String, SimpleStruct> copy(Map<String, SimpleStruct> mapOfStringToSimpleStructParam) {
+    static Map<String, SimpleStruct> copy(Map<String, ? extends SimpleStruct> mapOfStringToSimpleStructParam) {
+        Map<String, SimpleStruct> map;
         if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToSimpleStructParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, SimpleStruct> mapOfStringToSimpleStructParamCopy = mapOfStringToSimpleStructParam.entrySet().stream()
-                                                                                                     .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToSimpleStructParamCopy);
+        return map;
     }
 
     static Map<String, SimpleStruct> copyFromBuilder(Map<String, ? extends SimpleStruct.Builder> mapOfStringToSimpleStructParam) {
-        if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof DefaultSdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+        Map<String, SimpleStruct> map;
+        if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof SdkAutoConstructMap) {
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToSimpleStructParam.forEach((key, value) -> {
+                SimpleStruct member = value.build();
+                modifiableMap.put(key, member);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        return copy(mapOfStringToSimpleStructParam.entrySet().stream()
-                                                  .collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+        return map;
+    }
+
+    static Map<String, SimpleStruct.Builder> copyToBuilder(Map<String, ? extends SimpleStruct> mapOfStringToSimpleStructParam) {
+        Map<String, SimpleStruct.Builder> map;
+        if (mapOfStringToSimpleStructParam == null || mapOfStringToSimpleStructParam instanceof SdkAutoConstructMap) {
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, SimpleStruct.Builder> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToSimpleStructParam.forEach((key, value) -> {
+                SimpleStruct.Builder member = value.toBuilder();
+                modifiableMap.put(key, member);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
+        }
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/mapofstringtostringcopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -12,11 +12,16 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 @Generated("software.amazon.awssdk:codegen")
 final class MapOfStringToStringCopier {
     static Map<String, String> copy(Map<String, String> mapOfStringToStringParam) {
+        Map<String, String> map;
         if (mapOfStringToStringParam == null || mapOfStringToStringParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, String> modifiableMap = new LinkedHashMap<>();
+            mapOfStringToStringParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, String> mapOfStringToStringParamCopy = mapOfStringToStringParam.entrySet().stream()
-            .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(mapOfStringToStringParamCopy);
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivelisttypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivelisttypecopier.java
@@ -12,18 +12,47 @@ import software.amazon.awssdk.core.util.SdkAutoConstructList;
 
 @Generated("software.amazon.awssdk:codegen")
 final class RecursiveListTypeCopier {
-    static List<RecursiveStructType> copy(Collection<RecursiveStructType> recursiveListTypeParam) {
+    static List<RecursiveStructType> copy(Collection<? extends RecursiveStructType> recursiveListTypeParam) {
+        List<RecursiveStructType> list;
         if (recursiveListTypeParam == null || recursiveListTypeParam instanceof SdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<RecursiveStructType> modifiableList = new ArrayList<>();
+            recursiveListTypeParam.forEach(entry -> {
+                modifiableList.add(entry);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        List<RecursiveStructType> recursiveListTypeParamCopy = new ArrayList<>(recursiveListTypeParam);
-        return Collections.unmodifiableList(recursiveListTypeParamCopy);
+        return list;
     }
 
     static List<RecursiveStructType> copyFromBuilder(Collection<? extends RecursiveStructType.Builder> recursiveListTypeParam) {
-        if (recursiveListTypeParam == null || recursiveListTypeParam instanceof DefaultSdkAutoConstructList) {
-            return DefaultSdkAutoConstructList.getInstance();
+        List<RecursiveStructType> list;
+        if (recursiveListTypeParam == null || recursiveListTypeParam instanceof SdkAutoConstructList) {
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<RecursiveStructType> modifiableList = new ArrayList<>();
+            recursiveListTypeParam.forEach(entry -> {
+                RecursiveStructType member = entry.build();
+                modifiableList.add(member);
+            });
+            list = Collections.unmodifiableList(modifiableList);
         }
-        return copy(recursiveListTypeParam.stream().map(RecursiveStructType.Builder::build).collect(toList()));
+        return list;
+    }
+
+    static List<RecursiveStructType.Builder> copyToBuilder(Collection<? extends RecursiveStructType> recursiveListTypeParam) {
+        List<RecursiveStructType.Builder> list;
+        if (recursiveListTypeParam == null || recursiveListTypeParam instanceof SdkAutoConstructList) {
+            list = DefaultSdkAutoConstructList.getInstance();
+        } else {
+            List<RecursiveStructType.Builder> modifiableList = new ArrayList<>();
+            recursiveListTypeParam.forEach(entry -> {
+                RecursiveStructType.Builder member = entry.toBuilder();
+                modifiableList.add(member);
+            });
+            list = Collections.unmodifiableList(modifiableList);
+        }
+        return list;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivemaptypecopier.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.services.jsonprotocoltests.model;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
@@ -11,20 +11,48 @@ import software.amazon.awssdk.core.util.SdkAutoConstructMap;
 
 @Generated("software.amazon.awssdk:codegen")
 final class RecursiveMapTypeCopier {
-    static Map<String, RecursiveStructType> copy(Map<String, RecursiveStructType> recursiveMapTypeParam) {
+    static Map<String, RecursiveStructType> copy(Map<String, ? extends RecursiveStructType> recursiveMapTypeParam) {
+        Map<String, RecursiveStructType> map;
         if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof SdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, RecursiveStructType> modifiableMap = new LinkedHashMap<>();
+            recursiveMapTypeParam.forEach((key, value) -> {
+                modifiableMap.put(key, value);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        Map<String, RecursiveStructType> recursiveMapTypeParamCopy = recursiveMapTypeParam.entrySet().stream()
-                                                                                          .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
-        return Collections.unmodifiableMap(recursiveMapTypeParamCopy);
+        return map;
     }
 
     static Map<String, RecursiveStructType> copyFromBuilder(
         Map<String, ? extends RecursiveStructType.Builder> recursiveMapTypeParam) {
-        if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof DefaultSdkAutoConstructMap) {
-            return DefaultSdkAutoConstructMap.getInstance();
+        Map<String, RecursiveStructType> map;
+        if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof SdkAutoConstructMap) {
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, RecursiveStructType> modifiableMap = new LinkedHashMap<>();
+            recursiveMapTypeParam.forEach((key, value) -> {
+                RecursiveStructType member = value.build();
+                modifiableMap.put(key, member);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
         }
-        return copy(recursiveMapTypeParam.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().build())));
+        return map;
+    }
+
+    static Map<String, RecursiveStructType.Builder> copyToBuilder(Map<String, ? extends RecursiveStructType> recursiveMapTypeParam) {
+        Map<String, RecursiveStructType.Builder> map;
+        if (recursiveMapTypeParam == null || recursiveMapTypeParam instanceof SdkAutoConstructMap) {
+            map = DefaultSdkAutoConstructMap.getInstance();
+        } else {
+            Map<String, RecursiveStructType.Builder> modifiableMap = new LinkedHashMap<>();
+            recursiveMapTypeParam.forEach((key, value) -> {
+                RecursiveStructType.Builder member = value.toBuilder();
+                modifiableMap.put(key, member);
+            });
+            map = Collections.unmodifiableMap(modifiableMap);
+        }
+        return map;
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.core.util.SdkAutoConstructMap;
-import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
@@ -34,49 +33,49 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class RecursiveStructType implements SdkPojo, Serializable,
-        ToCopyableBuilder<RecursiveStructType.Builder, RecursiveStructType> {
+                                                  ToCopyableBuilder<RecursiveStructType.Builder, RecursiveStructType> {
     private static final SdkField<String> NO_RECURSE_FIELD = SdkField.<String> builder(MarshallingType.STRING)
-            .memberName("NoRecurse").getter(getter(RecursiveStructType::noRecurse)).setter(setter(Builder::noRecurse))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NoRecurse").build()).build();
+                                                                     .memberName("NoRecurse").getter(getter(RecursiveStructType::noRecurse)).setter(setter(Builder::noRecurse))
+                                                                     .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NoRecurse").build()).build();
 
     private static final SdkField<RecursiveStructType> RECURSIVE_STRUCT_FIELD = SdkField
-            .<RecursiveStructType> builder(MarshallingType.SDK_POJO).memberName("RecursiveStruct")
-            .getter(getter(RecursiveStructType::recursiveStruct)).setter(setter(Builder::recursiveStruct))
-            .constructor(RecursiveStructType::builder)
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
+        .<RecursiveStructType> builder(MarshallingType.SDK_POJO).memberName("RecursiveStruct")
+        .getter(getter(RecursiveStructType::recursiveStruct)).setter(setter(Builder::recursiveStruct))
+        .constructor(RecursiveStructType::builder)
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveStruct").build()).build();
 
     private static final SdkField<List<RecursiveStructType>> RECURSIVE_LIST_FIELD = SdkField
-            .<List<RecursiveStructType>> builder(MarshallingType.LIST)
-            .memberName("RecursiveList")
-            .getter(getter(RecursiveStructType::recursiveList))
-            .setter(setter(Builder::recursiveList))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveList").build(),
-                    ListTrait
-                            .builder()
-                            .memberLocationName(null)
-                            .memberFieldInfo(
-                                    SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
-                                            .constructor(RecursiveStructType::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("member").build()).build()).build()).build();
+        .<List<RecursiveStructType>> builder(MarshallingType.LIST)
+        .memberName("RecursiveList")
+        .getter(getter(RecursiveStructType::recursiveList))
+        .setter(setter(Builder::recursiveList))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveList").build(),
+                ListTrait
+                    .builder()
+                    .memberLocationName(null)
+                    .memberFieldInfo(
+                        SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
+                                .constructor(RecursiveStructType::builder)
+                                .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                     .locationName("member").build()).build()).build()).build();
 
     private static final SdkField<Map<String, RecursiveStructType>> RECURSIVE_MAP_FIELD = SdkField
-            .<Map<String, RecursiveStructType>> builder(MarshallingType.MAP)
-            .memberName("RecursiveMap")
-            .getter(getter(RecursiveStructType::recursiveMap))
-            .setter(setter(Builder::recursiveMap))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveMap").build(),
-                    MapTrait.builder()
-                            .keyLocationName("key")
-                            .valueLocationName("value")
-                            .valueFieldInfo(
-                                    SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
-                                            .constructor(RecursiveStructType::builder)
-                                            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
-                                                    .locationName("value").build()).build()).build()).build();
+        .<Map<String, RecursiveStructType>> builder(MarshallingType.MAP)
+        .memberName("RecursiveMap")
+        .getter(getter(RecursiveStructType::recursiveMap))
+        .setter(setter(Builder::recursiveMap))
+        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("RecursiveMap").build(),
+                MapTrait.builder()
+                        .keyLocationName("key")
+                        .valueLocationName("value")
+                        .valueFieldInfo(
+                            SdkField.<RecursiveStructType> builder(MarshallingType.SDK_POJO)
+                                    .constructor(RecursiveStructType::builder)
+                                    .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD)
+                                                         .locationName("value").build()).build()).build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(NO_RECURSE_FIELD,
-            RECURSIVE_STRUCT_FIELD, RECURSIVE_LIST_FIELD, RECURSIVE_MAP_FIELD));
+                                                                                                   RECURSIVE_STRUCT_FIELD, RECURSIVE_LIST_FIELD, RECURSIVE_MAP_FIELD));
 
     private static final long serialVersionUID = 1L;
 
@@ -97,7 +96,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
 
     /**
      * Returns the value of the NoRecurse property for this object.
-     * 
+     *
      * @return The value of the NoRecurse property for this object.
      */
     public final String noRecurse() {
@@ -106,7 +105,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
 
     /**
      * Returns the value of the RecursiveStruct property for this object.
-     * 
+     *
      * @return The value of the RecursiveStruct property for this object.
      */
     public final RecursiveStructType recursiveStruct() {
@@ -129,7 +128,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
      * <p>
      * You can use {@link #hasRecursiveList()} to see if a value was sent in this field.
      * </p>
-     * 
+     *
      * @return The value of the RecursiveList property for this object.
      */
     public final List<RecursiveStructType> recursiveList() {
@@ -152,7 +151,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
      * <p>
      * You can use {@link #hasRecursiveMap()} to see if a value was sent in this field.
      * </p>
-     * 
+     *
      * @return The value of the RecursiveMap property for this object.
      */
     public final Map<String, RecursiveStructType> recursiveMap() {
@@ -200,8 +199,8 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
         RecursiveStructType other = (RecursiveStructType) obj;
         return Objects.equals(noRecurse(), other.noRecurse()) && Objects.equals(recursiveStruct(), other.recursiveStruct())
-                && hasRecursiveList() == other.hasRecursiveList() && Objects.equals(recursiveList(), other.recursiveList())
-                && hasRecursiveMap() == other.hasRecursiveMap() && Objects.equals(recursiveMap(), other.recursiveMap());
+               && hasRecursiveList() == other.hasRecursiveList() && Objects.equals(recursiveList(), other.recursiveList())
+               && hasRecursiveMap() == other.hasRecursiveMap() && Objects.equals(recursiveMap(), other.recursiveMap());
     }
 
     /**
@@ -211,22 +210,22 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
     @Override
     public final String toString() {
         return ToString.builder("RecursiveStructType").add("NoRecurse", noRecurse()).add("RecursiveStruct", recursiveStruct())
-                .add("RecursiveList", hasRecursiveList() ? recursiveList() : null)
-                .add("RecursiveMap", hasRecursiveMap() ? recursiveMap() : null).build();
+                       .add("RecursiveList", hasRecursiveList() ? recursiveList() : null)
+                       .add("RecursiveMap", hasRecursiveMap() ? recursiveMap() : null).build();
     }
 
     public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "NoRecurse":
-            return Optional.ofNullable(clazz.cast(noRecurse()));
-        case "RecursiveStruct":
-            return Optional.ofNullable(clazz.cast(recursiveStruct()));
-        case "RecursiveList":
-            return Optional.ofNullable(clazz.cast(recursiveList()));
-        case "RecursiveMap":
-            return Optional.ofNullable(clazz.cast(recursiveMap()));
-        default:
-            return Optional.empty();
+            case "NoRecurse":
+                return Optional.ofNullable(clazz.cast(noRecurse()));
+            case "RecursiveStruct":
+                return Optional.ofNullable(clazz.cast(recursiveStruct()));
+            case "RecursiveList":
+                return Optional.ofNullable(clazz.cast(recursiveList()));
+            case "RecursiveMap":
+                return Optional.ofNullable(clazz.cast(recursiveMap()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -270,7 +269,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
          *
          * When the {@link Consumer} completes, {@link RecursiveStructType.Builder#build()} is called immediately and
          * its result is passed to {@link #recursiveStruct(RecursiveStructType)}.
-         * 
+         *
          * @param recursiveStruct
          *        a consumer that will call methods on {@link RecursiveStructType.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -306,7 +305,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
          *
          * When the {@link Consumer} completes, {@link List<RecursiveStructType>.Builder#build()} is called immediately
          * and its result is passed to {@link #recursiveList(List<RecursiveStructType>)}.
-         * 
+         *
          * @param recursiveList
          *        a consumer that will call methods on {@link List<RecursiveStructType>.Builder}
          * @return Returns a reference to this object so that method calls can be chained together.
@@ -371,12 +370,12 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
             this.recursiveStruct = recursiveStruct != null ? recursiveStruct.build() : null;
         }
 
-        public final Collection<Builder> getRecursiveList() {
-            if (recursiveList instanceof SdkAutoConstructList) {
+        public final List<Builder> getRecursiveList() {
+            List<Builder> result = RecursiveListTypeCopier.copyToBuilder(this.recursiveList);
+            if (result instanceof SdkAutoConstructList) {
                 return null;
             }
-            return recursiveList != null ? recursiveList.stream().map(RecursiveStructType::toBuilder)
-                    .collect(Collectors.toList()) : null;
+            return result;
         }
 
         @Override
@@ -396,7 +395,7 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         @SafeVarargs
         public final Builder recursiveList(Consumer<Builder>... recursiveList) {
             recursiveList(Stream.of(recursiveList).map(c -> RecursiveStructType.builder().applyMutation(c).build())
-                    .collect(Collectors.toList()));
+                                .collect(Collectors.toList()));
             return this;
         }
 
@@ -405,10 +404,11 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
 
         public final Map<String, Builder> getRecursiveMap() {
-            if (recursiveMap instanceof SdkAutoConstructMap) {
+            Map<String, Builder> result = RecursiveMapTypeCopier.copyToBuilder(this.recursiveMap);
+            if (result instanceof SdkAutoConstructMap) {
                 return null;
             }
-            return recursiveMap != null ? CollectionUtils.mapValues(recursiveMap, RecursiveStructType::toBuilder) : null;
+            return result;
         }
 
         @Override
@@ -432,4 +432,3 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
@@ -13,7 +13,6 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
-import software.amazon.awssdk.core.adapter.StandardMemberCopier;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.LocationTrait;
@@ -25,10 +24,10 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public final class StructWithNestedBlobType implements SdkPojo, Serializable,
-        ToCopyableBuilder<StructWithNestedBlobType.Builder, StructWithNestedBlobType> {
+                                                       ToCopyableBuilder<StructWithNestedBlobType.Builder, StructWithNestedBlobType> {
     private static final SdkField<SdkBytes> NESTED_BLOB_FIELD = SdkField.<SdkBytes> builder(MarshallingType.SDK_BYTES)
-            .memberName("NestedBlob").getter(getter(StructWithNestedBlobType::nestedBlob)).setter(setter(Builder::nestedBlob))
-            .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NestedBlob").build()).build();
+                                                                        .memberName("NestedBlob").getter(getter(StructWithNestedBlobType::nestedBlob)).setter(setter(Builder::nestedBlob))
+                                                                        .traits(LocationTrait.builder().location(MarshallLocation.PAYLOAD).locationName("NestedBlob").build()).build();
 
     private static final List<SdkField<?>> SDK_FIELDS = Collections.unmodifiableList(Arrays.asList(NESTED_BLOB_FIELD));
 
@@ -42,7 +41,7 @@ public final class StructWithNestedBlobType implements SdkPojo, Serializable,
 
     /**
      * Returns the value of the NestedBlob property for this object.
-     * 
+     *
      * @return The value of the NestedBlob property for this object.
      */
     public final SdkBytes nestedBlob() {
@@ -100,10 +99,10 @@ public final class StructWithNestedBlobType implements SdkPojo, Serializable,
 
     public final <T> Optional<T> getValueForField(String fieldName, Class<T> clazz) {
         switch (fieldName) {
-        case "NestedBlob":
-            return Optional.ofNullable(clazz.cast(nestedBlob()));
-        default:
-            return Optional.empty();
+            case "NestedBlob":
+                return Optional.ofNullable(clazz.cast(nestedBlob()));
+            default:
+                return Optional.empty();
         }
     }
 
@@ -147,7 +146,7 @@ public final class StructWithNestedBlobType implements SdkPojo, Serializable,
 
         @Override
         public final Builder nestedBlob(SdkBytes nestedBlob) {
-            this.nestedBlob = StandardMemberCopier.copy(nestedBlob);
+            this.nestedBlob = nestedBlob;
             return this;
         }
 
@@ -166,4 +165,3 @@ public final class StructWithNestedBlobType implements SdkPojo, Serializable,
         }
     }
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,11 @@
                         <onlyModified>true</onlyModified>
                         <excludes>
                             <exclude>*.internal.*</exclude>
+                            <exclude>*.SubscribeToShardEvent$BuilderImpl</exclude>
+                            <exclude>*.ConfigurationEvent$BuilderImpl</exclude>
+                            <exclude>*.IntentResultEvent$BuilderImpl</exclude>
+                            <exclude>*.TextResponseEvent$BuilderImpl</exclude>
+                            <exclude>*.IntentResultEvent$BuilderImpl</exclude>
                         </excludes>
 
                         <excludeModules>

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
@@ -229,6 +229,7 @@
         "SimpleList":{"shape":"ListOfStrings"},
         "ListOfEnums":{"shape":"ListOfEnums"},
         "ListOfMaps":{"shape":"ListOfMapStringToString"},
+        "ListOfListOfMapsOfStringToStruct":{"shape":"ListOfListOfMapOfStringToSimpleStruct"},
         "ListOfMapsOfStringToStruct":{"shape":"ListOfMapOfStringToSimpleStruct"},
         "ListOfStructs":{"shape":"ListOfSimpleStructs"},
         "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
@@ -326,6 +327,10 @@
     "ListOfMapStringToString":{
       "type":"list",
       "member":{"shape":"MapOfStringToString"}
+    },
+    "ListOfListOfMapOfStringToSimpleStruct":{
+      "type":"list",
+      "member":{"shape":"ListOfMapOfStringToSimpleStruct"}
     },
     "ListOfMapOfStringToSimpleStruct":{
       "type":"list",

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/ModelSerializationTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/ModelSerializationTest.java
@@ -71,6 +71,8 @@ public class ModelSerializationTest {
                                                     .simpleList("foo", "bar")
                                                     .listOfMaps(singletonList(singletonMap("foo", "bar")))
                                                     .listOfMapsOfStringToStruct(singletonList(singletonMap("bar", simpleStruct)))
+                                                    .listOfListOfMapsOfStringToStruct(
+                                                        singletonList(singletonList(singletonMap("bar", simpleStruct))))
                                                     .listOfStructs(simpleStruct)
                                                     .mapOfStringToIntegerList(singletonMap("foo", singletonList(5)))
                                                     .mapOfStringToStruct(singletonMap("foo", simpleStruct))


### PR DESCRIPTION
This fixes an issue where DynamoDB types like BatchGetResponse.Builder could not be serialized using
a bean-based serializer, because it contained a Map<K, List<Map<K2, V>>.