### PR TITLE
Integration test buckets deletion failed as it had attached access points

### DIFF
--- a/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3AccessPointsIntegrationTest.java
+++ b/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3AccessPointsIntegrationTest.java
@@ -76,8 +76,8 @@ public class S3AccessPointsIntegrationTest extends S3ControlIntegrationTestBase 
 
     @AfterClass
     public static void tearDown() {
-        deleteBucketAndAllContents(BUCKET);
         s3control.deleteAccessPoint(b -> b.accountId(accountId).name(AP_NAME));
+        deleteBucketAndAllContents(BUCKET);
     }
 
     @Test

--- a/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3AsyncAccessPointsIntegrationTest.java
+++ b/services/s3control/src/it/java/software.amazon.awssdk.services.s3control/S3AsyncAccessPointsIntegrationTest.java
@@ -65,8 +65,8 @@ public class S3AsyncAccessPointsIntegrationTest extends S3ControlIntegrationTest
 
     @AfterClass
     public static void tearDown() {
-        deleteBucketAndAllContents(BUCKET);
         s3control.deleteAccessPoint(b -> b.accountId(accountId).name(AP_NAME)).join();
+        deleteBucketAndAllContents(BUCKET);
     }
 
     @Test


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Tear down for Accesspointsintegrationtest was not deleting buckets as it was failing with below exception
```
Failed to delete bucket: s3asyncaccesspointsintegrationtest
software.amazon.awssdk.services.s3.model.S3Exception: Bucket has access points attached and cannot be deleted. (Service: S3, Status Code: 400
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->
Integration test buckets deletion failed as it had attached access points.

Changed the order where Access point is deleted before the bucket is deleted.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified in local workspace. Without the fix the exception is logged at the end of the test. 
With the fix we donot get failure exception

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
