### PR TITLE
Update update-master-from-release.yml to only update SNAPSHOT version if we're not already on a SNAPSHOT version.

### DIFF
--- a/buildspecs/update-master-from-release.yml
+++ b/buildspecs/update-master-from-release.yml
@@ -31,10 +31,16 @@ phases:
     - git checkout master
     - git merge public/release --no-edit
     -
-    - mvn versions:set -DnewVersion=$NEW_VERSION_SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true
-    - sed -i -E "s/(<version>).+(<\/version>)/\1$RELEASE_VERSION\2/" README.md
-    - sed -i -E "s/(<awsjavasdk.previous.version>).+(<\/awsjavasdk.previous.version>)/\1$RELEASE_VERSION\2/" pom.xml
-    -
-    - 'git commit -am "Update to next snapshot version: $NEW_VERSION_SNAPSHOT"'
+    - MASTER_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec`
+    - echo "Master version - $MASTER_VERSION"
+    - |
+      if [ "$MASTER_VERSION" != "$NEW_VERSION_SNAPSHOT" ]; then
+
+        mvn versions:set -DnewVersion=$NEW_VERSION_SNAPSHOT -DgenerateBackupPoms=false -DprocessAllModules=true
+        sed -i -E "s/(<version>).+(<\/version>)/\1$RELEASE_VERSION\2/" README.md
+        sed -i -E "s/(<awsjavasdk.previous.version>).+(<\/awsjavasdk.previous.version>)/\1$RELEASE_VERSION\2/" pom.xml
+
+        git commit -am "Update to next snapshot version: $NEW_VERSION_SNAPSHOT"
+      fi
     -
     - git push


### PR DESCRIPTION
This fixes an issue where running the script when master is already on a 'SNAPSHOT' version will update the version to '1.0'.