### PR TITLE
Bypass CloudcontrolServiceMetadata for japicmp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,7 @@
                             <exclude>software.amazon.awssdk.thirdparty.*</exclude>
                             <exclude>software.amazon.awssdk.awscore.client.handler.AwsAsyncClientHandler</exclude>
                             <exclude>software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler</exclude>
+                            <exclude>software.amazon.awssdk.regions.servicemetadata.CloudcontrolServiceMetadata.*</exclude>
                         </excludes>
 
                         <excludeModules>


### PR DESCRIPTION
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license