### PR TITLE
Remove buffer copy since it's no longer needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.10</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.13.5</awscrt.version>
+        <awscrt.version>0.13.11</awscrt.version>
 
         <!--Test dependencies -->
         <junit.version>4.13.1</junit.version>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/CrtResponseDataConsumerAdapter.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/CrtResponseDataConsumerAdapter.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.Logger;
 
 /**
@@ -81,10 +80,7 @@ public class CrtResponseDataConsumerAdapter<ReturnT> implements ResponseDataCons
     @Override
     public void onResponseData(ByteBuffer byteBuffer) {
         log.trace(() -> "Received data of size " + byteBuffer.remaining());
-
-        // Need to make a copy because the incoming byteBuffer might get released soon
-        ByteBuffer newByteBuffer = ByteBuffer.wrap(BinaryUtils.copyAllBytesFrom(byteBuffer));
-        publisher.deliverData(newByteBuffer);
+        publisher.deliverData(byteBuffer);
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/CrtResponseDataConsumerAdapterTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/CrtResponseDataConsumerAdapterTest.java
@@ -54,17 +54,4 @@ public class CrtResponseDataConsumerAdapterTest {
         assertThat(captor.getValue().responseMetadata().requestId()).isEqualTo("UNKNOWN");
         assertThat(captor.getValue().sdkHttpResponse()).isNotNull();
     }
-
-    @Test
-    public void onResponseData_shouldCopyByteBuffer() {
-        ArgumentCaptor<ByteBuffer> captor = ArgumentCaptor.forClass(ByteBuffer.class);
-        byte[] expectedBytes = "helloworld".getBytes(StandardCharsets.UTF_8);
-        ByteBuffer byteBuffer = ByteBuffer.wrap(expectedBytes);
-        adapter.onResponseData(byteBuffer);
-
-        verify(publisher).deliverData(captor.capture());
-        ByteBuffer actualByteBuffer = captor.getValue();
-        assertThat(actualByteBuffer).isNotSameAs(byteBuffer);
-        assertThat(actualByteBuffer.array()).isEqualTo(expectedBytes);
-    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

- Bump up crt version
- Remove buffer copy because it's no longer needed. https://github.com/awslabs/aws-crt-java/pull/352

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
