### PR TITLE
DynamoDB Enhanced: Adds support for configuring the ReturnValue for PutItem and UpdateItem

### DIFF
--- a/.changes/feature-AWSDynamoDBEnhanced-2283.json
+++ b/.changes/feature-AWSDynamoDBEnhanced-2283.json
@@ -1,0 +1,6 @@
+{
+  "category": "DynamoDB Enhanced Client",
+  "contributor": "marcdejonge",
+  "type": "feature",
+  "description": "Adds the option to change the ReturnValue for PutItemEnhancedRequest and UpdateItemEnhancedRequest."
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbAsyncTable.java
@@ -460,9 +460,10 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      *
      * @param request A {@link PutItemEnhancedRequest} that includes the item to enter into
      * the table, its class and optional directives.
-     * @return a {@link CompletableFuture} that returns no results which will complete when the operation is done.
+     * @return a {@link CompletableFuture} that returns the old return value if requested so (or null of not),
+     *         which will complete when the operation is done.
      */
-    default CompletableFuture<Void> putItem(PutItemEnhancedRequest<T> request) {
+    default CompletableFuture<T> putItem(PutItemEnhancedRequest<T> request) {
         throw new UnsupportedOperationException();
     }
 
@@ -486,9 +487,10 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      *
      * @param requestConsumer A {@link Consumer} of {@link PutItemEnhancedRequest.Builder} that includes the item
      * to enter into the table, its class and optional directives.
-     * @return a {@link CompletableFuture} that returns no results which will complete when the operation is done.
+     * @return a {@link CompletableFuture} that returns the old return value if requested so (or null of not),
+     *         which will complete when the operation is done.
      */
-    default CompletableFuture<Void> putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
+    default CompletableFuture<T> putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
@@ -508,9 +510,10 @@ public interface DynamoDbAsyncTable<T> extends MappedTableResource<T> {
      * </pre>
      *
      * @param item the modelled item to be inserted into or overwritten in the database table.
-     * @return a {@link CompletableFuture} that returns no results which will complete when the operation is done.
+     * @return a {@link CompletableFuture} that returns the old return value if requested so (or null of not),
+     *         which will complete when the operation is done.
      */
-    default CompletableFuture<Void> putItem(T item) {
+    default CompletableFuture<T> putItem(T item) {
         throw new UnsupportedOperationException();
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DynamoDbTable.java
@@ -444,8 +444,9 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      *
      * @param request A {@link PutItemEnhancedRequest} that includes the item to enter into
      * the table, its class and optional directives.
+     * @return The old return value if requested so, otherwise null
      */
-    default void putItem(PutItemEnhancedRequest<T> request) {
+    default T putItem(PutItemEnhancedRequest<T> request) {
         throw new UnsupportedOperationException();
     }
 
@@ -469,8 +470,9 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      *
      * @param requestConsumer A {@link Consumer} of {@link PutItemEnhancedRequest.Builder} that includes the item
      * to enter into the table, its class and optional directives.
+     * @return The old return value if requested so, otherwise null
      */
-    default void putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
+    default T putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
         throw new UnsupportedOperationException();
     }
 
@@ -490,8 +492,9 @@ public interface DynamoDbTable<T> extends MappedTableResource<T> {
      * </pre>
      *
      * @param item the modelled item to be inserted into or overwritten in the database table.
+     * @return The old return value if requested so, otherwise null
      */
-    default void putItem(T item) {
+    default T putItem(T item) {
         throw new UnsupportedOperationException();
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbAsyncTable.java
@@ -173,13 +173,13 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
     }
 
     @Override
-    public CompletableFuture<Void> putItem(PutItemEnhancedRequest<T> request) {
-        TableOperation<T, ?, ?, Void> operation = PutItemOperation.create(request);
+    public CompletableFuture<T> putItem(PutItemEnhancedRequest<T> request) {
+        TableOperation<T, ?, ?, T> operation = PutItemOperation.create(request);
         return operation.executeOnPrimaryIndexAsync(tableSchema, tableName, extension, dynamoDbClient);
     }
 
     @Override
-    public CompletableFuture<Void> putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
+    public CompletableFuture<T> putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
         PutItemEnhancedRequest.Builder<T> builder =
             PutItemEnhancedRequest.builder(this.tableSchema.itemType().rawClass());
         requestConsumer.accept(builder);
@@ -187,7 +187,7 @@ public final class DefaultDynamoDbAsyncTable<T> implements DynamoDbAsyncTable<T>
     }
 
     @Override
-    public CompletableFuture<Void> putItem(T item) {
+    public CompletableFuture<T> putItem(T item) {
         return putItem(r -> r.item(item));
     }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/client/DefaultDynamoDbTable.java
@@ -175,22 +175,22 @@ public class DefaultDynamoDbTable<T> implements DynamoDbTable<T> {
     }
 
     @Override
-    public void putItem(PutItemEnhancedRequest<T> request) {
-        TableOperation<T, ?, ?, Void> operation = PutItemOperation.create(request);
-        operation.executeOnPrimaryIndex(tableSchema, tableName, extension, dynamoDbClient);
+    public T putItem(PutItemEnhancedRequest<T> request) {
+        TableOperation<T, ?, ?, T> operation = PutItemOperation.create(request);
+        return operation.executeOnPrimaryIndex(tableSchema, tableName, extension, dynamoDbClient);
     }
 
     @Override
-    public void putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
+    public T putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
         PutItemEnhancedRequest.Builder<T> builder =
             PutItemEnhancedRequest.builder(this.tableSchema.itemType().rawClass());
         requestConsumer.accept(builder);
-        putItem(builder.build());
+        return putItem(builder.build());
     }
 
     @Override
-    public void putItem(T item) {
-        putItem(r -> r.item(item));
+    public T putItem(T item) {
+        return putItem(r -> r.item(item));
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
@@ -31,7 +31,13 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.DefaultDynam
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.Put;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
 @SdkInternalApi
 public class PutItemOperation<T>
@@ -83,7 +89,7 @@ public class PutItemOperation<T>
                                                               .tableName(operationContext.tableName())
                                                               .item(itemMap);
 
-        if(request.returnValue() != null) {
+        if (request.returnValue() != null) {
             requestBuilder = requestBuilder.returnValues(request.returnValue());
         }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
@@ -85,8 +85,11 @@ public class PutItemOperation<T>
 
         PutItemRequest.Builder requestBuilder = PutItemRequest.builder()
                                                               .tableName(operationContext.tableName())
-                                                              .item(itemMap)
-                                                              .returnValues(request.returnValue());
+                                                              .item(itemMap);
+
+        if(request.returnValue() != null) {
+            requestBuilder = requestBuilder.returnValues(request.returnValue());
+        }
 
         requestBuilder = addExpressionsIfExist(requestBuilder, transformation);
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java
@@ -85,7 +85,8 @@ public class PutItemOperation<T>
 
         PutItemRequest.Builder requestBuilder = PutItemRequest.builder()
                                                               .tableName(operationContext.tableName())
-                                                              .item(itemMap);
+                                                              .item(itemMap)
+                                                              .returnValues(request.returnValue());
 
         requestBuilder = addExpressionsIfExist(requestBuilder, transformation);
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperation.java
@@ -41,7 +41,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 import software.amazon.awssdk.services.dynamodb.model.Update;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
@@ -104,7 +103,7 @@ public class UpdateItemOperation<T>
         UpdateItemRequest.Builder requestBuilder = UpdateItemRequest.builder()
             .tableName(operationContext.tableName())
             .key(keyAttributeValues)
-            .returnValues(ReturnValue.ALL_NEW);
+            .returnValues(request.returnValue());
 
         Map<String, AttributeValue> filteredAttributeValues = itemMap.entrySet().stream()
             .filter(entry -> !primaryKeys.contains(entry.getKey()))

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
-import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -116,7 +115,6 @@ public final class PutItemEnhancedRequest<T> {
         private ReturnValue returnValue;
 
         private Builder() {
-            returnValue = ReturnValue.ALL_NEW;
         }
 
         /**
@@ -145,7 +143,8 @@ public final class PutItemEnhancedRequest<T> {
         }
 
         /**
-         *  Sets what the update operation should return. By default, the value is ALL_NEW.
+         *  Sets what the update operation should return. When set to null (which is also the default), this value will
+         *  not be added in the request.
          *  <p>
          *  See {@link ReturnValue} for the types that are possible.
          *
@@ -153,7 +152,6 @@ public final class PutItemEnhancedRequest<T> {
          * @return a builder of this type
          */
         public Builder<T> returnValue(ReturnValue returnValue) {
-            Objects.requireNonNull(returnValue, "returnValue can not be null");
             this.returnValue = returnValue;
             return this;
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
@@ -15,13 +15,12 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
-
-import java.util.Objects;
 
 /**
  * Defines parameters used to write an item to a DynamoDb table using the putItem() operation (such as
@@ -58,7 +57,7 @@ public final class PutItemEnhancedRequest<T> {
      * Returns a builder initialized with all existing values on the request object.
      */
     public Builder<T> toBuilder() {
-        return new Builder<T>().item(item).conditionExpression(conditionExpression);
+        return new Builder<T>().item(item).conditionExpression(conditionExpression).returnValue(returnValue);
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequest.java
@@ -19,6 +19,9 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+
+import java.util.Objects;
 
 /**
  * Defines parameters used to write an item to a DynamoDb table using the putItem() operation (such as
@@ -32,10 +35,12 @@ public final class PutItemEnhancedRequest<T> {
 
     private final T item;
     private final Expression conditionExpression;
+    private final ReturnValue returnValue;
 
     private PutItemEnhancedRequest(Builder<T> builder) {
         this.item = builder.item;
         this.conditionExpression = builder.conditionExpression;
+        this.returnValue = builder.returnValue;
     }
 
     /**
@@ -64,6 +69,13 @@ public final class PutItemEnhancedRequest<T> {
     }
 
     /**
+     * Returns if the put operation should return the data before the update or after the update.
+     */
+    public ReturnValue returnValue() {
+        return returnValue;
+    }
+
+    /**
      * Returns the condition {@link Expression} set on this request object, or null if it doesn't exist.
      */
     public Expression conditionExpression() {
@@ -81,12 +93,17 @@ public final class PutItemEnhancedRequest<T> {
 
         PutItemEnhancedRequest<?> putItem = (PutItemEnhancedRequest<?>) o;
 
+        if (returnValue != null ? ! returnValue.equals(putItem.returnValue) : putItem.returnValue != null) {
+            return false;
+        }
         return item != null ? item.equals(putItem.item) : putItem.item == null;
     }
 
     @Override
     public int hashCode() {
-        return item != null ? item.hashCode() : 0;
+        int result = item != null ? item.hashCode() : 0;
+        result = 31 * result + (returnValue != null ? returnValue.hashCode() : 0);
+        return result;
     }
 
     /**
@@ -97,8 +114,10 @@ public final class PutItemEnhancedRequest<T> {
     public static final class Builder<T> {
         private T item;
         private Expression conditionExpression;
+        private ReturnValue returnValue;
 
         private Builder() {
+            returnValue = ReturnValue.ALL_NEW;
         }
 
         /**
@@ -123,6 +142,20 @@ public final class PutItemEnhancedRequest<T> {
          */
         public Builder<T> conditionExpression(Expression conditionExpression) {
             this.conditionExpression = conditionExpression;
+            return this;
+        }
+
+        /**
+         *  Sets what the update operation should return. By default, the value is ALL_NEW.
+         *  <p>
+         *  See {@link ReturnValue} for the types that are possible.
+         *
+         * @param returnValue the return value
+         * @return a builder of this type
+         */
+        public Builder<T> returnValue(ReturnValue returnValue) {
+            Objects.requireNonNull(returnValue, "returnValue can not be null");
+            this.returnValue = returnValue;
             return this;
         }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
@@ -19,6 +19,9 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+
+import java.util.Objects;
 
 /**
  * Defines parameters used to update an item to a DynamoDb table using the updateItem() operation (such as
@@ -35,11 +38,13 @@ public final class UpdateItemEnhancedRequest<T> {
     private final T item;
     private final Boolean ignoreNulls;
     private final Expression conditionExpression;
+    private final ReturnValue returnValue;
 
     private UpdateItemEnhancedRequest(Builder<T> builder) {
         this.item = builder.item;
         this.ignoreNulls = builder.ignoreNulls;
         this.conditionExpression = builder.conditionExpression;
+        this.returnValue = builder.returnValue;
     }
 
     /**
@@ -57,7 +62,7 @@ public final class UpdateItemEnhancedRequest<T> {
      * Returns a builder initialized with all existing values on the request object.
      */
     public Builder<T> toBuilder() {
-        return new Builder<T>().item(item).ignoreNulls(ignoreNulls);
+        return new Builder<T>().item(item).ignoreNulls(ignoreNulls).returnValue(returnValue);
     }
 
     /**
@@ -81,6 +86,13 @@ public final class UpdateItemEnhancedRequest<T> {
         return conditionExpression;
     }
 
+    /**
+     * Returns if the update operation should return the data before the update or after the update.
+     */
+    public ReturnValue returnValue() {
+        return returnValue;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -95,6 +107,9 @@ public final class UpdateItemEnhancedRequest<T> {
         if (item != null ? ! item.equals(that.item) : that.item != null) {
             return false;
         }
+        if (returnValue != null ? ! returnValue.equals(that.returnValue) : that.returnValue != null) {
+            return false;
+        }
         return ignoreNulls != null ? ignoreNulls.equals(that.ignoreNulls) : that.ignoreNulls == null;
     }
 
@@ -102,6 +117,7 @@ public final class UpdateItemEnhancedRequest<T> {
     public int hashCode() {
         int result = item != null ? item.hashCode() : 0;
         result = 31 * result + (ignoreNulls != null ? ignoreNulls.hashCode() : 0);
+        result = 31 * result + (returnValue != null ? returnValue.hashCode() : 0);
         return result;
     }
 
@@ -114,8 +130,10 @@ public final class UpdateItemEnhancedRequest<T> {
         private T item;
         private Boolean ignoreNulls;
         private Expression conditionExpression;
+        private ReturnValue returnValue;
 
         private Builder() {
+            returnValue = ReturnValue.ALL_NEW;
         }
 
         /**
@@ -144,6 +162,20 @@ public final class UpdateItemEnhancedRequest<T> {
          */
         public Builder<T> conditionExpression(Expression conditionExpression) {
             this.conditionExpression = conditionExpression;
+            return this;
+        }
+
+        /**
+         *  Sets what the update operation should return. By default, the value is ALL_NEW.
+         *  <p>
+         *  See {@link ReturnValue} for the types that are possible.
+         *
+         * @param returnValue the return value
+         * @return a builder of this type
+         */
+        public Builder<T> returnValue(ReturnValue returnValue) {
+            Objects.requireNonNull(returnValue, "returnValue can not be null");
+            this.returnValue = returnValue;
             return this;
         }
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequest.java
@@ -15,13 +15,12 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.model;
 
+import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
-
-import java.util.Objects;
 
 /**
  * Defines parameters used to update an item to a DynamoDb table using the updateItem() operation (such as

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/EmptyBinaryTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/EmptyBinaryTest.java
@@ -36,13 +36,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
-import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EmptyBinaryTest {
@@ -94,6 +88,9 @@ public class EmptyBinaryTest {
         TestBean testBean = new TestBean();
         testBean.setId("id123");
         testBean.setB(EMPTY_BYTES);
+
+        PutItemResponse response = PutItemResponse.builder().build();
+        when(mockDynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(response);
 
         dynamoDbTable.putItem(testBean);
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/EmptyStringTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/EmptyStringTest.java
@@ -35,13 +35,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
-import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EmptyStringTest {
@@ -92,6 +86,9 @@ public class EmptyStringTest {
         TestBean testBean = new TestBean();
         testBean.setId("id123");
         testBean.setS("");
+
+        PutItemResponse response = PutItemResponse.builder().build();
+        when(mockDynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(response);
 
         dynamoDbTable.putItem(testBean);
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperationTest.java
@@ -359,6 +359,41 @@ public class UpdateItemOperationTest {
     }
 
     @Test
+    public void generateRequest_canSetReturnValue() {
+        FakeItemWithSort item = createUniqueFakeItemWithSort();
+        item.setOtherAttribute1("value-1");
+        UpdateItemOperation<FakeItemWithSort> updateItemOperation =
+                UpdateItemOperation.create(UpdateItemEnhancedRequest.builder(FakeItemWithSort.class)
+                        .item(item)
+                        .returnValue(ReturnValue.NONE)
+                        .build());
+        Map<String, AttributeValue> expectedKey = new HashMap<>();
+        expectedKey.put("id", AttributeValue.builder().s(item.getId()).build());
+        expectedKey.put("sort", AttributeValue.builder().s(item.getSort()).build());
+        Map<String, AttributeValue> expectedValues =
+                singletonMap(OTHER_ATTRIBUTE_1_VALUE, AttributeValue.builder().s("value-1").build());
+        Map<String, String> expectedNames = new HashMap<>();
+        expectedNames.put(OTHER_ATTRIBUTE_1_NAME, "other_attribute_1");
+        expectedNames.put(OTHER_ATTRIBUTE_2_NAME, "other_attribute_2");
+        UpdateItemRequest expectedRequest = UpdateItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .updateExpression("SET " + OTHER_ATTRIBUTE_1_NAME + " = " + OTHER_ATTRIBUTE_1_VALUE +
+                                  " REMOVE " + OTHER_ATTRIBUTE_2_NAME)
+                .expressionAttributeValues(expectedValues)
+                .expressionAttributeNames(expectedNames)
+                .key(expectedKey)
+                .returnValues(ReturnValue.NONE)
+                .build();
+
+
+        UpdateItemRequest request = updateItemOperation.generateRequest(FakeItemWithSort.getTableSchema(),
+                PRIMARY_CONTEXT,
+                null);
+
+        assertThat(request, is(expectedRequest));
+    }
+
+    @Test
     public void generateRequest_keyOnlyItem() {
         FakeItemWithSort item = createUniqueFakeItemWithSort();
         UpdateItemOperation<FakeItemWithSort> updateItemOperation =

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/PutItemEnhancedRequestTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PutItemEnhancedRequestTest {
@@ -53,10 +54,12 @@ public class PutItemEnhancedRequestTest {
         PutItemEnhancedRequest<FakeItem> builtObject = PutItemEnhancedRequest.builder(FakeItem.class)
                                                                              .item(fakeItem)
                                                                              .conditionExpression(conditionExpression)
+                                                                             .returnValue(ReturnValue.NONE)
                                                                              .build();
 
         assertThat(builtObject.item(), is(fakeItem));
         assertThat(builtObject.conditionExpression(), is(conditionExpression));
+        assertThat(builtObject.returnValue(), is(ReturnValue.NONE));
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequestTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/model/UpdateItemEnhancedRequestTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateItemEnhancedRequestTest {
@@ -55,11 +56,13 @@ public class UpdateItemEnhancedRequestTest {
                                                                                    .item(fakeItem)
                                                                                    .ignoreNulls(true)
                                                                                    .conditionExpression(conditionExpression)
+                                                                                   .returnValue(ReturnValue.UPDATED_NEW)
                                                                                    .build();
 
         assertThat(builtObject.item(), is(fakeItem));
         assertThat(builtObject.ignoreNulls(), is(true));
         assertThat(builtObject.conditionExpression(), is(conditionExpression));
+        assertThat(builtObject.returnValue(), is(ReturnValue.UPDATED_NEW));
     }
 
     @Test


### PR DESCRIPTION
Adds support for configuring the ReturnValue for PutItem and UpdateItem

## Description
When executing a PutItem or UpdateItem request, there is an option to change the return value. This can be useful in many situation, for example to see what the values were before the change was applied.

## Motivation and Context
#2283 

In our project, we'd like to execute an UpdateItem while only getting the old values back of fields that have actually changed. With the current enhanced client this is actually not possible. That's why this change is needed.

## Testing
- Added a Unit test for the Request themselves
- Added a Unit test for the relevant Operation object
- Manually tried out the change in a personal project

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
