### PR TITLE
Adding SqsBatchManager for sync client

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchAndSend.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchAndSend.java
@@ -28,5 +28,5 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 @FunctionalInterface
 @SdkProtectedApi
 public interface BatchAndSend<RequestT, BatchResponseT> {
-    CompletableFuture<BatchResponseT> batchAndSend(List<IdentifiableMessage<RequestT>> identifiedRequests, String batchGroupId);
+    CompletableFuture<BatchResponseT> batchAndSend(List<IdentifiableMessage<RequestT>> identifiedRequests, String batchKey);
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
@@ -162,13 +162,13 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
         requestsAndResponsesMaps.forEach((batchKey, batchBuffer) -> {
             requestsAndResponsesMaps.cancelScheduledFlush(batchKey);
             Map<String, BatchingExecutionContext<RequestT, ResponseT>> flushableRequests =
-                requestsAndResponsesMaps.flushableScheduledRequests(batchKey, maxBatchItems);
+                requestsAndResponsesMaps.flushableRequests(batchKey, maxBatchItems);
 
             while (!flushableRequests.isEmpty()) {
                 flushBuffer(batchKey, flushableRequests);
             }
         });
-        requestsAndResponsesMaps.waitForFlushesAndClear(log);
+        requestsAndResponsesMaps.clear();
     }
 
     public static final class DefaultBuilder<RequestT, ResponseT, BatchResponseT> implements Builder<RequestT, ResponseT,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
