### PR TITLE
Support customization of contentTypeOverride for Header ContentType

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-3f3c0e0.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-3f3c0e0.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix for PR [#2510](https://github.com/aws/aws-sdk-java-v2/issues/2510) by adding Support for customization of contentType for Header ContentType for services like aws WellArchitected service."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/MetadataConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/MetadataConfig.java
@@ -32,6 +32,11 @@ public class MetadataConfig {
         this.protocol = protocol;
     }
 
+    /**
+     * Gets the Custom value for Content Type Header.
+     * This customization is supported only for JSON protocol.
+     * @return contentType.
+     */
     public String getContentType() {
         return contentType;
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.awscore.eventstream.EventStreamAsyncResponseTransf
 import software.amazon.awssdk.awscore.eventstream.EventStreamTaggedUnionPojoSupplier;
 import software.amazon.awssdk.awscore.eventstream.RestEventStreamAsyncResponseTransformer;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.codegen.model.config.customization.MetadataConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.Metadata;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -94,8 +95,13 @@ public class JsonProtocolSpec implements ProtocolSpec {
                       .addCode(".protocolVersion($S)\n", metadata.getJsonVersion())
                       .addCode("$L", customErrorCodeFieldName());
 
-        if (metadata.getContentType() != null) {
-            methodSpec.addCode(".withContentTypeOverride($S)", metadata.getContentType());
+
+        String contentType = Optional.ofNullable(model.getCustomizationConfig().getCustomServiceMetadata())
+                .map(MetadataConfig::getContentType)
+                .orElse(metadata.getContentType());
+
+        if (contentType != null) {
+            methodSpec.addCode(".contentType($S)", contentType);
         }
 
         registerModeledExceptions(model, poetExtensions).forEach(methodSpec::addCode);

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -85,6 +85,18 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel customContentTypeModels() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/customservicemetadata/service-2.json").getFile());
+        File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/customservicemetadata/customization.config").getFile());
+
+        C2jModels models = C2jModels.builder()
+                .serviceModel(getServiceModel(serviceModel))
+                .customizationConfig(getCustomizationConfig(customizationModel))
+                .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     public static IntermediateModel internalConfigModels() {
         File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/internalconfig/service-2.json").getFile());
         File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/internalconfig/customization.config").getFile());

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
@@ -104,4 +104,17 @@ public class PoetClientFunctionalTests {
                 GeneratorTaskParams.create(ClientTestModels.endpointDiscoveryModels(), "sources/", "tests/"));
         assertThat(asyncClientEndpointDiscovery, generatesTo("test-endpoint-discovery-async.java"));
     }
+
+    @Test
+    public void asyncClientCustomServiceMetaData() throws Exception {
+        ClassSpec asyncClientCustomServiceMetaData = new AsyncClientClass(
+                GeneratorTaskParams.create(ClientTestModels.customContentTypeModels(), "sources/", "tests/"));
+        assertThat(asyncClientCustomServiceMetaData, generatesTo("test-customservicemetadata-async.java"));
+    }
+
+    @Test
+    public void syncClientCustomServiceMetaData() throws Exception {
+        ClassSpec syncClientCustomServiceMetaData = createSyncClientClass(ClientTestModels.customContentTypeModels());
+        assertThat(syncClientCustomServiceMetaData, generatesTo("test-customservicemetadata-sync.java"));
+    }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/customservicemetadata/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/customservicemetadata/customization.config
@@ -1,0 +1,3 @@
+{
+  "customServiceMetadata": {"contentType" : "application/json"}
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/customservicemetadata/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/customservicemetadata/service-2.json
@@ -1,0 +1,36 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"customservicemetadataconfig",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"AmazonProtocolRestJsonWithContentType",
+    "serviceFullName":"Amazon Protocol Rest Json",
+    "serviceId":"AmazonProtocolRestJsonWithCustomContentType",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsService",
+    "uid":"restjson-2016-03-11"
+  },
+  "operations":{
+    "OneOperation":{
+      "name":"OneOperation",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/oneoperation"
+      },
+      "input":{"shape":"OneShape"}
+    }
+  },
+  "shapes": {
+    "OneShape": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape": "String"
+        }
+      }
+    },
+    "String":{"type":"string"}
+  }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
@@ -1,0 +1,146 @@
+package software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.model.OneOperationRequest;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.model.OneOperationResponse;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.model.ProtocolRestJsonWithCustomContentTypeException;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.transform.OneOperationRequestMarshaller;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
+
+/**
+ * Internal implementation of {@link ProtocolRestJsonWithCustomContentTypeAsyncClient}.
+ *
+ * @see ProtocolRestJsonWithCustomContentTypeAsyncClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements ProtocolRestJsonWithCustomContentTypeAsyncClient {
+    private static final Logger log = LoggerFactory.getLogger(DefaultProtocolRestJsonWithCustomContentTypeAsyncClient.class);
+
+    private final AsyncClientHandler clientHandler;
+
+    private final AwsJsonProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    protected DefaultProtocolRestJsonWithCustomContentTypeAsyncClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration;
+        this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    /**
+     * Invokes the OneOperation operation asynchronously.
+     *
+     * @param oneOperationRequest
+     * @return A Java Future containing the result of the OneOperation operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>ProtocolRestJsonWithCustomContentTypeException Base class for all service exceptions. Unknown
+     *         exceptions will be thrown as an instance of this type.</li>
+     *         </ul>
+     * @sample ProtocolRestJsonWithCustomContentTypeAsyncClient.OneOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/restjson-2016-03-11/OneOperation" target="_top">AWS API
+     *      Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OneOperationResponse> oneOperation(OneOperationRequest oneOperationRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, oneOperationRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "AmazonProtocolRestJsonWithCustomContentType");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OneOperation");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                    .isPayloadJson(true).build();
+
+            HttpResponseHandler<OneOperationResponse> responseHandler = protocolFactory.createResponseHandler(operationMetadata,
+                    OneOperationResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                    operationMetadata);
+
+            CompletableFuture<OneOperationResponse> executeFuture = clientHandler
+                    .execute(new ClientExecutionParams<OneOperationRequest, OneOperationResponse>()
+                            .withOperationName("OneOperation").withMarshaller(new OneOperationRequestMarshaller(protocolFactory))
+                            .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                            .withMetricCollector(apiCallMetricCollector).withInput(oneOperationRequest));
+            AwsRequestOverrideConfiguration requestOverrideConfig = oneOperationRequest.overrideConfiguration().orElse(null);
+            CompletableFuture<OneOperationResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+
+    private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
+        return builder.clientConfiguration(clientConfiguration)
+                .defaultServiceExceptionSupplier(ProtocolRestJsonWithCustomContentTypeException::builder)
+                .protocol(AwsJsonProtocol.REST_JSON).protocolVersion("1.1").contentType("application/json");
+    }
+
+    private static List<MetricPublisher> resolveMetricPublishers(SdkClientConfiguration clientConfiguration,
+                                                                 RequestOverrideConfiguration requestOverrideConfiguration) {
+        List<MetricPublisher> publishers = null;
+        if (requestOverrideConfiguration != null) {
+            publishers = requestOverrideConfiguration.metricPublishers();
+        }
+        if (publishers == null || publishers.isEmpty()) {
+            publishers = clientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS);
+        }
+        if (publishers == null) {
+            publishers = Collections.emptyList();
+        }
+        return publishers;
+    }
+
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
+                                                                                JsonOperationMetadata operationMetadata) {
+        return protocolFactory.createErrorResponseHandler(operationMetadata);
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
@@ -1,0 +1,132 @@
+package software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype;
+
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.client.handler.SyncClientHandler;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.NoOpMetricCollector;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.model.OneOperationRequest;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.model.OneOperationResponse;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.model.ProtocolRestJsonWithCustomContentTypeException;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.transform.OneOperationRequestMarshaller;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Internal implementation of {@link ProtocolRestJsonWithCustomContentTypeClient}.
+ *
+ * @see ProtocolRestJsonWithCustomContentTypeClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultProtocolRestJsonWithCustomContentTypeClient implements ProtocolRestJsonWithCustomContentTypeClient {
+    private static final Logger log = Logger.loggerFor(DefaultProtocolRestJsonWithCustomContentTypeClient.class);
+
+    private final SyncClientHandler clientHandler;
+
+    private final AwsJsonProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    protected DefaultProtocolRestJsonWithCustomContentTypeClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration;
+        this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    /**
+     * Invokes the OneOperation operation.
+     *
+     * @param oneOperationRequest
+     * @return Result of the OneOperation operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws ProtocolRestJsonWithCustomContentTypeException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample ProtocolRestJsonWithCustomContentTypeClient.OneOperation
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/restjson-2016-03-11/OneOperation" target="_top">AWS API
+     *      Documentation</a>
+     */
+    @Override
+    public OneOperationResponse oneOperation(OneOperationRequest oneOperationRequest) throws AwsServiceException,
+            SdkClientException, ProtocolRestJsonWithCustomContentTypeException {
+        JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                .isPayloadJson(true).build();
+
+        HttpResponseHandler<OneOperationResponse> responseHandler = protocolFactory.createResponseHandler(operationMetadata,
+                OneOperationResponse::builder);
+
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                operationMetadata);
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, oneOperationRequest
+                .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+                .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "AmazonProtocolRestJsonWithCustomContentType");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OneOperation");
+
+            return clientHandler.execute(new ClientExecutionParams<OneOperationRequest, OneOperationResponse>()
+                    .withOperationName("OneOperation").withResponseHandler(responseHandler)
+                    .withErrorResponseHandler(errorResponseHandler).withInput(oneOperationRequest)
+                    .withMetricCollector(apiCallMetricCollector)
+                    .withMarshaller(new OneOperationRequestMarshaller(protocolFactory)));
+        } finally {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+        }
+    }
+
+    private static List<MetricPublisher> resolveMetricPublishers(SdkClientConfiguration clientConfiguration,
+                                                                 RequestOverrideConfiguration requestOverrideConfiguration) {
+        List<MetricPublisher> publishers = null;
+        if (requestOverrideConfiguration != null) {
+            publishers = requestOverrideConfiguration.metricPublishers();
+        }
+        if (publishers == null || publishers.isEmpty()) {
+            publishers = clientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS);
+        }
+        if (publishers == null) {
+            publishers = Collections.emptyList();
+        }
+        return publishers;
+    }
+
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
+                                                                                JsonOperationMetadata operationMetadata) {
+        return protocolFactory.createErrorResponseHandler(operationMetadata);
+    }
+
+    private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
+        return builder.clientConfiguration(clientConfiguration)
+                .defaultServiceExceptionSupplier(ProtocolRestJsonWithCustomContentTypeException::builder)
+                .protocol(AwsJsonProtocol.REST_JSON).protocolVersion("1.1").contentType("application/json");
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/AwsJsonProtocolMetadata.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/AwsJsonProtocolMetadata.java
@@ -25,10 +25,12 @@ public final class AwsJsonProtocolMetadata {
 
     private final AwsJsonProtocol protocol;
     private final String protocolVersion;
+    private final String contentType;
 
     private AwsJsonProtocolMetadata(Builder builder) {
         this.protocol = builder.protocol;
         this.protocolVersion = builder.protocolVersion;
+        this.contentType = builder.contentType;
     }
 
     /**
@@ -49,9 +51,18 @@ public final class AwsJsonProtocolMetadata {
         return new AwsJsonProtocolMetadata.Builder();
     }
 
+    /**
+     *
+     * @return the content Type.
+     */
+    public String contentType() {
+        return contentType;
+    }
+
     public static final class Builder {
         private AwsJsonProtocol protocol;
         private String protocolVersion;
+        private String contentType;
 
         private Builder() {
         }
@@ -63,6 +74,11 @@ public final class AwsJsonProtocolMetadata {
 
         public Builder protocolVersion(String protocolVersion) {
             this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder contentType(String contentType) {
+            this.contentType = contentType;
             return this;
         }
 

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/BaseAwsJsonProtocolFactory.java
@@ -147,7 +147,8 @@ public abstract class BaseAwsJsonProtocolFactory {
 
     @SdkTestInternalApi
     protected final String getContentType() {
-        return getContentTypeResolver().resolveContentType(protocolMetadata);
+        return protocolMetadata.contentType() != null ? protocolMetadata.contentType()
+                : getContentTypeResolver().resolveContentType(protocolMetadata);
     }
 
     /**
@@ -239,6 +240,18 @@ public abstract class BaseAwsJsonProtocolFactory {
          */
         public final SubclassT protocolVersion(String protocolVersion) {
             protocolMetadata.protocolVersion(protocolVersion);
+            return getSubclass();
+        }
+
+        /**
+         * ContentType  of the client (By default it is used from {@link #AWS_JSON} ).
+         * Used to determine content type.
+         *
+         * @param contentType JSON protocol contentType.
+         * @return This builder for method chaining.
+         */
+        public final SubclassT contentType(String contentType) {
+            protocolMetadata.contentType(contentType);
             return getSubclass();
         }
 

--- a/services/wellarchitected/src/main/resources/codegen-resources/customization.config
+++ b/services/wellarchitected/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,3 @@
+{
+  "customServiceMetadata": {"contentType" : "application/json"}
+}

--- a/test/protocol-tests/src/main/resources/codegen-resources/awsjson/customized/customization.config
+++ b/test/protocol-tests/src/main/resources/codegen-resources/awsjson/customized/customization.config
@@ -1,4 +1,5 @@
 {
+    "customServiceMetadata": {"contentType" : "application/json"},
     "calculateCrc32FromCompressedData": true,
     "verifiedSimpleMethods" : [
         "allTypes",

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/customservicemetadata/CustomServiceMetaDataServiceTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/customservicemetadata/CustomServiceMetaDataServiceTest.java
@@ -1,0 +1,83 @@
+package software.amazon.awssdk.protocol.tests.customservicemetadata;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+
+
+import java.net.URI;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.protocoljsonrpc.ProtocolJsonRpcClient;
+import software.amazon.awssdk.services.protocoljsonrpccustomized.ProtocolJsonRpcCustomizedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocoljsonrpccustomized.model.SimpleRequest;
+import software.amazon.awssdk.services.protocoljsonrpccustomized.model.SimpleResponse;
+import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesRequest;
+import software.amazon.awssdk.services.protocoljsonrpc.model.AllTypesResponse;
+
+public class CustomServiceMetaDataServiceTest {
+
+    @Rule
+    public WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
+            .port(0)
+            .fileSource(new SingleRootFileSource("src/test/resources")));
+
+    private static final String JSON_BODY = "{\"StringMember\":\"foo\"}";
+    private static final String JSON_BODY_GZIP = "compressed_json_body.gz";
+    private static final String JSON_BODY_Crc32_CHECKSUM = "3049587505";
+    private static final String JSON_BODY_GZIP_Crc32_CHECKSUM = "3023995622";
+    private static final StaticCredentialsProvider FAKE_CREDENTIALS_PROVIDER =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("foo", "bar"));
+
+    @Test
+    public void clientWithCustomizedMetadata_has_contenttype_as_mentioned_customization() {
+
+        stubFor(post(urlEqualTo("/")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Encoding", "gzip")
+                .withHeader("x-amz-crc32", JSON_BODY_GZIP_Crc32_CHECKSUM)
+                .withBodyFile(JSON_BODY_GZIP)));
+
+        ProtocolJsonRpcCustomizedClient jsonRpc = ProtocolJsonRpcCustomizedClient.builder()
+                .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
+                .region(Region.US_EAST_1)
+                .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
+                .build();
+        jsonRpc.simple(SimpleRequest.builder().build());
+
+        WireMock.verify(postRequestedFor(urlPathEqualTo("/"))
+                .withHeader("Content-Type", containing("application/json")));
+    }
+
+    @Test
+    public void clientWithNoCustomizedMetadata_has_default_contenttype() {
+        stubFor(post(urlEqualTo("/")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("x-amz-crc32", JSON_BODY_Crc32_CHECKSUM)
+                .withBody(JSON_BODY)));
+
+        ProtocolJsonRpcClient jsonRpc = ProtocolJsonRpcClient.builder()
+                .credentialsProvider(FAKE_CREDENTIALS_PROVIDER)
+                .region(Region.US_EAST_1)
+                .endpointOverride(URI.create("http://localhost:" + mockServer.port()))
+                .build();
+
+        AllTypesResponse result =
+                jsonRpc.allTypes(AllTypesRequest.builder().build());
+
+        WireMock.verify(postRequestedFor(urlPathEqualTo("/"))
+                .withHeader("Content-Type", containing("application/x-amz-json-1.1")));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Support customization of contentTypeOverride for Header ContentType
<!--- Describe your changes in detail -->

## Motivation and Context

- By default the ContentType Header for Json type is set to  ```application/x-amz-json-1.1``` for json protocol.
- While wellarchitected accepted  ```application/json```  ContentType Header.
- These changes will add a customization for services which accept ```application/json```ContentType header.


Why is this change required? What problem does it solve? 
- Customization required for  ```application/json```ContentType header. Else the API calls to Services which accept  ```application/json```ContentType header will not be successful.

 If it fixes an open issue, please link to the issue here  :  PR #2510 


## File Modification
### JsonProtocolSpec.java :  
contentType attribute is populated only if CustomizationConfig is set. If not then we look for metadata.getContentType() else we donot add any ContentType, in this case it uses from DefaultJsonContentTypeResolver.

### AwsJsonProtocolMetadata
Added contentType which is used while we resolve the ContentType.

### BaseAwsJsonProtocolFactory
The Factory method that creates Builders for AwsJsonProtocolFactory. ContentType is added in the attributes which will be set by codegen. Here we select from ContentType if the ContentType is set else we select the default one as we used to do before.


### services/wellarchitected/src/main/resources/codegen-resources/customization.config 
The Config file to set wellarchitected services ContentType as application/json

### codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
### codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
Expected generated files when ContentType Customization is set.

Rest of the changes are for testing.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->



## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
