### PR TITLE
Don't attempt to use empty session tokens

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-64dd59e.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-64dd59e.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Don't attempt to use empty session tokens"
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
@@ -67,8 +67,8 @@ public abstract class SystemSettingsCredentialsProvider implements AwsCredential
                                     .build();
         }
 
-        return sessionToken == null ? AwsBasicCredentials.create(accessKey, secretKey)
-                                    : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
+        return StringUtils.isEmpty(sessionToken) ? AwsBasicCredentials.create(accessKey, secretKey)
+                                                 : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
     }
 
     /**

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java
@@ -49,7 +49,7 @@ public abstract class SystemSettingsCredentialsProvider implements AwsCredential
         String secretKey = trim(loadSetting(SdkSystemSetting.AWS_SECRET_ACCESS_KEY).orElse(null));
         String sessionToken = trim(loadSetting(SdkSystemSetting.AWS_SESSION_TOKEN).orElse(null));
 
-        if (StringUtils.isEmpty(accessKey)) {
+        if (StringUtils.isBlank(accessKey)) {
             throw SdkClientException.builder()
                                     .message(String.format("Unable to load credentials from system settings. Access key must be" +
                                              " specified either via environment variable (%s) or system property (%s).",
@@ -58,7 +58,7 @@ public abstract class SystemSettingsCredentialsProvider implements AwsCredential
                                     .build();
         }
 
-        if (StringUtils.isEmpty(secretKey)) {
+        if (StringUtils.isBlank(secretKey)) {
             throw SdkClientException.builder()
                                     .message(String.format("Unable to load credentials from system settings. Secret key must be" +
                                              " specified either via environment variable (%s) or system property (%s).",
@@ -67,7 +67,7 @@ public abstract class SystemSettingsCredentialsProvider implements AwsCredential
                                     .build();
         }
 
-        return StringUtils.isEmpty(sessionToken) ? AwsBasicCredentials.create(accessKey, secretKey)
+        return StringUtils.isBlank(sessionToken) ? AwsBasicCredentials.create(accessKey, secretKey)
                                                  : AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
     }
 


### PR DESCRIPTION
An empty session token would never be valid. In the case that certain environmental conditions may produce an empty session token (rather than null), don't attempt to use it.

This change also moves from using `StringUtils.isEmpty()` to `StringUtils.isBlank()`, as a form of precaution, but there is no functional change introduced by this commit on the other fields (accessKey and secretKey) because we are already calling `trim()` on all fields.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
