### PR TITLE
Create a shared, project-level IntelliJ inspection profile

### DIFF
--- a/.changes/next-release/documentation-AWSSDKforJavav2-45b31c6.json
+++ b/.changes/next-release/documentation-AWSSDKforJavav2-45b31c6.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "documentation", 
+    "description": "Create a shared, project-level IntelliJ inspection profile"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # IntelliJ un-ignore
 !.idea/codeStyles/
 !.idea/copyright/
+!.idea/inspectionProfiles/
 
 # Mac
 .DS_Store

--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -1,0 +1,3 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" />
+</component>

--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -1,3 +1,5 @@
 <component name="InspectionProjectProfileManager">
-  <profile version="1.0" />
+  <profile version="1.0">
+    <option name="myName" value="AWS Java SDK 2.0" />
+  </profile>
 </component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="AWS Java SDK 2.0" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -7,15 +7,19 @@
   generator][codegen]
 
 ### Development Environment Setup Tips
-If you use IntelliJ IDEA, we recommend using the following config files, which will be used by default for your project-level settings:
+If you use IntelliJ IDEA, the following config files will be used by default for your project-level settings:
+
+- [Copyright](https://raw.githubusercontent.com/aws/aws-sdk-java-v2/master/.idea/copyright/AWS_Java_SDK_2_0.xml)
+
+  This automatically inserts the license header to the top of source files that you create.
 
 - [Code style](https://raw.githubusercontent.com/aws/aws-sdk-java-v2/master/.idea/codeStyles/Project.xml)
   
   This will help ensure your code follows our code style guidelines.
 
-- [Copyright](https://raw.githubusercontent.com/aws/aws-sdk-java-v2/master/.idea/copyright/AWS_Java_SDK_2_0.xml)
+- [Inspections](https://raw.githubusercontent.com/aws/aws-sdk-java-v2/master/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml)
 
-  This automatically inserts the license header to the top of source files that you create.
+  This will help ensure your code is correct and follows our best practices. Please ensure your changes do not generate any new inspection warnings.
 
 If you have Checkstyle integrated with your IDE, we also recommend
 configuring it with our


### PR DESCRIPTION
## Motivation

Similar to how https://github.com/aws/aws-sdk-java-v2/pull/2652 recently
moved our code style & copyright configuration files to the
project-level, we can also do the same for IntelliJ inspections. This
has the benefit of keeping inspections in sync for all users, as well as
automatically informing new users of our expected coding best practices.

We do not currently have an existing inspection profile, so we will take
this opportunity to start with a new, blank inspection profile. Users
may then propose customizing the inspections via PRs, subject to the
normal review process. Over time we will gravitate towards a shared
inspection profile that we can all agree on.

## Modifications

* Create a new, blank "AWS Java SDK 2.0" inspection profile
* Update profiles_settings.xml to make users use this profile
* Add corresponding gitignore update
* Add corresponding GettingStarted update

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
