### PR TITLE
Adding SqsBatchManager for Async client

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchManagerBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchManagerBuilder.java
@@ -35,6 +35,9 @@ public interface BatchManagerBuilder<RequestT, ResponseT, BatchResponseT, B> {
     /**
      * Adds a {@link ScheduledExecutorService} to be used by the BatchManager to schedule periodic flushes of the underlying
      * buffers.
+     * <p>
+     * Creating a SqsBatchManager directly from a service client will use the service client's scheduled executor. If supplied by
+     * the user, this ScheduledExecutorService must be closed by the caller when it is ready to be shut down.
      *
      * @param scheduledExecutor the provided scheduled executor.
      * @return a reference to this object so that method calls can be chained together.

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -16,13 +16,11 @@
 package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsAsyncBatchManager;
-import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsBatchManager;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -16,9 +16,13 @@
 package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsBatchManager;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
@@ -85,7 +89,7 @@ public interface SqsAsyncBatchManager extends SdkAutoCloseable {
      * @return a builder
      */
     static SqsAsyncBatchManager.Builder builder() {
-        throw new UnsupportedOperationException();
+        return DefaultSqsAsyncBatchManager.builder();
     }
 
     /**
@@ -117,6 +121,17 @@ public interface SqsAsyncBatchManager extends SdkAutoCloseable {
          * @return a reference to this object so that method calls can be chained together.
          */
         SqsAsyncBatchManager.Builder client(SqsAsyncClient client);
+
+        /**
+         * Sets a custom {@link ScheduledExecutorService} that will be used to schedule periodic buffer flushes.
+         * <p>
+         * Creating a SqsBatchManager directly from the client will use the client's scheduled executor. If supplied by the
+         * user, this ScheduledExecutorService must be closed by the caller when it is ready to be shut down.
+         *
+         * @param scheduledExecutor the scheduledExecutor to be used.
+         * @return a reference to this object so that method calls can be chained together.
+         */
+        SqsAsyncBatchManager.Builder scheduledExecutor(ScheduledExecutorService scheduledExecutor);
 
         /**
          * Builds an instance of {@link SqsAsyncBatchManager} based on the configurations supplied to this builder.

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -92,15 +92,6 @@ public interface SqsBatchManager extends SdkAutoCloseable {
         return DefaultSqsBatchManager.builder();
     }
 
-    /**
-     * Create an instance of {@link SqsBatchManager} with the default configuration.
-     *
-     * @return an instance of {@link SqsBatchManager}
-     */
-    static SqsBatchManager create() {
-        throw new UnsupportedOperationException();
-    }
-
     interface Builder {
 
         /**

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchAsyncFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.changeVisibilityResponseMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchAsyncFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.deleteMessageResponseMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageBatchAsyncFunction;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageBatchKeyMapper;
+import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageResponseMapper;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.core.batchmanager.BatchManager;
+import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+@SdkInternalApi
+public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
+
+    private final SqsAsyncClient client;
+    private final BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> sendMessageBatchManager;
+    private final BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> deleteMessageBatchManager;
+    private final BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
+        ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager;
+
+    private DefaultSqsAsyncBatchManager(DefaultBuilder builder) {
+        this.client = builder.client;
+        SqsBatchConfiguration config = new SqsBatchConfiguration(builder.overrideConfiguration);
+        BatchOverrideConfiguration overrideConfiguration = BatchOverrideConfiguration.builder()
+                                                                                     .maxBatchItems(config.maxBatchItems())
+                                                                                     .maxBatchOpenInMs(config.maxBatchOpenInMs())
+                                                                                     .build();
+        ScheduledExecutorService scheduledExecutor = builder.scheduledExecutor;
+
+        this.sendMessageBatchManager = BatchManager.builder(SendMessageRequest.class, SendMessageResponse.class,
+                                                            SendMessageBatchResponse.class)
+                                                   .batchFunction(sendMessageBatchAsyncFunction(client))
+                                                   .responseMapper(sendMessageResponseMapper())
+                                                   .batchKeyMapper(sendMessageBatchKeyMapper())
+                                                   .overrideConfiguration(overrideConfiguration)
+                                                   .scheduledExecutor(scheduledExecutor)
+                                                   .build();
+
+        this.deleteMessageBatchManager = BatchManager.builder(DeleteMessageRequest.class, DeleteMessageResponse.class,
+                                                              DeleteMessageBatchResponse.class)
+                                                     .batchFunction(deleteMessageBatchAsyncFunction(client))
+                                                     .responseMapper(deleteMessageResponseMapper())
+                                                     .batchKeyMapper(deleteMessageBatchKeyMapper())
+                                                     .overrideConfiguration(overrideConfiguration)
+                                                     .scheduledExecutor(scheduledExecutor)
+                                                     .build();
+
+        this.changeVisibilityBatchManager = BatchManager.builder(ChangeMessageVisibilityRequest.class,
+                                                                 ChangeMessageVisibilityResponse.class,
+                                                                 ChangeMessageVisibilityBatchResponse.class)
+                                                        .batchFunction(changeVisibilityBatchAsyncFunction(client))
+                                                        .responseMapper(changeVisibilityResponseMapper())
+                                                        .batchKeyMapper(changeVisibilityBatchKeyMapper())
+                                                        .overrideConfiguration(overrideConfiguration)
+                                                        .scheduledExecutor(scheduledExecutor)
+                                                        .build();
+    }
+
+    @SdkTestInternalApi
+    public DefaultSqsAsyncBatchManager(SqsAsyncClient client, ScheduledExecutorService scheduledExecutor,
+                                  BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse>
+                                      sendMessageBatchManager,
+                                  BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse>
+                                      deleteMessageBatchManager,
+                                  BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
+                                      ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager) {
+        this.client = client;
+        this.sendMessageBatchManager = sendMessageBatchManager;
+        this.deleteMessageBatchManager = deleteMessageBatchManager;
+        this.changeVisibilityBatchManager = changeVisibilityBatchManager;
+    }
+
+    @Override
+    public CompletableFuture<SendMessageResponse> sendMessage(SendMessageRequest message) {
+        return sendMessageBatchManager.sendRequest(message);
+    }
+
+    @Override
+    public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(ChangeMessageVisibilityRequest
+                                                                                              changeRequest) {
+        return changeVisibilityBatchManager.sendRequest(changeRequest);
+    }
+
+    @Override
+    public CompletableFuture<DeleteMessageResponse> deleteMessage(DeleteMessageRequest deleteRequest) {
+        return deleteMessageBatchManager.sendRequest(deleteRequest);
+    }
+
+    @Override
+    public void close() {
+        sendMessageBatchManager.close();
+        changeVisibilityBatchManager.close();
+        deleteMessageBatchManager.close();
+    }
+
+    public static SqsAsyncBatchManager.Builder builder() {
+        return new DefaultSqsAsyncBatchManager.DefaultBuilder();
+    }
+
+    public static final class DefaultBuilder implements Builder {
+        private BatchOverrideConfiguration overrideConfiguration;
+        private SqsAsyncClient client;
+        private ScheduledExecutorService scheduledExecutor;
+
+        private DefaultBuilder() {
+        }
+
+        @Override
+        public Builder overrideConfiguration(BatchOverrideConfiguration overrideConfiguration) {
+            this.overrideConfiguration = overrideConfiguration;
+            return this;
+        }
+
+        @Override
+        public Builder client(SqsAsyncClient client) {
+            this.client = client;
+            return this;
+        }
+
+        @Override
+        public Builder scheduledExecutor(ScheduledExecutorService scheduledExecutor) {
+            this.scheduledExecutor = scheduledExecutor;
+            return this;
+        }
+
+        public SqsAsyncBatchManager build() {
+            return new DefaultSqsAsyncBatchManager(this);
+        }
+    }
+}

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -26,14 +26,12 @@ import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatch
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageResponseMapper;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.batchmanager.BatchManager;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -96,7 +96,7 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
     }
 
     @SdkTestInternalApi
-    public DefaultSqsBatchManager(SqsClient client, ExecutorService executor,
+    public DefaultSqsBatchManager(SqsClient client, ExecutorService executor, ScheduledExecutorService scheduledExecutor,
                                   BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse>
                                       sendMessageBatchManager,
                                   BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse>

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
@@ -196,7 +196,7 @@ public final class SqsBatchFunctions {
     }
 
     public static BatchAndSend<ChangeMessageVisibilityRequest, ChangeMessageVisibilityBatchResponse>
-    changeVisibilityBatchAsyncFunction(SqsAsyncClient client) {
+        changeVisibilityBatchAsyncFunction(SqsAsyncClient client) {
         return (identifiedRequests, batchKey) -> {
             ChangeMessageVisibilityBatchRequest batchRequest = createChangeVisibilityBatchRequest(identifiedRequests, batchKey);
             return client.changeMessageVisibilityBatch(batchRequest);

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.core.internal.batchmanager.BatchAndSend;
 import software.amazon.awssdk.core.internal.batchmanager.BatchKeyMapper;
 import software.amazon.awssdk.core.internal.batchmanager.BatchResponseMapper;
 import software.amazon.awssdk.core.internal.batchmanager.IdentifiableMessage;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
@@ -53,30 +54,42 @@ public final class SqsBatchFunctions {
 
     public static BatchAndSend<SendMessageRequest, SendMessageBatchResponse> sendMessageBatchFunction(SqsClient client,
                                                                                                       ExecutorService executor) {
-        return (identifiedRequests, destination) -> {
-            List<SendMessageBatchRequestEntry> entries =
-                identifiedRequests.stream()
-                                  .map(identifiedRequest -> createSendMessageBatchRequestEntry(identifiedRequest.id(),
-                                                                                               identifiedRequest.message()))
-                                  .collect(Collectors.toList());
-
-            // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration, all
-            // requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first request.
-            Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
-                                                                                                .message()
-                                                                                                .overrideConfiguration();
-            SendMessageBatchRequest batchRequest =
-                overrideConfiguration.map(overrideConfig -> SendMessageBatchRequest.builder()
-                                                                                   .queueUrl(destination)
-                                                                                   .overrideConfiguration(overrideConfig)
-                                                                                   .entries(entries)
-                                                                                   .build())
-                                     .orElse(SendMessageBatchRequest.builder()
-                                                                    .queueUrl(destination)
-                                                                    .entries(entries)
-                                                                    .build());
+        return (identifiedRequests, batchKey) -> {
+            SendMessageBatchRequest batchRequest = createSendMessageBatchRequest(identifiedRequests, batchKey);
             return CompletableFuture.supplyAsync(() -> client.sendMessageBatch(batchRequest), executor);
         };
+    }
+
+    public static BatchAndSend<SendMessageRequest, SendMessageBatchResponse> sendMessageBatchAsyncFunction(SqsAsyncClient
+                                                                                                               client) {
+        return (identifiedRequests, batchKey) -> {
+            SendMessageBatchRequest batchRequest = createSendMessageBatchRequest(identifiedRequests, batchKey);
+            return client.sendMessageBatch(batchRequest);
+        };
+    }
+
+    public static SendMessageBatchRequest createSendMessageBatchRequest(
+        List<IdentifiableMessage<SendMessageRequest>> identifiedRequests, String batchKey) {
+        List<SendMessageBatchRequestEntry> entries =
+            identifiedRequests.stream()
+                              .map(identifiedRequest -> createSendMessageBatchRequestEntry(identifiedRequest.id(),
+                                                                                           identifiedRequest.message()))
+                              .collect(Collectors.toList());
+
+        // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration, all
+        // requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first request.
+        Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                            .message()
+                                                                                            .overrideConfiguration();
+        return overrideConfiguration.map(overrideConfig -> SendMessageBatchRequest.builder()
+                                                                                  .queueUrl(batchKey)
+                                                                                  .overrideConfiguration(overrideConfig)
+                                                                                  .entries(entries)
+                                                                                  .build())
+                                    .orElse(SendMessageBatchRequest.builder()
+                                                                   .queueUrl(batchKey)
+                                                                   .entries(entries)
+                                                                   .build());
     }
 
     public static BatchResponseMapper<SendMessageBatchResponse, SendMessageResponse> sendMessageResponseMapper() {
@@ -108,31 +121,43 @@ public final class SqsBatchFunctions {
 
     public static BatchAndSend<DeleteMessageRequest, DeleteMessageBatchResponse> deleteMessageBatchFunction(
         SqsClient client, ExecutorService executor) {
-        return (identifiedRequests, destination) -> {
-            List<DeleteMessageBatchRequestEntry> entries =
-                identifiedRequests.stream()
-                                  .map(identifiedRequest -> createDeleteMessageBatchRequestEntry(identifiedRequest.id(),
-                                                                                                 identifiedRequest.message()))
-                                  .collect(Collectors.toList());
-
-            // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration, all
-            // requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first request.
-            Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
-                                                                                                .message()
-                                                                                                .overrideConfiguration();
-            DeleteMessageBatchRequest batchRequest =
-                overrideConfiguration.map(overrideConfig -> DeleteMessageBatchRequest.builder()
-                                                                                     .queueUrl(destination)
-                                                                                     .overrideConfiguration(overrideConfig)
-                                                                                     .entries(entries)
-                                                                                     .build())
-                                     .orElse(DeleteMessageBatchRequest.builder()
-                                                                      .queueUrl(destination)
-                                                                      .entries(entries)
-                                                                      .build());
-
+        return (identifiedRequests, batchKey) -> {
+            DeleteMessageBatchRequest batchRequest = createDeleteMessageBatchRequest(identifiedRequests, batchKey);
             return CompletableFuture.supplyAsync(() -> client.deleteMessageBatch(batchRequest), executor);
         };
+    }
+
+    public static BatchAndSend<DeleteMessageRequest, DeleteMessageBatchResponse> deleteMessageBatchAsyncFunction(
+        SqsAsyncClient client) {
+        return (identifiedRequests, batchKey) -> {
+            DeleteMessageBatchRequest batchRequest = createDeleteMessageBatchRequest(identifiedRequests, batchKey);
+            return client.deleteMessageBatch(batchRequest);
+        };
+    }
+
+    public static DeleteMessageBatchRequest createDeleteMessageBatchRequest(
+        List<IdentifiableMessage<DeleteMessageRequest>> identifiedRequests, String batchKey) {
+        List<DeleteMessageBatchRequestEntry> entries =
+            identifiedRequests.stream()
+                              .map(identifiedRequest -> createDeleteMessageBatchRequestEntry(identifiedRequest.id(),
+                                                                                             identifiedRequest.message()))
+                              .collect(Collectors.toList());
+
+        // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration, all
+        // requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first request.
+        Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                            .message()
+                                                                                            .overrideConfiguration();
+        return overrideConfiguration.map(overrideConfig -> DeleteMessageBatchRequest.builder()
+                                                                                    .queueUrl(batchKey)
+                                                                                    .overrideConfiguration(overrideConfig)
+                                                                                    .entries(entries)
+                                                                                    .build())
+                                    .orElse(DeleteMessageBatchRequest.builder()
+                                                                     .queueUrl(batchKey)
+                                                                     .entries(entries)
+                                                                     .build());
+
     }
 
     public static BatchResponseMapper<DeleteMessageBatchResponse, DeleteMessageResponse> deleteMessageResponseMapper() {
@@ -164,33 +189,43 @@ public final class SqsBatchFunctions {
 
     public static BatchAndSend<ChangeMessageVisibilityRequest, ChangeMessageVisibilityBatchResponse>
         changeVisibilityBatchFunction(SqsClient client, ExecutorService executor) {
-        return (identifiedRequests, destination) -> {
-            List<ChangeMessageVisibilityBatchRequestEntry> entries =
-                identifiedRequests.stream()
-                                  .map(identifiedRequest -> createChangVisibilityBatchRequestEntry(identifiedRequest.id(),
-                                                                                                   identifiedRequest.message()))
-                                  .collect(Collectors.toList());
-
-            // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration, all
-            // requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first request.
-            Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
-                                                                                                .message()
-                                                                                                .overrideConfiguration();
-            ChangeMessageVisibilityBatchRequest batchRequest =
-                overrideConfiguration.map(overrideConfig ->
-                                              ChangeMessageVisibilityBatchRequest.builder()
-                                                                                 .queueUrl(destination)
-                                                                                 .overrideConfiguration(overrideConfig)
-                                                                                 .entries(entries)
-                                                                                 .build())
-                                     .orElse(ChangeMessageVisibilityBatchRequest.builder()
-                                                                                .queueUrl(destination)
-                                                                                .entries(entries)
-                                                                                .build());
-
-            // TODO: Pass client executor in supplyAsync once an executor is added into the client.
+        return (identifiedRequests, batchKey) -> {
+            ChangeMessageVisibilityBatchRequest batchRequest = createChangeVisibilityBatchRequest(identifiedRequests, batchKey);
             return CompletableFuture.supplyAsync(() -> client.changeMessageVisibilityBatch(batchRequest), executor);
         };
+    }
+
+    public static BatchAndSend<ChangeMessageVisibilityRequest, ChangeMessageVisibilityBatchResponse>
+    changeVisibilityBatchAsyncFunction(SqsAsyncClient client) {
+        return (identifiedRequests, batchKey) -> {
+            ChangeMessageVisibilityBatchRequest batchRequest = createChangeVisibilityBatchRequest(identifiedRequests, batchKey);
+            return client.changeMessageVisibilityBatch(batchRequest);
+        };
+    }
+
+    public static ChangeMessageVisibilityBatchRequest createChangeVisibilityBatchRequest(
+        List<IdentifiableMessage<ChangeMessageVisibilityRequest>> identifiedRequests, String batchKey) {
+        List<ChangeMessageVisibilityBatchRequestEntry> entries =
+            identifiedRequests.stream()
+                              .map(identifiedRequest -> createChangVisibilityBatchRequestEntry(identifiedRequest.id(),
+                                                                                               identifiedRequest.message()))
+                              .collect(Collectors.toList());
+
+        // Since requests are batched together according to a combination of their queueUrl and overrideConfiguration, all
+        // requests must have the same overrideConfiguration so it is sufficient to retrieve it from the first request.
+        Optional<AwsRequestOverrideConfiguration> overrideConfiguration = identifiedRequests.get(0)
+                                                                                            .message()
+                                                                                            .overrideConfiguration();
+        return overrideConfiguration.map(overrideConfig ->
+                                             ChangeMessageVisibilityBatchRequest.builder()
+                                                                                .queueUrl(batchKey)
+                                                                                .overrideConfiguration(overrideConfig)
+                                                                                .entries(entries)
+                                                                                .build())
+                                    .orElse(ChangeMessageVisibilityBatchRequest.builder()
+                                                                               .queueUrl(batchKey)
+                                                                               .entries(entries)
+                                                                               .build());
     }
 
     public static BatchResponseMapper<ChangeMessageVisibilityBatchResponse, ChangeMessageVisibilityResponse>

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/BaseSqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/BaseSqsBatchManagerTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.ClassRule;
+import org.junit.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Md5Utils;
+
+public abstract class BaseSqsBatchManagerTest {
+
+    private static final String DEFAULT_QUEUE_URl = "SomeQueueUrl";
+    private static final int DEFAULT_MAX_BATCH_OPEN = 200;
+
+    @ClassRule
+    public static WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+
+    @Test
+    public void sendMessageBatchFunction_batchMessageCorrectly() {
+        String id1 = "0";
+        String id2 = "1";
+        String messageBody1 = getMd5Hash(id1);
+        String messageBody2 = getMd5Hash(id2);
+        String responseBody = String.format(
+            "<SendMessageBatchResponse>\n"
+            + "<SendMessageBatchResult>\n"
+            + "    <SendMessageBatchResultEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
+            + "    </SendMessageBatchResultEntry>\n"
+            + "    <SendMessageBatchResultEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
+            + "    </SendMessageBatchResultEntry>\n"
+            + "</SendMessageBatchResult>\n"
+            + "</SendMessageBatchResponse>", id1, messageBody1, id2, messageBody2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
+
+        SendMessageResponse completedResponse1 = responses.get(0).join();
+        SendMessageResponse completedResponse2 = responses.get(1).join();
+        assertThat(completedResponse1.md5OfMessageBody()).isEqualTo(messageBody1);
+        assertThat(completedResponse2.md5OfMessageBody()).isEqualTo(messageBody2);
+    }
+
+    // TODO: Update tests after updating how batchEntryFailures are handled
+    @Test
+    public void sendMessageBatchFunctionWithBatchEntryFailures_wrapFailureMessageInBatchEntry() {
+        String id1 = "0";
+        String id2 = "1";
+        String errorCode = "400";
+        String errorMessage = "Some error";
+        String responseBody = String.format(
+            "<SendMessageBatchResponse>\n"
+            + "<SendMessageBatchResult>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "</SendMessageBatchResult>\n"
+            + "</SendMessageBatchResponse>", id1, errorCode, errorMessage, id2, errorCode, errorMessage);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
+
+        SendMessageResponse completedResponse1 = responses.get(0).join();
+        SendMessageResponse completedResponse2 = responses.get(1).join();
+        assertThat(completedResponse1.md5OfMessageBody()).isNullOrEmpty();
+        assertThat(completedResponse2.md5OfMessageBody()).isNullOrEmpty();
+    }
+
+    @Test
+    public void sendMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
+        String id1 = "0";
+        String id2 = "1";
+        String responseBody = "<Error>\n"
+                              + "<Code>CustomError</Code>\n"
+                              + "<Message>Foo bar</Message>\n"
+                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                              + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
+        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
+
+        CompletableFuture<SendMessageResponse> response1 = responses.get(0);
+        CompletableFuture<SendMessageResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+    }
+
+    @Test
+    public void sendMessageBatchNetworkError_causesConnectionResetException() {
+        String id1 = "0";
+        String id2 = "1";
+        String errorMessage = "Unable to execute HTTP request";
+        stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
+
+        CompletableFuture<SendMessageResponse> response1 = responses.get(0);
+        CompletableFuture<SendMessageResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SdkClientException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SdkClientException.class).hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    public void deleteMessageBatchFunction_batchMessageCorrectly() {
+        String id1 = "0";
+        String id2 = "1";
+        String responseBody = String.format(
+            "<DeleteMessageBatchResponse>\n"
+            + "    <DeleteMessageBatchResult>\n"
+            + "        <DeleteMessageBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </DeleteMessageBatchResultEntry>\n"
+            + "        <DeleteMessageBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </DeleteMessageBatchResultEntry>\n"
+            + "    </DeleteMessageBatchResult>\n"
+            + "</DeleteMessageBatchResponse>\n", id1, id2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+        long startTime = System.nanoTime();
+        List<CompletableFuture<DeleteMessageResponse>> responses = createAndSendDeleteMessageRequests();
+        long endTime = System.nanoTime();
+        CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
+
+        assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isLessThan(DEFAULT_MAX_BATCH_OPEN + 100);
+    }
+
+    @Test
+    public void deleteMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
+        String responseBody = "<Error>\n"
+                              + "<Code>CustomError</Code>\n"
+                              + "<Message>Foo bar</Message>\n"
+                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                              + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
+        List<CompletableFuture<DeleteMessageResponse>> responses = createAndSendDeleteMessageRequests();
+
+        CompletableFuture<DeleteMessageResponse> response1 = responses.get(0);
+        CompletableFuture<DeleteMessageResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+    }
+
+    @Test
+    public void changeVisibilityBatchFunction_batchMessageCorrectly() {
+        String id1 = "0";
+        String id2 = "1";
+        String responseBody = String.format(
+            "<ChangeMessageVisibilityBatchResponse>\n"
+            + "    <ChangeMessageVisibilityBatchResult>\n"
+            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
+            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
+            + "            <Id>%s</Id>\n"
+            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
+            + "    </ChangeMessageVisibilityBatchResult>\n"
+            + "</ChangeMessageVisibilityBatchResponse>", id1, id2);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+        long startTime = System.nanoTime();
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = createAndSendChangeVisibilityRequests();
+        long endTime = System.nanoTime();
+        CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
+
+        assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isLessThan(DEFAULT_MAX_BATCH_OPEN + 100);
+    }
+
+    @Test
+    public void changeVisibilityBatchFunctionReturnsWithError_completeMessagesExceptionally() {
+        String responseBody = "<Error>\n"
+                              + "<Code>CustomError</Code>\n"
+                              + "<Message>Foo bar</Message>\n"
+                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
+                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
+                              + "</Error>";
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = createAndSendChangeVisibilityRequests();
+
+        CompletableFuture<ChangeMessageVisibilityResponse> response1 = responses.get(0);
+        CompletableFuture<ChangeMessageVisibilityResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
+    }
+
+    public abstract List<CompletableFuture<SendMessageResponse>> createAndSendSendMessageRequests(String message1,
+                                                                                                 String message2);
+
+    public abstract List<CompletableFuture<DeleteMessageResponse>> createAndSendDeleteMessageRequests();
+
+    public abstract List<CompletableFuture<ChangeMessageVisibilityResponse>> createAndSendChangeVisibilityRequests();
+
+    SendMessageRequest createSendMessageRequest(String messageBody) {
+        return SendMessageRequest.builder()
+                                 .messageBody(messageBody)
+                                 .queueUrl(DEFAULT_QUEUE_URl)
+                                 .build();
+    }
+
+    DeleteMessageRequest createDeleteMessageRequest() {
+        return DeleteMessageRequest.builder()
+                                   .queueUrl(DEFAULT_QUEUE_URl)
+                                   .build();
+    }
+
+    ChangeMessageVisibilityRequest createChangeVisibilityRequest() {
+        return ChangeMessageVisibilityRequest.builder()
+                                             .queueUrl(DEFAULT_QUEUE_URl)
+                                             .build();
+    }
+
+    private String getMd5Hash(String message) {
+        byte[] expectedMd5;
+        expectedMd5 = Md5Utils.computeMD5Hash(message.getBytes(StandardCharsets.UTF_8));
+        return BinaryUtils.toHex(expectedMd5);
+    }
+}

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsAsyncBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsAsyncBatchManagerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.batchmanager.BatchManager;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SqsAsyncBatchManagerTest extends BaseSqsBatchManagerTest {
+
+    private static ScheduledExecutorService scheduledExecutor;
+    private static SqsAsyncClient client;
+    private SqsAsyncBatchManager batchManager;
+
+    @Mock
+    private BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> mockSendMessageBatchManager;
+
+    @Mock
+    private BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> mockDeleteMessageBatchManager;
+
+    @Mock
+    private BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
+        ChangeMessageVisibilityBatchResponse> mockChangeVisibilityBatchManager;
+
+    private static SqsAsyncClientBuilder getAsyncClientBuilder(URI http_localhost_uri) {
+        return SqsAsyncClient.builder()
+                             .region(Region.US_EAST_1)
+                             .endpointOverride(http_localhost_uri)
+                             .credentialsProvider(
+                                 StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")));
+    }
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().threadNamePrefix("SqsBatchManager").build();
+        scheduledExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
+        URI http_localhost_uri = URI.create(String.format("http://localhost:%s/", wireMock.port()));
+        client = getAsyncClientBuilder(http_localhost_uri).build();
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown() {
+        client.close();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Before
+    public void setUp() {
+        batchManager = SqsAsyncBatchManager.builder()
+                                           .client(client)
+                                           .scheduledExecutor(scheduledExecutor)
+                                           .build();
+    }
+
+    @After
+    public void tearDown() {
+        batchManager.close();
+    }
+
+    @Test
+    public void closeBatchManager_shouldNotCloseExecutorsOrClient() {
+        SqsAsyncBatchManager batchManager = new DefaultSqsAsyncBatchManager(client, scheduledExecutor,
+                                                                            mockSendMessageBatchManager,
+                                                                            mockDeleteMessageBatchManager,
+                                                                            mockChangeVisibilityBatchManager);
+        batchManager.close();
+        verify(mockSendMessageBatchManager).close();
+        verify(mockDeleteMessageBatchManager).close();
+        verify(mockChangeVisibilityBatchManager).close();
+        assertThat(scheduledExecutor.isShutdown()).isFalse();
+    }
+
+    @Override
+    public List<CompletableFuture<SendMessageResponse>> createAndSendSendMessageRequests(String message1, String message2) {
+        List<SendMessageRequest> requests = new ArrayList<>();
+        requests.add(createSendMessageRequest(message1));
+        requests.add(createSendMessageRequest(message2));
+
+        List<CompletableFuture<SendMessageResponse>> responses = new ArrayList<>();
+        for (SendMessageRequest request : requests) {
+            responses.add(batchManager.sendMessage(request));
+        }
+        return responses;
+    }
+
+    @Override
+    public List<CompletableFuture<DeleteMessageResponse>> createAndSendDeleteMessageRequests() {
+        List<DeleteMessageRequest> requests = new ArrayList<>();
+        requests.add(createDeleteMessageRequest());
+        requests.add(createDeleteMessageRequest());
+        List<CompletableFuture<DeleteMessageResponse>> responses = new ArrayList<>();
+
+        for (DeleteMessageRequest request : requests) {
+            responses.add(batchManager.deleteMessage(request));
+        }
+        return responses;
+    }
+
+    @Override
+    public List<CompletableFuture<ChangeMessageVisibilityResponse>> createAndSendChangeVisibilityRequests() {
+        List<ChangeMessageVisibilityRequest> requests = new ArrayList<>();
+        requests.add(createChangeVisibilityRequest());
+        requests.add(createChangeVisibilityRequest());
+
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = new ArrayList<>();
+        for (ChangeMessageVisibilityRequest request : requests) {
+            responses.add(batchManager.changeMessageVisibility(request));
+        }
+
+        return responses;
+    }
+}

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
@@ -48,7 +48,6 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import software.amazon.awssdk.utils.BinaryUtils;
 import software.amazon.awssdk.utils.Md5Utils;
 
-// TODO: Will refactor code in this test file for async tests.
 public class SqsBatchFunctionsTest {
 
     @Test
@@ -93,16 +92,8 @@ public class SqsBatchFunctionsTest {
     @Test
     public void sendMessageBatchKeyMapperWithOverrideConfig_hasSameBatchKey() {
         String queueUrl = "myQueue";
-        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
-        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(10);
-        SendMessageRequest request1 = SendMessageRequest.builder()
-                                                        .queueUrl(queueUrl)
-                                                        .overrideConfiguration(overrideConfiguration1)
-                                                        .build();
-        SendMessageRequest request2 = SendMessageRequest.builder()
-                                                        .queueUrl(queueUrl)
-                                                        .overrideConfiguration(overrideConfiguration2)
-                                                        .build();
+        SendMessageRequest request1 = createSendMessageRequestWithOverrideConfig(queueUrl, 10);
+        SendMessageRequest request2 = createSendMessageRequestWithOverrideConfig(queueUrl, 10);
         String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
         assertThat(batchKey1).isEqualTo(batchKey2);
@@ -111,16 +102,8 @@ public class SqsBatchFunctionsTest {
     @Test
     public void sendMessageBatchKeyMapperWithDifferentOverrideConfig_hasDifferentBatchKey() {
         String queueUrl = "myQueue";
-        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
-        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(20);
-        SendMessageRequest request1 = SendMessageRequest.builder()
-                                                        .queueUrl(queueUrl)
-                                                        .overrideConfiguration(overrideConfiguration1)
-                                                        .build();
-        SendMessageRequest request2 = SendMessageRequest.builder()
-                                                        .queueUrl(queueUrl)
-                                                        .overrideConfiguration(overrideConfiguration2)
-                                                        .build();
+        SendMessageRequest request1 = createSendMessageRequestWithOverrideConfig(queueUrl, 10);
+        SendMessageRequest request2 = createSendMessageRequestWithOverrideConfig(queueUrl, 20);
         String batchKey1 = sendMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = sendMessageBatchKeyMapper().getBatchKey(request2);
         assertThat(batchKey1).isNotEqualTo(batchKey2);
@@ -165,16 +148,8 @@ public class SqsBatchFunctionsTest {
     @Test
     public void deleteMessageBatchKeyMapperWithOverrideConfig_hasSameBatchKey() {
         String queueUrl = "myQueue";
-        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
-        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(10);
-        DeleteMessageRequest request1 = DeleteMessageRequest.builder()
-                                                            .queueUrl(queueUrl)
-                                                            .overrideConfiguration(overrideConfiguration1)
-                                                            .build();
-        DeleteMessageRequest request2 = DeleteMessageRequest.builder()
-                                                            .queueUrl(queueUrl)
-                                                            .overrideConfiguration(overrideConfiguration2)
-                                                            .build();
+        DeleteMessageRequest request1 = createDeleteMessageRequestWithOverrideConfig(queueUrl, 10);
+        DeleteMessageRequest request2 = createDeleteMessageRequestWithOverrideConfig(queueUrl, 10);
         String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
         assertThat(batchKey1).isEqualTo(batchKey2);
@@ -183,16 +158,8 @@ public class SqsBatchFunctionsTest {
     @Test
     public void deleteMessageBatchKeyMapperWithDifferentOverrideConfig_hasDifferentBatchKey() {
         String queueUrl = "myQueue";
-        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
-        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(20);
-        DeleteMessageRequest request1 = DeleteMessageRequest.builder()
-                                                            .queueUrl(queueUrl)
-                                                            .overrideConfiguration(overrideConfiguration1)
-                                                            .build();
-        DeleteMessageRequest request2 = DeleteMessageRequest.builder()
-                                                            .queueUrl(queueUrl)
-                                                            .overrideConfiguration(overrideConfiguration2)
-                                                            .build();
+        DeleteMessageRequest request1 = createDeleteMessageRequestWithOverrideConfig(queueUrl, 10);
+        DeleteMessageRequest request2 = createDeleteMessageRequestWithOverrideConfig(queueUrl, 20);
         String batchKey1 = deleteMessageBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = deleteMessageBatchKeyMapper().getBatchKey(request2);
         assertThat(batchKey1).isNotEqualTo(batchKey2);
@@ -237,16 +204,8 @@ public class SqsBatchFunctionsTest {
     @Test
     public void changeVisibilityBatchKeyMapperWithOverrideConfig_hasSameBatchKey() {
         String queueUrl = "myQueue";
-        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
-        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(10);
-        ChangeMessageVisibilityRequest request1 = ChangeMessageVisibilityRequest.builder()
-                                                                                .queueUrl(queueUrl)
-                                                                                .overrideConfiguration(overrideConfiguration1)
-                                                                                .build();
-        ChangeMessageVisibilityRequest request2 = ChangeMessageVisibilityRequest.builder()
-                                                                                .queueUrl(queueUrl)
-                                                                                .overrideConfiguration(overrideConfiguration2)
-                                                                                .build();
+        ChangeMessageVisibilityRequest request1 = createChangeVisibilityRequestWithOverrideConfig(queueUrl, 10);
+        ChangeMessageVisibilityRequest request2 = createChangeVisibilityRequestWithOverrideConfig(queueUrl, 10);
         String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
         assertThat(batchKey1).isEqualTo(batchKey2);
@@ -255,19 +214,35 @@ public class SqsBatchFunctionsTest {
     @Test
     public void changeVisibilityBatchKeyMapperWithDifferentOverrideConfig_hasDifferentBatchKey() {
         String queueUrl = "myQueue";
-        AwsRequestOverrideConfiguration overrideConfiguration1 = createOverrideConfig(10);
-        AwsRequestOverrideConfiguration overrideConfiguration2 = createOverrideConfig(20);
-        ChangeMessageVisibilityRequest request1 = ChangeMessageVisibilityRequest.builder()
-                                                                                .queueUrl(queueUrl)
-                                                                                .overrideConfiguration(overrideConfiguration1)
-                                                                                .build();
-        ChangeMessageVisibilityRequest request2 = ChangeMessageVisibilityRequest.builder()
-                                                                                .queueUrl(queueUrl)
-                                                                                .overrideConfiguration(overrideConfiguration2)
-                                                                                .build();
+        ChangeMessageVisibilityRequest request1 = createChangeVisibilityRequestWithOverrideConfig(queueUrl, 10);
+        ChangeMessageVisibilityRequest request2 = createChangeVisibilityRequestWithOverrideConfig(queueUrl, 20);
         String batchKey1 = changeVisibilityBatchKeyMapper().getBatchKey(request1);
         String batchKey2 = changeVisibilityBatchKeyMapper().getBatchKey(request2);
         assertThat(batchKey1).isNotEqualTo(batchKey2);
+    }
+
+    private SendMessageRequest createSendMessageRequestWithOverrideConfig(String queueUrl, int millis) {
+        AwsRequestOverrideConfiguration overrideConfiguration = createOverrideConfig(millis);
+        return SendMessageRequest.builder()
+                                 .queueUrl(queueUrl)
+                                 .overrideConfiguration(overrideConfiguration)
+                                 .build();
+    }
+
+    private DeleteMessageRequest createDeleteMessageRequestWithOverrideConfig(String queueUrl, int millis) {
+        AwsRequestOverrideConfiguration overrideConfiguration = createOverrideConfig(millis);
+        return DeleteMessageRequest.builder()
+                                   .queueUrl(queueUrl)
+                                   .overrideConfiguration(overrideConfiguration)
+                                   .build();
+    }
+
+    private ChangeMessageVisibilityRequest createChangeVisibilityRequestWithOverrideConfig(String queueUrl, int millis) {
+        AwsRequestOverrideConfiguration overrideConfiguration = createOverrideConfig(millis);
+        return ChangeMessageVisibilityRequest.builder()
+                                             .queueUrl(queueUrl)
+                                             .overrideConfiguration(overrideConfiguration)
+                                             .build();
     }
 
     private SendMessageBatchResponse createSendMessageBatchResponse(AwsResponseMetadata responseMetadata,

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -15,20 +15,10 @@
 
 package software.amazon.awssdk.services.sqs;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
-import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -40,7 +30,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -48,7 +37,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.batchmanager.BatchManager;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
 import software.amazon.awssdk.services.sqs.internal.batchmanager.DefaultSqsBatchManager;
@@ -61,20 +49,14 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
-import software.amazon.awssdk.services.sqs.model.SqsException;
-import software.amazon.awssdk.utils.BinaryUtils;
-import software.amazon.awssdk.utils.Md5Utils;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SqsBatchManagerTest {
+public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
 
-    private static final int DEFAULT_MAX_BATCH_OPEN = 200;
-    private static final String DEFAULT_QUEUE_URl = "SomeQueueUrl";
     private static ScheduledExecutorService scheduledExecutor;
     private static ExecutorService executor;
     private static SqsClient client;
-    private static URI http_localhost_uri;
     private SqsBatchManager batchManager;
 
     @Mock
@@ -87,10 +69,7 @@ public class SqsBatchManagerTest {
     private BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
         ChangeMessageVisibilityBatchResponse> mockChangeVisibilityBatchManager;
 
-    @ClassRule
-    public static WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
-
-    private static SqsClientBuilder getSyncClientBuilder() {
+    private static SqsClientBuilder getSyncClientBuilder(URI http_localhost_uri) {
         return SqsClient.builder()
                         .region(Region.US_EAST_1)
                         .endpointOverride(http_localhost_uri)
@@ -103,8 +82,8 @@ public class SqsBatchManagerTest {
         ThreadFactory threadFactory = new ThreadFactoryBuilder().threadNamePrefix("SqsBatchManager").build();
         scheduledExecutor = Executors.newSingleThreadScheduledExecutor(threadFactory);
         executor = Executors.newSingleThreadExecutor();
-        http_localhost_uri = URI.create(String.format("http://localhost:%s/", wireMock.port()));
-        client = getSyncClientBuilder().build();
+        URI http_localhost_uri = URI.create(String.format("http://localhost:%s/", wireMock.port()));
+        client = getSyncClientBuilder(http_localhost_uri).build();
     }
 
     @AfterClass
@@ -129,222 +108,9 @@ public class SqsBatchManagerTest {
     }
 
     @Test
-    public void sendMessageBatchFunction_batchMessageCorrectly() {
-        String id1 = "0";
-        String id2 = "1";
-        String messageBody1 = getMd5Hash(id1);
-        String messageBody2 = getMd5Hash(id2);
-        String responseBody = String.format(
-            "<SendMessageBatchResponse>\n"
-            + "<SendMessageBatchResult>\n"
-            + "    <SendMessageBatchResultEntry>\n"
-            + "        <Id>%s</Id>\n"
-            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
-            + "    </SendMessageBatchResultEntry>\n"
-            + "    <SendMessageBatchResultEntry>\n"
-            + "        <Id>%s</Id>\n"
-            + "        <MD5OfMessageBody>%s</MD5OfMessageBody>\n"
-            + "    </SendMessageBatchResultEntry>\n"
-            + "</SendMessageBatchResult>\n"
-            + "</SendMessageBatchResponse>", id1, messageBody1, id2, messageBody2);
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
-        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
-
-        SendMessageResponse completedResponse1 = responses.get(0).join();
-        SendMessageResponse completedResponse2 = responses.get(1).join();
-        assertThat(completedResponse1.md5OfMessageBody()).isEqualTo(messageBody1);
-        assertThat(completedResponse2.md5OfMessageBody()).isEqualTo(messageBody2);
-    }
-
-    // TODO: Update tests after updating how batchEntryFailures are handled
-    @Test
-    public void sendMessageBatchFunctionWithBatchEntryFailures_wrapFailureMessageInBatchEntry() {
-        String id1 = "0";
-        String id2 = "1";
-        String errorCode = "400";
-        String errorMessage = "Some error";
-        String responseBody = String.format(
-            "<SendMessageBatchResponse>\n"
-            + "<SendMessageBatchResult>\n"
-            + "    <BatchResultErrorEntry>\n"
-            + "        <Id>%s</Id>\n"
-            + "        <Code>%s</Code>\n"
-            + "        <Message>%s</Message>\n"
-            + "    </BatchResultErrorEntry>\n"
-            + "    <BatchResultErrorEntry>\n"
-            + "        <Id>%s</Id>\n"
-            + "        <Code>%s</Code>\n"
-            + "        <Message>%s</Message>\n"
-            + "    </BatchResultErrorEntry>\n"
-            + "</SendMessageBatchResult>\n"
-            + "</SendMessageBatchResponse>", id1, errorCode, errorMessage, id2, errorCode, errorMessage);
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
-        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
-
-        SendMessageResponse completedResponse1 = responses.get(0).join();
-        SendMessageResponse completedResponse2 = responses.get(1).join();
-        assertThat(completedResponse1.md5OfMessageBody()).isNullOrEmpty();
-        assertThat(completedResponse2.md5OfMessageBody()).isNullOrEmpty();
-    }
-
-    @Test
-    public void sendMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
-        String id1 = "0";
-        String id2 = "1";
-        String responseBody = "<Error>\n"
-                              + "<Code>CustomError</Code>\n"
-                              + "<Message>Foo bar</Message>\n"
-                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
-                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
-                              + "</Error>";
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
-        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
-
-        CompletableFuture<SendMessageResponse> response1 = responses.get(0);
-        CompletableFuture<SendMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
-        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
-    }
-
-    @Test
-    public void sendMessageBatchNetworkError_causesConnectionResetException() {
-        String id1 = "0";
-        String id2 = "1";
-        String errorMessage = "Unable to execute HTTP request";
-        stubFor(any(anyUrl()).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
-
-        List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
-
-        CompletableFuture<SendMessageResponse> response1 = responses.get(0);
-        CompletableFuture<SendMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).hasCauseInstanceOf(SdkClientException.class).hasMessageContaining(errorMessage);
-        assertThatThrownBy(response2::join).hasCauseInstanceOf(SdkClientException.class).hasMessageContaining(errorMessage);
-    }
-
-    @Test
-    public void deleteMessageBatchFunction_batchMessageCorrectly() {
-        String id1 = "0";
-        String id2 = "1";
-        String responseBody = String.format(
-            "<DeleteMessageBatchResponse>\n"
-            + "    <DeleteMessageBatchResult>\n"
-            + "        <DeleteMessageBatchResultEntry>\n"
-            + "            <Id>%s</Id>\n"
-            + "        </DeleteMessageBatchResultEntry>\n"
-            + "        <DeleteMessageBatchResultEntry>\n"
-            + "            <Id>%s</Id>\n"
-            + "        </DeleteMessageBatchResultEntry>\n"
-            + "    </DeleteMessageBatchResult>\n"
-            + "</DeleteMessageBatchResponse>\n", id1, id2);
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
-
-        List<DeleteMessageRequest> requests = new ArrayList<>();
-        requests.add(createDeleteMessageRequest());
-        requests.add(createDeleteMessageRequest());
-
-        List<CompletableFuture<DeleteMessageResponse>> responses = new ArrayList<>();
-        long startTime = System.nanoTime();
-        for (DeleteMessageRequest request : requests) {
-            responses.add(batchManager.deleteMessage(request));
-        }
-        long endTime = System.nanoTime();
-        CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
-
-        assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isLessThan(DEFAULT_MAX_BATCH_OPEN + 100);
-    }
-
-    @Test
-    public void deleteMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
-        String responseBody = "<Error>\n"
-                              + "<Code>CustomError</Code>\n"
-                              + "<Message>Foo bar</Message>\n"
-                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
-                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
-                              + "</Error>";
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
-
-        List<DeleteMessageRequest> requests = new ArrayList<>();
-        requests.add(createDeleteMessageRequest());
-        requests.add(createDeleteMessageRequest());
-
-        List<CompletableFuture<DeleteMessageResponse>> responses = new ArrayList<>();
-        for (DeleteMessageRequest request : requests) {
-            responses.add(batchManager.deleteMessage(request));
-        }
-
-        CompletableFuture<DeleteMessageResponse> response1 = responses.get(0);
-        CompletableFuture<DeleteMessageResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
-        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
-    }
-
-    @Test
-    public void changeVisibilityBatchFunction_batchMessageCorrectly() {
-        String id1 = "0";
-        String id2 = "1";
-        String responseBody = String.format(
-            "<ChangeMessageVisibilityBatchResponse>\n"
-            + "    <ChangeMessageVisibilityBatchResult>\n"
-            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
-            + "            <Id>%s</Id>\n"
-            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
-            + "        <ChangeMessageVisibilityBatchResultEntry>\n"
-            + "            <Id>%s</Id>\n"
-            + "        </ChangeMessageVisibilityBatchResultEntry>\n"
-            + "    </ChangeMessageVisibilityBatchResult>\n"
-            + "</ChangeMessageVisibilityBatchResponse>", id1, id2);
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
-
-        List<ChangeMessageVisibilityRequest> requests = new ArrayList<>();
-        requests.add(createChangeVisibilityRequest());
-        requests.add(createChangeVisibilityRequest());
-
-        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = new ArrayList<>();
-        long startTime = System.nanoTime();
-        for (ChangeMessageVisibilityRequest request : requests) {
-            responses.add(batchManager.changeMessageVisibility(request));
-        }
-        long endTime = System.nanoTime();
-        CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
-
-        assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isLessThan(DEFAULT_MAX_BATCH_OPEN + 100);
-    }
-
-    @Test
-    public void changeVisibilityBatchFunctionReturnsWithError_completeMessagesExceptionally() {
-        String responseBody = "<Error>\n"
-                              + "<Code>CustomError</Code>\n"
-                              + "<Message>Foo bar</Message>\n"
-                              + "<RequestId>656c76696e6727732072657175657374</RequestId>\n"
-                              + "<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\n"
-                              + "</Error>";
-
-        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(400).withBody(responseBody)));
-
-        List<ChangeMessageVisibilityRequest> requests = new ArrayList<>();
-        requests.add(createChangeVisibilityRequest());
-        requests.add(createChangeVisibilityRequest());
-
-        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = new ArrayList<>();
-        for (ChangeMessageVisibilityRequest request : requests) {
-            responses.add(batchManager.changeMessageVisibility(request));
-        }
-
-        CompletableFuture<ChangeMessageVisibilityResponse> response1 = responses.get(0);
-        CompletableFuture<ChangeMessageVisibilityResponse> response2 = responses.get(1);
-        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
-        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining("Status Code: 400");
-    }
-
-    @Test
     public void closeBatchManager_shouldNotCloseExecutorsOrClient() {
-        SqsBatchManager batchManager = new DefaultSqsBatchManager(client, executor, mockSendMessageBatchManager,
+        SqsBatchManager batchManager = new DefaultSqsBatchManager(client, executor, scheduledExecutor,
+                                                                  mockSendMessageBatchManager,
                                                                   mockDeleteMessageBatchManager,
                                                                   mockChangeVisibilityBatchManager);
         batchManager.close();
@@ -352,9 +118,11 @@ public class SqsBatchManagerTest {
         verify(mockDeleteMessageBatchManager).close();
         verify(mockChangeVisibilityBatchManager).close();
         assertThat(executor.isShutdown()).isFalse();
+        assertThat(scheduledExecutor.isShutdown()).isFalse();
     }
 
-    private List<CompletableFuture<SendMessageResponse>> createAndSendSendMessageRequests(String message1, String message2) {
+    @Override
+    public List<CompletableFuture<SendMessageResponse>> createAndSendSendMessageRequests(String message1, String message2) {
         List<SendMessageRequest> requests = new ArrayList<>();
         requests.add(createSendMessageRequest(message1));
         requests.add(createSendMessageRequest(message2));
@@ -366,28 +134,30 @@ public class SqsBatchManagerTest {
         return responses;
     }
 
-    private SendMessageRequest createSendMessageRequest(String messageBody) {
-        return SendMessageRequest.builder()
-                                 .messageBody(messageBody)
-                                 .queueUrl(DEFAULT_QUEUE_URl)
-                                 .build();
+    @Override
+    public List<CompletableFuture<DeleteMessageResponse>> createAndSendDeleteMessageRequests() {
+        List<DeleteMessageRequest> requests = new ArrayList<>();
+        requests.add(createDeleteMessageRequest());
+        requests.add(createDeleteMessageRequest());
+        List<CompletableFuture<DeleteMessageResponse>> responses = new ArrayList<>();
+
+        for (DeleteMessageRequest request : requests) {
+            responses.add(batchManager.deleteMessage(request));
+        }
+        return responses;
     }
 
-    private DeleteMessageRequest createDeleteMessageRequest() {
-        return DeleteMessageRequest.builder()
-                                   .queueUrl(DEFAULT_QUEUE_URl)
-                                   .build();
-    }
+    @Override
+    public List<CompletableFuture<ChangeMessageVisibilityResponse>> createAndSendChangeVisibilityRequests() {
+        List<ChangeMessageVisibilityRequest> requests = new ArrayList<>();
+        requests.add(createChangeVisibilityRequest());
+        requests.add(createChangeVisibilityRequest());
 
-    private ChangeMessageVisibilityRequest createChangeVisibilityRequest() {
-        return ChangeMessageVisibilityRequest.builder()
-                                             .queueUrl(DEFAULT_QUEUE_URl)
-                                             .build();
-    }
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = new ArrayList<>();
+        for (ChangeMessageVisibilityRequest request : requests) {
+            responses.add(batchManager.changeMessageVisibility(request));
+        }
 
-    private String getMd5Hash(String message) {
-        byte[] expectedMd5;
-        expectedMd5 = Md5Utils.computeMD5Hash(message.getBytes(StandardCharsets.UTF_8));
-        return BinaryUtils.toHex(expectedMd5);
+        return responses;
     }
 }


### PR DESCRIPTION
## Motivation and Context
Hand coding the `SqsAsyncBatchManager` for the async client to demonstrate how a code generated service batch manager might look like and interact with the core batch manager.

## Description
In this PR, I am implementing a `DefaultSqsAsyncBatchManager` that is created when customers want to use client-side buffering and automatic request batching with SQS' async client. A lot of the changes involved refactoring existing code used by the sync `SqsBatchManager` to be usable by the async client as well. 

## Testing
Tests for the sync `BatchManager` were refactored into a base abstract class. The tests for the `SqsAsyncBatchManager` leverages this base class and differs from the  tests for the sync `BatchManager` by passing in a `SqsAsyncClient` and `SqsAsyncBatchManager`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
