### PR TITLE
Add IntelliJ .ipr project files to gitignore

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-885b171.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-885b171.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Add IntelliJ .ipr files to gitignore"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Intellij
 .idea/
 *.iml
+*.ipr
 *.iws
 
 # Mac


### PR DESCRIPTION
We do not store IntelliJ project files in git, but local workspaces
automatically create an aws-sdk-java-pom.ipr file, which shows up under
the default version control changelist.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
