### PR TITLE
Adding New StsWebIdentityTokenFileCredentialsProvider in sts module that accepts STSClient

### DIFF
--- a/.changes/next-release/feature-AmazonSts-0c7ee68.json
+++ b/.changes/next-release/feature-AmazonSts-0c7ee68.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon STS",
+    "contributor": "", 
+    "type": "feature", 
+    "description": "New StsWebIdentityTokenFileCredentialsProvider that accepts StsClient in its create method and Builder args."
+}

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityTokenFileCredentialsProvider.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.internal;
+
+import static software.amazon.awssdk.utils.StringUtils.trim;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.internal.WebIdentityTokenCredentialProperties;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.utils.ToString;
+
+
+/**
+ * A credential provider that will read web identity token file path, aws role arn, aws session name
+ * from system properties or environment variables  and StsClient for using
+ * web identity token credentials with STS. If StsClient is not passed or null then it will use Default Sts client.
+ */
+@SdkPublicApi
+public class StsWebIdentityTokenFileCredentialsProvider implements AwsCredentialsProvider {
+
+    private final AwsCredentialsProvider credentialsProvider;
+    private final RuntimeException loadException;
+
+    private StsWebIdentityTokenFileCredentialsProvider(BuilderImpl builder) {
+        AwsCredentialsProvider credentialsProviderLocal = null;
+        RuntimeException loadExceptionLocal = null;
+
+        try {
+            Path webIdentityTokenFile =
+                builder.webIdentityTokenFile != null ? builder.webIdentityTokenFile
+                                                     : Paths.get(trim(SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE
+                                                                          .getStringValueOrThrow()));
+
+            String roleArn = builder.roleArn != null ? builder.roleArn
+                                                     : trim(SdkSystemSetting.AWS_ROLE_ARN.getStringValueOrThrow());
+
+            Optional<String> roleSessionName =
+                builder.roleSessionName != null ? Optional.of(builder.roleSessionName)
+                                                : SdkSystemSetting.AWS_ROLE_SESSION_NAME.getStringValue();
+
+            WebIdentityTokenCredentialProperties credentialProperties =
+                WebIdentityTokenCredentialProperties.builder()
+                                                    .roleArn(roleArn)
+                                                    .roleSessionName(roleSessionName.orElse(null))
+                                                    .webIdentityTokenFile(webIdentityTokenFile)
+                                                    .build();
+
+            credentialsProviderLocal = new StsWebIdentityCredentialsProviderFactory().create(credentialProperties,
+                    builder.stsClient);
+        } catch (RuntimeException e) {
+            // If we couldn't load the credentials provider for some reason, save an exception describing why. This exception
+            // will only be raised on calls to getCredentials. We don't want to raise an exception here because it may be
+            // expected (eg. in the default credential chain).
+            loadExceptionLocal = e;
+        }
+
+        this.loadException = loadExceptionLocal;
+        this.credentialsProvider = credentialsProviderLocal;
+    }
+
+    public static StsWebIdentityTokenFileCredentialsProvider create() {
+
+        return StsWebIdentityTokenFileCredentialsProvider.builder().build();
+    }
+
+    public static StsWebIdentityTokenFileCredentialsProvider create(StsClient stsClient) {
+        return StsWebIdentityTokenFileCredentialsProvider.builder().stsClient(stsClient).build();
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        if (loadException != null) {
+            throw loadException;
+        }
+        return credentialsProvider.resolveCredentials();
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.create("WebIdentityTokenCredentialsProvider");
+    }
+
+    /**
+     * A builder for creating a custom {@link StsWebIdentityTokenFileCredentialsProvider}.
+     */
+    public interface Builder {
+
+        /**
+         * Define the role arn that should be used by this credentials provider.
+         */
+        Builder roleArn(String roleArn);
+
+        /**
+         * Define the role session name that should be used by this credentials provider.
+         */
+        Builder roleSessionName(String roleSessionName);
+
+        /**
+         * Define the absolute path to the web identity token file that should be used by this credentials provider.
+         */
+        Builder webIdentityTokenFile(Path webIdentityTokenFile);
+
+
+        /**
+         * Define the StsClient that is used for accessing AWS Security Token Service.
+         */
+        Builder stsClient(StsClient stsClient);
+
+        /**
+         * Create a {@link StsWebIdentityTokenFileCredentialsProvider} using the configuration applied to this builder.
+         */
+        StsWebIdentityTokenFileCredentialsProvider build();
+    }
+
+    static final class BuilderImpl implements Builder {
+        private String roleArn;
+        private String roleSessionName;
+        private Path webIdentityTokenFile;
+        private StsClient stsClient;
+
+        BuilderImpl() {
+        }
+
+        @Override
+        public Builder roleArn(String roleArn) {
+            this.roleArn = roleArn;
+            return this;
+        }
+
+        public void setRoleArn(String roleArn) {
+            roleArn(roleArn);
+        }
+
+        @Override
+        public Builder roleSessionName(String roleSessionName) {
+            this.roleSessionName = roleSessionName;
+            return this;
+        }
+
+        public void setRoleSessionName(String roleSessionName) {
+            roleSessionName(roleSessionName);
+        }
+
+        @Override
+        public Builder webIdentityTokenFile(Path webIdentityTokenFile) {
+            this.webIdentityTokenFile = webIdentityTokenFile;
+            return this;
+        }
+
+        public void setWebIdentityTokenFile(Path webIdentityTokenFile) {
+            webIdentityTokenFile(webIdentityTokenFile);
+        }
+
+        @Override
+        public Builder stsClient(StsClient stsClient) {
+            this.stsClient = stsClient;
+            return this;
+        }
+
+        public void setStsClient(StsClient stsClient) {
+            this.stsClient = stsClient;
+        }
+
+        @Override
+        public StsWebIdentityTokenFileCredentialsProvider build() {
+            return new StsWebIdentityTokenFileCredentialsProvider(this);
+        }
+    }
+}

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityTokenCredentialProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/StsWebIdentityTokenCredentialProviderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StsWebIdentityTokenCredentialProviderTest {
+
+    @Mock
+    StsClient stsClient;
+
+    @Test
+    public void createAssumeRoleWithWebIdentityTokenCredentialsProviderWithoutStsClient() {
+
+        String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
+        System.setProperty("aws.roleArn", "someRole");
+        System.setProperty("aws.webIdentityTokenFile", webIdentityTokenPath);
+        System.setProperty("aws.roleSessionName", "tempRoleSession");
+        StsWebIdentityTokenFileCredentialsProvider provider =
+                StsWebIdentityTokenFileCredentialsProvider.create();
+        Assert.assertNotNull(provider);
+    }
+
+    @Test
+    public void createAssumeRoleWithWebIdentityTokenCredentialsProviderCreateStsClient() {
+        String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
+        System.setProperty("aws.roleArn", "someRole");
+        System.setProperty("aws.webIdentityTokenFile", webIdentityTokenPath);
+        System.setProperty("aws.roleSessionName", "/src/test/token.jwt");
+        StsWebIdentityTokenFileCredentialsProvider provider =
+                StsWebIdentityTokenFileCredentialsProvider.create(stsClient);
+        when(stsClient.assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class)))
+                .thenReturn(AssumeRoleWithWebIdentityResponse.builder()
+                        .credentials(Credentials.builder().accessKeyId("key")
+                                .expiration(Instant.now())
+                                .sessionToken("session").secretAccessKey("secret").build()).build());
+        provider.resolveCredentials();
+        Mockito.verify(stsClient, Mockito.times(1)).assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class));
+    }
+
+    @Test
+    public void createAssumeRoleWithWebIdentityTokenCredentialsProviderStsClientBuilder() {
+
+        String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
+        StsWebIdentityTokenFileCredentialsProvider provider =
+                StsWebIdentityTokenFileCredentialsProvider.builder().stsClient(stsClient)
+                        .roleArn("someRole")
+                        .webIdentityTokenFile(Paths.get(webIdentityTokenPath))
+                        .roleSessionName("tempRoleSession")
+                        .build();
+
+        when(stsClient.assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class)))
+                .thenReturn(AssumeRoleWithWebIdentityResponse.builder()
+                        .credentials(Credentials.builder().accessKeyId("key")
+                                .expiration(Instant.now())
+                                .sessionToken("session").secretAccessKey("secret").build()).build());
+        provider.resolveCredentials();
+        Mockito.verify(stsClient, Mockito.times(1)).assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class));
+    }
+}


