### PR TITLE
Fix for Marshalling List/Map of TimeStamps

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-b9a56b9.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-b9a56b9.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix for NullPointerException while Marshalling List/Map of TimeStamps"
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java
@@ -105,7 +105,7 @@ public final class SimpleTypeJsonMarshaller {
         if (paramName != null) {
             jsonGenerator.writeFieldName(paramName);
         }
-        TimestampFormatTrait trait = sdkField.getTrait(TimestampFormatTrait.class);
+        TimestampFormatTrait trait = sdkField != null ? sdkField.getTrait(TimestampFormatTrait.class) : null;
         if (trait != null) {
             switch (trait.format()) {
                 case UNIX_TIMESTAMP:

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/json-core-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/json-core-input.json
@@ -474,5 +474,45 @@
         }
       }
     }
+  },
+  {
+    "description": "TimeStampMap member in the payload is marshalled as seconds with millisecond precision",
+    "given": {
+      "input": {
+        "MapOfTimeStamp": {
+          "key1": 1422172801123
+        }
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "serializedAs": {
+        "body": {
+          "jsonEquals":"{\"MapOfTimeStamp\": {\"key1\": 1422172801.123}}"
+        }
+      }
+    }
+  },
+  {
+    "description": "TimestampList member in the payload is marshalled as seconds with millisecond precision",
+    "given": {
+      "input": {
+        "ListOfTimeStamp": [1422172801123]
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "serializedAs": {
+        "body": {
+          "jsonEquals": "{\"ListOfTimeStamp\": [1422172801.123]}"
+        }
+      }
+    }
   }
 ]

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/json-core-output.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/json-core-output.json
@@ -525,5 +525,43 @@
 	      ]
 	  }
       }
+  },
+  {
+    "description": "ListOfTimeStamp  with known values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"ListOfTimeStamp\": [1398796238.123]}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "ListOfTimeStamp": [1398796238123]
+      }
+    }
+  },
+  {
+    "description": "MapOfTimeStamp with known values unmarshalled correctly",
+    "given": {
+      "response": {
+        "status_code": 200,
+        "body": "{\"MapOfTimeStamp\": { \"key1\": 1398796238.123}}"
+      }
+    },
+    "when": {
+      "action": "unmarshall",
+      "operation": "AllTypes"
+    },
+    "then": {
+      "deserializedAs": {
+        "MapOfTimeStamp": {
+          "key1": 1398796238123
+        }
+      }
+    }
   }
 ]

--- a/test/protocol-tests/src/main/resources/codegen-resources/awsjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/awsjson/service-2.json
@@ -91,7 +91,9 @@
         "PolymorphicTypeWithoutSubTypes":{"shape":"SubTypeOne"},
         "EnumMember":{"shape":"EnumType"},
         "ListOfEnums":{"shape":"ListOfEnums"},
-        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"}
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
+        "ListOfTimeStamp":{"shape":"ListOfTimeStamp"},
+        "MapOfTimeStamp":{"shape":"MapOfTimeStamp"}
       }
     },
     "BaseType":{
@@ -294,6 +296,15 @@
         "SubTypeOneMember":{"shape":"String"}
       }
     },
-    "Timestamp":{"type":"timestamp"}
+    "Timestamp":{"type":"timestamp"},
+    "ListOfTimeStamp":{
+      "type":"list",
+      "member":{"shape":"Timestamp"}
+    },
+    "MapOfTimeStamp":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"Timestamp"}
+    }
   }
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/service-2.json
@@ -239,7 +239,9 @@
         "PolymorphicTypeWithoutSubTypes":{"shape":"SubTypeOne"},
         "EnumMember":{"shape":"EnumType"},
         "ListOfEnums":{"shape":"ListOfEnums"},
-        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"}
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
+        "ListOfTimeStamp":{"shape":"ListOfTimeStamp"},
+        "MapOfTimeStamp":{"shape":"MapOfTimeStamp"}
       }
     },
     "BaseType":{
@@ -753,6 +755,15 @@
       }
     },
     "Timestamp":{"type":"timestamp"},
+    "ListOfTimeStamp":{
+      "type":"list",
+      "member":{"shape":"Timestamp"}
+    },
+    "MapOfTimeStamp":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"Timestamp"}
+    },
     "EventStreamOperationRequest": {
       "type": "structure",
       "required": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- NullPointerException from SimpleTypeJsonMarshaller while Unmarshailling Timestamps
- This was happening because the SdkField is not passed for  List Of Timestamps Refer [JsonMarshallerContext](https://github.com/aws/aws-sdk-java-v2/blob/cdfb7d3f6a7dafb37be84f6e95e49feb0d0af273/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonMarshallerContext.java#L80) which is called from [LIST Marshaller](https://github.com/aws/aws-sdk-java-v2/blob/cdfb7d3f6a7dafb37be84f6e95e49feb0d0af273/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java#L146)

- We are keeping the behaviuor same as V1 where we default to unixTimeStamp if MarshellerInfo is not found for TimeStamp Value. Refer [SimpleTypeJsonMarshallers Of V1](https://github.com/aws/aws-sdk-java/blob/1c94d1504753629995764231a311f787d42a9c8c/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/internal/SimpleTypeJsonMarshallers.java#L117-L120)


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added test case for
1. Marshaling/UnMarshaling of List and Maps with Timestamps
2. Tested by sending CreateAnalysis Request to  QuickSight service  call with List of  Parameters DateAttributes list.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x ] I confirm that this pull request can be released under the Apache 2 license
