### PR TITLE
Fix a typo in the new S3TransferManager README

### DIFF
--- a/services-custom/s3-transfer-manager/README.md
+++ b/services-custom/s3-transfer-manager/README.md
@@ -42,7 +42,7 @@ S3TransferManager transferManager =
 ```
 
 ### Download an S3 object to a file
-To download an object, you just need to provide the destion file path and the `GetObjectRequest` that should be used for the download.
+To download an object, you just need to provide the destination file path and the `GetObjectRequest` that should be used for the download.
 
 ```java
 Download download = 


### PR DESCRIPTION
Just fixing a typo.

## Motivation and Context
Related to https://github.com/aws/aws-sdk-java-v2/issues/37. I followed the link to this README from that ticket.

## Description
n/a

## Testing
n/a
## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
