### PR TITLE
Add file overload to DownloadRequest and UploadRequest

### DIFF
--- a/.changes/next-release/feature-S3TransferManager-a6fd00b.json
+++ b/.changes/next-release/feature-S3TransferManager-a6fd00b.json
@@ -1,0 +1,6 @@
+{
+    "category": "S3 Transfer Manager", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Now users can pass `File` to `DownloadRequest` and `UploadRequest` in `S3TransferManager`."
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/DownloadRequest.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/DownloadRequest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -111,6 +112,17 @@ public final class DownloadRequest implements TransferRequest, ToCopyableBuilder
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder destination(Path destination);
+
+        /**
+         * The file that response contents will be written to. The file must not exist or this method
+         * will throw an exception. If the file is not writable by the current user then an exception will be thrown.
+         *
+         * @param destination the destination path
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        default Builder destination(File destination) {
+            return destination(destination.toPath());
+        }
 
         /**
          * The {@link GetObjectRequest} request that should be used for the download

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/DownloadRequest.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/DownloadRequest.java
@@ -121,6 +121,7 @@ public final class DownloadRequest implements TransferRequest, ToCopyableBuilder
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         default Builder destination(File destination) {
+            Validate.paramNotNull(destination, "destination");
             return destination(destination.toPath());
         }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/UploadRequest.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/UploadRequest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.transfer.s3;
 
 import static software.amazon.awssdk.utils.Validate.paramNotNull;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -111,6 +112,18 @@ public final class UploadRequest implements TransferRequest, ToCopyableBuilder<U
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         Builder source(Path source);
+
+        /**
+         * The file containing data to send to the service. File will be read entirely and may be read
+         * multiple times in the event of a retry. If the file does not exist or the current user does not have
+         * access to read it then an exception will be thrown.
+         *
+         * @param source the source path
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        default Builder source(File source) {
+            return this.source(source.toPath());
+        }
 
         /**
          * Configure the {@link PutObjectRequest} that should be used for the upload

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/UploadRequest.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/UploadRequest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -122,6 +123,7 @@ public final class UploadRequest implements TransferRequest, ToCopyableBuilder<U
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         default Builder source(File source) {
+            Validate.paramNotNull(source, "source");
             return this.source(source.toPath());
         }
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/DownloadRequestTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/DownloadRequestTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.transfer.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,17 @@ public class DownloadRequestTest {
         DownloadRequest.builder()
                        .getObjectRequest(b -> b.bucket("bucket").key("key"))
                        .build();
+    }
+
+    @Test
+    public void usingFile() {
+        Path path = Paths.get(".");
+        DownloadRequest requestUsingFile = DownloadRequest.builder()
+                                                          .getObjectRequest(b -> b.bucket("bucket").key("key"))
+                                                          .destination(path.toFile())
+                                                          .build();
+
+        assertThat(requestUsingFile.destination()).isEqualTo(path);
     }
 
     @Test

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/DownloadRequestTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/DownloadRequestTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.transfer.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Rule;
@@ -58,6 +59,18 @@ public class DownloadRequestTest {
                                                           .build();
 
         assertThat(requestUsingFile.destination()).isEqualTo(path);
+    }
+
+    @Test
+    public void usingFile_null_shouldThrowException() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("destination");
+        File file = null;
+        DownloadRequest.builder()
+                       .getObjectRequest(b -> b.bucket("bucket").key("key"))
+                       .destination(file)
+                       .build();
+
     }
 
     @Test

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/UploadRequestTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/UploadRequestTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.transfer.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Rule;
@@ -51,9 +52,21 @@ public class UploadRequestTest {
     public void sourceUsingFile() {
         Path path = Paths.get(".");
         UploadRequest request = UploadRequest.builder()
-                                           .source(path.toFile())
-                                           .build();
+                                             .putObjectRequest(b -> b.bucket("bucket").key("key"))
+                                             .source(path.toFile())
+                                             .build();
         assertThat(request.source()).isEqualTo(path);
+    }
+
+    @Test
+    public void sourceUsingFile_null_shouldThrowException() {
+        File file = null;
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("source");
+        UploadRequest.builder()
+                     .putObjectRequest(b -> b.bucket("bucket").key("key"))
+                     .source(file)
+                     .build();
     }
 
     @Test

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/UploadRequestTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/UploadRequestTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.transfer.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +45,15 @@ public class UploadRequestTest {
         UploadRequest.builder()
                      .putObjectRequest(PutObjectRequest.builder().build())
                      .build();
+    }
+
+    @Test
+    public void sourceUsingFile() {
+        Path path = Paths.get(".");
+        UploadRequest request = UploadRequest.builder()
+                                           .source(path.toFile())
+                                           .build();
+        assertThat(request.source()).isEqualTo(path);
     }
 
     @Test


### PR DESCRIPTION

## Description
Add file overload to DownloadRequest and UploadRequest to be consistent with `FileRequetBody` which also accepts both `File` and `Path`

## Testing
Added test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
