### PR TITLE
Don't create object if no implicit members

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
@@ -187,11 +187,17 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
         List<MemberModel> unboundMembers = new ArrayList<>();
         if (members != null) {
             for (MemberModel member : members) {
-                if (member.getHttp().getLocation() == null) {
+                if (member.getHttp().getLocation() == null && !member.getHttp().getIsPayload()) {
                     if (hasPayloadMember) {
+                        // There is an explicit payload, but this unbound
+                        // member isn't it.
+                        // Note: Somewhat unintuitive, explicit payloads don't
+                        // have an explicit location; they're identified by
+                        // the payload HTTP trait being true.
                         throw new IllegalStateException(String.format(
-                                "C2J Shape %s has both an explicit payload member and unbound (no explicit location) members. "
-                                + "This is undefined behavior, verify the correctness of the C2J model", c2jName));
+                                "C2J Shape %s has both an explicit payload member and unbound (no explicit location) member, %s."
+                                + " This is undefined behavior, verify the correctness of the C2J model.",
+                                c2jName, member.getName()));
                     }
                     unboundMembers.add(member);
                 }
@@ -221,7 +227,12 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
     public boolean hasPayloadMembers() {
         return hasPayloadMember ||
                getExplicitEventPayloadMember() != null ||
-               !getUnboundMembers().isEmpty() ||
+               hasImplicitPayloadMembers();
+
+    }
+
+    public boolean hasImplicitPayloadMembers() {
+        return !getUnboundMembers().isEmpty() ||
                (isEvent() && !getUnboundEventMembers().isEmpty());
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/JsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/JsonMarshallerSpec.java
@@ -95,6 +95,7 @@ public class JsonMarshallerSpec implements MarshallerProtocolSpec {
                                       .add(".httpMethod($T.$L)", SdkHttpMethod.class, shapeModel.getMarshaller().getVerb())
                                       .add(".hasExplicitPayloadMember($L)", shapeModel.isHasPayloadMember() ||
                                                                             shapeModel.getExplicitEventPayloadMember() != null)
+                                      .add(".hasImplicitPayloadMembers($L)", shapeModel.hasImplicitPayloadMembers())
                                       .add(".hasPayloadMembers($L)", shapeModel.hasPayloadMembers());
 
         if (StringUtils.isNotBlank(shapeModel.getMarshaller().getTarget())) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/alltypesrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/alltypesrequestmarshaller.java
@@ -19,7 +19,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class AllTypesRequestMarshaller implements Marshaller<AllTypesRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().requestUri("/")
-                                                                            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasPayloadMembers(true).build();
+            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasImplicitPayloadMembers(true)
+            .hasPayloadMembers(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -32,11 +33,10 @@ public class AllTypesRequestMarshaller implements Marshaller<AllTypesRequest> {
         Validate.paramNotNull(allTypesRequest, "allTypesRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(allTypesRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationrequestmarshaller.java
@@ -19,8 +19,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventStreamOperationRequestMarshaller implements Marshaller<EventStreamOperationRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
-                                                                            .requestUri("/2016-03-11/eventStreamOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(true)
-                                                                            .hasPayloadMembers(true).hasEventStreamingInput(true).build();
+            .requestUri("/2016-03-11/eventStreamOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(true)
+            .hasImplicitPayloadMembers(false).hasPayloadMembers(true).hasEventStreamingInput(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -33,7 +33,7 @@ public class EventStreamOperationRequestMarshaller implements Marshaller<EventSt
         Validate.paramNotNull(eventStreamOperationRequest, "eventStreamOperationRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventStreamOperationRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationwithonlyinputrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventstreamoperationwithonlyinputrequestmarshaller.java
@@ -17,11 +17,11 @@ import software.amazon.awssdk.utils.Validate;
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
-public class EventStreamOperationWithOnlyInputRequestMarshaller implements
-                                                                Marshaller<EventStreamOperationWithOnlyInputRequest> {
+public class EventStreamOperationWithOnlyInputRequestMarshaller implements Marshaller<EventStreamOperationWithOnlyInputRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
-                                                                            .requestUri("/2016-03-11/EventStreamOperationWithOnlyInput").httpMethod(SdkHttpMethod.POST)
-                                                                            .hasExplicitPayloadMember(false).hasPayloadMembers(true).hasEventStreamingInput(true).build();
+            .requestUri("/2016-03-11/EventStreamOperationWithOnlyInput").httpMethod(SdkHttpMethod.POST)
+            .hasExplicitPayloadMember(false).hasImplicitPayloadMembers(true).hasPayloadMembers(true).hasEventStreamingInput(true)
+            .build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -34,11 +34,10 @@ public class EventStreamOperationWithOnlyInputRequestMarshaller implements
         Validate.paramNotNull(eventStreamOperationWithOnlyInputRequest, "eventStreamOperationWithOnlyInputRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventStreamOperationWithOnlyInputRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/nestedcontainersrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/nestedcontainersrequestmarshaller.java
@@ -19,7 +19,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class NestedContainersRequestMarshaller implements Marshaller<NestedContainersRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().requestUri("/")
-                                                                            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasPayloadMembers(true).build();
+            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasImplicitPayloadMembers(true)
+            .hasPayloadMembers(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -32,11 +33,10 @@ public class NestedContainersRequestMarshaller implements Marshaller<NestedConta
         Validate.paramNotNull(nestedContainersRequest, "nestedContainersRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(nestedContainersRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/operationwithnoinputoroutputrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/operationwithnoinputoroutputrequestmarshaller.java
@@ -17,10 +17,10 @@ import software.amazon.awssdk.utils.Validate;
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
-public class OperationWithNoInputOrOutputRequestMarshaller implements
-                                                           Marshaller<OperationWithNoInputOrOutputRequest> {
+public class OperationWithNoInputOrOutputRequestMarshaller implements Marshaller<OperationWithNoInputOrOutputRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().requestUri("/")
-                                                                            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasPayloadMembers(false).build();
+            .httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false).hasImplicitPayloadMembers(false)
+            .hasPayloadMembers(false).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -33,11 +33,10 @@ public class OperationWithNoInputOrOutputRequestMarshaller implements
         Validate.paramNotNull(operationWithNoInputOrOutputRequest, "operationWithNoInputOrOutputRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(operationWithNoInputOrOutputRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/streaminginputoperationrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/streaminginputoperationrequestmarshaller.java
@@ -19,8 +19,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class StreamingInputOperationRequestMarshaller implements Marshaller<StreamingInputOperationRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
-                                                                            .requestUri("/2016-03-11/streamingInputOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(true)
-                                                                            .hasPayloadMembers(true).hasStreamingInput(true).build();
+            .requestUri("/2016-03-11/streamingInputOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(true)
+            .hasImplicitPayloadMembers(false).hasPayloadMembers(true).hasStreamingInput(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -33,11 +33,10 @@ public class StreamingInputOperationRequestMarshaller implements Marshaller<Stre
         Validate.paramNotNull(streamingInputOperationRequest, "streamingInputOperationRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(streamingInputOperationRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/streamingoutputoperationrequestmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/streamingoutputoperationrequestmarshaller.java
@@ -19,8 +19,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class StreamingOutputOperationRequestMarshaller implements Marshaller<StreamingOutputOperationRequest> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder()
-                                                                            .requestUri("/2016-03-11/streamingOutputOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false)
-                                                                            .hasPayloadMembers(false).build();
+            .requestUri("/2016-03-11/streamingOutputOperation").httpMethod(SdkHttpMethod.POST).hasExplicitPayloadMember(false)
+            .hasImplicitPayloadMembers(false).hasPayloadMembers(false).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -33,11 +33,10 @@ public class StreamingOutputOperationRequestMarshaller implements Marshaller<Str
         Validate.paramNotNull(streamingOutputOperationRequest, "streamingOutputOperationRequest");
         try {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
-                .createProtocolMarshaller(SDK_OPERATION_BINDING);
+                    .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(streamingOutputOperationRequest);
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationInfo.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/OperationInfo.java
@@ -31,6 +31,7 @@ public final class OperationInfo {
     private final String apiVersion;
     private final boolean hasExplicitPayloadMember;
     private final boolean hasPayloadMembers;
+    private final boolean hasImplicitPayloadMembers;
     private final boolean hasStreamingInput;
     private final boolean hasEventStreamingInput;
     private final boolean hasEvent;
@@ -42,6 +43,7 @@ public final class OperationInfo {
         this.operationIdentifier = builder.operationIdentifier;
         this.apiVersion = builder.apiVersion;
         this.hasExplicitPayloadMember = builder.hasExplicitPayloadMember;
+        this.hasImplicitPayloadMembers = builder.hasImplicitPayloadMembers;
         this.hasPayloadMembers = builder.hasPayloadMembers;
         this.hasStreamingInput = builder.hasStreamingInput;
         this.additionalMetadata = builder.additionalMetadata.build();
@@ -96,6 +98,14 @@ public final class OperationInfo {
     }
 
     /**
+     * @return True if the operation has members that are not explicitly bound to a marshalling location, and thus are
+     * implicitly bound to the body.
+     */
+    public boolean hasImplicitPayloadMembers() {
+        return hasImplicitPayloadMembers;
+    }
+
+    /**
      * @return True if the operation has streaming input.
      */
     public boolean hasStreamingInput() {
@@ -144,6 +154,7 @@ public final class OperationInfo {
         private String operationIdentifier;
         private String apiVersion;
         private boolean hasExplicitPayloadMember;
+        private boolean hasImplicitPayloadMembers;
         private boolean hasPayloadMembers;
         private boolean hasStreamingInput;
         private boolean hasEventStreamingInput;
@@ -180,6 +191,11 @@ public final class OperationInfo {
 
         public Builder hasPayloadMembers(boolean hasPayloadMembers) {
             this.hasPayloadMembers = hasPayloadMembers;
+            return this;
+        }
+
+        public Builder hasImplicitPayloadMembers(boolean hasImplicitPayloadMembers) {
+            this.hasImplicitPayloadMembers = hasImplicitPayloadMembers;
             return this;
         }
 

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-contenttype.json
@@ -220,6 +220,60 @@
   }
 },
 {
+  "description": "NoPayloadGet",
+  "given": {
+    "input": {
+    }
+  },
+  "when": {
+    "action": "marshall",
+    "operation": "NoPayloadPost"
+  },
+  "then": {
+    "serializedAs": {
+      "uri": "/no-payload",
+      "method": "POST",
+      "headers": {
+        "doesNotContain": [
+          "Content-Type"
+        ]
+      },
+      "body": {
+        "equals": ""
+      }
+    }
+  }
+},
+{
+  "description": "NoPayloadGetWithHeader",
+  "given": {
+    "input": {
+      "testId": "t-12345"
+    }
+  },
+  "when": {
+    "action": "marshall",
+    "operation": "NoPayloadPost"
+  },
+  "then": {
+    "serializedAs": {
+      "uri": "/no-payload",
+      "method": "POST",
+      "headers": {
+        "contains": {
+          "x-amz-test-id": "t-12345"
+        },
+        "doesNotContain": [
+          "Content-Type"
+        ]
+      },
+      "body": {
+        "equals": ""
+      }
+    }
+  }
+},
+{
   "description": "TestBodyNoParams",
   "given": {
     "input": {

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/contenttype/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/contenttype/service-2.json
@@ -43,6 +43,14 @@
         "requestUri": "no-payload"
       },
       "input": {"shape": "NoPayloadRequest"}
+    },
+    "NoPayloadPost": {
+      "name": "NoPayloadPost",
+      "http": {
+        "method": "POST",
+        "requestUri": "no-payload"
+      },
+      "input": {"shape": "NoPayloadPostRequest"}
     }
   },
   "shapes":{
@@ -52,6 +60,19 @@
     "String":{"type":"string"},
     "Blob":{"type":"blob"},
     "NoPayloadRequest":{
+      "type":"structure",
+      "required":[],
+      "members":{
+        "testId":{
+          "shape":"TestId",
+          "documentation":"<p> The unique ID for a test. </p>",
+          "location":"header",
+          "locationName":"x-amz-test-id"
+        }
+      },
+      "documentation":"<p> The request structure for a no payload request. </p>"
+    },
+    "NoPayloadPostRequest":{
       "type":"structure",
       "required":[],
       "members":{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Bug fix.

## Description
This fixes an edge case in the REST-JSON marshaller: if the request has neither
an explicit payload nor implicit payload members (i.e. members not explicitly
bound to an location), then the marshaller should not create an create an
object. i.e. the request body should be "", and not "{}".

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
