### PR TITLE
Add waiter for Athena QueryExecutionFinished

### DIFF
--- a/services/athena/src/main/resources/codegen-resources/waiters-2.json
+++ b/services/athena/src/main/resources/codegen-resources/waiters-2.json
@@ -1,0 +1,31 @@
+{
+  "version": 2,
+  "waiters": {
+    "QueryExecutionFinished": {
+      "delay": 5,
+      "operation": "GetQueryExecution",
+      "description": "Wait until query execution is finished",
+      "maxAttempts": 720,
+      "acceptors": [
+        {
+          "matcher": "path",
+          "argument": "QueryExecution.Status.State",
+          "expected": "SUCCEEDED",
+          "state": "success"
+        },
+        {
+          "matcher": "path",
+          "argument": "QueryExecution.Status.State",
+          "expected": "FAILED",
+          "state": "failure"
+        },
+        {
+          "matcher": "path",
+          "argument": "QueryExecution.Status.State",
+          "expected": "CANCELLED",
+          "state": "failure"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Implements aws/aws-sdk#80 and aws/aws-sdk-java#1646 for the aws-java-sdk-v2.

## Motivation and Context
It makes it a lot easier to query athena from the sdk.  It does this by implementing a highly requested feature for boto and java v1 sdk.
This PR works and is submitted, I am however wondering if this is the correct place to do so.  As the files under `codegen-resources` seem to come from an (internal?) repository I cannot find back.  As these files seem to be shared somehow with other language bindings for AWS.

Let me know if PR's like this have to be submitted in any other way, then I will do accordingly.  I think it would be cool if this could be submitted and made available to other language bindings too and close aws/aws-sdk#80 for all of them.

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
