### PR TITLE
Attempt to fix the flakiness of the codegen-generated-classes-test tests.

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -56,7 +56,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.HttpStatusFamily;
 import software.amazon.awssdk.http.Protocol;
-import software.amazon.awssdk.http.SdkCancellationException;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
@@ -239,10 +238,8 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                         return;
                     }
                     try {
-                        SdkCancellationException e = new SdkCancellationException(
-                                "Subscriber cancelled before all events were published");
-                        log.warn("Subscriber cancelled before all events were published");
-                        executeFuture.completeExceptionally(e);
+                        log.warn("Subscriber cancelled before all events were published.");
+                        executeFuture.complete(null);
                     } finally {
                         runAndLogError("Could not release channel back to the pool",
                             () -> closeAndRelease(channelContext));


### PR DESCRIPTION
I wasn't able to reproduce the error locally or in codebuild, which manifests as an index-out-of-bounds exception in BaseAsyncCoreMetricsTest>apiCall_allRetryAttemptsFailedOfNetworkError:108 for async sub-classes.

This fixes one potential cause of the error: the result future for an operation can theoretically be completed before the metric gathering future (which is the HTTP call completion future). This change prevents completing the operation future until the HTTP call completion future is completed (in addition to the current future that's checked, the response handling future).