### PR TITLE
Fixed an issue in JSON-RPC event stream services (none exist yet) where retries excluded the initial-request event.

### DIFF
--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/AsyncStreamPrependerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/AsyncStreamPrependerTest.java
@@ -63,6 +63,21 @@ public class AsyncStreamPrependerTest {
     }
 
     @Test
+    public void multiSubscribe_stillPrepends() {
+        AsyncStreamPrepender<Long> prepender = new AsyncStreamPrepender<>(rangeLong(1L, 5L), 0L);
+        Flowable<Long> prepended1 = fromPublisher(prepender);
+        Flowable<Long> prepended2 = fromPublisher(prepender);
+
+        Iterator<Long> iterator1 = prepended1.blockingIterable(1).iterator();
+        Iterator<Long> iterator2 = prepended2.blockingIterable(1).iterator();
+
+        for (long i = 0; i <= 5; i++) {
+            assertEquals(i, iterator1.next().longValue());
+            assertEquals(i, iterator2.next().longValue());
+        }
+    }
+
+    @Test
     public void error() {
         Flowable<Long> error = Flowable.error(IllegalStateException::new);
         Flowable<Long> prepender = fromPublisher(new AsyncStreamPrepender<>(error, 0L));


### PR DESCRIPTION
Before this change, the AsyncStreamPrepender (a Publisher) does not support multiple subscribe calls, but each attempt makes a new subscribe call. Because of this, if a retry is encountered, backpressure is miscalculated and the initial-request
is not sent for the retries.