### PR TITLE
Deprecate S3 CopySource parameter for CopyObject & UploadPartCopy

### DIFF
--- a/.changes/next-release/documentation-AmazonS3-259552c.json
+++ b/.changes/next-release/documentation-AmazonS3-259552c.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon S3", 
+    "contributor": "", 
+    "type": "documentation", 
+    "description": "Deprecate S3 CopySource parameter for CopyObject & UploadPartCopy"
+}

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -35,6 +35,10 @@
       ],
       "modify": [
         {
+          "CopySource": {
+            "deprecated": true,
+            "deprecatedMessage": "The {@code copySource} parameter has been deprecated in favor of the more user-friendly {@code sourceBucket}, {@code sourceKey}, and {@code sourceVersionId} parameters. The {@code copySource} parameter will remain fully functional, but it must not be used in conjunction with its replacement parameters."
+          },
           "Bucket": {
             "emitPropertyName": "DestinationBucket",
             "existingNameDeprecated": true
@@ -65,6 +69,10 @@
       ],
       "modify": [
         {
+          "CopySource": {
+            "deprecated": true,
+            "deprecatedMessage": "The {@code copySource} parameter has been deprecated in favor of the more user-friendly {@code sourceBucket}, {@code sourceKey}, and {@code sourceVersionId} parameters. The {@code copySource} parameter will remain fully functional, but it must not be used in conjunction with its replacement parameters."
+          },
           "Bucket": {
             "emitPropertyName": "DestinationBucket",
             "existingNameDeprecated": true


### PR DESCRIPTION
## Motivation and Context

In https://github.com/aws/aws-sdk-java-v2/pull/2612 we recently
introduced replacement parameters for the S3 CopySource parameter.
However, we did not officially deprecate it since our codegen tooling
lacked support for deprecated members at the time. With
https://github.com/aws/aws-sdk-java-v2/pull/2622 we have since added
support for deprecated members to both models and model modifications
via customization.config files.

Now that this feature is fully supported, we should deprecate the
CopySource parameter to increase visibility and improve discoverability
of the new parameters that are offered. This will make users more likely
to discover the new parameters, allowing them to simplify their
application code accordingly.

## Description

* Annotate the CopySource parameter as deprecated for both CopySource
and UploadPartCopy

## Testing
Local build of S3 module and verified Javadoc results.

## Screenshots
![image](https://user-images.githubusercontent.com/11811448/126852287-00d85590-00f5-429d-b254-93e028b83866.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
