### PR TITLE
Refactoring the core BatchManager to change how it handles batch entry failures.

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchAndSend.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchAndSend.java
@@ -13,11 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.internal.batchmanager;
+package software.amazon.awssdk.core.batchmanager;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.batchmanager.IdentifiableMessage;
 
 /**
  * Takes a list of identified requests in addition to a destination and batches the requests into a batch request.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchKeyMapper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchKeyMapper.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.internal.batchmanager;
+package software.amazon.awssdk.core.batchmanager;
 
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchManagerBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchManagerBuilder.java
@@ -17,9 +17,6 @@ package software.amazon.awssdk.core.batchmanager;
 
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
-import software.amazon.awssdk.core.internal.batchmanager.BatchAndSend;
-import software.amazon.awssdk.core.internal.batchmanager.BatchKeyMapper;
-import software.amazon.awssdk.core.internal.batchmanager.BatchResponseMapper;
 
 @SdkProtectedApi
 public interface BatchManagerBuilder<RequestT, ResponseT, BatchResponseT, B> {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
@@ -80,6 +80,8 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
     @Override
     public Builder toBuilder() {
         return new Builder().maxBatchItems(maxBatchItems)
+                            .maxBatchKeys(maxBatchKeys)
+                            .maxBufferSize(maxBufferSize)
                             .maxBatchOpenInMs(maxBatchOpenInMs);
     }
 
@@ -87,6 +89,8 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
     public String toString() {
         return ToString.builder("BatchOverrideConfiguration")
                        .add("maxBatchItems", maxBatchItems)
+                       .add("maxBatchKeys", maxBatchKeys)
+                       .add("maxBufferSize", maxBufferSize)
                        .add("maxBatchOpenInMs", maxBatchOpenInMs.toMillis())
                        .build();
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
@@ -145,7 +145,11 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
         }
 
         /**
-         * Define the maximum number of batchKeys to keep track of.
+         * Define the maximum number of batchKeys to keep track of. A batchKey determines which requests are batched together
+         * and is calculated by the client based on the information in a request.
+         * <p>
+         * Ex. SQS determines a batchKey based on a request's queueUrl in combination with its overrideConfiguration, so
+         * requests with the same queueUrl and overrideConfiguration will have the same batchKey and be batched together.
          *
          * @param maxBatchKeys the new maxBatchKeys value.
          * @return This object for method chaining.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
@@ -33,11 +33,15 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
     BatchOverrideConfiguration> {
 
     private final Integer maxBatchItems;
+    private final Integer maxBatchKeys;
+    private final Integer maxBufferSize;
     private final Duration maxBatchOpenInMs;
 
     public BatchOverrideConfiguration(Builder builder) {
         this.maxBatchItems = Validate.isPositiveOrNull(builder.maxBatchItems, "maxBatchItems");
         this.maxBatchOpenInMs = Validate.isPositiveOrNull(builder.maxBatchOpenInMs, "maxBachOpenInMs");
+        this.maxBatchKeys = Validate.isPositiveOrNull(builder.maxBatchKeys, "maxBatchKeys");
+        this.maxBufferSize = Validate.isPositiveOrNull(builder.maxBufferSize, "maxBufferSize");
     }
 
     public static Builder builder() {
@@ -49,6 +53,20 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
      */
     public Optional<Integer> maxBatchItems() {
         return Optional.ofNullable(maxBatchItems);
+    }
+
+    /**
+     * @return the optional maximum number of batchKeys to keep track of.
+     */
+    public Optional<Integer> maxBatchKeys() {
+        return Optional.ofNullable(maxBatchKeys);
+    }
+
+    /**
+     * @return the maximum number of items to allow to be buffered for each batchKey.
+     */
+    public Optional<Integer> maxBufferSize() {
+        return Optional.ofNullable(maxBufferSize);
     }
 
     /**
@@ -87,12 +105,20 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
         if (maxBatchItems != null ? !maxBatchItems.equals(that.maxBatchItems) : that.maxBatchItems != null) {
             return false;
         }
+        if (maxBatchKeys != null ? !maxBatchKeys.equals(that.maxBatchKeys) : that.maxBatchKeys != null) {
+            return false;
+        }
+        if (maxBufferSize != null ? !maxBufferSize.equals(that.maxBufferSize) : that.maxBufferSize != null) {
+            return false;
+        }
         return maxBatchOpenInMs != null ? maxBatchOpenInMs.equals(that.maxBatchOpenInMs) : that.maxBatchOpenInMs == null;
     }
 
     @Override
     public int hashCode() {
         int result = maxBatchItems != null ? maxBatchItems.hashCode() : 0;
+        result = 31 * result + (maxBatchKeys != null ? maxBatchKeys.hashCode() : 0);
+        result = 31 * result + (maxBufferSize != null ? maxBufferSize.hashCode() : 0);
         result = 31 * result + (maxBatchOpenInMs != null ? maxBatchOpenInMs.hashCode() : 0);
         return result;
     }
@@ -100,6 +126,8 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
     public static final class Builder implements CopyableBuilder<Builder, BatchOverrideConfiguration> {
 
         private Integer maxBatchItems;
+        private Integer maxBatchKeys;
+        private Integer maxBufferSize;
         private Duration maxBatchOpenInMs;
 
         private Builder() {
@@ -117,6 +145,28 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
         }
 
         /**
+         * Define the maximum number of batchKeys to keep track of.
+         *
+         * @param maxBatchKeys the new maxBatchKeys value.
+         * @return This object for method chaining.
+         */
+        public Builder maxBatchKeys(Integer maxBatchKeys) {
+            this.maxBatchKeys = maxBatchKeys;
+            return this;
+        }
+
+        /**
+         * Define the maximum number of items to allow to be buffered for each batchKey.
+         *
+         * @param maxBufferSize the new maxBufferSize value.
+         * @return This object for method chaining.
+         */
+        public Builder maxBufferSize(Integer maxBufferSize) {
+            this.maxBufferSize = maxBufferSize;
+            return this;
+        }
+
+        /**
          * The maximum amount of time (in milliseconds) that an outgoing call waits for other requests before sending out a batch
          * request.
          *
@@ -127,6 +177,7 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
             this.maxBatchOpenInMs = maxBatchOpenInMs;
             return this;
         }
+
 
         public BatchOverrideConfiguration build() {
             return new BatchOverrideConfiguration(this);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchResponseMapper.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchResponseMapper.java
@@ -13,10 +13,12 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.internal.batchmanager;
+package software.amazon.awssdk.core.batchmanager;
 
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.batchmanager.IdentifiableMessage;
+import software.amazon.awssdk.utils.Either;
 
 /**
  * Unpacks the batch response, then transforms individual entries to the appropriate response type. Each entry's batch ID
@@ -27,5 +29,5 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 @FunctionalInterface
 @SdkProtectedApi
 public interface BatchResponseMapper<BatchResponseT, ResponseT> {
-    List<IdentifiableMessage<ResponseT>> mapBatchResponse(BatchResponseT batchResponse);
+    List<Either<IdentifiableMessage<ResponseT>, IdentifiableMessage<Throwable>>> mapBatchResponse(BatchResponseT batchResponse);
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/IdentifiableMessage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/IdentifiableMessage.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.core.internal.batchmanager;
+package software.amazon.awssdk.core.batchmanager;
 
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.Validate;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
@@ -99,7 +99,7 @@ public final class BatchBuffer<RequestT, ResponseT> {
         return idToBatchContext.get(key).response();
     }
 
-    public void put(RequestT request, CompletableFuture<ResponseT> response){
+    public void put(RequestT request, CompletableFuture<ResponseT> response) {
         synchronized (this) {
             if (idToBatchContext.size() == maxBufferSize) {
                 throw new IllegalStateException("Reached MaxBufferSize of: " + maxBufferSize);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
@@ -99,11 +99,10 @@ public final class BatchBuffer<RequestT, ResponseT> {
         return idToBatchContext.get(key).response();
     }
 
-    public void put(RequestT request, CompletableFuture<ResponseT> response)
-            throws IndexOutOfBoundsException {
+    public void put(RequestT request, CompletableFuture<ResponseT> response){
         synchronized (this) {
             if (idToBatchContext.size() == maxBufferSize) {
-                throw new IndexOutOfBoundsException("MaxBufferSize reached");
+                throw new IllegalStateException("Reached MaxBufferSize of: " + maxBufferSize);
             }
 
             if (nextId == Integer.MAX_VALUE) {

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
@@ -27,8 +27,12 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public final class BatchBuffer<RequestT, ResponseT> {
     private final Object flushLock = new Object();
-
     private final Map<String, BatchingExecutionContext<RequestT, ResponseT>> idToBatchContext;
+
+    /**
+     * Maximum number of elements that can be included in the BatchBuffer.
+     */
+    private final int maxBufferSize;
 
     // TODO: Figure out better name for nextId and nextBatchEntry.
     /**
@@ -50,8 +54,9 @@ public final class BatchBuffer<RequestT, ResponseT> {
      */
     private ScheduledFuture<?> scheduledFlush;
 
