### PR TITLE
Adding batchManager() method into code generated sync and async clients

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/BatchManagerMethod.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/BatchManagerMethod.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+/**
+ * Config required to generate a batchManager method that returns an instance of a BatchManager in addition to any required
+ * executors or scheduledExecutors.
+ */
+public class BatchManagerMethod {
+
+    public static final String METHOD_NAME = "batchManager";
+
+    /** Fqcn of the return type of the operation for the sync client */
+    private String returnType;
+
+    /** Fqcn of the return type of the operation for the async client */
+    private String asyncReturnType;
+
+    public String getReturnType() {
+        return returnType;
+    }
+
+    public void setReturnType(String returnType) {
+        this.returnType = returnType;
+    }
+
+    public String getAsyncReturnType() {
+        return asyncReturnType;
+    }
+
+    public void setAsyncReturnType(String asyncReturnType) {
+        this.asyncReturnType = asyncReturnType;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -189,6 +189,8 @@ public class CustomizationConfig {
 
     private String userAgent;
 
+    private BatchManagerMethod batchManagerMethod;
+
     private CustomizationConfig() {
     }
 
@@ -484,5 +486,13 @@ public class CustomizationConfig {
     public CustomizationConfig withUserAgent(String userAgent) {
         this.userAgent = userAgent;
         return this;
+    }
+
+    public BatchManagerMethod getBatchManagerMethod() {
+        return batchManagerMethod;
+    }
+
+    public void setBatchManagerMethod(BatchManagerMethod batchManagerMethod) {
+        this.batchManagerMethod = batchManagerMethod;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.codegen.docs.ClientType;
 import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.docs.WaiterDocs;
+import software.amazon.awssdk.codegen.model.config.customization.BatchManagerMethod;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -106,6 +107,10 @@ public class AsyncClientInterface implements ClassSpec {
 
         if (model.hasWaiters()) {
             result.addMethod(waiterMethod());
+        }
+
+        if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
+            result.addMethod(batchManagerMethod());
         }
 
         return result.build();
@@ -465,6 +470,19 @@ public class AsyncClientInterface implements ClassSpec {
                          .returns(poetExtensions.getAsyncWaiterInterface())
                          .addStatement("throw new $T()", UnsupportedOperationException.class)
                          .addJavadoc(WaiterDocs.waiterMethodInClient(poetExtensions.getAsyncWaiterInterface()))
+                         .build();
+    }
+
+    private MethodSpec batchManagerMethod() {
+        BatchManagerMethod config = model.getCustomizationConfig().getBatchManagerMethod();
+        ClassName returnType = PoetUtils.classNameFromFqcn(config.getAsyncReturnType());
+
+        return MethodSpec.methodBuilder("batchManager")
+                         .returns(returnType)
+                         .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                         .addStatement("throw new $T()", UnsupportedOperationException.class)
+                         .addJavadoc("Creates an instance of {@link $T} object with the "
+                                     + "configuration set on this client.", returnType)
                          .build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -270,27 +270,22 @@ final class ClientClassUtils {
     }
 
     static MethodSpec batchMangerMethod(IntermediateModel model, boolean isSync) {
-        String executor = "executor";
         String scheduledExecutor = "executorService";
-
         BatchManagerMethod config = model.getCustomizationConfig().getBatchManagerMethod();
-        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(BatchManagerMethod.METHOD_NAME)
-                                  .addModifiers(Modifier.PUBLIC)
-                                  .addAnnotation(Override.class);
         ClassName returnType;
         if (isSync) {
             returnType = PoetUtils.classNameFromFqcn(config.getReturnType());
-            methodBuilder.returns(returnType)
-                         .addStatement("return $T.builder().client(this).executor($N).scheduledExecutor($N).build()",
-                                       returnType, executor, scheduledExecutor);
         } else {
             returnType = PoetUtils.classNameFromFqcn(config.getAsyncReturnType());
-            methodBuilder.returns(returnType)
-                         .addStatement("return $T.builder().client(this).scheduledExecutor($N).build()",
-                                       returnType, scheduledExecutor);
         }
 
-        return methodBuilder.build();
+        return MethodSpec.methodBuilder(BatchManagerMethod.METHOD_NAME)
+                         .addModifiers(Modifier.PUBLIC)
+                         .addAnnotation(Override.class)
+                         .returns(returnType)
+                         .addStatement("return $T.builder().client(this).scheduledExecutor($N).build()",
+                                       returnType, scheduledExecutor)
+                         .build();
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
@@ -55,7 +54,6 @@ import software.amazon.awssdk.codegen.poet.client.specs.QueryProtocolSpec;
 import software.amazon.awssdk.codegen.poet.client.specs.XmlProtocolSpec;
 import software.amazon.awssdk.codegen.utils.PaginatorUtils;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
@@ -122,9 +120,6 @@ public class SyncClientClass implements ClassSpec {
 
         if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
             classBuilder.addMethod(batchMangerMethod());
-            classBuilder.addField(FieldSpec.builder(ClassName.get(Executor.class), "executor")
-                                           .addModifiers(PRIVATE, FINAL)
-                                           .build());
             classBuilder.addField(FieldSpec.builder(ClassName.get(ScheduledExecutorService.class), "executorService")
                                            .addModifiers(PRIVATE, FINAL)
                                            .build());
@@ -196,8 +191,6 @@ public class SyncClientClass implements ClassSpec {
         }
 
         if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
-            builder.addStatement("this.executor = clientConfiguration.option($T.FUTURE_COMPLETION_EXECUTOR)",
-                                 SdkAdvancedAsyncClientOption.class);
             builder.addStatement("this.executorService = clientConfiguration.option($T.SCHEDULED_EXECUTOR_SERVICE)",
                                  SdkClientOption.class);
         }
@@ -413,7 +406,6 @@ public class SyncClientClass implements ClassSpec {
     }
 
     private MethodSpec batchMangerMethod() {
-        String executor = "executor";
         String scheduledExecutor = "executorService";
 
         BatchManagerMethod config = model.getCustomizationConfig().getBatchManagerMethod();
@@ -424,7 +416,7 @@ public class SyncClientClass implements ClassSpec {
                          .addModifiers(Modifier.PUBLIC)
                          .addAnnotation(Override.class)
                          .addStatement("return $T.builder().client(this).executor($N).scheduledExecutor($N).build()",
-                                       returnType, executor, scheduledExecutor)
+                                       returnType, scheduledExecutor, scheduledExecutor)
                          .build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -21,6 +21,7 @@ import static javax.lang.model.element.Modifier.STATIC;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.addS3ArnableFieldCode;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applyPaginatorUserAgentMethod;
 import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.applySignerOverrideMethod;
+import static software.amazon.awssdk.codegen.poet.client.ClientClassUtils.batchMangerMethod;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
@@ -32,14 +33,16 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
-import software.amazon.awssdk.codegen.model.config.customization.BatchManagerMethod;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -64,6 +67,7 @@ import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 //TODO Make SyncClientClass extend SyncClientInterface (similar to what we do in AsyncClientClass)
 public class SyncClientClass implements ClassSpec {
@@ -119,8 +123,11 @@ public class SyncClientClass implements ClassSpec {
         }
 
         if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
-            classBuilder.addMethod(batchMangerMethod());
+            classBuilder.addMethod(batchMangerMethod(model, true));
             classBuilder.addField(FieldSpec.builder(ClassName.get(ScheduledExecutorService.class), "executorService")
+                                           .addModifiers(PRIVATE, FINAL)
+                                           .build());
+            classBuilder.addField(FieldSpec.builder(ClassName.get(ExecutorService.class), "executor")
                                            .addModifiers(PRIVATE, FINAL)
                                            .build());
         }
@@ -193,6 +200,9 @@ public class SyncClientClass implements ClassSpec {
         if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
             builder.addStatement("this.executorService = clientConfiguration.option($T.SCHEDULED_EXECUTOR_SERVICE)",
                                  SdkClientOption.class);
+            builder.addStatement("$T threadFactory = new $T().threadNamePrefix(\"$T\").build()",
+                                 ThreadFactory.class, ThreadFactoryBuilder.class, className);
+            builder.addStatement("this.executor = $T.newSingleThreadExecutor(threadFactory)", Executors.class);
         }
 
         return builder.build();
@@ -314,11 +324,16 @@ public class SyncClientClass implements ClassSpec {
     }
 
     private MethodSpec closeMethod() {
-        return MethodSpec.methodBuilder("close")
-                         .addAnnotation(Override.class)
-                         .addStatement("clientHandler.close()")
-                         .addModifiers(Modifier.PUBLIC)
-                         .build();
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("close")
+                                                     .addAnnotation(Override.class)
+                                                     .addStatement("clientHandler.close()")
+                                                     .addModifiers(Modifier.PUBLIC);
+
+        if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
+            methodBuilder.addStatement("executor.shutdownNow()");
+        }
+
+        return methodBuilder.build();
     }
 
     private MethodSpec utilitiesMethod() {
@@ -402,21 +417,6 @@ public class SyncClientClass implements ClassSpec {
                          .addStatement("return $T.builder().client(this).build()",
                                        poetExtensions.getSyncWaiterInterface())
                          .returns(poetExtensions.getSyncWaiterInterface())
-                         .build();
-    }
-
-    private MethodSpec batchMangerMethod() {
-        String scheduledExecutor = "executorService";
-
-        BatchManagerMethod config = model.getCustomizationConfig().getBatchManagerMethod();
-        ClassName returnType = PoetUtils.classNameFromFqcn(config.getReturnType());
-
-        return MethodSpec.methodBuilder(BatchManagerMethod.METHOD_NAME)
-                         .returns(returnType)
-                         .addModifiers(Modifier.PUBLIC)
-                         .addAnnotation(Override.class)
-                         .addStatement("return $T.builder().client(this).executor($N).scheduledExecutor($N).build()",
-                                       returnType, scheduledExecutor, scheduledExecutor)
                          .build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -32,12 +32,15 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
+import software.amazon.awssdk.codegen.model.config.customization.BatchManagerMethod;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -52,6 +55,7 @@ import software.amazon.awssdk.codegen.poet.client.specs.QueryProtocolSpec;
 import software.amazon.awssdk.codegen.poet.client.specs.XmlProtocolSpec;
 import software.amazon.awssdk.codegen.utils.PaginatorUtils;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
@@ -114,6 +118,16 @@ public class SyncClientClass implements ClassSpec {
 
         if (model.getCustomizationConfig().getUtilitiesMethod() != null) {
             classBuilder.addMethod(utilitiesMethod());
+        }
+
+        if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
+            classBuilder.addMethod(batchMangerMethod());
+            classBuilder.addField(FieldSpec.builder(ClassName.get(Executor.class), "executor")
+                                           .addModifiers(PRIVATE, FINAL)
+                                           .build());
+            classBuilder.addField(FieldSpec.builder(ClassName.get(ScheduledExecutorService.class), "executorService")
+                                           .addModifiers(PRIVATE, FINAL)
+                                           .build());
         }
 
         model.getEndpointOperation().ifPresent(
@@ -179,6 +193,13 @@ public class SyncClientClass implements ClassSpec {
             }
 
             builder.endControlFlow();
+        }
+
+        if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
+            builder.addStatement("this.executor = clientConfiguration.option($T.FUTURE_COMPLETION_EXECUTOR)",
+                                 SdkAdvancedAsyncClientOption.class);
+            builder.addStatement("this.executorService = clientConfiguration.option($T.SCHEDULED_EXECUTOR_SERVICE)",
+                                 SdkClientOption.class);
         }
 
         return builder.build();
@@ -388,6 +409,22 @@ public class SyncClientClass implements ClassSpec {
                          .addStatement("return $T.builder().client(this).build()",
                                        poetExtensions.getSyncWaiterInterface())
                          .returns(poetExtensions.getSyncWaiterInterface())
+                         .build();
+    }
+
+    private MethodSpec batchMangerMethod() {
+        String executor = "executor";
+        String scheduledExecutor = "executorService";
+
+        BatchManagerMethod config = model.getCustomizationConfig().getBatchManagerMethod();
+        ClassName returnType = PoetUtils.classNameFromFqcn(config.getReturnType());
+
+        return MethodSpec.methodBuilder(BatchManagerMethod.METHOD_NAME)
+                         .returns(returnType)
+                         .addModifiers(Modifier.PUBLIC)
+                         .addAnnotation(Override.class)
+                         .addStatement("return $T.builder().client(this).executor($N).scheduledExecutor($N).build()",
+                                       returnType, executor, scheduledExecutor)
                          .build();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.codegen.docs.ClientType;
 import software.amazon.awssdk.codegen.docs.DocConfiguration;
 import software.amazon.awssdk.codegen.docs.SimpleMethodOverload;
 import software.amazon.awssdk.codegen.docs.WaiterDocs;
+import software.amazon.awssdk.codegen.model.config.customization.BatchManagerMethod;
 import software.amazon.awssdk.codegen.model.config.customization.UtilitiesMethod;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -108,6 +109,10 @@ public final class SyncClientInterface implements ClassSpec {
 
         if (model.hasWaiters()) {
             result.addMethod(waiterMethod());
+        }
+
+        if (model.getCustomizationConfig().getBatchManagerMethod() != null) {
+            result.addMethod(batchManagerMethod());
         }
 
         return result.build();
@@ -496,6 +501,19 @@ public final class SyncClientInterface implements ClassSpec {
                          .addStatement("throw new $T()", UnsupportedOperationException.class)
                          .returns(poetExtensions.getSyncWaiterInterface())
                          .addJavadoc(WaiterDocs.waiterMethodInClient(poetExtensions.getSyncWaiterInterface()))
+                         .build();
+    }
+
+    private MethodSpec batchManagerMethod() {
+        BatchManagerMethod config = model.getCustomizationConfig().getBatchManagerMethod();
+        ClassName returnType = PoetUtils.classNameFromFqcn(config.getReturnType());
+
+        return MethodSpec.methodBuilder("batchManager")
+                         .returns(returnType)
+                         .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+                         .addStatement("throw new $T()", UnsupportedOperationException.class)
+                         .addJavadoc("Creates an instance of {@link $T} object with the "
+                                     + "configuration set on this client.", returnType)
                          .build();
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/ClientTestModels.java
@@ -109,6 +109,18 @@ public class ClientTestModels {
         return new IntermediateModelBuilder(models).build();
     }
 
+    public static IntermediateModel batchManagerModels() {
+        File serviceModel = new File(ClientTestModels.class.getResource("client/c2j/batchmanager/service-2.json").getFile());
+        File customizationModel = new File(ClientTestModels.class.getResource("client/c2j/batchmanager/customization.config").getFile());
+
+        C2jModels models = C2jModels.builder()
+                                    .serviceModel(getServiceModel(serviceModel))
+                                    .customizationConfig(getCustomizationConfig(customizationModel))
+                                    .build();
+
+        return new IntermediateModelBuilder(models).build();
+    }
+
     private static ServiceModel getServiceModel(File file) {
         return ModelLoaderUtils.loadModel(ServiceModel.class, file);
     }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/PoetClientFunctionalTests.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.ClientTestModels;
+import software.amazon.awssdk.codegen.poet.waiters.WaiterInterfaceSpec;
 
 public class PoetClientFunctionalTests {
 
@@ -116,5 +117,30 @@ public class PoetClientFunctionalTests {
     public void syncClientCustomServiceMetaData() throws Exception {
         ClassSpec syncClientCustomServiceMetaData = createSyncClientClass(ClientTestModels.customContentTypeModels());
         assertThat(syncClientCustomServiceMetaData, generatesTo("test-customservicemetadata-sync.java"));
+    }
+
+    @Test
+    public void syncClientBatchManager() throws Exception {
+        ClassSpec syncClientBatchManager = createSyncClientClass(ClientTestModels.batchManagerModels());
+        assertThat(syncClientBatchManager, generatesTo("test-batchmanager-sync-class.java"));
+    }
+
+    @Test
+    public void asyncClientBatchManager() throws Exception {
+        ClassSpec asyncClientBatchManager = new AsyncClientClass(
+            GeneratorTaskParams.create(ClientTestModels.batchManagerModels(), "sources/", "tests/"));
+        assertThat(asyncClientBatchManager, generatesTo("test-batchmanager-async-class.java"));
+    }
+
+    @Test
+    public void syncClientBatchManagerInterface() throws Exception {
+        ClassSpec syncClientBatchManagerInterface = new SyncClientInterface(ClientTestModels.batchManagerModels());
+        assertThat(syncClientBatchManagerInterface, generatesTo("test-batchmanager-sync-interface.java"));
+    }
+
+    @Test
+    public void asyncClientBatchManagerInterface() throws Exception {
+        ClassSpec asyncClientBatchManagerInterface = new AsyncClientInterface(ClientTestModels.batchManagerModels());
+        assertThat(asyncClientBatchManagerInterface, generatesTo("test-batchmanager-async-interface.java"));
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/customization.config
@@ -1,0 +1,6 @@
+{
+    "batchManagerMethod": {
+        "returnType": "software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager",
+        "asyncReturnType": "software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager"
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/customization.config
@@ -1,6 +1,6 @@
 {
     "batchManagerMethod": {
-        "returnType": "software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager",
-        "asyncReturnType": "software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager"
+        "returnType": "software.amazon.awssdk.services.batchmanagertest.batchmanager.SyncBatchManagerTest",
+        "asyncReturnType": "software.amazon.awssdk.services.batchmanagertest.batchmanager.AsyncBatchManagerTest"
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/batchmanager/service-2.json
@@ -1,0 +1,20 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"batchmanager",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"BatchManager",
+    "serviceFullName":"BatchManager",
+    "serviceId":"BatchManager",
+    "signatureVersion":"v4",
+    "uid":"batchmanager-2016-03-11"
+  },
+  "operations":{
+  },
+  "shapes": {
+    "String":{"type":"string"}
+  },
+  "documentation": "A service that implements the batchManager() method"
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-class.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
 import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.services.batchmanager.model.BatchManagerException;
-import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.batchmanagertest.batchmanager.AsyncBatchManagerTest;
 
 /**
  * Internal implementation of {@link BatchManagerAsyncClient}.
@@ -85,7 +85,7 @@ final class DefaultBatchManagerAsyncClient implements BatchManagerAsyncClient {
     }
 
     @Override
-    public SqsAsyncBatchManager batchManager() {
-        return SqsAsyncBatchManager.builder().client(this).scheduledExecutor(executorService).build();
+    public AsyncBatchManagerTest batchManager() {
+        return AsyncBatchManagerTest.builder().client(this).scheduledExecutor(executorService).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-class.java
@@ -1,0 +1,91 @@
+package software.amazon.awssdk.services.batchmanager;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.services.batchmanager.model.BatchManagerException;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+
+/**
+ * Internal implementation of {@link BatchManagerAsyncClient}.
+ *
+ * @see BatchManagerAsyncClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultBatchManagerAsyncClient implements BatchManagerAsyncClient {
+    private static final Logger log = LoggerFactory.getLogger(DefaultBatchManagerAsyncClient.class);
+
+    private final AsyncClientHandler clientHandler;
+
+    private final AwsJsonProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    private final ScheduledExecutorService executorService;
+
+    protected DefaultBatchManagerAsyncClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration;
+        this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+        this.executorService = clientConfiguration.option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+
+    private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
+        return builder.clientConfiguration(clientConfiguration).defaultServiceExceptionSupplier(BatchManagerException::builder)
+                      .protocol(AwsJsonProtocol.REST_JSON).protocolVersion("1.1");
+    }
+
+    private static List<MetricPublisher> resolveMetricPublishers(SdkClientConfiguration clientConfiguration,
+                                                                 RequestOverrideConfiguration requestOverrideConfiguration) {
+        List<MetricPublisher> publishers = null;
+        if (requestOverrideConfiguration != null) {
+            publishers = requestOverrideConfiguration.metricPublishers();
+        }
+        if (publishers == null || publishers.isEmpty()) {
+            publishers = clientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS);
+        }
+        if (publishers == null) {
+            publishers = Collections.emptyList();
+        }
+        return publishers;
+    }
+
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
+                                                                                JsonOperationMetadata operationMetadata) {
+        return protocolFactory.createErrorResponseHandler(operationMetadata);
+    }
+
+    @Override
+    public SqsAsyncBatchManager batchManager() {
+        return SqsAsyncBatchManager.builder().client(this).scheduledExecutor(executorService).build();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-interface.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.SdkClient;
-import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.batchmanagertest.batchmanager.AsyncBatchManagerTest;
 
 /**
  * Service client for accessing BatchManager asynchronously. This can be created using the static {@link #builder()}
@@ -41,9 +41,9 @@ public interface BatchManagerAsyncClient extends SdkClient {
     }
 
     /**
-     * Creates an instance of {@link SqsAsyncBatchManager} object with the configuration set on this client.
+     * Creates an instance of {@link AsyncBatchManagerTest} object with the configuration set on this client.
      */
-    default SqsAsyncBatchManager batchManager() {
+    default AsyncBatchManagerTest batchManager() {
         throw new UnsupportedOperationException();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async-interface.java
@@ -1,0 +1,49 @@
+package software.amazon.awssdk.services.batchmanager;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+
+/**
+ * Service client for accessing BatchManager asynchronously. This can be created using the static {@link #builder()}
+ * method.
+ *
+ * A service that implements the batchManager() method
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+@ThreadSafe
+public interface BatchManagerAsyncClient extends SdkClient {
+    String SERVICE_NAME = "batchmanager";
+
+    /**
+     * Value for looking up the service's metadata from the
+     * {@link software.amazon.awssdk.regions.ServiceMetadataProvider}.
+     */
+    String SERVICE_METADATA_ID = "batchmanager";
+
+    /**
+     * Create a {@link BatchManagerAsyncClient} with the region loaded from the
+     * {@link software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from the
+     * {@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider}.
+     */
+    static BatchManagerAsyncClient create() {
+        return builder().build();
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link BatchManagerAsyncClient}.
+     */
+    static BatchManagerAsyncClientBuilder builder() {
+        return new DefaultBatchManagerAsyncClientBuilder();
+    }
+
+    /**
+     * Creates an instance of {@link SqsAsyncBatchManager} object with the configuration set on this client.
+     */
+    default SqsAsyncBatchManager batchManager() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-class.java
@@ -2,10 +2,7 @@ package software.amazon.awssdk.services.batchmanager;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
@@ -23,7 +20,6 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.services.batchmanager.model.BatchManagerException;
 import software.amazon.awssdk.services.batchmanagertest.batchmanager.SyncBatchManagerTest;
 import software.amazon.awssdk.utils.Logger;
-import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 /**
  * Internal implementation of {@link BatchManagerClient}.
@@ -43,15 +39,11 @@ final class DefaultBatchManagerClient implements BatchManagerClient {
 
     private final ScheduledExecutorService executorService;
 
-    private final ExecutorService executor;
-
     protected DefaultBatchManagerClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
         this.clientConfiguration = clientConfiguration;
         this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
         this.executorService = clientConfiguration.option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
-        ThreadFactory threadFactory = new ThreadFactoryBuilder().threadNamePrefix("DefaultBatchManagerClient").build();
-        this.executor = Executors.newSingleThreadExecutor(threadFactory);
     }
 
     @Override
@@ -87,11 +79,10 @@ final class DefaultBatchManagerClient implements BatchManagerClient {
     @Override
     public void close() {
         clientHandler.close();
-        executor.shutdownNow();
     }
 
     @Override
     public SyncBatchManagerTest batchManager() {
-        return SyncBatchManagerTest.builder().client(this).executor(executor).scheduledExecutor(executorService).build();
+        return SyncBatchManagerTest.builder().client(this).scheduledExecutor(executorService).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-class.java
@@ -2,14 +2,12 @@ package software.amazon.awssdk.services.batchmanager;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.RequestOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.client.handler.SyncClientHandler;
@@ -39,15 +37,12 @@ final class DefaultBatchManagerClient implements BatchManagerClient {
 
     private final SdkClientConfiguration clientConfiguration;
 
-    private final Executor executor;
-
     private final ScheduledExecutorService executorService;
 
     protected DefaultBatchManagerClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
         this.clientConfiguration = clientConfiguration;
         this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
-        this.executor = clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
         this.executorService = clientConfiguration.option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
     }
 
@@ -88,6 +83,6 @@ final class DefaultBatchManagerClient implements BatchManagerClient {
 
     @Override
     public SqsBatchManager batchManager() {
-        return SqsBatchManager.builder().client(this).executor(executor).scheduledExecutor(executorService).build();
+        return SqsBatchManager.builder().client(this).executor(executorService).scheduledExecutor(executorService).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-class.java
@@ -1,0 +1,93 @@
+package software.amazon.awssdk.services.batchmanager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.RequestOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.client.handler.SyncClientHandler;
+import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.BaseAwsJsonProtocolFactory;
+import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
+import software.amazon.awssdk.services.batchmanager.model.BatchManagerException;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Internal implementation of {@link BatchManagerClient}.
+ *
+ * @see BatchManagerClient#builder()
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+final class DefaultBatchManagerClient implements BatchManagerClient {
+    private static final Logger log = Logger.loggerFor(DefaultBatchManagerClient.class);
+
+    private final SyncClientHandler clientHandler;
+
+    private final AwsJsonProtocolFactory protocolFactory;
+
+    private final SdkClientConfiguration clientConfiguration;
+
+    private final Executor executor;
+
+    private final ScheduledExecutorService executorService;
+
+    protected DefaultBatchManagerClient(SdkClientConfiguration clientConfiguration) {
+        this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
+        this.clientConfiguration = clientConfiguration;
+        this.protocolFactory = init(AwsJsonProtocolFactory.builder()).build();
+        this.executor = clientConfiguration.option(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR);
+        this.executorService = clientConfiguration.option(SdkClientOption.SCHEDULED_EXECUTOR_SERVICE);
+    }
+
+    @Override
+    public final String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    private static List<MetricPublisher> resolveMetricPublishers(SdkClientConfiguration clientConfiguration,
+                                                                 RequestOverrideConfiguration requestOverrideConfiguration) {
+        List<MetricPublisher> publishers = null;
+        if (requestOverrideConfiguration != null) {
+            publishers = requestOverrideConfiguration.metricPublishers();
+        }
+        if (publishers == null || publishers.isEmpty()) {
+            publishers = clientConfiguration.option(SdkClientOption.METRIC_PUBLISHERS);
+        }
+        if (publishers == null) {
+            publishers = Collections.emptyList();
+        }
+        return publishers;
+    }
+
+    private HttpResponseHandler<AwsServiceException> createErrorResponseHandler(BaseAwsJsonProtocolFactory protocolFactory,
+                                                                                JsonOperationMetadata operationMetadata) {
+        return protocolFactory.createErrorResponseHandler(operationMetadata);
+    }
+
+    private <T extends BaseAwsJsonProtocolFactory.Builder<T>> T init(T builder) {
+        return builder.clientConfiguration(clientConfiguration).defaultServiceExceptionSupplier(BatchManagerException::builder)
+                      .protocol(AwsJsonProtocol.REST_JSON).protocolVersion("1.1");
+    }
+
+    @Override
+    public void close() {
+        clientHandler.close();
+    }
+
+    @Override
+    public SqsBatchManager batchManager() {
+        return SqsBatchManager.builder().client(this).executor(executor).scheduledExecutor(executorService).build();
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-interface.java
@@ -5,7 +5,7 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.regions.ServiceMetadata;
-import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
+import software.amazon.awssdk.services.batchmanagertest.batchmanager.SyncBatchManagerTest;
 
 /**
  * Service client for accessing BatchManager. This can be created using the static {@link #builder()} method.
@@ -45,9 +45,9 @@ public interface BatchManagerClient extends SdkClient {
     }
 
     /**
-     * Creates an instance of {@link SqsBatchManager} object with the configuration set on this client.
+     * Creates an instance of {@link SyncBatchManagerTest} object with the configuration set on this client.
      */
-    default SqsBatchManager batchManager() {
+    default SyncBatchManagerTest batchManager() {
         throw new UnsupportedOperationException();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-sync-interface.java
@@ -1,0 +1,53 @@
+package software.amazon.awssdk.services.batchmanager;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.regions.ServiceMetadata;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager;
+
+/**
+ * Service client for accessing BatchManager. This can be created using the static {@link #builder()} method.
+ *
+ * A service that implements the batchManager() method
+ */
+@Generated("software.amazon.awssdk:codegen")
+@SdkPublicApi
+@ThreadSafe
+public interface BatchManagerClient extends SdkClient {
+    String SERVICE_NAME = "batchmanager";
+
+    /**
+     * Value for looking up the service's metadata from the
+     * {@link software.amazon.awssdk.regions.ServiceMetadataProvider}.
+     */
+    String SERVICE_METADATA_ID = "batchmanager";
+
+    /**
+     * Create a {@link BatchManagerClient} with the region loaded from the
+     * {@link software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain} and credentials loaded from the
+     * {@link software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider}.
+     */
+    static BatchManagerClient create() {
+        return builder().build();
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link BatchManagerClient}.
+     */
+    static BatchManagerClientBuilder builder() {
+        return new DefaultBatchManagerClientBuilder();
+    }
+
+    static ServiceMetadata serviceMetadata() {
+        return ServiceMetadata.of(SERVICE_METADATA_ID);
+    }
+
+    /**
+     * Creates an instance of {@link SqsBatchManager} object with the configuration set on this client.
+     */
+    default SqsBatchManager batchManager() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/batchmanager/BatchOverrideConfiguration.java
@@ -186,7 +186,6 @@ public final class BatchOverrideConfiguration implements ToCopyableBuilder<Batch
             return this;
         }
 
-
         public BatchOverrideConfiguration build() {
             return new BatchOverrideConfiguration(this);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/batchmanager/BatchBuffer.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public final class BatchBuffer<RequestT, ResponseT> {
     private final Object flushLock = new Object();
+
     private final Map<String, BatchingExecutionContext<RequestT, ResponseT>> idToBatchContext;
 
     /**

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -90,15 +90,6 @@ public interface SqsAsyncBatchManager extends SdkAutoCloseable {
         return DefaultSqsAsyncBatchManager.builder();
     }
 
-    /**
-     * Create an instance of {@link SqsAsyncBatchManager} with the default configuration.
-     *
-     * @return an instance of {@link SqsAsyncBatchManager}
-     */
-    static SqsAsyncBatchManager create() {
-        throw new UnsupportedOperationException();
-    }
-
     interface Builder {
 
         /**

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -133,7 +134,7 @@ public interface SqsBatchManager extends SdkAutoCloseable {
          * @param executor the executor to be used.
          * @returna reference to this object so that method calls can be chained together.
          */
-        Builder executor(ExecutorService executor);
+        Builder executor(Executor executor);
 
         /**
          * Builds an instance of {@link SqsBatchManager} based on the configurations supplied to this builder.

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -134,7 +134,7 @@ public interface SqsBatchManager extends SdkAutoCloseable {
          * @param executor the executor to be used.
          * @returna reference to this object so that method calls can be chained together.
          */
-        Builder executor(Executor executor);
+        Builder executor(ExecutorService executor);
 
         /**
          * Builds an instance of {@link SqsBatchManager} based on the configurations supplied to this builder.

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsBatchManager.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.services.sqs.batchmanager;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.batchmanager.BatchOverrideConfiguration;
@@ -125,15 +125,15 @@ public interface SqsBatchManager extends SdkAutoCloseable {
         Builder scheduledExecutor(ScheduledExecutorService scheduledExecutor);
 
         /**
-         * Sets a custom {@link ExecutorService} that will be used to execute client requests asynchronously.
+         * Sets a custom {@link Executor} that will be used to execute client requests asynchronously.
          * <p>
          * Creating a SqsBatchManager directly from the client will use the client's executor. If supplied by the user, this
-         * ExecutorService must be closed by the caller when it is ready to be shut down.
+         * Executor must be closed by the caller when it is ready to be shut down.
          *
          * @param executor the executor to be used.
-         * @returna reference to this object so that method calls can be chained together.
+         * @return a reference to this object so that method calls can be chained together.
          */
-        Builder executor(ExecutorService executor);
+        Builder executor(Executor executor);
 
         /**
          * Builds an instance of {@link SqsBatchManager} based on the configurations supplied to this builder.

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -91,7 +91,7 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
     }
 
     @SdkTestInternalApi
-    public DefaultSqsAsyncBatchManager(SqsAsyncClient client, ScheduledExecutorService scheduledExecutor,
+    public DefaultSqsAsyncBatchManager(SqsAsyncClient client,
                                   BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse>
                                       sendMessageBatchManager,
                                   BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse>

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -26,6 +26,7 @@ import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatch
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageResponseMapper;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -48,7 +49,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 public final class DefaultSqsBatchManager implements SqsBatchManager {
 
     private final SqsClient client;
-    private final ExecutorService executor;
+    private final Executor executor;
     private final BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> sendMessageBatchManager;
     private final BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse> deleteMessageBatchManager;
     private final BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
@@ -141,7 +142,7 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
         private BatchOverrideConfiguration overrideConfiguration;
         private SqsClient client;
         private ScheduledExecutorService scheduledExecutor;
-        private ExecutorService executor;
+        private Executor executor;
 
         private DefaultBuilder() {
         }
@@ -165,7 +166,7 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
         }
 
         @Override
-        public Builder executor(ExecutorService executor) {
+        public Builder executor(Executor executor) {
             this.executor = executor;
             return this;
         }

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -26,7 +26,6 @@ import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatch
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatchFunctions.sendMessageResponseMapper;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsBatchManager.java
@@ -27,7 +27,6 @@ import static software.amazon.awssdk.services.sqs.internal.batchmanager.SqsBatch
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
@@ -62,11 +61,8 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
                                                                                      .maxBatchItems(config.maxBatchItems())
                                                                                      .maxBatchOpenInMs(config.maxBatchOpenInMs())
                                                                                      .build();
-
-
         ScheduledExecutorService scheduledExecutor = builder.scheduledExecutor;
         this.executor = builder.executor;
-
         this.sendMessageBatchManager = BatchManager.builder(SendMessageRequest.class, SendMessageResponse.class,
                                                             SendMessageBatchResponse.class)
                                         .batchFunction(sendMessageBatchFunction(client, executor))
@@ -75,7 +71,6 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
                                         .overrideConfiguration(overrideConfiguration)
                                         .scheduledExecutor(scheduledExecutor)
                                         .build();
-
         this.deleteMessageBatchManager = BatchManager.builder(DeleteMessageRequest.class, DeleteMessageResponse.class,
                                                               DeleteMessageBatchResponse.class)
                                                      .batchFunction(deleteMessageBatchFunction(client, executor))
@@ -84,7 +79,6 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
                                                      .overrideConfiguration(overrideConfiguration)
                                                      .scheduledExecutor(scheduledExecutor)
                                                      .build();
-
         this.changeVisibilityBatchManager = BatchManager.builder(ChangeMessageVisibilityRequest.class,
                                                                  ChangeMessageVisibilityResponse.class,
                                                                  ChangeMessageVisibilityBatchResponse.class)
@@ -97,7 +91,7 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
     }
 
     @SdkTestInternalApi
-    public DefaultSqsBatchManager(SqsClient client, ExecutorService executor, ScheduledExecutorService scheduledExecutor,
+    public DefaultSqsBatchManager(SqsClient client,
                                   BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse>
                                       sendMessageBatchManager,
                                   BatchManager<DeleteMessageRequest, DeleteMessageResponse, DeleteMessageBatchResponse>
@@ -105,7 +99,7 @@ public final class DefaultSqsBatchManager implements SqsBatchManager {
                                   BatchManager<ChangeMessageVisibilityRequest, ChangeMessageVisibilityResponse,
                                       ChangeMessageVisibilityBatchResponse> changeVisibilityBatchManager) {
         this.client = client;
-        this.executor = executor;
+        this.executor = null;
         this.sendMessageBatchManager = sendMessageBatchManager;
         this.deleteMessageBatchManager = deleteMessageBatchManager;
         this.changeVisibilityBatchManager = changeVisibilityBatchManager;

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/SqsBatchFunctions.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
@@ -56,7 +56,7 @@ public final class SqsBatchFunctions {
     }
 
     public static BatchAndSend<SendMessageRequest, SendMessageBatchResponse> sendMessageBatchFunction(SqsClient client,
-                                                                                                      ExecutorService executor) {
+                                                                                                      Executor executor) {
         return (identifiedRequests, batchKey) -> {
             SendMessageBatchRequest batchRequest = createSendMessageBatchRequest(identifiedRequests, batchKey);
             return CompletableFuture.supplyAsync(() -> client.sendMessageBatch(batchRequest), executor);
@@ -124,7 +124,7 @@ public final class SqsBatchFunctions {
     }
 
     public static BatchAndSend<DeleteMessageRequest, DeleteMessageBatchResponse> deleteMessageBatchFunction(
-        SqsClient client, ExecutorService executor) {
+        SqsClient client, Executor executor) {
         return (identifiedRequests, batchKey) -> {
             DeleteMessageBatchRequest batchRequest = createDeleteMessageBatchRequest(identifiedRequests, batchKey);
             return CompletableFuture.supplyAsync(() -> client.deleteMessageBatch(batchRequest), executor);
@@ -192,7 +192,7 @@ public final class SqsBatchFunctions {
     }
 
     public static BatchAndSend<ChangeMessageVisibilityRequest, ChangeMessageVisibilityBatchResponse>
-        changeVisibilityBatchFunction(SqsClient client, ExecutorService executor) {
+        changeVisibilityBatchFunction(SqsClient client, Executor executor) {
         return (identifiedRequests, batchKey) -> {
             ChangeMessageVisibilityBatchRequest batchRequest = createChangeVisibilityBatchRequest(identifiedRequests, batchKey);
             return CompletableFuture.supplyAsync(() -> client.changeMessageVisibilityBatch(batchRequest), executor);

--- a/services/sqs/src/main/resources/codegen-resources/customization.config
+++ b/services/sqs/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,9 @@
 {
     "verifiedSimpleMethods" : [
         "listQueues"
-    ]
+    ],
+    "batchManagerMethod": {
+        "returnType": "software.amazon.awssdk.services.sqs.batchmanager.SqsBatchManager",
+        "asyncReturnType": "software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager"
+    }
 }

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsAsyncBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsAsyncBatchManagerTest.java
@@ -15,17 +15,13 @@
 
 package software.amazon.awssdk.services.sqs;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -49,13 +45,15 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
-import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SqsAsyncBatchManagerTest extends BaseSqsBatchManagerTest {
 
     private static SqsAsyncClient client;
     private SqsAsyncBatchManager batchManager;
+
+    @Mock
+    private SqsAsyncClient mockClient;
 
     @Mock
     private BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> mockSendMessageBatchManager;
@@ -98,7 +96,7 @@ public class SqsAsyncBatchManagerTest extends BaseSqsBatchManagerTest {
 
     @Test
     public void closeBatchManager_shouldNotCloseExecutorsOrClient() {
-        SqsAsyncBatchManager batchManager = new DefaultSqsAsyncBatchManager(client,
+        SqsAsyncBatchManager batchManager = new DefaultSqsAsyncBatchManager(mockClient,
                                                                             mockSendMessageBatchManager,
                                                                             mockDeleteMessageBatchManager,
                                                                             mockChangeVisibilityBatchManager);
@@ -106,7 +104,7 @@ public class SqsAsyncBatchManagerTest extends BaseSqsBatchManagerTest {
         verify(mockSendMessageBatchManager).close();
         verify(mockDeleteMessageBatchManager).close();
         verify(mockChangeVisibilityBatchManager).close();
-        assertThatCode(() -> client.serviceName()).doesNotThrowAnyException(); // To make sure client is not closed
+        verify(mockClient, never()).close();;
     }
 
     @Override

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -15,18 +15,13 @@
 
 package software.amazon.awssdk.services.sqs;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -50,13 +45,15 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
-import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
 
     private static SqsClient client;
     private SqsBatchManager batchManager;
+
+    @Mock
+    private SqsClient mockClient;
 
     @Mock
     private BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> mockSendMessageBatchManager;
@@ -99,7 +96,7 @@ public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
 
     @Test
     public void closeBatchManager_shouldNotCloseExecutorsOrClient() {
-        SqsBatchManager batchManager = new DefaultSqsBatchManager(client,
+        SqsBatchManager batchManager = new DefaultSqsBatchManager(mockClient,
                                                                   mockSendMessageBatchManager,
                                                                   mockDeleteMessageBatchManager,
                                                                   mockChangeVisibilityBatchManager);
@@ -107,7 +104,7 @@ public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
         verify(mockSendMessageBatchManager).close();
         verify(mockDeleteMessageBatchManager).close();
         verify(mockChangeVisibilityBatchManager).close();
-        assertThatCode(() -> client.serviceName()).doesNotThrowAnyException(); // To make sure client is not closed
+        verify(mockClient, never()).close();
     }
 
     @Override

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -54,6 +56,9 @@ public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
 
     @Mock
     private SqsClient mockClient;
+
+    @Mock
+    private ExecutorService mockExecutor;
 
     @Mock
     private BatchManager<SendMessageRequest, SendMessageResponse, SendMessageBatchResponse> mockSendMessageBatchManager;
@@ -96,7 +101,7 @@ public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
 
     @Test
     public void closeBatchManager_shouldNotCloseExecutorsOrClient() {
-        SqsBatchManager batchManager = new DefaultSqsBatchManager(mockClient,
+        SqsBatchManager batchManager = new DefaultSqsBatchManager(mockClient, mockExecutor,
                                                                   mockSendMessageBatchManager,
                                                                   mockDeleteMessageBatchManager,
                                                                   mockChangeVisibilityBatchManager);
@@ -104,6 +109,7 @@ public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
         verify(mockSendMessageBatchManager).close();
         verify(mockDeleteMessageBatchManager).close();
         verify(mockChangeVisibilityBatchManager).close();
+        verify(mockExecutor).shutdownNow();
         verify(mockClient, never()).close();
     }
 

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/SqsBatchManagerTest.java
@@ -100,8 +100,22 @@ public class SqsBatchManagerTest extends BaseSqsBatchManagerTest {
     }
 
     @Test
+    public void closeBatchManager_shouldCloseExecutorsButNotClient() {
+        SqsBatchManager batchManager = new DefaultSqsBatchManager(mockClient, mockExecutor, false,
+                                                                  mockSendMessageBatchManager,
+                                                                  mockDeleteMessageBatchManager,
+                                                                  mockChangeVisibilityBatchManager);
+        batchManager.close();
+        verify(mockSendMessageBatchManager).close();
+        verify(mockDeleteMessageBatchManager).close();
+        verify(mockChangeVisibilityBatchManager).close();
+        verify(mockExecutor, never()).shutdownNow();
+        verify(mockClient, never()).close();
+    }
+
+    @Test
     public void closeBatchManager_shouldNotCloseExecutorsOrClient() {
-        SqsBatchManager batchManager = new DefaultSqsBatchManager(mockClient, mockExecutor,
+        SqsBatchManager batchManager = new DefaultSqsBatchManager(mockClient, mockExecutor, true,
                                                                   mockSendMessageBatchManager,
                                                                   mockDeleteMessageBatchManager,
                                                                   mockChangeVisibilityBatchManager);


### PR DESCRIPTION
## Motivation and Context
Users should have the option to be able to create a `batchManager()` directly from a low level sqs client as outlined in the design document. Changes also had to be made to the generated clients to ensure that they contained the necessary executor/scheduledExecutor that would be used by the `batchManager`.

## Description
Added some changes to how the sync and async clients (as well as their corresponding interfaces) are generated. Specifically added in the `batchManager()` method to create a `batchManager` for that service. `Executors` and `ScheduledExecutors` were also added to the underlying clients if they supported the `batchManager()` method.

## Testing
Added some codegen tests to check the generated classes and interfaces matched expectations. Also modified existing SqsBatchManager tests to use the client's batchManager instead of creating one separately.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
