### PR TITLE
Amazon S3: Add option to download to and overwrite existing files

### DIFF
--- a/.changes/next-release/feature-AmazonS3-a7371a0.json
+++ b/.changes/next-release/feature-AmazonS3-a7371a0.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon S3",
+    "contributor": "mina-asham",
+    "description": "Add option to download to and overwrite existing files"
+}

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/ResponseTransformerTest.java
@@ -113,6 +113,18 @@ public class ResponseTransformerTest {
     }
 
     @Test
+    public void downloadToExistingFileWithOverwriteSucceeds() throws IOException {
+        stubForSuccess();
+
+        Path tmpFile = Files.createTempFile("overwrite-test.", ".tmp");
+        tmpFile.toFile().deleteOnExit();
+
+        testClient().streamingOutputOperation(StreamingOutputOperationRequest.builder().build(), ResponseTransformer.toFile(tmpFile, true));
+
+        assertThat(Files.readAllLines(tmpFile)).containsExactly("test \uD83D\uDE02");
+    }
+
+    @Test
     public void downloadToOutputStreamDoesNotRetry() throws IOException {
         stubForRetriesTimeoutReadingFromStreams();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

**Issue:** https://github.com/aws/aws-sdk-java-v2/issues/2300

Migrating from SDK V1 to V2 we hit an issue where do something like this (pseudo-code):
```
Path temp = Files.createTempFile(...);
s3.getObject(bucket, key, temp);
// use temp file
```
This allows us to download a temp file, validate it and if we are happy flip it to the actual path overriding the existing previous file.

This works on V1 because: because it just opens an outputstream which by default overwrites ([here](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java#L304))
but doesn't work on V2 because we are not passing any options to `Files.copy` ([here](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java#L106))

## Description
<!--- Describe your changes in detail -->
This adds the option to download to and overwrite existing files by adding another method overload for `toFile` with a boolean flag to overwrite which translate to calling `Files.copy` with `StandardCopyOption.REPLACE_EXISTING` option (only option allowed when using `Files.copy` with an input stream)

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [x] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
