### PR TITLE
Update getCanonicalizedHeaderString to follow SigV4 spec

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-74f2d55.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-74f2d55.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "skrueger", 
+    "type": "bugfix", 
+    "description": "Fix bug in SigV4 canonical request creation to handle multiple header values and leading & trailing whitespace in header values correctly."
+}

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4SignerTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/signer/internal/AbstractAws4SignerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer.internal;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractAws4SignerTest {
+
+    @Test
+    public void testAppendCompactedString() {
+        StringBuilder destination = new StringBuilder();
+        AbstractAws4Signer.appendCompactedString(destination, "    a   b   c  ");
+        String expected = "a b c";
+        assertEquals(expected, destination.toString());
+    }
+
+    @Test
+    public void testGetCanonicalizedHeaderString_SpecExample() {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("Host", Arrays.asList("iam.amazonaws.com"));
+        headers.put("Content-Type", Arrays.asList("application/x-www-form-urlencoded; charset=utf-8"));
+        headers.put("My-header1", Arrays.asList("    a   b   c  "));
+        headers.put("X-Amz-Date", Arrays.asList("20150830T123600Z"));
+        headers.put("My-Header2", Arrays.asList("    \"a   b   c\"  "));
+
+        Map<String, List<String>> canonicalizeSigningHeaders =
+                AbstractAws4Signer.canonicalizeSigningHeaders(headers);
+
+        String actual = AbstractAws4Signer.getCanonicalizedHeaderString(canonicalizeSigningHeaders);
+
+        String expected = String.join("\n",
+                "content-type:application/x-www-form-urlencoded; charset=utf-8",
+                "host:iam.amazonaws.com",
+                "my-header1:a b c",
+                "my-header2:\"a b c\"",
+                "x-amz-date:20150830T123600Z",
+                "");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetCanonicalizedHeaderString_MultipleHeaderValuess() {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("Host", Arrays.asList("iam.amazonaws.com"));
+        headers.put("Content-Type", Arrays.asList("application/x-www-form-urlencoded; charset=utf-8"));
+        headers.put("My-header1", Arrays.asList("    a   b   c  "));
+        headers.put("X-Amz-Date", Arrays.asList("20150830T123600Z"));
+        headers.put("My-Header1", Arrays.asList("    \"a   b   c\"  "));
+
+        Map<String, List<String>> canonicalizeSigningHeaders =
+                AbstractAws4Signer.canonicalizeSigningHeaders(headers);
+
+        String actual = AbstractAws4Signer.getCanonicalizedHeaderString(canonicalizeSigningHeaders);
+
+        String expected = String.join("\n",
+                "content-type:application/x-www-form-urlencoded; charset=utf-8",
+                "host:iam.amazonaws.com",
+                "my-header1:a b c,\"a b c\"",
+                "x-amz-date:20150830T123600Z",
+                "");
+
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
- Update to handle leading and trailing whitespace in header value
- Update to handle multiple header values

See Step 4 of https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
                                                                                                                         
Without this change a request to S3 with multiple header values or
a header value with leading and trailing spaces
(e.g.,
```
Header1: Cat\n
Header1: Dog\n
Header2:     "a   b   c"  \n
```
)
that is signed by the `AwsS3V4Signer` will receive a 403 Forbidden
response with an Error Code of SignatureDoesNotMatch from S3.


## Description
Currently my HTTP requests that contain multiple values for a specific header are receiving an 403 Forbidden response from S3 with an Error Code of `SignatureDoesNotMatch`. The S3's response would also return code would return the expected `<CanonicalRequest>`, which lead me to solving the issue.

## Motivation and Context
My requests to S3 are failing because the library does not correctly follow the SigV4 spec.

## Testing
* Added Unit Tests that cover the example given in the [SigV4 instructions on the AWS documentation website](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html), and also a test that covers multiple header values.
* Tested locally by sending requests to S3

## Screenshots

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
