### PR TITLE
Revert Japicmp version bump because of regression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
-        <japicmp-maven-plugin.version>0.15.3</japicmp-maven-plugin.version>
+        <japicmp-maven-plugin.version>0.14.4</japicmp-maven-plugin.version>
 
         <!-- These properties are used by Step functions for its dependencies -->
         <json-path.version>2.4.0</json-path.version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Revert Japicmp version bump

It seems starting from `0.15.0`, japicmp doesn't honor `ignoreMissingOldVersion` anymore, so the build would fail when the recently released version is not available on Maven.

