### PR TITLE
Bug Fix to support Document Type for Explicit Payload members

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-bd6fc5c.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-bd6fc5c.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Bug fix to handle DocumentType for Explicit payload members."
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonProtocolUnmarshaller.java
@@ -127,7 +127,10 @@ public final class JsonProtocolUnmarshaller {
     private static Document unmarshallDocument(JsonUnmarshallerContext context,
                                                JsonNode jsonContent,
                                                SdkField<Document> field) {
-        return jsonContent != null && !jsonContent.isNull() ? getDocumentFromJsonContent(jsonContent) : null;
+        if (jsonContent == null) {
+            return null;
+        }
+        return jsonContent.isNull() ? Document.fromNull() : getDocumentFromJsonContent(jsonContent);
     }
 
     private static Document getDocumentFromJsonContent(JsonNode jsonContent) {
@@ -238,8 +241,11 @@ public final class JsonProtocolUnmarshaller {
         if (jsonContent == null) {
             return null;
         }
-        return isExplicitPayloadMember(field) ? jsonContent : jsonContent.field(field.locationName())
-                                                                         .orElse(null);
+        return isFieldExplicitlyTransferredAsJson(field) ? jsonContent : jsonContent.field(field.locationName()).orElse(null);
+    }
+
+    private static boolean isFieldExplicitlyTransferredAsJson(SdkField<?> field) {
+        return isExplicitPayloadMember(field) && !MarshallingType.DOCUMENT.equals(field.marshallingType());
     }
 
     /**

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/documenttype/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/documenttype/service-2.json
@@ -1,0 +1,395 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2016-03-11",
+    "endpointPrefix":"customresponsemetadata",
+    "jsonVersion":"1.1",
+    "protocol":"rest-json",
+    "serviceAbbreviation":"AmazonDocumentTypeJson",
+    "serviceFullName":"Amazon Protocol Rest Json",
+    "serviceId":"AmazonDocumentTypeJson",
+    "signatureVersion":"v4",
+    "targetPrefix":"ProtocolTestsService",
+    "timestampFormat":"unixTimestamp",
+    "uid":"restjson-2016-03-11"
+  },
+  "operations":{
+    "AllTypes":{
+      "name":"AllTypes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypes"
+      },
+      "input":{"shape":"AllTypesImplicitPayload"},
+      "output":{"shape":"AllTypesImplicitPayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "AllTypesWithPayload":{
+      "name":"AllTypesWithPayload",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypesPayload"
+      },
+      "input":{"shape":"TypesWithExplicitPayload"},
+      "output":{"shape":"TypesWithExplicitPayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "WithExplicitDocumentPayload":{
+      "name":"WithExplicitDocumentPayload",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypesPayload"
+      },
+      "input":{"shape":"TypeWithExplicitDocumentPayload"},
+      "output":{"shape":"TypeWithExplicitDocumentPayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "ImplicitNestedDocumentPayload":{
+      "name":"ImplicitNestedDocumentPayload",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypesPayload"
+      },
+      "input":{"shape":"TypesWithImplicitNestedDocumentPayload"},
+      "output":{"shape":"TypesWithImplicitNestedDocumentPayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "ExplicitRecursivePayload":{
+      "name":"ExplicitRecursivePayload",
+      "http":{
+        "method":"POST",
+        "requestUri": "/v1/policy"
+      },
+      "input":{"shape":"TypeWithExplicitRecursivePayload"},
+      "output":{"shape":"TypeWithExplicitRecursivePayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "ImplicitRecursivePayload":{
+      "name":"ImplicitRecursivePayload",
+      "http":{
+        "method":"POST",
+        "requestUri": "/v1/policy"
+      },
+      "input":{"shape":"TypeWithImplicitRecursivePayload"},
+      "output":{"shape":"TypeWithImplicitRecursivePayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    },
+    "ImplicitOnlyDocumentPayload":{
+      "name":"ImplicitOnlyDocumentPayload",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypesPayload"
+      },
+      "input":{"shape":"TypesWithImplicitOnlyDocumentPayload"},
+      "output":{"shape":"TypesWithImplicitOnlyDocumentPayload"},
+      "errors":[
+        {"shape":"EmptyModeledException"}
+      ]
+    }
+  },
+  "shapes":{
+    "AllTypesImplicitPayload":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"},
+        "IntegerMember":{"shape":"Integer"},
+        "BooleanMember":{"shape":"Boolean"},
+        "FloatMember":{"shape":"Float"},
+        "DoubleMember":{"shape":"Double"},
+        "LongMember":{"shape":"Long"},
+        "ShortMember":{"shape":"Short"},
+        "EnumMember":{"shape":"EnumType"},
+        "SimpleList":{"shape":"ListOfStrings"},
+        "ListOfEnums":{"shape":"ListOfEnums"},
+        "ListOfMaps":{"shape":"ListOfMapStringToString"},
+        "ListOfListOfMapsOfStringToStruct":{"shape":"ListOfListOfMapOfStringToSimpleStruct"},
+        "ListOfMapsOfStringToStruct":{"shape":"ListOfMapOfStringToSimpleStruct"},
+        "ListOfStructs":{"shape":"ListOfSimpleStructs"},
+        "MapOfStringToIntegerList":{"shape":"MapOfStringToIntegerList"},
+        "MapOfStringToString":{"shape":"MapOfStringToString"},
+        "MapOfStringToStruct":{"shape":"MapOfStringToSimpleStruct"},
+        "MapOfEnumToEnum":{"shape":"MapOfEnumToEnum"},
+        "TimestampMember":{"shape":"Timestamp"},
+        "StructWithNestedTimestampMember":{"shape":"StructWithTimestamp"},
+        "BlobArg":{"shape":"BlobType"},
+        "StructWithNestedBlob":{"shape":"StructWithNestedBlobType"},
+        "BlobMap":{"shape":"BlobMapType"},
+        "ListOfBlobs":{"shape":"ListOfBlobsType"},
+        "RecursiveStruct":{"shape":"RecursiveStructType"},
+        "PolymorphicTypeWithSubTypes":{"shape":"StringPayload"},
+        "PolymorphicTypeWithoutSubTypes":{"shape":"SubTypeOne"},
+        "SetPrefixedMember":{"shape":"String"},
+        "MyDocument":{"shape":"MyDocument"}
+      }
+    },
+    "TypesWithExplicitPayload":{
+      "type":"structure",
+      "members":{
+        "StringPayload":{"shape":"StringPayload"},
+        "Accept": {
+          "shape": "AcceptHeader",
+          "location": "header",
+          "locationName": "accept",
+          "documentation": "The HTTP Accept header. Indicates the requested type for the thumbnail."
+        }
+      },
+      "payload": "StringPayload"
+    },
+    "TypeWithExplicitDocumentPayload":{
+      "type":"structure",
+      "members":{
+        "MyDocument":{"shape":"MyDocument"},
+        "Accept": {
+          "shape": "AcceptHeader",
+          "location": "header",
+          "locationName": "accept",
+          "documentation": "The HTTP Accept header. Indicates the requested type for the thumbnail."
+        }
+      },
+      "payload": "MyDocument"
+    },
+    "TypeWithExplicitRecursivePayload":{
+      "type":"structure",
+      "members":{
+        "RecursiveStructType":{"shape":"RecursiveStructType"},
+        "Accept": {
+          "shape": "AcceptHeader",
+          "location": "header",
+          "locationName": "accept",
+          "documentation": "The HTTP Accept header. Indicates the requested type for the thumbnail."
+        },
+        "RegistryName": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "registryName",
+          "documentation": "<p>The name of the registry.</p>"
+        }
+      },
+      "payload": "RecursiveStructType"
+    },
+    "TypeWithImplicitRecursivePayload":{
+      "type":"structure",
+      "members":{
+        "MyDocument":{"shape":"MyDocument"},
+        "MapOfStringToString":{"shape":"MapOfStringToString"},
+        "RecursiveStructType":{"shape":"RecursiveStructType"},
+        "Accept": {
+          "shape": "AcceptHeader",
+          "location": "header",
+          "locationName": "accept",
+          "documentation": "The HTTP Accept header. Indicates the requested type for the thumbnail."
+        },
+        "RegistryName": {
+          "shape": "String",
+          "location": "uri",
+          "locationName": "registryName",
+          "documentation": "<p>The name of the registry.</p>"
+        }
+      }
+    },
+    "TypesWithImplicitNestedDocumentPayload":{
+      "type":"structure",
+      "members":{
+        "NestedDocumentPayload":{"shape":"NestedDocumentPayload"},
+        "Accept": {
+          "shape": "AcceptHeader",
+          "location": "header",
+          "locationName": "accept",
+          "documentation": "The HTTP Accept header. Indicates the requested type for the thumbnail."
+        }
+      }
+    },
+    "TypesWithImplicitOnlyDocumentPayload":{
+      "type":"structure",
+      "members":{
+        "MyDocument":{"shape":"MyDocument"},
+        "Accept": {
+          "shape": "AcceptHeader",
+          "location": "header",
+          "locationName": "accept",
+          "documentation": "The HTTP Accept header. Indicates the requested type for the thumbnail."
+        }
+      }
+    },
+    "StringPayload":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "StringNonPayload":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "NestedDocumentPayload":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"},
+        "MyDocument":{"shape":"MyDocument"}
+      }
+    },
+    "BlobMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"BlobType"}
+    },
+    "BlobType":{"type":"blob"},
+    "Boolean":{"type":"boolean"},
+    "Double":{"type":"double"},
+    "EmptyModeledException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
+    "Float":{"type":"float"},
+    "Integer":{"type":"integer"},
+    "ListOfBlobsType":{
+      "type":"list",
+      "member":{"shape":"BlobType"}
+    },
+    "ListOfIntegers":{
+      "type":"list",
+      "member":{"shape":"Integer"}
+    },
+    "ListOfListOfListsOfStrings":{
+      "type":"list",
+      "member":{"shape":"ListOfListsOfStrings"}
+    },
+    "ListOfListsOfStrings":{
+      "type":"list",
+      "member":{"shape":"ListOfStrings"}
+    },
+    "ListOfMapStringToString":{
+      "type":"list",
+      "member":{"shape":"MapOfStringToString"}
+    },
+    "ListOfListOfMapOfStringToSimpleStruct":{
+      "type":"list",
+      "member":{"shape":"ListOfMapOfStringToSimpleStruct"}
+    },
+    "ListOfMapOfStringToSimpleStruct":{
+      "type":"list",
+      "member":{"shape":"MapOfStringToSimpleStruct"}
+    },
+    "ListOfSimpleStructs":{
+      "type":"list",
+      "member":{"shape":"SimpleStruct"}
+    },
+    "ListOfStrings":{
+      "type":"list",
+      "member":{"shape":"String"}
+    },
+    "ListOfEnums":{
+      "type":"list",
+      "member":{"shape":"EnumType"}
+    },
+    "Long":{"type":"long"},
+    "Short":{"type":"short"},
+    "MapOfStringToIntegerList":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfIntegers"}
+    },
+    "MapOfStringToListOfListsOfStrings":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"ListOfListsOfStrings"}
+    },
+    "MapOfStringToSimpleStruct":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"SimpleStruct"}
+    },
+    "MapOfStringToString":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"String"}
+    },
+    "MapOfEnumToEnum":{
+      "type":"map",
+      "key":{"shape":"EnumType"},
+      "value":{"shape":"EnumType"}
+    },
+    "SimpleStruct":{
+      "type":"structure",
+      "members":{
+        "StringMember":{"shape":"String"}
+      }
+    },
+    "StreamType":{
+      "type":"blob",
+      "streaming":true
+    },
+    "String":{"type":"string"},
+    "StructWithNestedBlobType":{
+      "type":"structure",
+      "members":{
+        "NestedBlob":{"shape":"BlobType"}
+      }
+    },
+    "StructWithTimestamp":{
+      "type":"structure",
+      "members":{
+        "NestedTimestamp":{"shape":"Timestamp"}
+      }
+    },
+    "SubTypeOne":{
+      "type":"structure",
+      "members":{
+        "SubTypeOneMember":{"shape":"String"}
+      }
+    },
+    "RecursiveListType":{
+      "type":"list",
+      "member":{"shape":"RecursiveStructType"}
+    },
+    "RecursiveStructType":{
+      "type":"structure",
+      "members":{
+        "NoRecurse":{"shape":"String"},
+        "MyDocument":{"shape":"MyDocument"},
+        "RecursiveStruct":{"shape":"RecursiveStructType"},
+        "RecursiveList":{"shape":"RecursiveListType"},
+        "RecursiveMap":{"shape":"RecursiveMapType"}
+      }
+    },
+    "RecursiveMapType":{
+      "type":"map",
+      "key":{"shape":"String"},
+      "value":{"shape":"RecursiveStructType"}
+    },
+    "Timestamp":{"type":"timestamp"},
+    "EnumType": {
+      "type":"string",
+      "enum": [
+        "EnumValue1", "EnumValue2"
+      ]
+    },
+    "MyDocument": {
+      "type": "structure",
+      "document": true
+    },
+    "AcceptHeader": {
+      "type": "string",
+      "enum": [
+        "image/jpeg"
+      ],
+      "documentation": "The HTTP Accept header. Indicates the requested type fothe thumbnail."
+    }
+  }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/documenttype/DocumentTypeTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/documenttype/DocumentTypeTest.java
@@ -1,0 +1,461 @@
+package software.amazon.awssdk.services.documenttype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.core.SdkNumber;
+import software.amazon.awssdk.core.document.Document;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.documenttypejson.DocumentTypeJsonClient;
+import software.amazon.awssdk.services.documenttypejson.model.AcceptHeader;
+import software.amazon.awssdk.services.documenttypejson.model.AllTypesResponse;
+import software.amazon.awssdk.services.documenttypejson.model.AllTypesWithPayloadResponse;
+import software.amazon.awssdk.services.documenttypejson.model.ExplicitRecursivePayloadResponse;
+import software.amazon.awssdk.services.documenttypejson.model.ImplicitNestedDocumentPayloadResponse;
+import software.amazon.awssdk.services.documenttypejson.model.ImplicitOnlyDocumentPayloadResponse;
+import software.amazon.awssdk.services.documenttypejson.model.ImplicitRecursivePayloadResponse;
+import software.amazon.awssdk.services.documenttypejson.model.NestedDocumentPayload;
+import software.amazon.awssdk.services.documenttypejson.model.RecursiveStructType;
+import software.amazon.awssdk.services.documenttypejson.model.StringPayload;
+import software.amazon.awssdk.services.documenttypejson.model.WithExplicitDocumentPayloadResponse;
+import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
+
+public class DocumentTypeTest {
+
+    public static final Document STRING_DOCUMENT = Document.fromString("docsString");
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    private DocumentTypeJsonClient jsonClient;
+
+    private SdkHttpClient httpClient;
+
+    @Before
+    public void setup() throws IOException {
+        httpClient = Mockito.mock(SdkHttpClient.class);
+        jsonClient = initializeSync(DocumentTypeJsonClient.builder()).build();
+    }
+
+    private void setUpStub(String contentBody) {
+        InputStream content = new StringInputStream(contentBody);
+        SdkHttpFullResponse successfulHttpResponse = SdkHttpResponse.builder()
+                                                                    .statusCode(200)
+                                                                    .putHeader("accept", AcceptHeader.IMAGE_JPEG.toString())
+                                                                    .putHeader("Content-Length",
+                                                                               String.valueOf(contentBody.length()))
+                                                                    .build();
+        ExecutableHttpRequest request = Mockito.mock(ExecutableHttpRequest.class);
+        try {
+            Mockito.when(request.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                       .responseBody(AbortableInputStream.create(content))
+                                                                       .response(successfulHttpResponse)
+                                                                       .build());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        Mockito.when(httpClient.prepareRequest(any())).thenReturn(request);
+    }
+
+    @Test
+    public void implicitPayloadEmptyRequestMarshallingAndUnMarshalling() {
+        setUpStub("{}");
+        AllTypesResponse allTypesResponse = jsonClient.allTypes(SdkBuilder::build);
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo("{}");
+        assertThat(allTypesResponse.myDocument()).isNull();
+    }
+
+    @Test
+    public void implicitPayloadNonEmptyRequestMarshallingAndUnMarshalling() {
+        setUpStub("{\"StringMember\":\"stringMember\",\"IntegerMember\":3,\"MyDocument\":\"stringDocument\"}");
+        AllTypesResponse allTypesResponse = jsonClient.allTypes(
+            c -> c.stringMember("stringMember").integerMember(3));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo("{\"StringMember\":\"stringMember\",\"IntegerMember\":3}");
+        assertThat(allTypesResponse.stringMember()).isEqualTo("stringMember");
+        assertThat(allTypesResponse.integerMember()).isEqualTo(3);
+        assertThat(allTypesResponse.myDocument()).isEqualTo(Document.fromString("stringDocument"));
+    }
+
+    @Test
+    public void explicitPayloadEmptyRequestMarshallingAndUnMarshalling() {
+        setUpStub("{}");
+        AllTypesWithPayloadResponse allTypesWithPayloadResponse =
+            jsonClient.allTypesWithPayload(c -> c.stringPayload(StringPayload.builder().build()));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo("{}");
+        assertThat(allTypesWithPayloadResponse.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+        assertThat(allTypesWithPayloadResponse.stringPayload().stringMember()).isNull();
+    }
+
+    @Test
+    public void explicitPayloadRequestMarshallingAndUnMarshalling() {
+        String jsonFormat = "{\"StringMember\":\"payloadMember\"}";
+        setUpStub(jsonFormat);
+        AllTypesWithPayloadResponse payloadMember = jsonClient.allTypesWithPayload(
+            c -> c.stringPayload(StringPayload.builder().stringMember("payloadMember").build()).build());
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        assertThat(payloadMember.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+        assertThat(payloadMember.stringPayload().stringMember()).isEqualTo("payloadMember");
+    }
+
+    @Test
+    public void implicitNestedPayloadWithSimpleDocument() {
+        String jsonFormat = "{\"NestedDocumentPayload\":{\"StringMember\":\"stringMember\","
+                            + "\"MyDocument\":\"stringDoc\"}}";
+        setUpStub(jsonFormat);
+        ImplicitNestedDocumentPayloadResponse implicitNestedDocumentPayload =
+            jsonClient.implicitNestedDocumentPayload(
+                c -> c.nestedDocumentPayload(
+                    NestedDocumentPayload.builder()
+                                         .myDocument(Document.fromString("stringDoc"))
+                                         .stringMember("stringMember")
+                                         .build()).build());
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        assertThat(implicitNestedDocumentPayload.nestedDocumentPayload().myDocument()).isEqualTo(Document.fromString("stringDoc"
+        ));
+        assertThat(implicitNestedDocumentPayload.nestedDocumentPayload().stringMember()).isEqualTo("stringMember");
+        assertThat(implicitNestedDocumentPayload.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+    }
+
+    @Test
+    public void implicitNestedPayloadWithDocumentMap() {
+        String jsonFormat = "{\""
+                            + "NestedDocumentPayload\":"
+                            + "{\"StringMember\":\"stringMember\","
+                            + "\"MyDocument\":"
+                            + "{\"number\":2,\"stringValue\":\"string\"}}"
+                            + "}";
+        setUpStub(jsonFormat);
+        Document document = Document.mapBuilder()
+                                    .putNumber("number", SdkNumber.fromString("2"))
+                                    .putString("stringValue", "string").build();
+        ImplicitNestedDocumentPayloadResponse response = jsonClient.implicitNestedDocumentPayload(
+            c -> c.nestedDocumentPayload(
+                      NestedDocumentPayload.builder()
+                                           .myDocument(document)
+                                           .stringMember("stringMember").build())
+                  .build());
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        assertThat(response.nestedDocumentPayload().stringMember()).isEqualTo("stringMember");
+        assertThat(response.nestedDocumentPayload().myDocument()).isEqualTo(document);
+        assertThat(response.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+    }
+
+    @Test
+    public void explicitDocumentOnlyStringPayload() {
+        String jsonFormat = "{\"MyDocument\":\"docsString\"}";
+        setUpStub(jsonFormat);
+        WithExplicitDocumentPayloadResponse response =
+            jsonClient.withExplicitDocumentPayload(c -> c.myDocument(STRING_DOCUMENT).accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.myDocument()).isEqualTo(STRING_DOCUMENT);
+        assertThat(response.myDocument().isString()).isTrue();
+    }
+
+    @Test
+    public void explicitDocumentOnlyListPayload() {
+        String jsonFormat = "{\"MyDocument\":[{\"key\":\"value\"},null,\"string\",3,false]}";
+        setUpStub(jsonFormat);
+        Document document = Document.listBuilder()
+                                    .addDocument(Document.mapBuilder().putString("key", "value").build())
+                                    .addNull().addString("string").addNumber(3).addBoolean(false).build();
+        WithExplicitDocumentPayloadResponse response =
+            jsonClient.withExplicitDocumentPayload(c -> c.myDocument(document).accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.myDocument()).isEqualTo(document);
+        assertThat(response.myDocument().isList()).isTrue();
+    }
+
+    @Test
+    public void explicitDocumentOnlyNullDocumentPayload() {
+        String jsonFormat = "{\"MyDocument\":null}";
+        setUpStub(jsonFormat);
+        WithExplicitDocumentPayloadResponse response =
+            jsonClient.withExplicitDocumentPayload(c -> c.myDocument(Document.fromNull()).accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.myDocument()).isNotNull();
+        assertThat(response.myDocument().isNull()).isTrue();
+    }
+
+    @Test
+    public void explicitDocumentOnlyNullPayload() {
+        String jsonFormat = "null";
+        setUpStub(jsonFormat);
+        WithExplicitDocumentPayloadResponse response =
+            jsonClient.withExplicitDocumentPayload(c -> c.myDocument(null).accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEmpty();
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.myDocument()).isNull();
+    }
+
+    @Test
+    public void explicitDocumentOnlyEmptyPayload() {
+        String jsonFormat = "";
+        setUpStub(jsonFormat);
+        WithExplicitDocumentPayloadResponse response =
+            jsonClient.withExplicitDocumentPayload(c -> c.myDocument(null).accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEmpty();
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.myDocument()).isNull();
+    }
+
+
+    @Test
+    public void explicitDocumentOnlyPayloadWithMemberNameAsKeyNames() {
+        String jsonFormat = "{\"MyDocument\":{\"MyDocument\":\"docsString\"}}";
+        setUpStub(jsonFormat);
+        Document document = Document.mapBuilder()
+                                    .putDocument("MyDocument", STRING_DOCUMENT).build();
+        WithExplicitDocumentPayloadResponse response =
+            jsonClient.withExplicitDocumentPayload(c -> c.myDocument(document).accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo("{\"MyDocument\":{\"MyDocument\":\"docsString\"}}");
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.myDocument()).isEqualTo(document);
+        assertThat(response.myDocument().isMap()).isTrue();
+
+    }
+
+
+    @Test
+    public void explicitPayloadWithRecursiveMember() {
+        String jsonFormat = "{\"NoRecurse\":\"noRecursive1\",\"MyDocument\":\"level1\","
+                            + "\"RecursiveStruct\":{\"NoRecurse\":\"noRecursive2\",\"MyDocument\":\"leve2\"}}";
+        setUpStub(jsonFormat);
+
+        ExplicitRecursivePayloadResponse response =
+            jsonClient.explicitRecursivePayload(c -> c.recursiveStructType(
+                                                          RecursiveStructType.builder()
+                                                                             .myDocument(Document.fromString("level1"))
+                                                                             .noRecurse("noRecursive1")
+
+                                                                             .recursiveStruct(RecursiveStructType.builder().myDocument(Document.fromString("leve2")).noRecurse(
+                                                                                 "noRecursive2").build())
+                                                                             .build())
+                                                      .registryName("registryName").accept(AcceptHeader.IMAGE_JPEG));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.registryName()).isNull();
+        assertThat(response.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+        assertThat(response.recursiveStructType().noRecurse()).isEqualTo("noRecursive1");
+        assertThat(response.recursiveStructType().myDocument()).isEqualTo(Document.fromString("level1"));
+        assertThat(response.recursiveStructType().recursiveStruct())
+            .isEqualTo(RecursiveStructType.builder().noRecurse("noRecursive2").myDocument(Document.fromString("leve2")).build());
+    }
+
+    @Test
+    public void explicitPayloadWithRecursiveMemberDocumentMap() {
+        String jsonFormat = "{"
+                            + "\"NoRecurse\":\"noRecursive1\","
+                            + "\"MyDocument\":"
+                            + "{\"docsL1\":\"docsStringL1\"},"
+                            + "\"RecursiveStruct\":"
+                            + "{\"NoRecurse\":\"noRecursive2\","
+                            + "\"MyDocument\":"
+                            + "{\"docsL2\":\"docsStringL2\"}"
+                            + "}"
+                            + "}";
+        setUpStub(jsonFormat);
+        Document documentOuter = Document.mapBuilder().putDocument("docsL1", Document.fromString("docsStringL1")).build();
+        Document documentInner = Document.mapBuilder().putDocument("docsL2", Document.fromString("docsStringL2")).build();
+
+        ExplicitRecursivePayloadResponse response =
+            jsonClient.explicitRecursivePayload(
+                c -> c.recursiveStructType(
+                          RecursiveStructType.builder()
+                                             .myDocument(documentOuter)
+                                             .noRecurse("noRecursive1")
+                                             .recursiveStruct(
+                                                 RecursiveStructType.builder()
+                                                                    .myDocument(documentInner)
+                                                                    .noRecurse("noRecursive2")
+                                                                    .build())
+                                             .build())
+                      .registryName("registryName")
+                      .accept(AcceptHeader.IMAGE_JPEG)
+            );
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.registryName()).isNull();
+        assertThat(response.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+        assertThat(response.recursiveStructType().noRecurse()).isEqualTo("noRecursive1");
+        assertThat(response.recursiveStructType().myDocument()).isEqualTo(documentOuter);
+        assertThat(response.recursiveStructType().recursiveStruct())
+            .isEqualTo(RecursiveStructType.builder().noRecurse("noRecursive2").myDocument(documentInner).build());
+    }
+
+    @Test
+    public void implicitPayloadWithRecursiveMemberDocumentMap() {
+        String jsonFormat = "{\"MyDocument\":[1,null,\"end\"],\"MapOfStringToString\":{\"key1\":\"value1\","
+                            + "\"key2\":\"value2\"},\"RecursiveStructType\":{\"NoRecurse\":\"noRecursive1\","
+                            + "\"MyDocument\":{\"docsL1\":\"docsStringL1\"},"
+                            + "\"RecursiveStruct\":{\"NoRecurse\":\"noRecursive2\","
+                            + "\"MyDocument\":{\"docsL2\":\"docsStringL2\"}}}}";
+        setUpStub(jsonFormat);
+        Document documentOuter = Document.mapBuilder().putDocument("docsL1", Document.fromString("docsStringL1")).build();
+        Document documentInner = Document.mapBuilder().putDocument("docsL2", Document.fromString("docsStringL2")).build();
+        Document listDocument = Document.listBuilder().addNumber(1).addNull().addString("end").build();
+
+        Map<String, String> stringStringMap = new HashMap<>();
+        stringStringMap.put("key1", "value1");
+        stringStringMap.put("key2", "value2");
+
+        ImplicitRecursivePayloadResponse response = jsonClient.implicitRecursivePayload(
+            c -> c.recursiveStructType(
+                      RecursiveStructType.builder()
+                                         .myDocument(documentOuter)
+                                         .noRecurse("noRecursive1")
+                                         .recursiveStruct(
+                                             RecursiveStructType.builder()
+                                                                .myDocument(documentInner)
+                                                                .noRecurse("noRecursive2")
+                                                                .build())
+                                         .build())
+                  .registryName("registryName")
+                  .myDocument(listDocument)
+                  .mapOfStringToString(stringStringMap)
+                  .accept(AcceptHeader.IMAGE_JPEG)
+        );
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(sdkHttpRequest.firstMatchingHeader("accept").get()).contains(AcceptHeader.IMAGE_JPEG.toString());
+        assertThat(response.registryName()).isNull();
+        assertThat(response.accept()).isEqualTo(AcceptHeader.IMAGE_JPEG);
+        assertThat(response.recursiveStructType().noRecurse()).isEqualTo("noRecursive1");
+        assertThat(response.recursiveStructType().myDocument()).isEqualTo(documentOuter);
+        assertThat(response.recursiveStructType().recursiveStruct())
+            .isEqualTo(RecursiveStructType.builder().noRecurse("noRecursive2").myDocument(documentInner).build());
+        assertThat(response.myDocument()).isEqualTo(listDocument);
+
+    }
+
+    @Test
+    public void implicitDocumentOnlyPayloadWithStringMember() {
+        String jsonFormat = "{\"MyDocument\":\"stringDocument\"}";
+        setUpStub(jsonFormat);
+        Document document = Document.fromString("stringDocument");
+
+        ImplicitOnlyDocumentPayloadResponse response =
+            jsonClient.implicitOnlyDocumentPayload(c -> c.myDocument(document));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo("{\"MyDocument\":\"stringDocument\"}");
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(response.myDocument()).isEqualTo(document);
+    }
+
+    @Test
+    public void implicitDocumentOnlyPayloadWithNullDocumentMember() {
+        String jsonFormat = "{\"MyDocument\":null}";
+        setUpStub(jsonFormat);
+        Document document = Document.fromNull();
+
+        ImplicitOnlyDocumentPayloadResponse response =
+            jsonClient.implicitOnlyDocumentPayload(c -> c.myDocument(document));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(response.myDocument()).isNotNull();
+        assertThat(response.myDocument()).isEqualTo(document);
+    }
+
+    @Test
+    public void implicitDocumentOnlyPayloadWithNull() {
+        String jsonFormat = "{}";
+        setUpStub(jsonFormat);
+        ImplicitOnlyDocumentPayloadResponse response =
+            jsonClient.implicitOnlyDocumentPayload(c -> c.myDocument(null));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo("{}");
+        SdkHttpRequest sdkHttpRequest = getSyncRequest();
+        assertThat(response.myDocument()).isNull();
+    }
+
+    @Test
+    public void implicitDocumentOnlyPayloadWithMapKeyAsMemberNames() {
+        String jsonFormat = "{\"MyDocument\":{\"MyDocument\":\"stringDocument\"}}";
+        setUpStub(jsonFormat);
+        Document document = Document.mapBuilder()
+                                    .putDocument("MyDocument", Document.fromString("stringDocument"))
+                                    .build();
+
+        ImplicitOnlyDocumentPayloadResponse response =
+            jsonClient.implicitOnlyDocumentPayload(c -> c.myDocument(document));
+        String syncRequest = getSyncRequestBody();
+        assertThat(syncRequest).isEqualTo(jsonFormat);
+        assertThat(response.myDocument()).isEqualTo(document);
+    }
+
+    private <T extends AwsSyncClientBuilder<T, ?> & AwsClientBuilder<T, ?>> T initializeSync(T syncClientBuilder) {
+        return initialize(syncClientBuilder.httpClient(httpClient));
+    }
+
+    private <T extends AwsClientBuilder<T, ?>> T initialize(T clientBuilder) {
+        return clientBuilder.credentialsProvider(AnonymousCredentialsProvider.create())
+                            .region(Region.US_WEST_2);
+    }
+
+    private SdkHttpRequest getSyncRequest() {
+        ArgumentCaptor<HttpExecuteRequest> captor = ArgumentCaptor.forClass(HttpExecuteRequest.class);
+        Mockito.verify(httpClient).prepareRequest(captor.capture());
+        return captor.getValue().httpRequest();
+    }
+
+    private String getSyncRequestBody() {
+        ArgumentCaptor<HttpExecuteRequest> captor = ArgumentCaptor.forClass(HttpExecuteRequest.class);
+        Mockito.verify(httpClient).prepareRequest(captor.capture());
+        InputStream inputStream = captor.getValue().contentStreamProvider().get().newStream();
+        return new BufferedReader(
+            new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+            .lines()
+            .collect(Collectors.joining("\n"));
+    }
+}

--- a/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/reflect/ShapeModelReflector.java
+++ b/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/reflect/ShapeModelReflector.java
@@ -180,13 +180,15 @@ public class ShapeModelReflector {
      * @param currentNode JsonNode containing value of member.
      */
     private Object getMemberValue(JsonNode currentNode, MemberModel memberModel) {
-        // Streaming members are not in the POJO
-        if (currentNode.isNull()) {
-            return null;
-        }
+
         String simpleType = memberModel.getVariable().getSimpleType();
+
         if (simpleType.equals("Document")) {
             return new JsonNodeToDocumentConvertor().visit(currentNode);
+        }
+        // Streaming members are not in the POJO, for Document type null Json Nodes are represented as NullDocument
+        if (currentNode.isNull()) {
+            return null;
         }
         if (memberModel.isSimple()) {
             return getSimpleMemberValue(currentNode, memberModel);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
1. DocumentType was not handled for explicit payload member.
2. In doMarshall() the Documents were getting Marshalled in below snippet whenever the Payload type was explicit payload
3. Explicit payload member are shapes where we Explicitly define the Payload member using "payload key"
```
         if (val != null && field.containsTrait(PayloadTrait.class)) {
                    jsonGenerator.writeStartObject();
                    doMarshall((SdkPojo) val);
                    jsonGenerator.writeEndObject();
                }
```

## Description
<!--- Describe your changes in detail -->
1. Fixed by adding specific check for DocumentType and calling its corresponding marshaling Type 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Added J-units for Explicit and Implicit payload
2. Note : test cases added in codegen-test because in protocol test there is an additional layer where the suite.json files gets marshalled , to make sure we test end-to-end added test in codegen-test .

Implicit and explicit Recursive payload test case added
```
{
  "MyDocument": [
    1,
    null,
    "end"
  ],
  "MapOfStringToString": {
    "key1": "value1",
    "key2": "value2"
  },
  "RecursiveStructType": {
    "NoRecurse": "noRecursive1",
    "MyDocument": {
      "docsL1": "docsStringL1"
    },
    "RecursiveStruct": {
      "NoRecurse": "noRecursive2",
      "MyDocument": {
        "docsL2": "docsStringL2"
      }
    }
  }
}
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
