### PR TITLE
Fix Sigv4a-signed requests to endpoints with non-standard ports.

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-3312616.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-3312616.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Update Sigv4a signer to include the port in the Host header, when the port does not match the standard port for the protocol. This allows requests to endpoints with non-standard ports to succeed."
+}

--- a/core/auth-crt/src/test/java/software/amazon/awssdk/authcrt/signer/AwsCrtV4aSignerTest.java
+++ b/core/auth-crt/src/test/java/software/amazon/awssdk/authcrt/signer/AwsCrtV4aSignerTest.java
@@ -45,6 +45,45 @@ public class AwsCrtV4aSignerTest {
     }
 
     @Test
+    public void hostHeaderExcludesStandardHttpPort() {
+        SigningTestCase testCase = SignerTestUtils.createBasicHeaderSigningTestCase();
+        ExecutionAttributes executionAttributes = SignerTestUtils.buildBasicExecutionAttributes(testCase);
+
+        SdkHttpFullRequest request = testCase.requestBuilder.protocol("http")
+                                                            .port(80)
+                                                            .build();
+        SdkHttpFullRequest signed = v4aSigner.sign(request, executionAttributes);
+
+        assertThat(signed.firstMatchingHeader("Host")).hasValue("demo.us-east-1.amazonaws.com");
+    }
+
+    @Test
+    public void hostHeaderExcludesStandardHttpsPort() {
+        SigningTestCase testCase = SignerTestUtils.createBasicHeaderSigningTestCase();
+        ExecutionAttributes executionAttributes = SignerTestUtils.buildBasicExecutionAttributes(testCase);
+
+        SdkHttpFullRequest request = testCase.requestBuilder.protocol("https")
+                                                            .port(443)
+                                                            .build();
+        SdkHttpFullRequest signed = v4aSigner.sign(request, executionAttributes);
+
+        assertThat(signed.firstMatchingHeader("Host")).hasValue("demo.us-east-1.amazonaws.com");
+    }
+
+    @Test
+    public void hostHeaderIncludesNonStandardPorts() {
+        SigningTestCase testCase = SignerTestUtils.createBasicHeaderSigningTestCase();
+        ExecutionAttributes executionAttributes = SignerTestUtils.buildBasicExecutionAttributes(testCase);
+
+        SdkHttpFullRequest request = testCase.requestBuilder.protocol("http")
+                                                            .port(443)
+                                                            .build();
+        SdkHttpFullRequest signed = v4aSigner.sign(request, executionAttributes);
+
+        assertThat(signed.firstMatchingHeader("Host")).hasValue("demo.us-east-1.amazonaws.com:443");
+    }
+
+    @Test
     public void testHeaderSigning() {
         SigningTestCase testCase = SignerTestUtils.createBasicHeaderSigningTestCase();
         ExecutionAttributes executionAttributes = SignerTestUtils.buildBasicExecutionAttributes(testCase);


### PR DESCRIPTION
The signed host header must match the host header sent on the wire. HTTP clients append the port to the host header if the port is non-standard for the protocol being used. The current Sigv4a signer only adds the host, not the port, to the host header. This means that endpoints with non-standard ports for the protocol (e.g. an HTTPS service on port 8443) would get a signature validation failure, because the HTTP client will change the host header. 

The Sigv4 signer handles this by adding the host header and port before calculating the signature. This PR adds that same logic to the Sigv4a signer.