### PR TITLE
Fix NPE in RetryPolicy.hashCode()

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-f2c1771.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-f2c1771.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix `NullPointerException` in `RetryPolicy.hashCode()`."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/RetryPolicy.java
@@ -234,7 +234,7 @@ public final class RetryPolicy implements ToCopyableBuilder<RetryPolicy.Builder,
         result = 31 * result + Boolean.hashCode(additionalRetryConditionsAllowed);
         result = 31 * result + backoffStrategy.hashCode();
         result = 31 * result + throttlingBackoffStrategy.hashCode();
-        result = 31 * result + Boolean.hashCode(fastFailRateLimiting);
+        result = 31 * result + Objects.hashCode(fastFailRateLimiting);
         return result;
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyTest.java
@@ -180,4 +180,9 @@ public class RetryPolicyTest {
     public void fastFailRateLimitingConfigured_retryModeAdaptive_doesNotThrow() {
         RetryPolicy.builder(RetryMode.ADAPTIVE).fastFailRateLimiting(true).build();
     }
+
+    @Test
+    public void hashCodeDoesNotThrow() {
+        RetryPolicy.defaultRetryPolicy().hashCode();
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