### PR DESCRIPTION
Adding New WebIdentityTokenFileCredentialsProvider  in sts that accepts STSClient

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Currently the WebIdentityTokenFileCredentialsProvider is in core module and it creates AwsCredentialsProvider with Default Sts Client.
- We cannot modify the [WebIdentityTokenCredentialsProviderFactory](https://github.com/aws/aws-sdk-java-v2/blob/584ccb59e770177aeaa4c3b6bda4e24015b8ece9/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenCredentialsProviderFactory.java) because  the interface is marked as @FunctionalInterface  and also StsClient is not available in core package so would need to pass SdkClient which would be confusing.
- Thus we have added a new WebIdentityTokenFileCredentialsProvider in Sts module and named it as StsWebIdentityTokenFileCredentialsProvider

### Usage

1. Credential provider that will read web identity token file path, aws role arn, aws session name from system properties or environment variables And DefaultStsClient
 ```
 StsWebIdentityTokenFileCredentialsProvider.create();
 ```

2. Credential provider that will read web identity token file path, aws role arn, aws session name from system properties or environment variables And StsClient will be used as it is passed in the constructor.

 ```
 StsWebIdentityTokenFileCredentialsProvider.create(stsClient);
 ```


3 . Credential provider that will read web identity token file path, aws role arn, aws session name from Builders And StsClient will be used as it is passed in the Builder.
 ```
                StsWebIdentityTokenFileCredentialsProvider.builder()
                        .stsClient(stsClient)
                        .roleArn("someRole")
                        .webIdentityTokenFile(Paths.get(webIdentityTokenPath))
                        .roleSessionName("tempRoleSession")
                        .build();
 ```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Please refer Pr #1881 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added JUnit Test cases.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
