### PR TITLE
 Fixed an issue where checksum validation only considered the first 4 bytes of the 16 byte checksum...

### DIFF
--- a/.changes/next-release/bugfix-AmazonS3-421839e.json
+++ b/.changes/next-release/bugfix-AmazonS3-421839e.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon S3", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed an issue where checksum validation only considered the first 4 bytes of the 16 byte checksum, creating the potential for corrupted downloads to go undetected."
+}

--- a/pom.xml
+++ b/pom.xml
@@ -511,9 +511,8 @@
                         <excludes>
                             <exclude>*.internal.*</exclude>
 
-                            <!-- Jackson removal -->
-                            <exclude>software.amazon.awssdk.core.util.json.JacksonUtils</exclude>
-                            <exclude>software.amazon.awssdk.protocols.json.*</exclude>
+                            <!-- Checksum bug fix -->
+                            <exclude>software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream</exclude>
                         </excludes>
 
                         <excludeModules>

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStream.java
@@ -17,11 +17,12 @@ package software.amazon.awssdk.services.s3.checksums;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
+import java.util.Arrays;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.Abortable;
+import software.amazon.awssdk.utils.BinaryUtils;
 
 @SdkInternalApi
 public class ChecksumValidatingInputStream extends InputStream implements Abortable {
@@ -34,7 +35,7 @@ public class ChecksumValidatingInputStream extends InputStream implements Aborta
     private long lengthRead = 0;
     // Preserve the computed checksum because some InputStream readers (e.g., java.util.Properties) read more than once at the
     // end of the stream.
-    private Integer computedChecksum;
+    private byte[] computedChecksum;
 
     /**
      * Creates an input stream using the specified Checksum, input stream, and length.
@@ -162,26 +163,15 @@ public class ChecksumValidatingInputStream extends InputStream implements Aborta
         inputStream.close();
     }
 
-    /**
-     * Gets the stream's checksum as an integer.
-     *
-     * @return checksum.
-     */
-    public int getStreamChecksum() {
-        ByteBuffer bb = ByteBuffer.wrap(streamChecksum);
-        return bb.getInt();
-    }
-
     private void validateAndThrow() {
-        int streamChecksumInt = getStreamChecksum();
         if (computedChecksum == null) {
-            computedChecksum = ByteBuffer.wrap(checkSum.getChecksumBytes()).getInt();
+            computedChecksum = checkSum.getChecksumBytes();
         }
 
-        if (streamChecksumInt != computedChecksum) {
+        if (!Arrays.equals(computedChecksum, streamChecksum)) {
             throw SdkClientException.builder().message(
-                String.format("Data read has a different checksum than expected. Was %d, but expected %d",
-                              computedChecksum, streamChecksumInt)).build();
+                String.format("Data read has a different checksum than expected. Was 0x%s, but expected 0x%s",
+                              BinaryUtils.toHex(computedChecksum), BinaryUtils.toHex(streamChecksum))).build();
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingPublisher.java
@@ -132,12 +132,11 @@ public final class ChecksumValidatingPublisher implements SdkPublisher<ByteBuffe
         @Override
         public void onComplete() {
             if (strippedLength > 0) {
-                int streamChecksumInt = ByteBuffer.wrap(streamChecksum).getInt();
-                int computedChecksumInt = ByteBuffer.wrap(sdkChecksum.getChecksumBytes()).getInt();
-                if (streamChecksumInt != computedChecksumInt) {
+                byte[] computedChecksum = sdkChecksum.getChecksumBytes();
+                if (!Arrays.equals(computedChecksum, streamChecksum)) {
                     onError(SdkClientException.create(
-                        String.format("Data read has a different checksum than expected. Was %d, but expected %d",
-                                      computedChecksumInt, streamChecksumInt)));
+                        String.format("Data read has a different checksum than expected. Was 0x%s, but expected 0x%s",
+                                      BinaryUtils.toHex(computedChecksum), BinaryUtils.toHex(streamChecksum))));
                     return; // Return after onError and not call onComplete below
                 }
             }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStreamTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/checksums/ChecksumValidatingInputStreamTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.checksums;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.checksums.Md5Checksum;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.utils.IoUtils;
+
+public class ChecksumValidatingInputStreamTest {
+    private static final int TEST_DATA_SIZE = 32;
+    private static final int CHECKSUM_SIZE = 16;
+
+    private static byte[] testData;
+    private static byte[] testDataWithoutChecksum;
+
+    @BeforeClass
+    public static void populateData() {
+        testData = new byte[TEST_DATA_SIZE + CHECKSUM_SIZE];
+        for (int i = 0; i < TEST_DATA_SIZE; i++) {
+            testData[i] = (byte)(i & 0x7f);
+        }
+
+        Md5Checksum checksum = new Md5Checksum();
+        checksum.update(testData, 0, TEST_DATA_SIZE);
+        byte[] checksumBytes = checksum.getChecksumBytes();
+
+        for (int i = 0; i < CHECKSUM_SIZE; i++) {
+            testData[TEST_DATA_SIZE + i] = checksumBytes[i];
+        }
+
+        testDataWithoutChecksum = Arrays.copyOfRange(testData, 0, TEST_DATA_SIZE);
+    }
+
+    @Test
+    public void validChecksumSucceeds() throws IOException {
+        InputStream validatingInputStream = newValidatingStream(testData);
+        byte[] dataFromValidatingStream = IoUtils.toByteArray(validatingInputStream);
+
+        assertArrayEquals(testDataWithoutChecksum, dataFromValidatingStream);
+    }
+
+    @Test
+    public void invalidChecksumFails() throws IOException {
+        for (int i = 0; i < testData.length; i++) {
+            // Make sure that corruption of any byte in the test data causes a checksum validation failure.
+            byte[] corruptedChecksumData = Arrays.copyOf(testData, testData.length);
+            corruptedChecksumData[i] = (byte) ~corruptedChecksumData[i];
+
+            InputStream validatingInputStream = newValidatingStream(corruptedChecksumData);
+
+            try {
+                IoUtils.toByteArray(validatingInputStream);
+                Assert.fail("Corruption at byte " + i + " was not detected.");
+            } catch (SdkClientException e) {
+                // Expected
+            }
+        }
+    }
+
+    private InputStream newValidatingStream(byte[] dataFromS3) {
+        return new ChecksumValidatingInputStream(new ByteArrayInputStream(dataFromS3),
+                                                 new Md5Checksum(),
+                                                 TEST_DATA_SIZE + CHECKSUM_SIZE);
+    }
+}


### PR DESCRIPTION
...creating the potential for corrupted downloads to go undetected.