### PR TITLE
Do not allow cross-region requests for S3 client with Fips Region.

### DIFF
--- a/.changes/next-release/bugfix-AWSS3-c21fe33.json
+++ b/.changes/next-release/bugfix-AWSS3-c21fe33.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS S3", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Do not allow cross-region requests for S3 client with Fips Region."
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtils.java
@@ -50,15 +50,6 @@ public final class S3EndpointUtils {
         return region;
     }
 
-    /**
-     * Returns whether a FIPS pseudo region is provided.
-     */
-    public static boolean isFipsRegionProvided(String clientRegion, String arnRegion, boolean useArnRegion) {
-        if (useArnRegion) {
-            return isFipsRegion(arnRegion);
-        }
-        return isFipsRegion(clientRegion);
-    }
 
     public static boolean isFipsRegion(String region) {
         return region.startsWith("fips-") || region.endsWith("-fips");

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/resource/S3AccessPointBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/resource/S3AccessPointBuilder.java
@@ -121,11 +121,11 @@ public class S3AccessPointBuilder {
 
         String uri;
         if (endpointOverride == null) {
-            String fipsSegment = Boolean.TRUE.equals(fipsEnabled) ? "fips-" : "";
+            String fipsSegment = Boolean.TRUE.equals(fipsEnabled) ? "-fips" : "";
             String dualStackSegment = Boolean.TRUE.equals(dualstackEnabled) ? ".dualstack" : "";
 
-            uri = String.format("%s://%s-%s.s3-accesspoint%s.%s%s.%s", protocol, urlEncode(accessPointName),
-                                accountId, dualStackSegment, fipsSegment, region, domain);
+            uri = String.format("%s://%s-%s.s3-accesspoint%s%s.%s.%s", protocol, urlEncode(accessPointName),
+                                accountId, fipsSegment, dualStackSegment, region, domain);
         } else {
             Validate.isTrue(!Boolean.TRUE.equals(fipsEnabled),
                             "FIPS regions are not supported with an endpoint override specified");

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/resource/S3ObjectLambdaEndpointBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/resource/S3ObjectLambdaEndpointBuilder.java
@@ -91,7 +91,7 @@ public class S3ObjectLambdaEndpointBuilder {
         validateHostnameCompliant(accountId, "accountId", "object lambda ARN");
         validateHostnameCompliant(accessPointName, "accessPointName", "object lambda ARN");
 
-        String fipsSegment = Boolean.TRUE.equals(fipsEnabled) ? "fips-" : "";
+        String fipsSegment = Boolean.TRUE.equals(fipsEnabled) ? "-fips" : "";
 
         String uriString;
         if (endpointOverride == null) {
@@ -99,7 +99,7 @@ public class S3ObjectLambdaEndpointBuilder {
                 throw new IllegalStateException("S3 Object Lambda does not support Dual stack endpoints.");
             }
 
-            uriString = String.format("%s://%s-%s.s3-object-lambda.%s%s.%s",
+            uriString = String.format("%s://%s-%s.s3-object-lambda%s.%s.%s",
                                       protocol, accessPointName, accountId, fipsSegment, region, domain);
         } else {
             StringBuilder uriSuffix = new StringBuilder(endpointOverride.getHost());

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3EndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3EndpointResolutionTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.internal.handlers.EndpointAddressInterceptor;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
@@ -49,6 +50,8 @@ public class S3EndpointResolutionTest {
     private static final String NON_DNS_COMPATIBLE_BUCKET = "SOME.BUCKET";
     private static final String ENDPOINT_WITHOUT_BUCKET = "https://s3.ap-south-1.amazonaws.com";
     private static final String ENDPOINT_WITH_BUCKET = String.format("https://%s.s3.ap-south-1.amazonaws.com", BUCKET);
+    public static final String USE_ARN_REGION_MESSAGE = "To enable this behavior and prevent this exception set " +
+            "'useArnRegionEnabled' to true in the configuration when building the S3 client.";
 
     private MockSyncHttpClient mockHttpClient;
     private Signer mockSigner;
@@ -506,6 +509,119 @@ public class S3EndpointResolutionTest {
                               .dualstackEnabled(true)
                               .accelerateModeEnabled(true)
                               .build();
+    }
+
+    @Test
+    public void accessPointArn_usEast1Region_s3External1_useArnRegionFalse_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("s3-external-1")).build();
+        String accessPointArn = "arn:aws:s3:us-east-1:12345678910:accesspoint:foobar";
+        assertThatThrownBy(() -> s3Client.listObjects(ListObjectsRequest.builder().bucket(accessPointArn).build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(USE_ARN_REGION_MESSAGE);
+    }
+
+    @Test
+    public void accessPointArn_usEast_1_region_s3External1_seArnRegionTrue() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("s3-external-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build()).build();
+        String accessPointArn = "arn:aws:s3:us-east-1:123456789012:accesspoint:foobar";
+        s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build());
+        assertThat(mockHttpClient.getLastRequest().getUri().getHost())
+                .isEqualTo("foobar-123456789012.s3-accesspoint.us-east-1.amazonaws.com");
+
+    }
+
+    @Test
+    public void accessPointArn_usEast1_region_awsGlobal_useArnRegionTrue() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.AWS_GLOBAL)
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build()).build();
+        String accessPointArn = "arn:aws:s3:us-east-1:123456789012:accesspoint:foobar";
+        s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build());
+        assertThat(mockHttpClient.getLastRequest().getUri().getHost())
+                .isEqualTo("foobar-123456789012.s3-accesspoint.us-east-1.amazonaws.com");
+
+    }
+
+    @Test
+    public void accessPointArn_usEast1_region_awsGlobal_useArnRegionFalse_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.AWS_GLOBAL).build();
+        String accessPointArn = "arn:aws:s3:us-east-1:12345678910:accesspoint:foobar";
+        assertThatThrownBy(() -> s3Client.listObjects(ListObjectsRequest.builder().bucket(accessPointArn).build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(USE_ARN_REGION_MESSAGE);
+    }
+
+    @Test
+    public void accessPointArn_NonFips_usGovEast1_region_FipsUsGovEast1_useArnRegionFalse() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("fips-us-gov-east-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(false).build()).build();
+        String accessPointArn = "arn:aws:s3:us-gov-east-1:123456789012:accesspoint:foobar";
+        s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build());
+        assertThat(mockHttpClient.getLastRequest().getUri().getHost())
+                .isEqualTo("foobar-123456789012.s3-accesspoint-fips.us-gov-east-1.amazonaws.com");
+    }
+
+    @Test
+    public void accessPointArn_NonFips_usGovEast1_region_FipsUsGovEast1_useArnRegionTrue() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("fips-us-gov-east-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build()).build();
+        String accessPointArn = "arn:aws:s3:us-gov-east-1:123456789012:accesspoint:foobar";
+        s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build());
+        assertThat(mockHttpClient.getLastRequest().getUri().getHost())
+                .isEqualTo("foobar-123456789012.s3-accesspoint-fips.us-gov-east-1.amazonaws.com");
+    }
+
+    @Test
+    public void accessPointArn_usGovWest1_clientRegion_FipsUsGovEast1_useArnRegionTrue_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("fips-us-gov-east-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build()).build();
+        String accessPointArn = "arn:aws:s3:us-west-1:123456789012:accesspoint:foobar";
+
+        assertThatThrownBy(() -> s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("The region field of the ARN being passed as a bucket parameter to an S3 operation does not match the region the client was configured with. Cross region access not allowed for fips region in client or arn. Provided region: 'us-west-1'; client region:'fips-us-gov-east-1'.");
+    }
+
+    @Test
+    public void accessPointArn_NonFips_usGovWest1_region_FipsUsGovEast1_useArnRegionTrue_dualStackEnabled() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("fips-us-gov-east-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).dualstackEnabled(true).build()).build();
+        String accessPointArn = "arn:aws:s3:us-gov-east-1:123456789012:accesspoint:foobar";
+        s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build());
+        assertThat(mockHttpClient.getLastRequest().getUri().getHost())
+                .isEqualTo("foobar-123456789012.s3-accesspoint-fips.dualstack.us-gov-east-1.amazonaws.com");
+    }
+
+    @Test
+    public void accessPointArnRegion_fips_clientRegion_nonFips_useArnRegionTrue_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("us-west-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build()).build();
+        String accessPointArn = "arn:aws-us-gov:s3:fips-us-gov-east-1:123456789012:accesspoint:myendpoint";
+
+        assertThatThrownBy(() -> s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN. Provided arn region: 'fips-us-gov-east-1'.");
+    }
+
+    @Test
+    public void accessPointArnRegion_fips_clientRegion_nonFips_useArnRegionFalse_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.of("us-west-1"))
+                .serviceConfiguration(S3Configuration.builder().useArnRegionEnabled(true).build()).build();
+        String accessPointArn = "arn:aws-us-gov:s3:fips-us-gov-east-1:123456789012:accesspoint:myendpoint";
+
+        assertThatThrownBy(() -> s3Client.getObject(GetObjectRequest.builder().bucket(accessPointArn).key("someKey").build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN. Provided arn region: 'fips-us-gov-east-1'.");
     }
 
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3AccessPointEndpointResolverTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3AccessPointEndpointResolverTest.java
@@ -15,21 +15,19 @@
 
 package software.amazon.awssdk.services.s3.internal.endpoints;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlEncode;
-
-import java.net.URI;
 import org.junit.Before;
 import org.junit.Test;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.internal.ConfiguredS3SdkHttpRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.utils.InterceptorTestUtils;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlEncode;
 
 public class S3AccessPointEndpointResolverTest {
 
@@ -189,45 +187,53 @@ public class S3AccessPointEndpointResolverTest {
     public void accesspointArn_withFipsRegionPrefix_noFipsInArn_shouldConvertEndpoint() {
         verifyAccesspointArn("http",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
+                             "http://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder(),
                              Region.of("fips-us-east-1"));
         verifyAccesspointArn("https",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
+                             "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder(),
                              Region.of("fips-us-east-1"));
     }
 
     @Test
-    public void accesspointArn_withFipsRegionPrefix_FipsInArn_shouldConvertEndpoint() {
-        verifyAccesspointArn("http",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder(),
-                             Region.of("fips-us-east-1"));
-        verifyAccesspointArn("https",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder(),
-                             Region.of("fips-us-east-1"));
+    public void accesspointArn_withFipsRegionPrefix_FipsInArn_throwsIllegalArgumentException() {
+
+
+        assertThatThrownBy(() -> verifyAccesspointArn("http",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "http://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder(),
+                Region.of("fips-us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
+
+        assertThatThrownBy(() -> verifyAccesspointArn("https",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder(),
+                Region.of("fips-us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
     }
 
     @Test
     public void accesspointArn_withFipsRegionPrefix_noFipsInArn_useArnRegionEnabled_shouldConvertEndpoint() {
         verifyAccesspointArn("http",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                             "http://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder().useArnRegionEnabled(true),
                              Region.of("fips-us-east-1"));
         verifyAccesspointArn("https",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                             "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder().useArnRegionEnabled(true),
                              Region.of("fips-us-east-1"));
@@ -235,22 +241,27 @@ public class S3AccessPointEndpointResolverTest {
 
 
     @Test
-    public void accesspointArn_withFipsRegionPrefix_FipsInArn_useArnRegionEnabled_shouldConvertEndpoint() {
-        verifyAccesspointArn("http",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().useArnRegionEnabled(true),
-                             Region.of("fips-us-east-1"));
-        verifyAccesspointArn("https",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().useArnRegionEnabled(true),
-                             Region.of("fips-us-east-1"));
+    public void accesspointArn_withFipsRegionPrefix_FipsInArn_useArnRegionEnabled_throwsIllegalArgumentException() {
+
+        assertThatThrownBy(() -> verifyAccesspointArn("http",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "http://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().useArnRegionEnabled(true),
+                Region.of("fips-us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
+        assertThatThrownBy(() -> verifyAccesspointArn("https",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().useArnRegionEnabled(true),
+                Region.of("fips-us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
     }
-
-
 
     @Test
     public void accesspointArn_withFipsRegionPrefix_ArnRegionNotMatches_shouldThrowIllegalArgumentException() {
@@ -276,96 +287,124 @@ public class S3AccessPointEndpointResolverTest {
     public void accesspointArn_withFipsRegionPrefix_noFipsInArn_DualstackEnabled_shouldConvertEndpoint() {
         verifyAccesspointArn("http",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.dualstack.fips-us-east-1.amazonaws.com",
+                             "http://foobar-12345678910.s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder().dualstackEnabled(true),
                              Region.of("fips-us-east-1"));
         verifyAccesspointArn("https",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.dualstack.fips-us-east-1.amazonaws.com",
+                             "https://foobar-12345678910.s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder().dualstackEnabled(true),
                              Region.of("fips-us-east-1"));
     }
 
     @Test
-    public void accesspointArn_withFipsRegionPrefix_FipsInArn_DualStackEnabled_shouldConvertEndpoint() {
-        verifyAccesspointArn("http",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.dualstack.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().dualstackEnabled(true),
-                             Region.of("fips-us-east-1"));
-        verifyAccesspointArn("https",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.dualstack.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().dualstackEnabled(true),
-                             Region.of("fips-us-east-1"));
+    public void accesspointArn_withFipsRegionPrefix_FipsInArn_DualStackEnabled_throwsIllegalArgumentException() {
+
+        assertThatThrownBy(() -> verifyAccesspointArn("http",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "http://foobar-12345678910.s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().dualstackEnabled(true),
+                Region.of("fips-us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
+        assertThatThrownBy(() -> verifyAccesspointArn("https",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "https://foobar-12345678910.s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().dualstackEnabled(true),
+                Region.of("fips-us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
     }
 
     @Test
     public void accesspointArn_withFipsRegionSuffix_noFipsinArn_shouldConvertEndpoint() {
         verifyAccesspointArn("http",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
+                             "http://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder(),
                              Region.of("us-east-1-fips"));
         verifyAccesspointArn("https",
                              "arn:aws:s3:us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
+                             "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
                              Region.of("us-east-1"),
                              S3Configuration.builder(),
                              Region.of("us-east-1-fips"));
     }
 
     @Test
-    public void accesspointArn_noFipsRegionPrefix_FipsInArn_shouldConvertEndpoint() {
-        verifyAccesspointArn("http",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder(),
-                             Region.of("us-east-1"));
-        verifyAccesspointArn("https",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder(),
-                             Region.of("us-east-1"));
+    public void accesspointArn_noFipsRegionPrefix_FipsInArn_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> verifyAccesspointArn("http",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "http://foobar-12345678910.s3-accesspoint.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder(),
+                Region.of("us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
+
+        assertThatThrownBy(() -> verifyAccesspointArn("https",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder(),
+                Region.of("us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
     }
 
     @Test
-    public void accesspointArn_noFipsRegionPrefix_FipsInArn_useArnRegionEnabled_shouldConvertEndpoint() {
-        verifyAccesspointArn("http",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().useArnRegionEnabled(true),
-                             Region.of("us-east-1"));
-        verifyAccesspointArn("https",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().useArnRegionEnabled(true),
-                             Region.of("us-east-1"));
+    public void accesspointArn_noFipsRegionPrefix_FipsInArn_useArnRegionEnabled_throwsIllegalArgumentException() {
+
+        assertThatThrownBy(() -> verifyAccesspointArn("http",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "http://foobar-12345678910.s3-accesspoint.fips-us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().useArnRegionEnabled(true),
+                Region.of("fips-us-gov-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN. Provided arn region: 'fips-us-east-1'.");
+
+
+        assertThatThrownBy(() -> verifyAccesspointArn("https",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "https://foobar-12345678910.s3-accesspoint-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().useArnRegionEnabled(true),
+                Region.of("us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN. Provided arn region: 'fips-us-east-1'.");
+
+
     }
 
     @Test
-    public void accesspointArn_noFipsRegionPrefix_FipsInArn_useArnRegionEnabled_DualstackEnabled_shouldConvertEndpoint() {
-        verifyAccesspointArn("http",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "http://foobar-12345678910.s3-accesspoint.dualstack.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().useArnRegionEnabled(true).dualstackEnabled(true),
-                             Region.of("us-east-1"));
-        verifyAccesspointArn("https",
-                             "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
-                             "https://foobar-12345678910.s3-accesspoint.dualstack.fips-us-east-1.amazonaws.com",
-                             Region.of("fips-us-east-1"),
-                             S3Configuration.builder().useArnRegionEnabled(true).dualstackEnabled(true),
-                             Region.of("us-east-1"));
+    public void accesspointArn_noFipsRegionPrefix_FipsInArn_useArnRegionEnabled_DualstackEnabled_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> verifyAccesspointArn("http",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "http://foobar-12345678910.s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().useArnRegionEnabled(true).dualstackEnabled(true),
+                Region.of("us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
+
+
+        assertThatThrownBy(() -> verifyAccesspointArn("https",
+                "arn:aws:s3:fips-us-east-1:12345678910:accesspoint/foobar",
+                "https://foobar-12345678910.s3-accesspoint.dualstack-fips.us-east-1.amazonaws.com",
+                Region.of("fips-us-east-1"),
+                S3Configuration.builder().useArnRegionEnabled(true).dualstackEnabled(true),
+                Region.of("us-east-1")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid ARN, FIPS region is not allowed in ARN.");
     }
 
     @Test

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtilsTest.java
@@ -43,14 +43,6 @@ public class S3EndpointUtilsTest {
     }
 
     @Test
-    public void isFipsRegionProvided() {
-        assertTrue(S3EndpointUtils.isFipsRegionProvided("fips-us-east-1", "us-east-1", false));
-        assertFalse(S3EndpointUtils.isFipsRegionProvided("us-east-1", "fips-us-east-1", false));
-        assertTrue(S3EndpointUtils.isFipsRegionProvided("us-east-1", "us-east-1-fips", true));
-        assertFalse(S3EndpointUtils.isFipsRegionProvided("us-east-1-fips", "us-east-1", true));
-    }
-
-    @Test
     public void isAccelerateEnabled() {
         assertFalse(S3EndpointUtils.isAccelerateEnabled(S3Configuration.builder().build()));
         assertFalse(S3EndpointUtils.isAccelerateEnabled(null));

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/S3AccessPointBuilderTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/S3AccessPointBuilderTest.java
@@ -69,7 +69,7 @@ public class S3AccessPointBuilderTest {
                                          .fipsEnabled(true)
                                          .toUri();
 
-        assertThat(result, is(URI.create("protocol://access-point-account-id.s3-accesspoint.fips-region.domain")));
+        assertThat(result, is(URI.create("protocol://access-point-account-id.s3-accesspoint-fips.region.domain")));
     }
 
     @Test

--- a/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/EndpointAddressInterceptor.java
+++ b/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/EndpointAddressInterceptor.java
@@ -85,7 +85,7 @@ public final class EndpointAddressInterceptor implements ExecutionInterceptor {
         String arnPartion = arn.partition();
         S3Resource parentS3Resource = s3Resource.parentS3Resource().orElse(null);
 
-        Validate.isTrue(!willCallFipsRegion(signingRegion, arnRegion, serviceConfig),
+        Validate.isTrue(!isFipsInvolved(signingRegion, arnRegion, serviceConfig),
                         "FIPS is not supported for outpost requests.");
 
         // Even though we validated that we're not *calling* a FIPS region, the client region may still be a FIPS region if we're
@@ -202,16 +202,12 @@ public final class EndpointAddressInterceptor implements ExecutionInterceptor {
         return executionAttributes.getAttribute(CLIENT_ENDPOINT);
     }
 
-    private boolean willCallFipsRegion(String signingRegion, String arnRegion, S3ControlConfiguration serviceConfig) {
-        if (useArnRegion(serviceConfig)) {
-            return isFipsRegion(arnRegion);
-        }
-
+    private boolean isFipsInvolved(String signingRegion, String arnRegion, S3ControlConfiguration serviceConfig) {
         if (serviceConfig.fipsModeEnabled()) {
             return true;
         }
 
-        return isFipsRegion(signingRegion);
+        return isFipsRegion(signingRegion) || isFipsRegion(arnRegion);
     }
 
     private String removeFipsIfNeeded(String region) {

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/functionaltests/arns/S3OutpostAccessPointArnTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/functionaltests/arns/S3OutpostAccessPointArnTest.java
@@ -206,35 +206,25 @@ public class S3OutpostAccessPointArnTest extends S3ControlWireMockTestBase {
 
     @Test
     public void outpostArnDifferentRegion_useArnRegionSet_shouldUseRegionFromArn() {
-
         String outpostArn = "arn:aws:s3-outposts:us-east-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint";
-
         String expectedHost = "s3-outposts.us-east-1.amazonaws.com";
         stubResponse();
-
         S3ControlClient s3WithUseArnRegion =
             initializedBuilderForAccessPoint().region(Region.of("us-west-2")).serviceConfiguration(b -> b.useArnRegionEnabled(true)).build();
-
         s3WithUseArnRegion.getAccessPoint(b -> b.name(outpostArn));
-
         verifyOutpostRequest("us-east-1", expectedHost);
     }
 
     @Test
-    public void clientFipsRegion_outpostArnDifferentRegion_useArnRegionSet_shouldUseRegionFromArn() {
+    public void clientFipsRegion_outpostArnDifferentRegion_useArnRegionTrue_throwsIllegalArgumentException() {
 
         String outpostArn = "arn:aws-us-gov:s3-outposts:us-gov-east-1:123456789012:outpost:op-01234567890123456:accesspoint"
                             + ":myaccesspoint";
-
-        String expectedHost = "s3-outposts.us-gov-east-1.amazonaws.com";
-        stubResponse();
-
         S3ControlClient s3WithUseArnRegion = initializedBuilderForAccessPoint().region(Region.of("fips-us-gov-east-1"))
                                                                                .serviceConfiguration(b -> b.useArnRegionEnabled(true)).build();
-
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("FIPS");
         s3WithUseArnRegion.getAccessPoint(b -> b.name(outpostArn));
-
-        verifyOutpostRequest("us-gov-east-1", expectedHost);
     }
 
     private S3ControlClientBuilder initializedBuilderForAccessPoint() {

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/functionaltests/arns/S3OutpostBucketArnTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/functionaltests/arns/S3OutpostBucketArnTest.java
@@ -209,16 +209,14 @@ public class S3OutpostBucketArnTest extends S3ControlWireMockTestBase {
     }
 
     @Test
-    public void fipsClientRegion_bucketArnDifferentRegion_useArnRegionSet_shouldUseRegionFromArn() {
+    public void fipsClientRegion_bucketArnDifferentRegion_useArnRegionSet_throwsIllegalArgumentException() {
         String bucketArn = "arn:aws-us-gov:s3-outposts:us-gov-east-1:123456789012:outpost:op-01234567890123456:bucket:mybucket";
         stubResponse();
-
         S3ControlClient s3WithUseArnRegion =
             initializedBuilder().region(Region.of("fips-us-gov-east-1")).serviceConfiguration(b -> b.useArnRegionEnabled(true)).build();
-
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("FIPS");
         s3WithUseArnRegion.getBucket(b -> b.bucket(bucketArn));
-
-        verifyRequest("us-gov-east-1");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Do not allow cross-region requests for Fips Enabled Client Regions


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Below are the cross region scenario and their expected behavior

 |ScenarioNo.|ClientRegion | ArnSourceRgion | useArnRegionFlag | ExpectedBehvior |
|-|-|-|-|-|
|1| Region.AWS_GLOBAL| us-east-1 |true | Success |
|2|Region.AWS_GLOBAL|us-east-1 | false |illegalArgumentException|
|3|s3-external-1 | us-east-1|true | Success| 
|4|s3-external-1 | us-east-1|false | illegalArgumentException| 
|5|fips-us-gov-east-1 | fips-us-gov-east-1|true | illegalArgumentException| 
|6|us-gov-east-1 | fips-us-gov-west-1|true | illegalArgumentException| 
|7|fips-us-gov-east-1 | us-gov-west-1|false | illegalArgumentException| 
|8|fips-us-gov-east-1 | us-gov-east-1|true | Success| 

 |ScenarioNo.|OldEndPoint | NewEndpoint | 
|-|-|-|
|1| myendpoint-123456789012.s3-accesspoint.dualstack.fips-us-gov-east-1.amazonaws.com| myendpoint-123456789012.s3-accesspoint-fips.dualstack.us-gov-east-1.amazonaws.com |
|2| myendpoint-123456789012.s3-object-lambda.fips-us-gov-east-1.amazonaws.com| myendpoint-123456789012.s3-object-lambda-fips.us-gov-east-1.amazonaws.com |





{accesspoint-name}-{account-id}.s3-accesspoint[-fips][.dualstack].{region}.{partition}


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits for above mentioned scenarios,


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