@@ -26,14 +26,12 @@ import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.batchmanager.BatchManager;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
-import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> implements BatchManager<RequestT, ResponseT,
     BatchResponseT> {
 
-    private static final Logger log = Logger.loggerFor(DefaultBatchManager.class);
     private final int maxBatchItems;
     private final Duration maxBatchOpenInMs;
 
@@ -47,18 +45,18 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
      * Takes a list of identified requests in addition to a destination and batches the requests into a batch request.
      * It then sends the batch request and returns a CompletableFuture of the response.
      */
-    private final BatchAndSend<RequestT, BatchResponseT> batchingFunction;
+    private final BatchAndSend<RequestT, BatchResponseT> batchFunction;
 
     /**
      * Unpacks the batch response, then transforms individual entries to the appropriate response type. Each entry's batch ID
      * is mapped to the individual response entry.
      */
-    private final BatchResponseMapper<BatchResponseT, ResponseT> mapResponsesFunction;
+    private final BatchResponseMapper<BatchResponseT, ResponseT> responseMapper;
 
     /**
      * Takes a request and extracts a batchKey as determined by the caller.
      */
-    private final BatchKeyMapper<RequestT> batchKeyMapperFunction;
+    private final BatchKeyMapper<RequestT> batchKeyMapper;
 
     /**
      * A scheduled executor that periodically schedules {@link #flushBuffer}.
@@ -70,9 +68,9 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
         this.requestsAndResponsesMaps = new BatchingMap<>();
         this.maxBatchItems = batchConfiguration.maxBatchItems();
         this.maxBatchOpenInMs = batchConfiguration.maxBatchOpenInMs();
-        this.batchingFunction = Validate.notNull(builder.batchFunction, "Null batchingFunction");
-        this.mapResponsesFunction = Validate.notNull(builder.responseMapper, "Null mapResponsesFunction");
-        this.batchKeyMapperFunction = Validate.notNull(builder.batchKeyMapper, "Null batchKeyMapperFunction");
+        this.batchFunction = Validate.notNull(builder.batchFunction, "Null batchFunction");
+        this.responseMapper = Validate.notNull(builder.responseMapper, "Null responseMapper");
+        this.batchKeyMapper = Validate.notNull(builder.batchKeyMapper, "Null batchKeyMapper");
         this.scheduledExecutor = builder.scheduledExecutor;
     }
 
@@ -84,7 +82,7 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
     public CompletableFuture<ResponseT> sendRequest(RequestT request) {
         CompletableFuture<ResponseT> response = new CompletableFuture<>();
         try {
-            String batchKey = batchKeyMapperFunction.getBatchKey(request);
+            String batchKey = batchKeyMapper.getBatchKey(request);
             requestsAndResponsesMaps.put(batchKey,
                                          () -> scheduleBufferFlush(batchKey, maxBatchOpenInMs.toMillis(), scheduledExecutor),
                                          request,
@@ -120,8 +118,8 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
                                       requestEntries.add(new IdentifiableMessage<>(contextId, batchExecutionContext.request())));
 
         if (!requestEntries.isEmpty()) {
-            batchingFunction.batchAndSend(requestEntries, batchKey)
-                            .whenComplete((result, ex) -> handleAndCompleteResponses(result, ex, flushableRequests));
+            batchFunction.batchAndSend(requestEntries, batchKey)
+                         .whenComplete((result, ex) -> handleAndCompleteResponses(result, ex, flushableRequests));
         }
     }
 
@@ -131,7 +129,7 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
             requests.forEach((contextId, batchExecutionContext) -> batchExecutionContext.response()
                                                                                         .completeExceptionally(exception));
         } else {
-            List<IdentifiableMessage<ResponseT>> identifiedResponses = mapResponsesFunction.mapBatchResponse(batchResult);
+            List<IdentifiableMessage<ResponseT>> identifiedResponses = responseMapper.mapBatchResponse(batchResult);
             for (IdentifiableMessage<ResponseT> identifiedResponse : identifiedResponses) {
                 String id = identifiedResponse.id();
                 ResponseT response = identifiedResponse.message();

--- a/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/BatchManagerSqsIntegrationTest.java
+++ b/services/sqs/src/it/java/software/amazon/awssdk/services/sqs/BatchManagerSqsIntegrationTest.java
@@ -41,8 +41,6 @@ import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -102,9 +104,9 @@ public interface SqsBatchManager extends SdkAutoCloseable {
     interface Builder {
 
         /**
-         * Defines overrides to the default BatchManager configuration
+         * Defines overrides to the default BatchManager configuration.
          *
-         * @param overrideConfiguration the override configuration to set
+         * @param overrideConfiguration the override configuration to set.
          * @return a reference to this object so that method calls can be chained together.
          */
         Builder overrideConfiguration(BatchOverrideConfiguration overrideConfiguration);
@@ -119,6 +121,28 @@ public interface SqsBatchManager extends SdkAutoCloseable {
          * @return a reference to this object so that method calls can be chained together.
          */
         Builder client(SqsClient client);
+
+        /**
+         * Sets a custom {@link ScheduledExecutorService} that will be used to schedule periodic buffer flushes.
+         * <p>
+         * Creating a SqsBatchManager directly from the client will use the client's scheduled executor. If supplied by the
+         * user, this ScheduledExecutorService must be closed by the caller when it is ready to be shut down.
+         *
+         * @param scheduledExecutor the scheduledExecutor to be used.
+         * @return a reference to this object so that method calls can be chained together.
+         */
+        Builder scheduledExecutor(ScheduledExecutorService scheduledExecutor);
+
+        /**
+         * Sets a custom {@link ExecutorService} that will be used to execute client requests asynchronously.
+         * <p>
+         * Creating a SqsBatchManager directly from the client will use the client's executor. If supplied by the user, this
+         * ExecutorService must be closed by the caller when it is ready to be shut down.
+         *
+         * @param executor the executor to be used.
+         * @returna reference to this object so that method calls can be chained together.
+         */
+        Builder executor(ExecutorService executor);
 
         /**
          * Builds an instance of {@link SqsBatchManager} based on the configurations supplied to this builder.

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsBatchManager;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
@@ -86,7 +87,7 @@ public interface SqsBatchManager extends SdkAutoCloseable {
      * @return a builder
      */
     static Builder builder() {
-        throw new UnsupportedOperationException();
+        return DefaultSqsBatchManager.builder();
     }
 
     /**

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.batchmanager.BatchManager;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -47,9 +48,10 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 public final class DefaultSqsBatchManager implements SqsBatchManager {
 
     private final SqsClient client;
+    private final ExecutorService executor;
     private final BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> sendMessageBatchManager;
     private final BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> deleteMessageBatchManager;
-    private BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
+    private final BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
         ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager;
 
     private DefaultSqsBatchManager(DefaultBuilder builder) {
@@ -62,7 +64,7 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
 
 
         ScheduledExecutorService scheduledExecutor = builder.scheduledExecutor;
-        ExecutorService executor = builder.executor;
+        this.executor = builder.executor;
 
         this.sendMessageBatchManager = BatchManager.builder(SendMessageRequest.class, SendMessageResponse.class,
                                                             SendMessageBatchResponse.class)
@@ -91,6 +93,19 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
                                                         .overrideConfiguration(overrideConfiguration)
                                                         .scheduledExecutor(scheduledExecutor)
                                                         .build();
+    }
+
+    @SdkTestInternalApi
+    public DefaultSqsBatchManager(SqsClient client, ExecutorService executor,
+                                  BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> sendMessageBatchManager,
+                                  BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> deleteMessageBatchManager,
+                                  BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
+                                      ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager) {
+        this.client = client;
+        this.executor = executor;
+        this.sendMessageBatchManager = sendMessageBatchManager;
+        this.deleteMessageBatchManager = deleteMessageBatchManager;
+        this.changeVisibilityBatchManager = changeVisibilityBatchManager;
     }
 
     @Override

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -97,8 +97,10 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
 
     @SdkTestInternalApi
     public DefaultSqsBatchManager(SqsClient client, ExecutorService executor,
-                                  BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> sendMessageBatchManager,
-                                  BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> deleteMessageBatchManager,
+                                  BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse>
+                                      sendMessageBatchManager,
+                                  BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse>
+                                          deleteMessageBatchManager,
                                   BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
                                       ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager) {
         this.client = client;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityResponseMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageResponseMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageBatchFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageResponseMapper;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.batchmanager.BatchManager;
+import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+@SdkInternalApi
+public final class DefaultSqsBatchManager implements SqsBatchManager {
+
+    private final SqsClient client;
+    private final BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> sendMessageBatchManager;
+    private final BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> deleteMessageBatchManager;
+    private BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
+        ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager;
+
+    private DefaultSqsBatchManager(DefaultBuilder builder) {
+        this.client = builder.client;
+        SqsBatchConfiguration config = new SqsBatchConfiguration(builder.overrideConfiguration);
+        BatchOverrideConfiguration overrideConfiguration = BatchOverrideConfiguration.builder()
+                                                                                     .maxBatchItems(config.maxBatchItems())
+                                                                                     .maxBatchOpenInMs(config.maxBatchOpenInMs())
+                                                                                     .build();
+
+        //TODO: Pass the client's scheduledExecutor after we add the scheduledExecutor into the client. Right now just creating it
+        // here
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().threadNamePrefix("SqsBatchManager").build();
+        ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
+
+        this.sendMessageBatchManager = BatchManager.builder(SendMessageRequest.class, SendMessageResponse.class,
+                                                            SendMessageBatchResponse.class)
+                                        .batchFunction(sendMessageBatchFunction(client))
+                                        .responseMapper(sendMessageResponseMapper())
+                                        .batchKeyMapper(sendMessageBatchKeyMapper())
+                                        .overrideConfiguration(overrideConfiguration)
+                                        .scheduledExecutor(scheduledExecutor)
+                                        .build();
+
+        this.deleteMessageBatchManager = BatchManager.builder(DeleteMessageRequest.class, DeleteMessageResponse.class,
+                                                              DeleteMessageBatchResponse.class)
+                                                     .batchFunction(deleteMessageBatchFunction(client))
+                                                     .responseMapper(deleteMessageResponseMapper())
+                                                     .batchKeyMapper(deleteMessageBatchKeyMapper())
+                                                     .overrideConfiguration(overrideConfiguration)
+                                                     .scheduledExecutor(scheduledExecutor)
+                                                     .build();
+
+        this.changeVisibilityBatchManager = BatchManager.builder(ChangeMessageVisibilityRequest.class,
+                                                                 ChangeMessageVisibilityResponse.class,
+                                                                 ChangeMessageVisibilityBatchResponse.class)
+                                                        .batchFunction(changeVisibilityBatchFunction(client))
+                                                        .responseMapper(changeVisibilityResponseMapper())
+                                                        .batchKeyMapper(changeVisibilityBatchKeyMapper())
+                                                        .overrideConfiguration(overrideConfiguration)
+                                                        .scheduledExecutor(scheduledExecutor)
+                                                        .build();
+    }
+
+    @Override
+    public CompletableFuture<SendMessageResponse> sendMessage(SendMessageRequest message) {
+        return sendMessageBatchManager.sendRequest(message);
+    }
+
+    @Override
+    public CompletableFuture<DeleteMessageResponse> deleteMessage(DeleteMessageRequest deleteRequest) {
+        return deleteMessageBatchManager.sendRequest(deleteRequest);
+    }
+
+    @Override
+    public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(ChangeMessageVisibilityRequest
+                                                                                              changeRequest) {
+        return changeVisibilityBatchManager.sendRequest(changeRequest);
+    }
+
+    @Override
+    public void close() {
+        sendMessageBatchManager.close();
+        deleteMessageBatchManager.close();
+    }
+
+    public static SqsBatchManager.Builder builder() {
+        return new DefaultBuilder();
+    }
+
+    public static final class DefaultBuilder implements Builder {
+        private BatchOverrideConfiguration overrideConfiguration;
+        private SqsClient client;
+
+        private DefaultBuilder() {
+        }
+
+        @Override
+        public Builder overrideConfiguration(BatchOverrideConfiguration overrideConfiguration) {
+            this.overrideConfiguration = overrideConfiguration;
+            return this;
+        }
+
+        @Override
+        public Builder client(SqsClient client) {
+            this.client = client;
+            return this;
+        }
+
+        public SqsBatchManager build() {
+            return new DefaultSqsBatchManager(this);
+        }
+    }
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import java.time.Duration;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
+
+@SdkInternalApi
+public final class SqsBatchConfiguration {
+    private static final int DEFAULT_MAX_BATCH_ITEMS = 10;
+    private static final Duration DEFAULT_MAX_BATCH_OPEN_IN_MS = Duration.ofMillis(200);
+    private final Integer maxBatchItems;
+    private final Duration maxBatchOpenInMs;
+
+    public SqsBatchConfiguration(BatchOverrideConfiguration overrideConfiguration) {
+        Optional<BatchOverrideConfiguration> configuration = Optional.ofNullable(overrideConfiguration);
+        this.maxBatchItems = configuration.flatMap(BatchOverrideConfiguration::maxBatchItems).orElse(DEFAULT_MAX_BATCH_ITEMS);
+        this.maxBatchOpenInMs = configuration.flatMap(BatchOverrideConfiguration::maxBatchOpenInMs)
+                                             .orElse(DEFAULT_MAX_BATCH_OPEN_IN_MS);
+    }
+
+    public Duration maxBatchOpenInMs() {
+        return maxBatchOpenInMs;
+    }
+
+    public int maxBatchItems() {
+        return maxBatchItems;
+    }
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchConfiguration.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
 import java.time.Duration;
-import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchConfiguration.java
@@ -28,10 +28,13 @@ public final class SqsBatchConfiguration {
     private final Duration maxBatchOpenInMs;
 
     public SqsBatchConfiguration(BatchOverrideConfiguration overrideConfiguration) {
-        Optional<BatchOverrideConfiguration> configuration = Optional.ofNullable(overrideConfiguration);
-        this.maxBatchItems = configuration.flatMap(BatchOverrideConfiguration::maxBatchItems).orElse(DEFAULT_MAX_BATCH_ITEMS);
-        this.maxBatchOpenInMs = configuration.flatMap(BatchOverrideConfiguration::maxBatchOpenInMs)
-                                             .orElse(DEFAULT_MAX_BATCH_OPEN_IN_MS);
+        if (overrideConfiguration == null) {
+            this.maxBatchItems = DEFAULT_MAX_BATCH_ITEMS;
+            this.maxBatchOpenInMs = DEFAULT_MAX_BATCH_OPEN_IN_MS;
+        } else {
+            this.maxBatchItems = overrideConfiguration.maxBatchItems().orElse(DEFAULT_MAX_BATCH_ITEMS);
+            this.maxBatchOpenInMs = overrideConfiguration.maxBatchOpenInMs().orElse(DEFAULT_MAX_BATCH_OPEN_IN_MS);
+        }
     }
 
     public Duration maxBatchOpenInMs() {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
@@ -149,13 +149,15 @@ public final class SqsBatchFunctions {
             deleteMessageBatchResponse.successful()
                                       .forEach(batchResponseEntry -> {
                                           String key = batchResponseEntry.id();
-                                          DeleteMessageResponse response = createDeleteMessageResponse(deleteMessageBatchResponse);
+                                          DeleteMessageResponse response =
+                                              createDeleteMessageResponse(deleteMessageBatchResponse);
                                           mappedResponses.add(new IdentifiableMessage<>(key, response));
                                       });
             deleteMessageBatchResponse.failed()
                                       .forEach(batchResponseEntry -> {
                                           String key = batchResponseEntry.id();
-                                          DeleteMessageResponse response = createDeleteMessageResponse(deleteMessageBatchResponse);
+                                          DeleteMessageResponse response =
+                                              createDeleteMessageResponse(deleteMessageBatchResponse);
                                           mappedResponses.add(new IdentifiableMessage<>(key, response));
                                       });
             return mappedResponses;
@@ -251,8 +253,8 @@ public final class SqsBatchFunctions {
         SendMessageResponse.Builder builder = SendMessageResponse.builder()
                                                                  .md5OfMessageAttributes(successfulEntry.md5OfMessageAttributes())
                                                                  .md5OfMessageBody(successfulEntry.md5OfMessageBody())
-                                                                 .md5OfMessageSystemAttributes(successfulEntry
-                                                                                                   .md5OfMessageSystemAttributes())
+                                                                 .md5OfMessageSystemAttributes(
+                                                                     successfulEntry.md5OfMessageSystemAttributes())
                                                                  .messageId(successfulEntry.messageId())
                                                                  .sequenceNumber(successfulEntry.sequenceNumber());
         if (batchResponse.responseMetadata() != null) {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.internal.batchmanager.BatchAndSend;
+import software.amazon.awssdk.core.internal.batchmanager.BatchKeyMapper;
+import software.amazon.awssdk.core.internal.batchmanager.BatchResponseMapper;
+import software.amazon.awssdk.core.internal.batchmanager.IdentifiableMessage;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Md5Utils;
+
+@SdkInternalApi
+public final class SqsBatchFunctions {
+
+    private SqsBatchFunctions() {
+    }
+
+    public static BatchAndSend<SendMessageRequest, SendMessageBatchResponse> sendMessageBatchFunction(SqsClient client) {
+        return (identifiedRequests, destination) -> {
+            List<SendMessageBatchRequestEntry> entries = new ArrayList<>(identifiedRequests.size());
+            identifiedRequests.forEach(identifiedRequest -> {
+                String id = identifiedRequest.id();
+                SendMessageRequest request = identifiedRequest.message();
+                entries.add(createSendMessageBatchRequestEntry(id, request));
+            });
+            // TODO: If the individual requests have an override configuration, should we pass it to the batch request builder as well?
+            //  If so, how should we do it? Just take the override configuration of the first individual request (since theoretically
+            //  they should all have the same override configuration).
+            Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                                .message()
+                                                                                                .overrideConfiguration();
+            SendMessageBatchRequest batchRequest;
+            if (overrideConfiguration.isPresent()) {
+                batchRequest = SendMessageBatchRequest.builder()
+                                                      .queueUrl(destination)
+                                                      .overrideConfiguration(overrideConfiguration.get())
+                                                      .entries(entries)
+                                                      .build();
+            } else {
+                batchRequest = SendMessageBatchRequest.builder()
+                                                      .queueUrl(destination)
+                                                      .entries(entries)
+                                                      .build();
+            }
+            // TODO: Pass client executor in supplyAsync once an executor is added into the client.
+            return CompletableFuture.supplyAsync(() -> client.sendMessageBatch(batchRequest));
+        };
+    }
+
+    public static BatchResponseMapper<SendMessageBatchResponse, SendMessageResponse> sendMessageResponseMapper() {
+     return sendMessageBatchResponse -> {
+         List<IdentifiableMessage<SendMessageResponse>> mappedResponses = new ArrayList<>();
+         sendMessageBatchResponse.successful()
+                                 .forEach(batchResponseEntry -> {
+                                     String key = batchResponseEntry.id();
+                                     SendMessageResponse response = createSendMessageResponse(batchResponseEntry);
+                                     mappedResponses.add(new IdentifiableMessage<>(key, response));
+                                 });
+         sendMessageBatchResponse.failed()
+                                 .forEach(batchResponseEntry -> {
+                                     String key = batchResponseEntry.id();
+                                     SendMessageResponse response = createSendMessageResponse(batchResponseEntry);
+                                     mappedResponses.add(new IdentifiableMessage<>(key, response));
+                                 });
+         return mappedResponses;
+     };
+    }
+
+    // TODO: This BatchKeyMapper for SQS is temporary. We have not decided on how to properly group batch requests
+    public static BatchKeyMapper<SendMessageRequest> sendMessageBatchKeyMapper() {
+        return request -> {
+            if (request.overrideConfiguration().isPresent()) {
+                return request.queueUrl() + request.overrideConfiguration().get();
+            } else {
+                return request.queueUrl();
+            }
+        };
+    }
+
+    public static BatchAndSend<DeleteMessageRequest, DeleteMessageBatchResponse> deleteMessageBatchFunction(SqsClient client) {
+        return (identifiedRequests, destination) -> {
+            List<DeleteMessageBatchRequestEntry> entries = new ArrayList<>(identifiedRequests.size());
+            identifiedRequests.forEach(identifiedRequest -> {
+                String id = identifiedRequest.id();
+                DeleteMessageRequest request = identifiedRequest.message();
+                entries.add(createDeleteMessageBatchRequestEntry(id, request));
+            });
+            // TODO: Fix overrideConfiguration.
+            Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                                .message()
+                                                                                                .overrideConfiguration();
+            DeleteMessageBatchRequest batchRequest;
+            if (overrideConfiguration.isPresent()) {
+                batchRequest = DeleteMessageBatchRequest.builder()
+                                                        .entries(entries)
+                                                        .overrideConfiguration(overrideConfiguration.get())
+                                                        .queueUrl(destination)
+                                                        .build();
+            } else {
+                batchRequest = DeleteMessageBatchRequest.builder()
+                                                        .entries(entries)
+                                                        .queueUrl(destination)
+                                                        .build();
+            }
+            // TODO: Pass client executor in supplyAsync once an executor is added into the client.
+            return CompletableFuture.supplyAsync(() -> client.deleteMessageBatch(batchRequest));
+        };
+    }
+
+    // TODO: How should we properly map a deleteMessageResponse? Seems like a DeleteMessageResponse builder doesn't really take
+    //  any fields.
+    public static BatchResponseMapper<DeleteMessageBatchResponse, DeleteMessageResponse> deleteMessageResponseMapper() {
+        return deleteMessageBatchResponse -> {
+            List<IdentifiableMessage<DeleteMessageResponse>> mappedResponses = new ArrayList<>();
+            deleteMessageBatchResponse.successful()
+                                      .forEach(batchResponseEntry -> {
+                                          String key = batchResponseEntry.id();
+                                          DeleteMessageResponse response = createDeleteMessageResponse();
+                                          mappedResponses.add(new IdentifiableMessage<>(key, response));
+                                      });
+            deleteMessageBatchResponse.failed()
+                                      .forEach(batchResponseEntry -> {
+                                          String key = batchResponseEntry.id();
+                                          DeleteMessageResponse response = createDeleteMessageResponse();
+                                          mappedResponses.add(new IdentifiableMessage<>(key, response));
+                                      });
+            return mappedResponses;
+        };
+    }
+
+    // TODO: Might be able to combine all batchKeyMapper functions if they are all the same. Only problem is they take
+    //    //  different types as parameters so maybe not?
+    public static BatchKeyMapper<DeleteMessageRequest> deleteMessageBatchKeyMapper() {
+        return request -> {
+            if (request.overrideConfiguration().isPresent()) {
+                return request.queueUrl() + request.overrideConfiguration().get();
+            } else {
+                return request.queueUrl();
+            }
+        };
+    }
+
+    public static BatchAndSend<ChangeMessageVisibilityRequest, ChangeMessageVisibilityBatchResponse>
+    changeVisibilityBatchFunction(SqsClient client) {
+        return (identifiedRequests, destination) -> {
+            List<ChangeMessageVisibilityBatchRequestEntry> entries = new ArrayList<>(identifiedRequests.size());
+            identifiedRequests.forEach(identifiedRequest -> {
+                String id = identifiedRequest.id();
+                ChangeMessageVisibilityRequest request = identifiedRequest.message();
+                entries.add(createChangVisibilityBatchRequestEntry(id, request));
+            });
+            // TODO: Fix overrideConfiguration.
+            Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                                .message()
+                                                                                                .overrideConfiguration();
+            ChangeMessageVisibilityBatchRequest batchRequest;
+            if (overrideConfiguration.isPresent()) {
+                batchRequest = ChangeMessageVisibilityBatchRequest.builder()
+                                                                  .entries(entries)
+                                                                  .overrideConfiguration(overrideConfiguration.get())
+                                                                  .queueUrl(destination)
+                                                                  .build();
+            } else {
+                batchRequest = ChangeMessageVisibilityBatchRequest.builder()
+                                                                  .entries(entries)
+                                                                  .queueUrl(destination)
+                                                                  .build();
+            }
+            // TODO: Pass client executor in supplyAsync once an executor is added into the client.
+            return CompletableFuture.supplyAsync(() -> client.changeMessageVisibilityBatch(batchRequest));
+        };
+    }
+
+    // TODO: Same problem with mapping ChangeMessageVisibilityResponse as with DeleteMessageResponse.
+    public static BatchResponseMapper<ChangeMessageVisibilityBatchResponse, ChangeMessageVisibilityResponse>
+    changeVisibilityResponseMapper() {
+        return changeMessageVisibilityResponses -> {
+            List<IdentifiableMessage<ChangeMessageVisibilityResponse>> mappedResponses = new ArrayList<>();
+            changeMessageVisibilityResponses.successful()
+                                            .forEach(batchResponseEntry -> {
+                                                String key = batchResponseEntry.id();
+                                                ChangeMessageVisibilityResponse response = createChangeVisibilityResponse();
+                                                mappedResponses.add(new IdentifiableMessage<>(key, response));
+                                            });
+            changeMessageVisibilityResponses.failed()
+                                            .forEach(batchResponseEntry -> {
+                                                String key = batchResponseEntry.id();
+                                                ChangeMessageVisibilityResponse response = createChangeVisibilityResponse();
+                                                mappedResponses.add(new IdentifiableMessage<>(key, response));
+                                            });
+            return mappedResponses;
+        };
+    }
+
+    // TODO: Might be able to combine all batchKeyMapper functions if they are all the same. Only problem is they take
+    //  different types as parameters so maybe not?
+    public static BatchKeyMapper<ChangeMessageVisibilityRequest> changeVisibilityBatchKeyMapper() {
+        return request -> {
+            if (request.overrideConfiguration().isPresent()) {
+                return request.queueUrl() + request.overrideConfiguration().get();
+            } else {
+                return request.queueUrl();
+            }
+        };
+    }
+
+    private static SendMessageBatchRequestEntry createSendMessageBatchRequestEntry(String id, SendMessageRequest request) {
+        return SendMessageBatchRequestEntry.builder()
+                                           .id(id)
+                                           .messageBody(request.messageBody())
+                                           .delaySeconds(request.delaySeconds())
+                                           .messageAttributes(request.messageAttributes())
+                                           .messageDeduplicationId(request.messageDeduplicationId())
+                                           .messageGroupId(request.messageGroupId())
+                                           .messageSystemAttributes(request.messageSystemAttributes())
+                                           .build();
+    }
+
+    private static SendMessageResponse createSendMessageResponse(SendMessageBatchResultEntry successfulEntry) {
+        return SendMessageResponse.builder()
+                                  .md5OfMessageAttributes(successfulEntry.md5OfMessageAttributes())
+                                  .md5OfMessageBody(successfulEntry.md5OfMessageBody())
+                                  .md5OfMessageSystemAttributes(successfulEntry.md5OfMessageSystemAttributes())
+                                  .messageId(successfulEntry.messageId())
+                                  .sequenceNumber(successfulEntry.sequenceNumber())
+                                  .build();
+    }
+
+    private static SendMessageResponse createSendMessageResponse(BatchResultErrorEntry failedEntry) {
+        String messageBody = String.format("%s: %s", failedEntry.code(), failedEntry.message());
+        return SendMessageResponse.builder()
+                                  .md5OfMessageBody(computeMd5Hash(messageBody))
+                                  .build();
+    }
+
+    private static DeleteMessageBatchRequestEntry createDeleteMessageBatchRequestEntry(String id, DeleteMessageRequest request) {
+        return DeleteMessageBatchRequestEntry.builder()
+                                             .id(id)
+                                             .receiptHandle(request.receiptHandle())
+                                             .build();
+    }
+
+    private static ChangeMessageVisibilityBatchRequestEntry createChangVisibilityBatchRequestEntry(String id,
+                                                                                         ChangeMessageVisibilityRequest request) {
+        return ChangeMessageVisibilityBatchRequestEntry.builder()
+                                                       .id(id)
+                                                       .receiptHandle(request.receiptHandle())
+                                                       .visibilityTimeout(request.visibilityTimeout())
+                                                       .build();
+    }
+
+    private static DeleteMessageResponse createDeleteMessageResponse() {
+        return DeleteMessageResponse.builder().build();
+    }
+
+    private static ChangeMessageVisibilityResponse createChangeVisibilityResponse() {
+        return ChangeMessageVisibilityResponse.builder().build();
+    }
+
+    private static String computeMd5Hash(String message) {
+        byte[] expectedMd5;
+        expectedMd5 = Md5Utils.computeMD5Hash(message.getBytes(StandardCharsets.UTF_8));
+        return BinaryUtils.toHex(expectedMd5);
+    }
+}

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityResponseMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageResponseMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageBatchFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageResponseMapper;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.internal.batchmanager.IdentifiableMessage;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResultEntry;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResultEntry;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Md5Utils;
+
+// TODO: Will refactor code in this test file for async tests.
+public class SqsBatchFunctionsTest {
+    private static final URI HTTP_LOCALHOST_URI = URI.create("http://localhost:8080/");
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule();
+
+    private SqsClientBuilder getSyncClientBuilder() {
+        return SqsClient.builder()
+                        .region(Region.US_EAST_1)
+                        .endpointOverride(HTTP_LOCALHOST_URI)
+                        .credentialsProvider(
+                            StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")));
+    }
+
+    @Test
+    public void sendMessageBatchFunction_batchMessageCorrectly() {
+        String id1 = "1";
+        String id2 = "2";
+        String messageBody1 = getMd5Hash("1");
+        String messageBody2 = getMd5Hash("2");
+        String responseBody = String.format(
+            "<SendMessageBatchResponse>\n"
+            + "<SendMessageBatchResult>\n"
+            + "    <SendMessageBatchResultEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
+            + "    </SendMessageBatchResultEntry>\n"
+            + "    <SendMessageBatchResultEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
+            + "    </SendMessageBatchResultEntry>\n"
+            + "</SendMessageBatchResult>\n"
+            + "</SendMessageBatchResponse>", id1, messageBody1, id2, messageBody2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        SqsClient sqsClient = getSyncClientBuilder().build();
+
+        List<IdentifiableMessage<SendMessageRequest>> requests = new ArrayList<>();
+        requests.add(new IdentifiableMessage<>("1", createSendMessageRequest("1")));
+        requests.add(new IdentifiableMessage<>("2", createSendMessageRequest("2")));
+        CompletableFuture<SendMessageBatchResponse> response = sendMessageBatchFunction(sqsClient).batchAndSend(requests,
+                                                                                                               "SomeId");
+        List<SendMessageBatchResultEntry> completedResponse = response.join().successful();
+        SendMessageBatchResultEntry completedResponse1 = completedResponse.get(0);
+        SendMessageBatchResultEntry completedResponse2 = completedResponse.get(1);
+        Assert.assertEquals(id1, completedResponse1.id());
+        Assert.assertEquals(messageBody1, completedResponse1.md5OfMessageBody());
+        Assert.assertEquals(id2, completedResponse2.id());
+        Assert.assertEquals(messageBody2, completedResponse2.md5OfMessageBody());
+    }
+
+    @Test
+    public void sendMessageResponseMapper_mapResponsesCorrectly() {
+        String id1 = "1";
+        String id2 = "2";
+        String messageBody1 = getMd5Hash("1");
+        String messageBody2 = getMd5Hash("2");
+        SendMessageBatchResultEntry entry1 = createSendMessageBatchEntry(id1, messageBody1);
+        SendMessageBatchResultEntry entry2 = createSendMessageBatchEntry(id2, messageBody2);
+        SendMessageBatchResponse batchResponse = SendMessageBatchResponse.builder()
+                                                                         .successful(entry1, entry2)
+                                                                         .build();
+        List<IdentifiableMessage<SendMessageResponse>> mappedResponses =
+            sendMessageResponseMapper().mapBatchResponse(batchResponse);
+
+        IdentifiableMessage<SendMessageResponse> response1 = mappedResponses.get(0);
+        IdentifiableMessage<SendMessageResponse> response2 = mappedResponses.get(1);
+        Assert.assertEquals(id1, response1.id());
+        Assert.assertEquals(messageBody1, response1.message().md5OfMessageBody());
+        Assert.assertEquals(id2, response2.id());
+        Assert.assertEquals(messageBody2, response2.message().md5OfMessageBody());
+    }
+
+    @Test
+    public void sendMessageBatchKeyMapperWithoutOverrideConfig_hasSameBatchKey() {
+        String queueUrl = "myQueue";
+        SendMessageRequest request1 = SendMessageRequest.builder().queueUrl(queueUrl).build();
+        SendMessageRequest request2 = SendMessageRequest.builder().queueUrl(queueUrl).build();
+        String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
+
+        Assert.assertEquals(queueUrl, batchKey1);
+        Assert.assertEquals(queueUrl, batchKey2);
+        Assert.assertEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void sendMessageBatchKeyMapperWithOverrideConfig_hasSameBatchKey() {
+        String queueUrl = "myQueue";
+        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
+        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(10);
+        SendMessageRequest request1 = SendMessageRequest.builder()
+                                                        .queueUrl(queueUrl)
+                                                        .overrideConfiguration(overrideConfiguration1)
+                                                        .build();
+        SendMessageRequest request2 = SendMessageRequest.builder()
+                                                        .queueUrl(queueUrl)
+                                                        .overrideConfiguration(overrideConfiguration2)
+                                                        .build();
+        String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
+        Assert.assertEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void sendMessageBatchKeyMapperWithDifferentOverrideConfig_hasDifferentBatchKey() {
+        String queueUrl = "myQueue";
+        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
+        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(20);
+        SendMessageRequest request1 = SendMessageRequest.builder()
+                                                        .queueUrl(queueUrl)
+                                                        .overrideConfiguration(overrideConfiguration1)
+                                                        .build();
+        SendMessageRequest request2 = SendMessageRequest.builder()
+                                                        .queueUrl(queueUrl)
+                                                        .overrideConfiguration(overrideConfiguration2)
+                                                        .build();
+        String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
+        Assert.assertNotEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void deleteMessageBatchFunction_batchMessageCorrectly() {
+        String id1 = "1";
+        String id2 = "2";
+        String responseBody = String.format(
+            "<DeleteMessageBatchResponse>\n"
+            + "    <DeleteMessageBatchResult>\n"
+            + "        <DeleteMessageBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </DeleteMessageBatchResultEntry>\n"
+            + "        <DeleteMessageBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </DeleteMessageBatchResultEntry>\n"
+            + "    </DeleteMessageBatchResult>\n"
+            + "</DeleteMessageBatchResponse>\n", id1, id2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        SqsClient sqsClient = getSyncClientBuilder().build();
+
+        List<IdentifiableMessage<DeleteMessageRequest>> requests = new ArrayList<>();
+        requests.add(new IdentifiableMessage<>("1", createDeleteMessageRequest()));
+        requests.add(new IdentifiableMessage<>("2", createDeleteMessageRequest()));
+        CompletableFuture<DeleteMessageBatchResponse> response = deleteMessageBatchFunction(sqsClient).batchAndSend(requests,
+                                                                                                                    "SomeId");
+        List<DeleteMessageBatchResultEntry> completedResponse = response.join().successful();
+        DeleteMessageBatchResultEntry completedResponse1 = completedResponse.get(0);
+        DeleteMessageBatchResultEntry completedResponse2 = completedResponse.get(1);
+        Assert.assertEquals(id1, completedResponse1.id());
+        Assert.assertEquals(id2, completedResponse2.id());
+    }
+
+    @Test
+    public void deleteMessageResponseMapper_mapResponsesCorrectly() {
+        String id1 = "1";
+        String id2 = "2";
+        DeleteMessageBatchResultEntry entry1 = createDeleteMessageBatchEntry(id1);
+        DeleteMessageBatchResultEntry entry2 = createDeleteMessageBatchEntry(id2);
+        DeleteMessageBatchResponse batchResponse = DeleteMessageBatchResponse.builder().successful(entry1, entry2).build();
+        List<IdentifiableMessage<DeleteMessageResponse>> mappedResponses =
+            deleteMessageResponseMapper().mapBatchResponse(batchResponse);
+
+        IdentifiableMessage<DeleteMessageResponse> response1 = mappedResponses.get(0);
+        IdentifiableMessage<DeleteMessageResponse> response2 = mappedResponses.get(1);
+        Assert.assertEquals(id1, response1.id());
+        Assert.assertEquals(id2, response2.id());
+    }
+
+    @Test
+    public void deleteMessageBatchKeyMapperWithoutOverrideConfig_hasSameBatchKey() {
+        String queueUrl = "myQueue";
+        DeleteMessageRequest request1 = DeleteMessageRequest.builder().queueUrl(queueUrl).build();
+        DeleteMessageRequest request2 = DeleteMessageRequest.builder().queueUrl(queueUrl).build();
+        String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
+
+        Assert.assertEquals(queueUrl, batchKey1);
+        Assert.assertEquals(queueUrl, batchKey2);
+        Assert.assertEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void deleteMessageBatchKeyMapperWithOverrideConfig_hasSameBatchKey() {
+        String queueUrl = "myQueue";
+        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
+        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(10);
+        DeleteMessageRequest request1 = DeleteMessageRequest.builder()
+                                                            .queueUrl(queueUrl)
+                                                            .overrideConfiguration(overrideConfiguration1)
+                                                            .build();
+        DeleteMessageRequest request2 = DeleteMessageRequest.builder()
+                                                            .queueUrl(queueUrl)
+                                                            .overrideConfiguration(overrideConfiguration2)
+                                                            .build();
+        String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
+        Assert.assertEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void deleteMessageBatchKeyMapperWithDifferentOverrideConfig_hasDifferentBatchKey() {
+        String queueUrl = "myQueue";
+        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
+        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(20);
+        DeleteMessageRequest request1 = DeleteMessageRequest.builder()
+                                                            .queueUrl(queueUrl)
+                                                            .overrideConfiguration(overrideConfiguration1)
+                                                            .build();
+        DeleteMessageRequest request2 = DeleteMessageRequest.builder()
+                                                            .queueUrl(queueUrl)
+                                                            .overrideConfiguration(overrideConfiguration2)
+                                                            .build();
+        String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
+        Assert.assertNotEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void changeVisibilityBatchFunction_batchMessageCorrectly() {
+        String id1 = "1";
+        String id2 = "2";
+        String responseBody = String.format(
+            "<ChangeMessageVisibilityBatchResponse>\n"
+            + "    <ChangeMessageVisibilityBatchResult>\n"
+            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
+            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
+            + "    </ChangeMessageVisibilityBatchResult>\n"
+            + "</ChangeMessageVisibilityBatchResponse>", id1, id2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        SqsClient sqsClient = getSyncClientBuilder().build();
+
+        List<IdentifiableMessage<ChangeMessageVisibilityRequest>> requests = new ArrayList<>();
+        requests.add(new IdentifiableMessage<>("1", createChangeVisibilityRequest()));
+        requests.add(new IdentifiableMessage<>("2", createChangeVisibilityRequest()));
+        CompletableFuture<ChangeMessageVisibilityBatchResponse> response =
+            changeVisibilityBatchFunction(sqsClient).batchAndSend(requests, "SomeId");
+
+        List<ChangeMessageVisibilityBatchResultEntry> completedResponse = response.join().successful();
+        ChangeMessageVisibilityBatchResultEntry completedResponse1 = completedResponse.get(0);
+        ChangeMessageVisibilityBatchResultEntry completedResponse2 = completedResponse.get(1);
+        Assert.assertEquals(id1, completedResponse1.id());
+        Assert.assertEquals(id2, completedResponse2.id());
+    }
+
+    @Test
+    public void changeVisibilityResponseMapper_mapResponsesCorrectly() {
+        String id1 = "1";
+        String id2 = "2";
+        ChangeMessageVisibilityBatchResultEntry entry1 = createChangeVisibilityBatchEntry(id1);
+        ChangeMessageVisibilityBatchResultEntry entry2 = createChangeVisibilityBatchEntry(id2);
+        ChangeMessageVisibilityBatchResponse batchResponse = ChangeMessageVisibilityBatchResponse.builder()
+                                                                                                 .successful(entry1, entry2)
+                                                                                                 .build();
+        List<IdentifiableMessage<ChangeMessageVisibilityResponse>> mappedResponses =
+            changeVisibilityResponseMapper().mapBatchResponse(batchResponse);
+
+        IdentifiableMessage<ChangeMessageVisibilityResponse> response1 = mappedResponses.get(0);
+        IdentifiableMessage<ChangeMessageVisibilityResponse> response2 = mappedResponses.get(1);
+        Assert.assertEquals(id1, response1.id());
+        Assert.assertEquals(id2, response2.id());
+    }
+
+    @Test
+    public void changeVisibilityBatchKeyMapperWithoutOverrideConfig_hasSameBatchKey() {
+        String queueUrl = "myQueue";
+        ChangeMessageVisibilityRequest request1 = ChangeMessageVisibilityRequest.builder().queueUrl(queueUrl).build();
+        ChangeMessageVisibilityRequest request2 = ChangeMessageVisibilityRequest.builder().queueUrl(queueUrl).build();
+        String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
+
+        Assert.assertEquals(queueUrl, batchKey1);
+        Assert.assertEquals(queueUrl, batchKey2);
+        Assert.assertEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void changeVisibilityBatchKeyMapperWithOverrideConfig_hasSameBatchKey() {
+        String queueUrl = "myQueue";
+        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
+        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(10);
+        ChangeMessageVisibilityRequest request1 = ChangeMessageVisibilityRequest.builder()
+                                                                                .queueUrl(queueUrl)
+                                                                                .overrideConfiguration(overrideConfiguration1)
+                                                                                .build();
+        ChangeMessageVisibilityRequest request2 = ChangeMessageVisibilityRequest.builder()
+                                                                                .queueUrl(queueUrl)
+                                                                                .overrideConfiguration(overrideConfiguration2)
+                                                                                .build();
+        String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
+        Assert.assertEquals(batchKey1, batchKey2);
+    }
+
+    @Test
+    public void changeVisibilityBatchKeyMapperWithDifferentOverrideConfig_hasDifferentBatchKey() {
+        String queueUrl = "myQueue";
+        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
+        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(20);
+        ChangeMessageVisibilityRequest request1 = ChangeMessageVisibilityRequest.builder()
+                                                                                .queueUrl(queueUrl)
+                                                                                .overrideConfiguration(overrideConfiguration1)
+                                                                                .build();
+        ChangeMessageVisibilityRequest request2 = ChangeMessageVisibilityRequest.builder()
+                                                                                .queueUrl(queueUrl)
+                                                                                .overrideConfiguration(overrideConfiguration2)
+                                                                                .build();
+        String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
+        String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
+        Assert.assertNotEquals(batchKey1, batchKey2);
+    }
+
+    private SendMessageRequest createSendMessageRequest(String messageBody) {
+        return SendMessageRequest.builder()
+                                 .messageBody(messageBody)
+                                 .build();
+    }
+
+
+    private DeleteMessageRequest createDeleteMessageRequest() {
+        return DeleteMessageRequest.builder().build();
+    }
+
+    private ChangeMessageVisibilityRequest createChangeVisibilityRequest() {
+        return ChangeMessageVisibilityRequest.builder().build();
+    }
+
+    private SendMessageBatchResultEntry createSendMessageBatchEntry(String id, String messageBody) {
+        return SendMessageBatchResultEntry.builder()
+                                          .id(id)
+                                          .md5OfMessageBody(messageBody)
+                                          .build();
+    }
+
+    private DeleteMessageBatchResultEntry createDeleteMessageBatchEntry(String id) {
+        return DeleteMessageBatchResultEntry.builder().id(id).build();
+    }
+
+    private ChangeMessageVisibilityBatchResultEntry createChangeVisibilityBatchEntry(String id) {
+        return ChangeMessageVisibilityBatchResultEntry.builder().id(id).build();
+    }
+
+    private AwsRequestOverrideConfiguration createOverrideConfig(int millis) {
+        Duration apiCallTimeout = Duration.ofMillis(millis);
+        return AwsRequestOverrideConfiguration.builder().apiCallTimeout(apiCallTimeout).build();
+    }
+
+    private String getMd5Hash(String message) {
+        byte[] expectedMd5;
+        expectedMd5 = Md5Utils.computeMD5Hash(message.getBytes(StandardCharsets.UTF_8));
+        return BinaryUtils.toHex(expectedMd5);
+    }
+}

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.sqs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchKeyMapper;
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityResponseMapper;
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchKeyMapper;
@@ -25,7 +26,6 @@ import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatch
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.internal.batchmanager.IdentifiableMessage;
@@ -63,10 +63,10 @@ public class SqsBatchFunctionsTest {
 
         IdentifiableMessage<SendMessageResponse> response1 = mappedResponses.get(0);
         IdentifiableMessage<SendMessageResponse> response2 = mappedResponses.get(1);
-        Assert.assertEquals(id1, response1.id());
-        Assert.assertEquals(messageBody1, response1.message().md5OfMessageBody());
-        Assert.assertEquals(id2, response2.id());
-        Assert.assertEquals(messageBody2, response2.message().md5OfMessageBody());
+        assertThat(response1.id()).isEqualTo(id1);
+        assertThat(response1.message().md5OfMessageBody()).isEqualTo(messageBody1);
+        assertThat(response2.id()).isEqualTo(id2);
+        assertThat(response2.message().md5OfMessageBody()).isEqualTo(messageBody2);
     }
 
     @Test
@@ -77,9 +77,9 @@ public class SqsBatchFunctionsTest {
         String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
 
-        Assert.assertEquals(queueUrl, batchKey1);
-        Assert.assertEquals(queueUrl, batchKey2);
-        Assert.assertEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isEqualTo(queueUrl);
+        assertThat(batchKey2).isEqualTo(queueUrl);
+        assertThat(batchKey1).isEqualTo(batchKey2);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class SqsBatchFunctionsTest {
                                                         .build();
         String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
-        Assert.assertEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isEqualTo(batchKey2);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class SqsBatchFunctionsTest {
                                                         .build();
         String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
-        Assert.assertNotEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isNotEqualTo(batchKey2);
     }
 
     @Test
@@ -130,8 +130,8 @@ public class SqsBatchFunctionsTest {
 
         IdentifiableMessage<DeleteMessageResponse> response1 = mappedResponses.get(0);
         IdentifiableMessage<DeleteMessageResponse> response2 = mappedResponses.get(1);
-        Assert.assertEquals(id1, response1.id());
-        Assert.assertEquals(id2, response2.id());
+        assertThat(response1.id()).isEqualTo(id1);
+        assertThat(response2.id()).isEqualTo(id2);
     }
 
     @Test
@@ -142,9 +142,9 @@ public class SqsBatchFunctionsTest {
         String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
 
-        Assert.assertEquals(queueUrl, batchKey1);
-        Assert.assertEquals(queueUrl, batchKey2);
-        Assert.assertEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isEqualTo(queueUrl);
+        assertThat(batchKey2).isEqualTo(queueUrl);
+        assertThat(batchKey1).isEqualTo(batchKey2);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class SqsBatchFunctionsTest {
                                                             .build();
         String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
-        Assert.assertEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isEqualTo(batchKey2);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class SqsBatchFunctionsTest {
                                                             .build();
         String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
-        Assert.assertNotEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isNotEqualTo(batchKey2);
     }
 
     @Test
@@ -197,8 +197,8 @@ public class SqsBatchFunctionsTest {
 
         IdentifiableMessage<ChangeMessageVisibilityResponse> response1 = mappedResponses.get(0);
         IdentifiableMessage<ChangeMessageVisibilityResponse> response2 = mappedResponses.get(1);
-        Assert.assertEquals(id1, response1.id());
-        Assert.assertEquals(id2, response2.id());
+        assertThat(response1.id()).isEqualTo(id1);
+        assertThat(response2.id()).isEqualTo(id2);
     }
 
     @Test
@@ -209,9 +209,9 @@ public class SqsBatchFunctionsTest {
         String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
 
-        Assert.assertEquals(queueUrl, batchKey1);
-        Assert.assertEquals(queueUrl, batchKey2);
-        Assert.assertEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isEqualTo(queueUrl);
+        assertThat(batchKey2).isEqualTo(queueUrl);
+        assertThat(batchKey1).isEqualTo(batchKey2);
     }
 
     @Test
@@ -229,7 +229,7 @@ public class SqsBatchFunctionsTest {
                                                                                 .build();
         String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
-        Assert.assertEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isEqualTo(batchKey2);
     }
 
     @Test
@@ -247,7 +247,7 @@ public class SqsBatchFunctionsTest {
                                                                                 .build();
         String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
-        Assert.assertNotEquals(batchKey1, batchKey2);
+        assertThat(batchKey1).isNotEqualTo(batchKey2);
     }
 
     private SendMessageBatchResultEntry createSendMessageBatchEntry(String id, String messageBody) {

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
@@ -36,6 +36,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,12 +99,13 @@ public class SqsBatchFunctionsTest {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
 
         SqsClient sqsClient = getSyncClientBuilder().build();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
 
         List<IdentifiableMessage<SendMessageRequest>> requests = new ArrayList<>();
         requests.add(new IdentifiableMessage<>("1", createSendMessageRequest("1")));
         requests.add(new IdentifiableMessage<>("2", createSendMessageRequest("2")));
-        CompletableFuture<SendMessageBatchResponse> response = sendMessageBatchFunction(sqsClient).batchAndSend(requests,
-                                                                                                               "SomeId");
+        CompletableFuture<SendMessageBatchResponse> response =
+            sendMessageBatchFunction(sqsClient, executor).batchAndSend(requests, "SomeId");
         List<SendMessageBatchResultEntry> completedResponse = response.join().successful();
         SendMessageBatchResultEntry completedResponse1 = completedResponse.get(0);
         SendMessageBatchResultEntry completedResponse2 = completedResponse.get(1);
@@ -202,12 +205,13 @@ public class SqsBatchFunctionsTest {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
 
         SqsClient sqsClient = getSyncClientBuilder().build();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
 
         List<IdentifiableMessage<DeleteMessageRequest>> requests = new ArrayList<>();
         requests.add(new IdentifiableMessage<>("1", createDeleteMessageRequest()));
         requests.add(new IdentifiableMessage<>("2", createDeleteMessageRequest()));
-        CompletableFuture<DeleteMessageBatchResponse> response = deleteMessageBatchFunction(sqsClient).batchAndSend(requests,
-                                                                                                                    "SomeId");
+        CompletableFuture<DeleteMessageBatchResponse> response =
+            deleteMessageBatchFunction(sqsClient, executor).batchAndSend(requests, "SomeId");
         List<DeleteMessageBatchResultEntry> completedResponse = response.join().successful();
         DeleteMessageBatchResultEntry completedResponse1 = completedResponse.get(0);
         DeleteMessageBatchResultEntry completedResponse2 = completedResponse.get(1);
@@ -299,12 +303,13 @@ public class SqsBatchFunctionsTest {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
 
         SqsClient sqsClient = getSyncClientBuilder().build();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
 
         List<IdentifiableMessage<ChangeMessageVisibilityRequest>> requests = new ArrayList<>();
         requests.add(new IdentifiableMessage<>("1", createChangeVisibilityRequest()));
         requests.add(new IdentifiableMessage<>("2", createChangeVisibilityRequest()));
         CompletableFuture<ChangeMessageVisibilityBatchResponse> response =
-            changeVisibilityBatchFunction(sqsClient).batchAndSend(requests, "SomeId");
+            changeVisibilityBatchFunction(sqsClient, executor).batchAndSend(requests, "SomeId");
 
         List<ChangeMessageVisibilityBatchResultEntry> completedResponse = response.join().successful();
         ChangeMessageVisibilityBatchResultEntry completedResponse1 = completedResponse.get(0);

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -31,7 +31,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -48,6 +47,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.batchmanager.BatchManager;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
 import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsBatchManager;
@@ -60,6 +60,7 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.Md5Utils;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
@@ -202,8 +203,8 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<SendMessageResponse> response1 = responses.get(0);
         CompletableFuture<SendMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
     }
 
     @Test
@@ -217,8 +218,8 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<SendMessageResponse> response1 = responses.get(0);
         CompletableFuture<SendMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining(errorMessage);
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SdkClientException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SdkClientException.class).hasMessageContaining(errorMessage);
     }
 
     @Test
@@ -276,8 +277,8 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<DeleteMessageResponse> response1 = responses.get(0);
         CompletableFuture<DeleteMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
     }
 
     @Test
@@ -335,8 +336,8 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<ChangeMessageVisibilityResponse> response1 = responses.get(0);
         CompletableFuture<ChangeMessageVisibilityResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
     }
 
     @Test

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -202,22 +202,23 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<SendMessageResponse> response1 = responses.get(0);
         CompletableFuture<SendMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class);
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class);
+        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
     }
 
     @Test
     public void sendMessageBatchNetworkError_causesConnectionResetException() {
         String id1 = "0";
         String id2 = "1";
+        String errorMessage = "Unable to execute HTTP request";
         stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
         List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
 
         CompletableFuture<SendMessageResponse> response1 = responses.get(0);
         CompletableFuture<SendMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class);
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class);
+        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining(errorMessage);
     }
 
     @Test
@@ -275,8 +276,8 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<DeleteMessageResponse> response1 = responses.get(0);
         CompletableFuture<DeleteMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("400");
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("400");
+        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
     }
 
     @Test
@@ -334,8 +335,8 @@ public class SqsBatchManagerTest {
 
         CompletableFuture<ChangeMessageVisibilityResponse> response1 = responses.get(0);
         CompletableFuture<ChangeMessageVisibilityResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("400");
-        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("400");
+        assertThatThrownBy(response1::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).isInstanceOf(CompletionException.class).hasMessageContaining("Status Code: 400");
     }
 
     @Test

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -87,7 +87,7 @@ public class SqsBatchManagerTest {
         ChangeMessageVisibilityBatchResponse> mockChangeVisibilityBatchManager;
 
     @Rule
-    public WireMockRule wireMock = new WireMockRule();
+    public WireMockRule wireMock = new WireMockRule(0);
 
     private static SqsClientBuilder getSyncClientBuilder() {
         return SqsClient.builder()

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Md5Utils;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+public class SqsBatchManagerTest {
+
+    private static final int DEFAULT_MAX_BATCH_OPEN = 200;
+    private static final String DEFAULT_QUEUE_URl = "SomeQueueUrl";
+    private static final URI HTTP_LOCALHOST_URI = URI.create("http://localhost:8080/");
+    private static ScheduledExecutorService scheduledExecutor;
+    private static ExecutorService executor;
+    private static SqsClient client;
+    private SqsBatchManager batchManager;
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule();
+
+    private static SqsClientBuilder getSyncClientBuilder() {
+        return SqsClient.builder()
+                        .region(Region.US_EAST_1)
+                        .endpointOverride(HTTP_LOCALHOST_URI)
+                        .credentialsProvider(
+                            StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")));
+    }
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().threadNamePrefix("SqsBatchManager").build();
+        scheduledExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
+        executor = Executors.newSingleThreadExecutor();
+        client = getSyncClientBuilder().build();
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown() {
+        client.close();
+        scheduledExecutor.shutdownNow();
+        executor.shutdownNow();
+    }
+
+    @Before
+    public void setUp() {
+        batchManager = SqsBatchManager.builder()
+                                      .client(client)
+                                      .scheduledExecutor(scheduledExecutor)
+                                      .executor(executor)
+                                      .build();
+    }
+
+    @After
+    public void tearDown() {
+        batchManager.close();
+    }
+
+    @Test
+    public void sendMessageBatchFunction_batchMessageCorrectly() {
+        String id1 = "0";
+        String id2 = "1";
+        String messageBody1 = getMd5Hash(id1);
+        String messageBody2 = getMd5Hash(id2);
+        String responseBody = String.format(
+            "<SendMessageBatchResponse>\n"
+            + "<SendMessageBatchResult>\n"
+            + "    <SendMessageBatchResultEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
+            + "    </SendMessageBatchResultEntry>\n"
+            + "    <SendMessageBatchResultEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
+            + "    </SendMessageBatchResultEntry>\n"
+            + "</SendMessageBatchResult>\n"
+            + "</SendMessageBatchResponse>", id1, messageBody1, id2, messageBody2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        List<SendMessageRequest> requests = new ArrayList<>();
+        requests.add(createSendMessageRequest(id1));
+        requests.add(createSendMessageRequest(id2));
+
+        List<CompletableFuture<SendMessageResponse>> responses = new ArrayList<>();
+        for (SendMessageRequest request : requests) {
+            responses.add(batchManager.sendMessage(request));
+        }
+
+        SendMessageResponse completedResponse1 = responses.get(0).join();
+        SendMessageResponse completedResponse2 = responses.get(1).join();
+        Assert.assertEquals(messageBody1, completedResponse1.md5OfMessageBody());
+        Assert.assertEquals(messageBody2, completedResponse2.md5OfMessageBody());
+    }
+
+    @Test
+    public void sendMessageBatchFunctionWithBatchEntryFailures_wrapFailureMessageInBatchEntry() {
+        String id1 = "0";
+        String id2 = "1";
+        String errorCode = "400";
+        String errorMessage = "Some error";
+        String responseBody = String.format(
+            "<SendMessageBatchResponse>\n"
+            + "<SendMessageBatchResult>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "</SendMessageBatchResult>\n"
+            + "</SendMessageBatchResponse>", id1, errorCode, errorMessage, id2, errorCode, errorMessage);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        List<SendMessageRequest> requests = new ArrayList<>();
+        requests.add(createSendMessageRequest(id1));
+        requests.add(createSendMessageRequest(id2));
+
+        List<CompletableFuture<SendMessageResponse>> responses = new ArrayList<>();
+        for (SendMessageRequest request : requests) {
+            responses.add(batchManager.sendMessage(request));
+        }
+
+        SendMessageResponse completedResponse1 = responses.get(0).join();
+        SendMessageResponse completedResponse2 = responses.get(1).join();
+        String expectedHash = getMd5Hash(String.format("%s: %s", errorCode, errorMessage));
+        Assert.assertEquals(expectedHash, completedResponse1.md5OfMessageBody());
+        Assert.assertEquals(expectedHash, completedResponse2.md5OfMessageBody());
+    }
+
+    @Test
+    public void sendMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
+        String id1 = "0";
+        String id2 = "1";
+        String responseBody = "<Error>\n"
+                              + "<Code>CustomError</Code>\n"
+                              + "<Message>Foo bar</Message>\n"
+                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                              + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
+
+        List<SendMessageRequest> requests = new ArrayList<>();
+        requests.add(createSendMessageRequest(id1));
+        requests.add(createSendMessageRequest(id2));
+
+        List<CompletableFuture<SendMessageResponse>> responses = new ArrayList<>();
+        for (SendMessageRequest request : requests) {
+            responses.add(batchManager.sendMessage(request));
+        }
+
+        Assert.assertThrows(Exception.class, () -> responses.get(0).join());
+        Assert.assertThrows(Exception.class, () -> responses.get(1).join());
+    }
+
+    @Test
+    public void deleteMessageBatchFunction_batchMessageCorrectly() {
+        String id1 = "0";
+        String id2 = "1";
+        String responseBody = String.format(
+            "<DeleteMessageBatchResponse>\n"
+            + "    <DeleteMessageBatchResult>\n"
+            + "        <DeleteMessageBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </DeleteMessageBatchResultEntry>\n"
+            + "        <DeleteMessageBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </DeleteMessageBatchResultEntry>\n"
+            + "    </DeleteMessageBatchResult>\n"
+            + "</DeleteMessageBatchResponse>\n", id1, id2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        List<DeleteMessageRequest> requests = new ArrayList<>();
+        requests.add(createDeleteMessageRequest());
+        requests.add(createDeleteMessageRequest());
+
+        List<CompletableFuture<DeleteMessageResponse>> responses = new ArrayList<>();
+        long startTime = System.nanoTime();
+        for (DeleteMessageRequest request : requests) {
+            responses.add(batchManager.deleteMessage(request));
+        }
+        long endTime = System.nanoTime();
+        CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
+
+        Assert.assertTrue(Duration.ofNanos(endTime - startTime).toMillis() < DEFAULT_MAX_BATCH_OPEN + 100);
+    }
+
+    @Test
+    public void deleteMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
+        String responseBody = "<Error>\n"
+                              + "<Code>CustomError</Code>\n"
+                              + "<Message>Foo bar</Message>\n"
+                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                              + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
+
+        List<DeleteMessageRequest> requests = new ArrayList<>();
+        requests.add(createDeleteMessageRequest());
+        requests.add(createDeleteMessageRequest());
+
+        List<CompletableFuture<DeleteMessageResponse>> responses = new ArrayList<>();
+        for (DeleteMessageRequest request : requests) {
+            responses.add(batchManager.deleteMessage(request));
+        }
+
+        Assert.assertThrows(Exception.class, () -> responses.get(0).join());
+        Assert.assertThrows(Exception.class, () -> responses.get(1).join());
+    }
+
+    @Test
+    public void changeVisibilityBatchFunction_batchMessageCorrectly() {
+        String id1 = "0";
+        String id2 = "1";
+        String responseBody = String.format(
+            "<ChangeMessageVisibilityBatchResponse>\n"
+            + "    <ChangeMessageVisibilityBatchResult>\n"
+            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
+            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
+            + "    </ChangeMessageVisibilityBatchResult>\n"
+            + "</ChangeMessageVisibilityBatchResponse>", id1, id2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        List<ChangeMessageVisibilityRequest> requests = new ArrayList<>();
+        requests.add(createChangeVisibilityRequest());
+        requests.add(createChangeVisibilityRequest());
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = new ArrayList<>();
+        long startTime = System.nanoTime();
+        for (ChangeMessageVisibilityRequest request : requests) {
+            responses.add(batchManager.changeMessageVisibility(request));
+        }
+        long endTime = System.nanoTime();
+        CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
+
+        Assert.assertTrue(Duration.ofNanos(endTime - startTime).toMillis() < DEFAULT_MAX_BATCH_OPEN + 100);
+    }
+
+    @Test
+    public void changeVisibilityBatchFunctionReturnsWithError_completeMessagesExceptionally() {
+        String responseBody = "<Error>\n"
+                              + "<Code>CustomError</Code>\n"
+                              + "<Message>Foo bar</Message>\n"
+                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                              + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
+
+        List<ChangeMessageVisibilityRequest> requests = new ArrayList<>();
+        requests.add(createChangeVisibilityRequest());
+        requests.add(createChangeVisibilityRequest());
+
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = new ArrayList<>();
+        for (ChangeMessageVisibilityRequest request : requests) {
+            responses.add(batchManager.changeMessageVisibility(request));
+        }
+
+        Assert.assertThrows(Exception.class, () -> responses.get(0).join());
+        Assert.assertThrows(Exception.class, () -> responses.get(1).join());
+    }
+
+    private SendMessageRequest createSendMessageRequest(String messageBody) {
+        return SendMessageRequest.builder()
+                                 .messageBody(messageBody)
+                                 .queueUrl(DEFAULT_QUEUE_URl)
+                                 .build();
+    }
+
+    private DeleteMessageRequest createDeleteMessageRequest() {
+        return DeleteMessageRequest.builder()
+                                   .queueUrl(DEFAULT_QUEUE_URl)
+                                   .build();
+    }
+
+    private ChangeMessageVisibilityRequest createChangeVisibilityRequest() {
+        return ChangeMessageVisibilityRequest.builder()
+                                             .queueUrl(DEFAULT_QUEUE_URl)
+                                             .build();
+    }
+
+    private String getMd5Hash(String message) {
+        byte[] expectedMd5;
+        expectedMd5 = Md5Utils.computeMD5Hash(message.getBytes(StandardCharsets.UTF_8));
+        return BinaryUtils.toHex(expectedMd5);
+    }
+}

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -212,8 +213,8 @@ public class SqsBatchManagerTest {
             responses.add(batchManager.sendMessage(request));
         }
 
-        assertThatThrownBy(() -> responses.get(0).join()).isInstanceOf(Exception.class).hasMessageContaining("400");
-        assertThatThrownBy(() -> responses.get(1).join()).isInstanceOf(Exception.class).hasMessageContaining("400");
+        assertThatThrownBy(() -> responses.get(0).join()).isInstanceOf(CompletionException.class).hasMessageContaining("400");
+        assertThatThrownBy(() -> responses.get(1).join()).isInstanceOf(CompletionException.class).hasMessageContaining("400");
     }
 
     @Test
@@ -269,8 +270,8 @@ public class SqsBatchManagerTest {
             responses.add(batchManager.deleteMessage(request));
         }
 
-        assertThatThrownBy(() -> responses.get(0).join()).isInstanceOf(Exception.class).hasMessageContaining("400");
-        assertThatThrownBy(() -> responses.get(1).join()).isInstanceOf(Exception.class).hasMessageContaining("400");
+        assertThatThrownBy(() -> responses.get(0).join()).isInstanceOf(CompletionException.class).hasMessageContaining("400");
+        assertThatThrownBy(() -> responses.get(1).join()).isInstanceOf(CompletionException.class).hasMessageContaining("400");
     }
 
     @Test
@@ -325,8 +326,8 @@ public class SqsBatchManagerTest {
             responses.add(batchManager.changeMessageVisibility(request));
         }
 
-        assertThatThrownBy(() -> responses.get(0).join()).isInstanceOf(Exception.class).hasMessageContaining("400");
-        assertThatThrownBy(() -> responses.get(1).join()).isInstanceOf(Exception.class).hasMessageContaining("400");
+        assertThatThrownBy(() -> responses.get(0).join()).isInstanceOf(CompletionException.class).hasMessageContaining("400");
+        assertThatThrownBy(() -> responses.get(1).join()).isInstanceOf(CompletionException.class).hasMessageContaining("400");
     }
 
     @Mock

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -197,7 +197,7 @@ public class SqsBatchManagerTest {
     }
 
     @Test
-    public void sendMessageBatchNetworkError() {
+    public void sendMessageBatchNetworkError_causesConnectionResetException() {
         String id1 = "0";
         String id2 = "1";
         stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));


### PR DESCRIPTION
## Motivation and Context
Hand coding the `SqsBatchManager` for the sync client to demonstrate how a code generated service batch manager might look like and interact with the core batch manager.

## Description
In this PR, I am implementing a `DefaultSqsBatchManager` that is created when customers want to use client-side buffering and automatic request batching in SQS. Some small changes were also made to the core batch manager to clean up some bugs as well as fix some naming issues to be more consistent. 

## Testing
The integration test was modified to now use the `SqsBatchManager` instead of the core `BatchManager`. Additional tests were also added to test the behavior of other batchable Apis (in addition to `sendMessage`, there is `deleteMessage`, and `changeMessageVisibility`). Furthermore, unit tests and wire mock tests were also added to test the functionality implemented in the `SqsBatchFunctions` file. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
