### PR TITLE
Move SDK-provided global execution.interceptors to a hard-coded list.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-69eb988.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-69eb988.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Remove SDK usage of global execution.interceptors files. This reduces the need for customers to use a special transformer for execution.interceptors files when they are creating an uber-jar of all SDK modules. Customers should still consider using such an appender, in case other libraries rely on execution.interceptors files."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.awscore.client.builder;
 
 import java.net.URI;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
@@ -26,6 +26,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.client.config.AwsAdvancedClientOption;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
+import software.amazon.awssdk.awscore.eventstream.EventStreamInitialRequestInterceptor;
 import software.amazon.awssdk.awscore.interceptor.HelpfulUnknownHostExceptionInterceptor;
 import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
 import software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder;
@@ -267,6 +268,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     }
 
     private List<ExecutionInterceptor> awsInterceptors() {
-        return Collections.singletonList(new HelpfulUnknownHostExceptionInterceptor());
+        return Arrays.asList(new HelpfulUnknownHostExceptionInterceptor(),
+                             new EventStreamInitialRequestInterceptor());
     }
 }

--- a/core/aws-core/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/core/aws-core/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,1 +1,0 @@
-software.amazon.awssdk.awscore.eventstream.EventStreamInitialRequestInterceptor

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -42,6 +42,7 @@ import static software.amazon.awssdk.utils.Validate.paramNotNull;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -63,6 +64,7 @@ import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkAsyncHttpClientBuilder;
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.core.internal.interceptor.HttpChecksumRequiredInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.core.util.SdkUserAgent;
@@ -334,8 +336,18 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
      * Finalize which execution interceptors will be used for the created client.
      */
     private List<ExecutionInterceptor> resolveExecutionInterceptors(SdkClientConfiguration config) {
-        List<ExecutionInterceptor> globalInterceptors = new ClasspathInterceptorChainFactory().getGlobalInterceptors();
+        List<ExecutionInterceptor> globalInterceptors = new ArrayList<>();
+        globalInterceptors.addAll(sdkInterceptors());
+        globalInterceptors.addAll(new ClasspathInterceptorChainFactory().getGlobalInterceptors());
         return mergeLists(globalInterceptors, config.option(EXECUTION_INTERCEPTORS));
+    }
+
+
+    /**
+     * The set of interceptors that should be included with all services.
+     */
+    private List<ExecutionInterceptor> sdkInterceptors() {
+        return Collections.singletonList(new HttpChecksumRequiredInterceptor());
     }
 
     @Override

--- a/core/sdk-core/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/core/sdk-core/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,1 +1,0 @@
-software.amazon.awssdk.core.internal.interceptor.HttpChecksumRequiredInterceptor


### PR DESCRIPTION
This reduces the need for customers to use a special transformer for execution.interceptors files when they are creating an uber-jar of all SDK modules. Customers should still consider using such an appender, in case other libraries rely on execution.interceptors files.