-    public BatchBuffer(ScheduledFuture<?> scheduledFlush) {
+    public BatchBuffer(int maxBufferSize, ScheduledFuture<?> scheduledFlush) {
         this.idToBatchContext = new ConcurrentHashMap<>();
+        this.maxBufferSize = maxBufferSize;
         this.nextId = 0;
         this.nextBatchEntry = 0;
         this.scheduledFlush = scheduledFlush;
@@ -94,13 +99,18 @@ public final class BatchBuffer<RequestT, ResponseT> {
         return idToBatchContext.get(key).response();
     }
 
-    public BatchingExecutionContext<RequestT, ResponseT> put(RequestT request, CompletableFuture<ResponseT> response) {
+    public void put(RequestT request, CompletableFuture<ResponseT> response)
+            throws IndexOutOfBoundsException {
         synchronized (this) {
+            if (idToBatchContext.size() == maxBufferSize) {
+                throw new IndexOutOfBoundsException("MaxBufferSize reached");
+            }
+
             if (nextId == Integer.MAX_VALUE) {
                 nextId = 0;
             }
             String id = Integer.toString(nextId++);
-            return idToBatchContext.put(id, new BatchingExecutionContext<>(request, response));
+            idToBatchContext.put(id, new BatchingExecutionContext<>(request, response));
         }
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchConfiguration.java
@@ -51,11 +51,11 @@ public final class BatchConfiguration {
         return maxBatchItems;
     }
 
-    public int getMaxBatchKeys() {
+    public int maxBatchKeys() {
         return maxBatchKeys;
     }
 
-    public int getMaxBufferSize() {
+    public int maxBufferSize() {
         return maxBufferSize;
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchConfiguration.java
@@ -25,13 +25,20 @@ public final class BatchConfiguration {
 
     // TODO: Update these default values.
     private static final int DEFAULT_MAX_BATCH_ITEMS = 5;
+    private static final int DEFAULT_MAX_BATCH_KEYS = 100;
+    private static final int DEFAULT_MAX_BUFFER_SIZE = 500;
     private static final Duration DEFAULT_MAX_BATCH_OPEN_IN_MS = Duration.ofMillis(200);
+
     private final Integer maxBatchItems;
+    private final Integer maxBatchKeys;
+    private final Integer maxBufferSize;
     private final Duration maxBatchOpenInMs;
 
     public BatchConfiguration(BatchOverrideConfiguration overrideConfiguration) {
         Optional<BatchOverrideConfiguration> configuration = Optional.ofNullable(overrideConfiguration);
         this.maxBatchItems = configuration.flatMap(BatchOverrideConfiguration::maxBatchItems).orElse(DEFAULT_MAX_BATCH_ITEMS);
+        this.maxBatchKeys = configuration.flatMap(BatchOverrideConfiguration::maxBatchKeys).orElse(DEFAULT_MAX_BATCH_KEYS);
+        this.maxBufferSize = configuration.flatMap(BatchOverrideConfiguration::maxBufferSize).orElse(DEFAULT_MAX_BUFFER_SIZE);
         this.maxBatchOpenInMs = configuration.flatMap(BatchOverrideConfiguration::maxBatchOpenInMs)
                                              .orElse(DEFAULT_MAX_BATCH_OPEN_IN_MS);
     }
@@ -42,5 +49,13 @@ public final class BatchConfiguration {
 
     public int maxBatchItems() {
         return maxBatchItems;
+    }
+
+    public int getMaxBatchKeys() {
+        return maxBatchKeys;
+    }
+
+    public int getMaxBufferSize() {
+        return maxBufferSize;
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchingMap.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchingMap.java
@@ -44,10 +44,10 @@ public final class BatchingMap<RequestT, ResponseT> {
     // flushableScheduledRequests. This is done because removeBufferIfNeeded removes the underlying buffer and so we want to
     // guarantee that we don't try to put items into a buffer that is removed.
     public void put(String batchKey, Supplier<ScheduledFuture<?>> scheduleFlush, RequestT request,
-                     CompletableFuture<ResponseT> response) throws IndexOutOfBoundsException {
+                     CompletableFuture<ResponseT> response) throws IllegalStateException {
         batchContextMap.computeIfAbsent(batchKey, k -> {
             if (batchContextMap.size() == maxBatchKeys) {
-                throw new IndexOutOfBoundsException("MaxBatchKeys reached");
+                throw new IllegalStateException("Reached MaxBatchKeys of: " + maxBatchKeys);
             }
             return new BatchBuffer<>(maxBufferSize, scheduleFlush.get());
         })

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
@@ -30,7 +30,6 @@ import software.amazon.awssdk.core.batchmanager.BatchManager;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.core.batchmanager.BatchResponseMapper;
 import software.amazon.awssdk.core.batchmanager.IdentifiableMessage;
-import software.amazon.awssdk.utils.Either;
 import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
@@ -69,8 +68,8 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
 
     private DefaultBatchManager(DefaultBuilder<RequestT, ResponseT, BatchResponseT> builder) {
         BatchConfiguration batchConfiguration = new BatchConfiguration(builder.overrideConfiguration);
-        this.requestsAndResponsesMaps = new BatchingMap<>(batchConfiguration.getMaxBatchKeys(),
-                                                          batchConfiguration.getMaxBufferSize());
+        this.requestsAndResponsesMaps = new BatchingMap<>(batchConfiguration.maxBatchKeys(),
+                                                          batchConfiguration.maxBufferSize());
         this.maxBatchItems = batchConfiguration.maxBatchItems();
         this.maxBatchOpenInMs = batchConfiguration.maxBatchOpenInMs();
         this.batchFunction = Validate.notNull(builder.batchFunction, "Null batchFunction");
@@ -140,8 +139,7 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
                                                                                  .complete(actualResponse.message()),
                                                        throwable -> requests.get(throwable.id())
                                                                             .response()
-                                                                            .completeExceptionally(throwable.message()))
-                          );
+                                                                            .completeExceptionally(throwable.message())));
         }
         requests.clear();
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
@@ -24,14 +24,18 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.batchmanager.BatchAndSend;
+import software.amazon.awssdk.core.batchmanager.BatchKeyMapper;
 import software.amazon.awssdk.core.batchmanager.BatchManager;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
+import software.amazon.awssdk.core.batchmanager.BatchResponseMapper;
+import software.amazon.awssdk.core.batchmanager.IdentifiableMessage;
+import software.amazon.awssdk.utils.Either;
 import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> implements BatchManager<RequestT, ResponseT,
     BatchResponseT> {
-
     private final int maxBatchItems;
     private final Duration maxBatchOpenInMs;
 
@@ -65,7 +69,8 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
 
     private DefaultBatchManager(DefaultBuilder<RequestT, ResponseT, BatchResponseT> builder) {
         BatchConfiguration batchConfiguration = new BatchConfiguration(builder.overrideConfiguration);
-        this.requestsAndResponsesMaps = new BatchingMap<>();
+        this.requestsAndResponsesMaps = new BatchingMap<>(batchConfiguration.getMaxBatchKeys(),
+                                                          batchConfiguration.getMaxBufferSize());
         this.maxBatchItems = batchConfiguration.maxBatchItems();
         this.maxBatchOpenInMs = batchConfiguration.maxBatchOpenInMs();
         this.batchFunction = Validate.notNull(builder.batchFunction, "Null batchFunction");
@@ -116,7 +121,6 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
         List<IdentifiableMessage<RequestT>> requestEntries = new ArrayList<>();
         flushableRequests.forEach((contextId, batchExecutionContext) ->
                                       requestEntries.add(new IdentifiableMessage<>(contextId, batchExecutionContext.request())));
-
         if (!requestEntries.isEmpty()) {
             batchFunction.batchAndSend(requestEntries, batchKey)
                          .whenComplete((result, ex) -> handleAndCompleteResponses(result, ex, flushableRequests));
@@ -129,13 +133,17 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
             requests.forEach((contextId, batchExecutionContext) -> batchExecutionContext.response()
                                                                                         .completeExceptionally(exception));
         } else {
-            List<IdentifiableMessage<ResponseT>> identifiedResponses = responseMapper.mapBatchResponse(batchResult);
-            for (IdentifiableMessage<ResponseT> identifiedResponse : identifiedResponses) {
-                String id = identifiedResponse.id();
-                ResponseT response = identifiedResponse.message();
-                requests.get(id)
-                        .response()
-                        .complete(response);
+            List<Either<IdentifiableMessage<ResponseT>, IdentifiableMessage<Throwable>>> identifiedResponses =
+                responseMapper.mapBatchResponse(batchResult);
+            for (Either<IdentifiableMessage<ResponseT>, IdentifiableMessage<Throwable>> response : identifiedResponses) {
+                response.map(
+                    actualResponse -> requests.get(actualResponse.id())
+                                              .response()
+                                              .complete(actualResponse.message()),
+                    throwable -> requests.get(throwable.id())
+                                         .response()
+                                         .completeExceptionally(throwable.message())
+                );
             }
         }
         requests.clear();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/DefaultBatchManager.java
@@ -133,18 +133,15 @@ public final class DefaultBatchManager<RequestT, ResponseT, BatchResponseT> impl
             requests.forEach((contextId, batchExecutionContext) -> batchExecutionContext.response()
                                                                                         .completeExceptionally(exception));
         } else {
-            List<Either<IdentifiableMessage<ResponseT>, IdentifiableMessage<Throwable>>> identifiedResponses =
-                responseMapper.mapBatchResponse(batchResult);
-            for (Either<IdentifiableMessage<ResponseT>, IdentifiableMessage<Throwable>> response : identifiedResponses) {
-                response.map(
-                    actualResponse -> requests.get(actualResponse.id())
-                                              .response()
-                                              .complete(actualResponse.message()),
-                    throwable -> requests.get(throwable.id())
-                                         .response()
-                                         .completeExceptionally(throwable.message())
-                );
-            }
+            responseMapper.mapBatchResponse(batchResult)
+                          .forEach(
+                              response -> response.map(actualResponse -> requests.get(actualResponse.id())
+                                                                                 .response()
+                                                                                 .complete(actualResponse.message()),
+                                                       throwable -> requests.get(throwable.id())
+                                                                            .response()
+                                                                            .completeExceptionally(throwable.message()))
+                          );
         }
         requests.clear();
     }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/BatchOverrideConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/BatchOverrideConfigurationTest.java
@@ -29,6 +29,8 @@ public class BatchOverrideConfigurationTest {
     private BatchOverrideConfiguration overrideConfiguration;
     private ScheduledExecutorService scheduledExecutor;
     private final int maxBatchItems = 10;
+    private final int maxBatchKeys = 100;
+    private final int maxBufferSize = 200;
     private final int maxBatchOpenInMs = 200;
 
     @Before
@@ -37,6 +39,8 @@ public class BatchOverrideConfigurationTest {
         overrideConfiguration = BatchOverrideConfiguration.builder()
                                                           .maxBatchItems(maxBatchItems)
                                                           .maxBatchOpenInMs(Duration.ofMillis(maxBatchOpenInMs))
+                                                          .maxBatchKeys(maxBatchKeys)
+                                                          .maxBufferSize(maxBufferSize)
                                                           .build();
     }
 
@@ -49,6 +53,8 @@ public class BatchOverrideConfigurationTest {
     public void createNewBatchOverrideConfiguration() {
         Assert.assertEquals(maxBatchItems, overrideConfiguration.maxBatchItems().get().intValue());
         Assert.assertEquals(maxBatchOpenInMs, overrideConfiguration.maxBatchOpenInMs().get().toMillis());
+        Assert.assertEquals(maxBatchKeys, overrideConfiguration.maxBatchKeys().get().intValue());
+        Assert.assertEquals(maxBufferSize, overrideConfiguration.maxBufferSize().get().intValue());
     }
 
     @Test
@@ -56,7 +62,10 @@ public class BatchOverrideConfigurationTest {
         BatchOverrideConfiguration overrideConfigurationCopy = overrideConfiguration.toBuilder().build();
         Assert.assertEquals(maxBatchItems, overrideConfigurationCopy.maxBatchItems().get().intValue());
         Assert.assertEquals(maxBatchOpenInMs, overrideConfigurationCopy.maxBatchOpenInMs().get().toMillis());
+        Assert.assertEquals(maxBatchKeys, overrideConfiguration.maxBatchKeys().get().intValue());
+        Assert.assertEquals(maxBufferSize, overrideConfiguration.maxBufferSize().get().intValue());
         Assert.assertEquals(overrideConfiguration, overrideConfigurationCopy);
+        Assert.assertEquals(overrideConfiguration.toString(), overrideConfigurationCopy.toString());
         Assert.assertEquals(overrideConfiguration.hashCode(), overrideConfigurationCopy.hashCode());
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/BatchOverrideConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/BatchOverrideConfigurationTest.java
@@ -72,7 +72,8 @@ public class BatchOverrideConfigurationTest {
     @Test
     public void toStringMethod() {
         String stringRepresentation = overrideConfiguration.toString();
-        String expected = String.format("BatchOverrideConfiguration(maxBatchItems=%d, maxBatchOpenInMs=%d)", maxBatchItems,
+        String expected = String.format("BatchOverrideConfiguration(maxBatchItems=%d, maxBatchKeys=%d, "
+                                        + "maxBufferSize=%d, maxBatchOpenInMs=%d)", maxBatchItems, maxBatchKeys, maxBufferSize,
                                         maxBatchOpenInMs);
         Assert.assertEquals(expected, stringRepresentation);
     }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/BatchManagerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/BatchManagerTest.java
@@ -212,7 +212,7 @@ public class BatchManagerTest {
     }
 
     @Test
-    public void batchKeyLimitExceededReturnsIndexOutOfBoundsException() {
+    public void batchKeyLimitExceededReturnsIllegalStateException() {
         BatchOverrideConfiguration overrideConfiguration = BatchOverrideConfiguration.builder()
                                                                                      .maxBatchKeys(1)
                                                                                      .build();
@@ -238,13 +238,13 @@ public class BatchManagerTest {
 
         assertThat(responses.get("0").join()).isEqualTo(requests.get("0"));
         CompletableFuture<String> completableResponse = responses.get("1");
-        assertThatThrownBy(completableResponse::join).hasCauseInstanceOf(IndexOutOfBoundsException.class)
-                                                     .hasMessageContaining("MaxBatchKeys reached");
+        assertThatThrownBy(completableResponse::join).hasCauseInstanceOf(IllegalStateException.class)
+                                                     .hasMessageContaining("Reached MaxBatchKeys of:");
         assertThat(responses.get("2").join()).isEqualTo(requests.get("2"));
     }
 
     @Test
-    public void batchBufferLimitExceededReturnsIndexOutOfBoundsException() {
+    public void batchBufferLimitExceededReturnsIllegalStateException() {
         BatchOverrideConfiguration overrideConfiguration = BatchOverrideConfiguration.builder()
                                                                                      .maxBufferSize(1)
                                                                                      .build();
@@ -266,8 +266,8 @@ public class BatchManagerTest {
 
         assertThat(responses.get("0").join()).isEqualTo(requests.get("0"));
         CompletableFuture<String> completableResponse = responses.get("1");
-        assertThatThrownBy(completableResponse::join).hasCauseInstanceOf(IndexOutOfBoundsException.class)
-                                                     .hasMessageContaining("MaxBufferSize reached");
+        assertThatThrownBy(completableResponse::join).hasCauseInstanceOf(IllegalStateException.class)
+                                                     .hasMessageContaining("Reached MaxBufferSize of:");
     }
 
     private static final BatchAndSend<String, BatchResponse> exceptionBatchFunction =

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/IdentifiableMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/IdentifiableMessageTest.java
@@ -48,4 +48,10 @@ public class IdentifiableMessageTest {
         Assert.assertNotEquals(myRequest1.hashCode(), myRequest2.hashCode());
     }
 
+    @Test
+    public void checkSameIdentifiableMesagesIsEqual() {
+        IdentifiableMessage<String> myRequest1 = new IdentifiableMessage<>("id1", "request1");
+        Assert.assertEquals(myRequest1, myRequest1);
+    }
+
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/IdentifiableMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/IdentifiableMessageTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.internal.batchmanager;
 
 import org.junit.Assert;
 import org.junit.Test;
+import software.amazon.awssdk.core.batchmanager.IdentifiableMessage;
 
 public class IdentifiableMessageTest {
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/IdentifiableMessageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/batchmanager/IdentifiableMessageTest.java
@@ -48,10 +48,4 @@ public class IdentifiableMessageTest {
         Assert.assertNotEquals(myRequest1.hashCode(), myRequest2.hashCode());
     }
 
-    @Test
-    public void checkSameIdentifiableMesagesIsEqual() {
-        IdentifiableMessage<String> myRequest1 = new IdentifiableMessage<>("id1", "request1");
-        Assert.assertEquals(myRequest1, myRequest1);
-    }
-
 }

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/BaseSqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/BaseSqsBatchManagerTest.java
@@ -79,7 +79,6 @@ public abstract class BaseSqsBatchManagerTest {
         assertThat(completedResponse2.md5OfMessageBody()).isEqualTo(messageBody2);
     }
 
-    // TODO: Update tests after updating how batchEntryFailures are handled
     @Test
     public void sendMessageBatchFunctionWithBatchEntryFailures_wrapFailureMessageInBatchEntry() {
         String id1 = "0";
@@ -105,10 +104,10 @@ public abstract class BaseSqsBatchManagerTest {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
         List<CompletableFuture<SendMessageResponse>> responses = createAndSendSendMessageRequests(id1, id2);
 
-        SendMessageResponse completedResponse1 = responses.get(0).join();
-        SendMessageResponse completedResponse2 = responses.get(1).join();
-        assertThat(completedResponse1.md5OfMessageBody()).isNullOrEmpty();
-        assertThat(completedResponse2.md5OfMessageBody()).isNullOrEmpty();
+        CompletableFuture<SendMessageResponse> response1 = responses.get(0);
+        CompletableFuture<SendMessageResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining(errorMessage);
     }
 
     @Test

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/BaseSqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/BaseSqsBatchManagerTest.java
@@ -172,6 +172,37 @@ public abstract class BaseSqsBatchManagerTest {
     }
 
     @Test
+    public void deleteMessageBatchFunctionWithBatchEntryFailures_wrapFailureMessageInBatchEntry() {
+        String id1 = "0";
+        String id2 = "1";
+        String errorCode = "400";
+        String errorMessage = "Some error";
+        String responseBody = String.format(
+            "<DeleteMessageBatchResponse>\n"
+            + "<DeleteMessageBatchResult>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "</DeleteMessageBatchResult>\n"
+            + "</DeleteMessageBatchResponse>", id1, errorCode, errorMessage, id2, errorCode, errorMessage);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+        List<CompletableFuture<DeleteMessageResponse>> responses = createAndSendDeleteMessageRequests();
+
+        CompletableFuture<DeleteMessageResponse> response1 = responses.get(0);
+        CompletableFuture<DeleteMessageResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining(errorMessage);
+    }
+
+    @Test
     public void deleteMessageBatchFunctionReturnsWithError_completeMessagesExceptionally() {
         String responseBody = "<Error>\n"
                               + "<Code>CustomError</Code>\n"
@@ -212,6 +243,37 @@ public abstract class BaseSqsBatchManagerTest {
         CompletableFuture.allOf(responses.toArray(new CompletableFuture[0])).join();
 
         assertThat(Duration.ofNanos(endTime - startTime).toMillis()).isLessThan(DEFAULT_MAX_BATCH_OPEN + 100);
+    }
+
+    @Test
+    public void changeVisibilityBatchFunctionWithBatchEntryFailures_wrapFailureMessageInBatchEntry() {
+        String id1 = "0";
+        String id2 = "1";
+        String errorCode = "400";
+        String errorMessage = "Some error";
+        String responseBody = String.format(
+            "<ChangeMessageVisibilityBatchResponse>\n"
+            + "<ChangeMessageVisibilityBatchResult>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "    <BatchResultErrorEntry>\n"
+            + "        <Id>%s</Id>\n"
+            + "        <Code>%s</Code>\n"
+            + "        <Message>%s</Message>\n"
+            + "    </BatchResultErrorEntry>\n"
+            + "</ChangeMessageVisibilityBatchResult>\n"
+            + "</ChangeMessageVisibilityBatchResponse>", id1, errorCode, errorMessage, id2, errorCode, errorMessage);
+
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody(responseBody)));
+        List<CompletableFuture<ChangeMessageVisibilityResponse>> responses = createAndSendChangeVisibilityRequests();
+
+        CompletableFuture<ChangeMessageVisibilityResponse> response1 = responses.get(0);
+        CompletableFuture<ChangeMessageVisibilityResponse> response2 = responses.get(1);
+        assertThatThrownBy(response1::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining(errorMessage);
+        assertThatThrownBy(response2::join).hasCauseInstanceOf(SqsException.class).hasMessageContaining(errorMessage);
     }
 
     @Test

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchFunctionsTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.AwsResponseMetadata;
-import software.amazon.awssdk.core.internal.batchmanager.IdentifiableMessage;
+import software.amazon.awssdk.core.batchmanager.IdentifiableMessage;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResultEntry;
@@ -46,6 +46,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Either;
 import software.amazon.awssdk.utils.Md5Utils;
 
 public class SqsBatchFunctionsTest {
@@ -61,11 +62,11 @@ public class SqsBatchFunctionsTest {
         AwsResponseMetadata responseMetadata = createAwsResponseMetadata();
         SdkHttpResponse httpResponse = createSdkHttpResponse();
         SendMessageBatchResponse batchResponse = createSendMessageBatchResponse(responseMetadata, httpResponse, entry1, entry2);
-        List<IdentifiableMessage<SendMessageResponse>> mappedResponses =
+        List<Either<IdentifiableMessage<SendMessageResponse>, IdentifiableMessage<Throwable>>> mappedResponses =
             sendMessageResponseMapper().mapBatchResponse(batchResponse);
 
-        IdentifiableMessage<SendMessageResponse> response1 = mappedResponses.get(0);
-        IdentifiableMessage<SendMessageResponse> response2 = mappedResponses.get(1);
+        IdentifiableMessage<SendMessageResponse> response1 = mappedResponses.get(0).left().get();
+        IdentifiableMessage<SendMessageResponse> response2 = mappedResponses.get(1).left().get();
         assertThat(response1.id()).isEqualTo(id1);
         assertThat(response1.message().md5OfMessageBody()).isEqualTo(messageBody1);
         assertThat(response1.message().sdkHttpResponse()).isEqualTo(httpResponse);
@@ -119,11 +120,11 @@ public class SqsBatchFunctionsTest {
         SdkHttpResponse httpResponse = createSdkHttpResponse();
         DeleteMessageBatchResponse batchResponse = createDeleteMessageBatchResponse(responseMetadata, httpResponse, entry1,
                                                                                     entry2);
-        List<IdentifiableMessage<DeleteMessageResponse>> mappedResponses =
+        List<Either<IdentifiableMessage<DeleteMessageResponse>, IdentifiableMessage<Throwable>>> mappedResponses =
             deleteMessageResponseMapper().mapBatchResponse(batchResponse);
 
-        IdentifiableMessage<DeleteMessageResponse> response1 = mappedResponses.get(0);
-        IdentifiableMessage<DeleteMessageResponse> response2 = mappedResponses.get(1);
+        IdentifiableMessage<DeleteMessageResponse> response1 = mappedResponses.get(0).left().get();
+        IdentifiableMessage<DeleteMessageResponse> response2 = mappedResponses.get(1).left().get();
         assertThat(response1.id()).isEqualTo(id1);
         assertThat(response1.message().sdkHttpResponse()).isEqualTo(httpResponse);
         assertThat(response1.message().responseMetadata().requestId()).isEqualTo(responseMetadata.requestId());
@@ -175,11 +176,11 @@ public class SqsBatchFunctionsTest {
         SdkHttpResponse httpResponse = createSdkHttpResponse();
         ChangeMessageVisibilityBatchResponse batchResponse = createChangeVisibilityBatchResponse(responseMetadata, httpResponse,
                                                                                                  entry1, entry2);
-        List<IdentifiableMessage<ChangeMessageVisibilityResponse>> mappedResponses =
+        List<Either<IdentifiableMessage<ChangeMessageVisibilityResponse>, IdentifiableMessage<Throwable>>> mappedResponses =
             changeVisibilityResponseMapper().mapBatchResponse(batchResponse);
 
-        IdentifiableMessage<ChangeMessageVisibilityResponse> response1 = mappedResponses.get(0);
-        IdentifiableMessage<ChangeMessageVisibilityResponse> response2 = mappedResponses.get(1);
+        IdentifiableMessage<ChangeMessageVisibilityResponse> response1 = mappedResponses.get(0).left().get();
+        IdentifiableMessage<ChangeMessageVisibilityResponse> response2 = mappedResponses.get(1).left().get();
         assertThat(response1.id()).isEqualTo(id1);
         assertThat(response1.message().sdkHttpResponse()).isEqualTo(httpResponse);
         assertThat(response1.message().responseMetadata().requestId()).isEqualTo(responseMetadata.requestId());


### PR DESCRIPTION
## Motivation and Context
Currently failures in a batch entry are handled by returning an empty response of the same type as a successful response. Instead, we want to be able to handle failed batch entries by filling the returned response with an appropriate exception. Separately, the core `BatchManager` currently allows for an unlimited number of `batchKey`s and an unlimited number of requests to be buffered for each `batchKey`. We should limit this to prevent excessive memory usage and give customers the option to override these limits with a configurable value.

## Description
In this PR, I am modifying the `SqsBatchFunctions` to return an exception for each batch entry that failed. The core `BatchManager` now either expects a normal response or an Exception, and when it encounters an exception, it completes the corresponding response exceptionally. I also modified the `BatchOverrideConfiguration` to accept configurable values for the `BatchKey` limit and `BatchBuffer` limit.  Currently, exceeding this limit just returns an exception that is handled by the core `BatchManager` (handles it by completing the corresponding response exceptionally). However, how to properly handle this situation should definitely be changed. I propose that when the `batchKey` limit is reached, the `batchingMap` should remove the least recently used empty `batchKey`. Handling the `batchBuffer` limit should not remove any requests that are already buffered, instead it could maybe wait until more space opens up or return an exception directly to the customer to notify that the `BatchBuffer` is full.

## Testing
Tests were refactored to test if exceptions were properly returned on batch entry failures. Additional tests were also added to test the functionality of the `batchKey` limit and `batchBuffer` limit being reached/exceeded.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
