### PR TITLE
[Default Configuration Part 3]: add defaults from defaults mode to the configuration resolution chain

### DIFF
--- a/codegen-lite-maven-plugin/src/main/java/software/amazon/awssdk/codegen/lite/maven/plugin/DefaultsModeGenerationMojo.java
+++ b/codegen-lite-maven-plugin/src/main/java/software/amazon/awssdk/codegen/lite/maven/plugin/DefaultsModeGenerationMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.project.MavenProject;
 import software.amazon.awssdk.codegen.lite.CodeGenerator;
 import software.amazon.awssdk.codegen.lite.defaultsmode.DefaultConfiguration;
 import software.amazon.awssdk.codegen.lite.defaultsmode.DefaultsLoader;
+import software.amazon.awssdk.codegen.lite.defaultsmode.DefaultsModeConfigurationGenerator;
 import software.amazon.awssdk.codegen.lite.defaultsmode.DefaultsModeGenerator;
 
 /**
@@ -34,6 +35,7 @@ import software.amazon.awssdk.codegen.lite.defaultsmode.DefaultsModeGenerator;
 public class DefaultsModeGenerationMojo extends AbstractMojo {
 
     private static final String DEFAULTS_MODE_BASE = "software.amazon.awssdk.defaultsmode";
+    private static final String DEFAULTS_MODE_CONFIGURATION_BASE = "software.amazon.awssdk.internal.defaultsmode";
 
     @Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}")
     private String outputDirectory;
@@ -52,6 +54,7 @@ public class DefaultsModeGenerationMojo extends AbstractMojo {
         DefaultConfiguration configuration = DefaultsLoader.load(defaultConfigurationFile);
 
         generateDefaultsModeClass(baseSourcesDirectory, configuration);
+        generateDefaultsModeConfiguartionClass(baseSourcesDirectory, configuration);
 
         project.addCompileSourceRoot(baseSourcesDirectory.toFile().getAbsolutePath());
         project.addTestCompileSourceRoot(testsDirectory.toFile().getAbsolutePath());
@@ -62,4 +65,10 @@ public class DefaultsModeGenerationMojo extends AbstractMojo {
         new CodeGenerator(sourcesDirectory.toString(), new DefaultsModeGenerator(DEFAULTS_MODE_BASE, configuration)).generate();
     }
 
+    public void generateDefaultsModeConfiguartionClass(Path baseSourcesDirectory, DefaultConfiguration configuration) {
+        Path sourcesDirectory = baseSourcesDirectory.resolve(DEFAULTS_MODE_CONFIGURATION_BASE.replace(".", "/"));
+        new CodeGenerator(sourcesDirectory.toString(), new DefaultsModeConfigurationGenerator(DEFAULTS_MODE_CONFIGURATION_BASE,
+                                                                                              DEFAULTS_MODE_BASE,
+                                                                                              configuration)).generate();
+    }
 }

--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsModeConfigurationGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsModeConfigurationGenerator.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.lite.defaultsmode;
+
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.codegen.lite.PoetClass;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Generates DefaultsModeConfiguration class that contains default options for each mode
+ */
+public class DefaultsModeConfigurationGenerator implements PoetClass {
+
+    private final String basePackage;
+    private final String defaultsModeBase;
+    private final DefaultConfiguration configuration;
+
+    private static final Map<String, OptionMetadata> CONFIGURATION_MAPPING = new HashMap<>();
+
+    private static final Map<String, OptionMetadata> HTTP_CONFIGURATION_MAPPING = new HashMap<>();
+
+    static {
+        HTTP_CONFIGURATION_MAPPING.put("connectTimeoutInMillis",
+                                       new OptionMetadata(ClassName.get("java.time", "Duration"),
+                                                          ClassName.get("software.amazon.awssdk.http",
+                                                                        "SdkHttpConfigurationOption", "CONNECTION_TIMEOUT")));
+        CONFIGURATION_MAPPING.put("retryMode", new OptionMetadata(ClassName.get("software.amazon.awssdk.core.retry", "RetryMode"
+        ), ClassName.get("software.amazon.awssdk.core.client.config","SdkClientOption", "DEFAULT_RETRY_MODE")));
+    }
+
+    public DefaultsModeConfigurationGenerator(String basePackage, String defaultsModeBase, DefaultConfiguration configuration) {
+        this.basePackage = basePackage;
+        this.configuration = configuration;
+        this.defaultsModeBase = defaultsModeBase;
+    }
+
+    @Override
+    public TypeSpec poetClass() {
+        TypeSpec.Builder builder = TypeSpec.classBuilder(className())
+                                           .addModifiers(PUBLIC, FINAL)
+                                           .addJavadoc(documentation())
+                                           .addAnnotation(SdkInternalApi.class)
+                                           .addAnnotation(AnnotationSpec.builder(Generated.class)
+                                                                        .addMember("value",
+                                                                                   "$S",
+                                                                                   "software.amazon.awssdk:codegen")
+                                                                        .build())
+                                           .addMethod(defaultHttpConfigMethod(configuration.modeDefaults().keySet()))
+                                           .addMethod(defaultSdkConfigMethod(configuration.modeDefaults().keySet()))
+                                           .addMethod(createConstructor());
+
+
+        configuration.modeDefaults().entrySet().forEach(entry -> {
+            builder.addField(addDefaultsFieldForMode(entry));
+            builder.addField(addHttpDefaultsFieldForMode(entry));
+        });
+
+        addDefaultsFieldForLegacy(builder, "LEGACY_DEFAULTS");
+        addDefaultsFieldForLegacy(builder, "LEGACY_HTTP_DEFAULTS");
+        return builder.build();
+    }
+
+    @Override
+    public ClassName className() {
+        return ClassName.get(basePackage, "DefaultsModeConfiguration");
+    }
+
+    private FieldSpec addDefaultsFieldForMode(Map.Entry<String, Map<String, String>> modeEntry) {
+        String mode = modeEntry.getKey();
+        String fieldName = sanitizeMode(mode) + "_DEFAULTS";
+
+
+        CodeBlock.Builder attributeBuilder = CodeBlock.builder()
+                                                      .add("$T.builder()", AttributeMap.class);
+
+        modeEntry.getValue()
+                 .entrySet()
+                 .stream()
+                 .filter(e -> CONFIGURATION_MAPPING.containsKey(e.getKey()))
+                 .forEach(e -> attributeMapBuilder(e.getKey(), e.getValue(), attributeBuilder));
+
+
+        FieldSpec.Builder fieldSpec = FieldSpec.builder(AttributeMap.class, fieldName, PRIVATE, STATIC, FINAL)
+                                               .initializer(attributeBuilder
+                                                                .add(".build()")
+                                                                .build());
+
+
+        return fieldSpec.build();
+    }
+
+    private void addDefaultsFieldForLegacy(TypeSpec.Builder builder, String name) {
+        FieldSpec field = FieldSpec.builder(AttributeMap.class, name, PRIVATE, STATIC, FINAL)
+                                   .initializer("$T.empty()", AttributeMap.class).build();
+        builder.addField(field);
+    }
+
+    private void attributeMapBuilder(String option, String value, CodeBlock.Builder attributeBuilder) {
+        OptionMetadata optionMetadata = CONFIGURATION_MAPPING.get(option);
+        switch (option) {
+            case "retryMode":
+                attributeBuilder.add(".put($T, $T.$N)", optionMetadata.attribute, optionMetadata.type, value.toUpperCase(Locale.US));
+                break;
+            default:
+                throw new IllegalStateException("Unsupported option " + option);
+        }
+    }
+
+    private void httpAttributeMapBuilder(String option, String value, CodeBlock.Builder attributeBuilder) {
+        OptionMetadata optionMetadata = HTTP_CONFIGURATION_MAPPING.get(option);
+        switch (option) {
+            case "connectTimeoutInMillis":
+                attributeBuilder.add(".put($T, $T.ofMillis($N))", optionMetadata.attribute, optionMetadata.type, value);
+                break;
+            default:
+                throw new IllegalStateException("Unsupported option " + option);
+        }
+    }
+
+    private FieldSpec addHttpDefaultsFieldForMode(Map.Entry<String, Map<String, String>> modeEntry) {
+        String mode = modeEntry.getKey();
+        String fieldName = sanitizeMode(mode) + "_HTTP_DEFAULTS";
+
+        CodeBlock.Builder attributeBuilder = CodeBlock.builder()
+                                                      .add("$T.builder()", AttributeMap.class);
+
+        modeEntry.getValue()
+                 .entrySet()
+                 .stream()
+                 .filter(e -> HTTP_CONFIGURATION_MAPPING.containsKey(e.getKey()))
+                 .forEach(e -> httpAttributeMapBuilder(e.getKey(), e.getValue(), attributeBuilder));
+
+        FieldSpec.Builder fieldSpec = FieldSpec.builder(AttributeMap.class, fieldName, PRIVATE, STATIC, FINAL)
+                                               .initializer(attributeBuilder
+                                                                .add(".build()")
+                                                                .build());
+
+        return fieldSpec.build();
+    }
+
+    private String sanitizeMode(String str) {
+        return str.replace('-', '_').toUpperCase(Locale.US);
+    }
+
+    private CodeBlock documentation() {
+        CodeBlock.Builder builder = CodeBlock.builder()
+                                             .add("Contains a collection of default configuration options for each "
+                                                  + "DefaultsMode");
+
+        return builder.build();
+    }
+
+
+    private MethodSpec defaultHttpConfigMethod(Set<String> modes) {
+        String nameSuffix = "_HTTP_DEFAULTS";
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("defaultHttpConfig")
+                                                     .returns(AttributeMap.class)
+                                                     .addModifiers(PUBLIC, STATIC)
+                                                     .addJavadoc("Return the default HTTP config options for a given defaults "
+                                                                 + "mode")
+                                                     .addParameter(defaultsModeClassName(), "mode")
+                                                     .beginControlFlow("switch (mode)");
+
+
+        addSwitchCaseForEachMode(modes, nameSuffix, methodBuilder);
+
+        addLegacyCase(methodBuilder, "LEGACY" + nameSuffix);
+
+        return methodBuilder
+            .addStatement("default: throw new IllegalArgumentException($S + $N)", "Unsupported mode: ", "mode")
+            .endControlFlow()
+            .build();
+    }
+
+    private void addSwitchCaseForEachMode(Set<String> modes, String nameSuffix, MethodSpec.Builder methodBuilder) {
+        modes.forEach(m -> {
+            String mode = sanitizeMode(m);
+            methodBuilder.addCode("case $N:", mode);
+            methodBuilder.addStatement("return $N", mode + nameSuffix);
+        });
+    }
+
+    private MethodSpec defaultSdkConfigMethod(Set<String> modes) {
+        String nameSuffix = "_DEFAULTS";
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("defaultConfig")
+                                                     .returns(AttributeMap.class)
+                                                     .addModifiers(PUBLIC, STATIC)
+                                                     .addJavadoc("Return the default SDK config options for a given defaults "
+                                                                 + "mode")
+                                                     .addParameter(defaultsModeClassName(), "mode")
+                                                     .beginControlFlow("switch (mode)");
+
+
+        addSwitchCaseForEachMode(modes, nameSuffix, methodBuilder);
+        addLegacyCase(methodBuilder, "LEGACY" + nameSuffix);
+
+        return methodBuilder
+            .addStatement("default: throw new IllegalArgumentException($S + $N)", "Unsupported mode: ", "mode")
+            .endControlFlow()
+            .build();
+    }
+
+    private void addLegacyCase(MethodSpec.Builder methodBuilder, String name) {
+        methodBuilder.addCode("case LEGACY:");
+        methodBuilder.addStatement("return $N", name);
+    }
+
+    private ClassName defaultsModeClassName() {
+        return ClassName.get(defaultsModeBase, "DefaultsMode");
+    }
+
+    private MethodSpec createConstructor() {
+        return MethodSpec.constructorBuilder()
+                         .addModifiers(Modifier.PRIVATE)
+                         .build();
+    }
+
+    private static final class OptionMetadata {
+        private final ClassName type;
+        private final ClassName attribute;
+
+        public OptionMetadata(ClassName type, ClassName attribute) {
+            this.type = type;
+            this.attribute = attribute;
+        }
+    }
+}

--- a/codegen-lite/src/test/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsModeGenerationTest.java
+++ b/codegen-lite/src/test/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsModeGenerationTest.java
@@ -42,4 +42,10 @@ public class DefaultsModeGenerationTest {
         assertThat(generator, generatesTo("defaults-mode.java"));
     }
 
+    @Test
+    public void defaultsModeConfigurationClass() {
+        DefaultsModeConfigurationGenerator generator = new DefaultsModeConfigurationGenerator(DEFAULTS_MODE_BASE, DEFAULTS_MODE_BASE, defaultConfiguration);
+        assertThat(generator, generatesTo("defaults-mode-configuration.java"));
+    }
+
 }

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode-configuration.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode-configuration.java
@@ -1,0 +1,87 @@
+package software.amazon.awssdk.defaultsmode;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Contains a collection of default configuration options for each DefaultsMode
+ */
+@SdkInternalApi
+@Generated("software.amazon.awssdk:codegen")
+public final class DefaultsModeConfiguration {
+    private static final AttributeMap STANDARD_DEFAULTS = AttributeMap.builder()
+                                                                      .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD).build();
+
+    private static final AttributeMap STANDARD_HTTP_DEFAULTS = AttributeMap.builder()
+                                                                           .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(2000)).build();
+
+    private static final AttributeMap MOBILE_DEFAULTS = AttributeMap.builder()
+                                                                    .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.ADAPTIVE).build();
+
+    private static final AttributeMap MOBILE_HTTP_DEFAULTS = AttributeMap.builder()
+                                                                         .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(10000)).build();
+
+    private static final AttributeMap CROSS_REGION_DEFAULTS = AttributeMap.builder()
+                                                                          .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD).build();
+
+    private static final AttributeMap CROSS_REGION_HTTP_DEFAULTS = AttributeMap.builder()
+                                                                               .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(2800)).build();
+
+    private static final AttributeMap IN_REGION_DEFAULTS = AttributeMap.builder()
+                                                                       .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD).build();
+
+    private static final AttributeMap IN_REGION_HTTP_DEFAULTS = AttributeMap.builder()
+                                                                            .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(1000)).build();
+
+    private static final AttributeMap LEGACY_DEFAULTS = AttributeMap.empty();
+
+    private static final AttributeMap LEGACY_HTTP_DEFAULTS = AttributeMap.empty();
+
+    private DefaultsModeConfiguration() {
+    }
+
+    /**
+     * Return the default HTTP config options for a given defaults mode
+     */
+    public static AttributeMap defaultHttpConfig(DefaultsMode mode) {
+        switch (mode) {
+            case STANDARD:
+                return STANDARD_HTTP_DEFAULTS;
+            case MOBILE:
+                return MOBILE_HTTP_DEFAULTS;
+            case CROSS_REGION:
+                return CROSS_REGION_HTTP_DEFAULTS;
+            case IN_REGION:
+                return IN_REGION_HTTP_DEFAULTS;
+            case LEGACY:
+                return LEGACY_HTTP_DEFAULTS;
+            default:
+                throw new IllegalArgumentException("Unsupported mode: " + mode);
+        }
+    }
+
+    /**
+     * Return the default SDK config options for a given defaults mode
+     */
+    public static AttributeMap defaultConfig(DefaultsMode mode) {
+        switch (mode) {
+            case STANDARD:
+                return STANDARD_DEFAULTS;
+            case MOBILE:
+                return MOBILE_DEFAULTS;
+            case CROSS_REGION:
+                return CROSS_REGION_DEFAULTS;
+            case IN_REGION:
+                return IN_REGION_DEFAULTS;
+            case LEGACY:
+                return LEGACY_DEFAULTS;
+            default:
+                throw new IllegalArgumentException("Unsupported mode: " + mode);
+        }
+    }
+}

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode-configuration.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode-configuration.java
@@ -1,6 +1,8 @@
 package software.amazon.awssdk.defaultsmode;
 
 import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
@@ -42,46 +44,37 @@ public final class DefaultsModeConfiguration {
 
     private static final AttributeMap LEGACY_HTTP_DEFAULTS = AttributeMap.empty();
 
+    private static final Map<DefaultsMode, AttributeMap> DEFAULT_CONFIG_BY_MODE = new EnumMap<>(DefaultsMode.class);
+
+    private static final Map<DefaultsMode, AttributeMap> DEFAULT_HTTP_CONFIG_BY_MODE = new EnumMap<>(DefaultsMode.class);
+
+    static {
+        DEFAULT_CONFIG_BY_MODE.put(DefaultsMode.STANDARD, STANDARD_DEFAULTS);
+        DEFAULT_CONFIG_BY_MODE.put(DefaultsMode.MOBILE, MOBILE_DEFAULTS);
+        DEFAULT_CONFIG_BY_MODE.put(DefaultsMode.CROSS_REGION, CROSS_REGION_DEFAULTS);
+        DEFAULT_CONFIG_BY_MODE.put(DefaultsMode.IN_REGION, IN_REGION_DEFAULTS);
+        DEFAULT_CONFIG_BY_MODE.put(DefaultsMode.LEGACY, LEGACY_DEFAULTS);
+        DEFAULT_HTTP_CONFIG_BY_MODE.put(DefaultsMode.STANDARD, STANDARD_HTTP_DEFAULTS);
+        DEFAULT_HTTP_CONFIG_BY_MODE.put(DefaultsMode.MOBILE, MOBILE_HTTP_DEFAULTS);
+        DEFAULT_HTTP_CONFIG_BY_MODE.put(DefaultsMode.CROSS_REGION, CROSS_REGION_HTTP_DEFAULTS);
+        DEFAULT_HTTP_CONFIG_BY_MODE.put(DefaultsMode.IN_REGION, IN_REGION_HTTP_DEFAULTS);
+        DEFAULT_HTTP_CONFIG_BY_MODE.put(DefaultsMode.LEGACY, LEGACY_HTTP_DEFAULTS);
+    }
+
     private DefaultsModeConfiguration() {
     }
 
     /**
-     * Return the default HTTP config options for a given defaults mode
+     * Return the default config options for a given defaults mode
      */
-    public static AttributeMap defaultHttpConfig(DefaultsMode mode) {
-        switch (mode) {
-            case STANDARD:
-                return STANDARD_HTTP_DEFAULTS;
-            case MOBILE:
-                return MOBILE_HTTP_DEFAULTS;
-            case CROSS_REGION:
-                return CROSS_REGION_HTTP_DEFAULTS;
-            case IN_REGION:
-                return IN_REGION_HTTP_DEFAULTS;
-            case LEGACY:
-                return LEGACY_HTTP_DEFAULTS;
-            default:
-                throw new IllegalArgumentException("Unsupported mode: " + mode);
-        }
+    public static AttributeMap defaultConfig(DefaultsMode mode) {
+        return DEFAULT_CONFIG_BY_MODE.getOrDefault(mode, AttributeMap.empty());
     }
 
     /**
-     * Return the default SDK config options for a given defaults mode
+     * Return the default config options for a given defaults mode
      */
-    public static AttributeMap defaultConfig(DefaultsMode mode) {
-        switch (mode) {
-            case STANDARD:
-                return STANDARD_DEFAULTS;
-            case MOBILE:
-                return MOBILE_DEFAULTS;
-            case CROSS_REGION:
-                return CROSS_REGION_DEFAULTS;
-            case IN_REGION:
-                return IN_REGION_DEFAULTS;
-            case LEGACY:
-                return LEGACY_DEFAULTS;
-            default:
-                throw new IllegalArgumentException("Unsupported mode: " + mode);
-        }
+    public static AttributeMap defaultHttpConfig(DefaultsMode mode) {
+        return DEFAULT_HTTP_CONFIG_BY_MODE.getOrDefault(mode, AttributeMap.empty());
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -50,6 +50,7 @@ import software.amazon.awssdk.regions.ServiceMetadata;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.Logger;
 
 /**
  * An SDK-internal implementation of the methods in {@link AwsClientBuilder}, {@link AwsAsyncClientBuilder} and
@@ -73,6 +74,7 @@ import software.amazon.awssdk.utils.CollectionUtils;
 public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<BuilderT, ClientT>, ClientT>
     extends SdkDefaultClientBuilder<BuilderT, ClientT>
     implements AwsClientBuilder<BuilderT, ClientT> {
+    private static final Logger log = Logger.loggerFor(AwsClientBuilder.class);
     private static final String DEFAULT_ENDPOINT_PROTOCOL = "https";
     private final AutoDefaultsModeDiscovery autoDefaultsModeDiscovery;
 
@@ -253,8 +255,10 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                                                         .profileName(config.option(SdkClientOption.PROFILE_NAME))
                                                         .resolve();
 
-        if (defaultsMode.equals(DefaultsMode.AUTO)) {
+        if (defaultsMode == DefaultsMode.AUTO) {
             defaultsMode = autoDefaultsModeDiscovery.discover(config.option(AwsClientOption.AWS_REGION));
+            DefaultsMode finalDefaultsMode = defaultsMode;
+            log.debug(() -> "The resolved defaults mode is: " + finalDefaultsMode);
         }
 
         return defaultsMode;

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -258,7 +258,8 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
         if (defaultsMode == DefaultsMode.AUTO) {
             defaultsMode = autoDefaultsModeDiscovery.discover(config.option(AwsClientOption.AWS_REGION));
             DefaultsMode finalDefaultsMode = defaultsMode;
-            log.debug(() -> "The resolved defaults mode is: " + finalDefaultsMode);
+            log.debug(() -> String.format("Resolved %s client's AUTO configuration mode to %s", serviceName(),
+                      finalDefaultsMode));
         }
 
         return defaultsMode;

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscovery.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/defaultsmode/AutoDefaultsModeDiscovery.java
@@ -31,7 +31,7 @@ import software.amazon.awssdk.utils.internal.SystemSettingUtils;
  * back to the {@link DefaultsMode#STANDARD} mode if the target mode cannot be determined.
  */
 @SdkInternalApi
-public final class AutoDefaultsModeDiscovery {
+public class AutoDefaultsModeDiscovery {
     private static final String EC2_METADATA_REGION_PATH = "/latest/meta-data/placement/region";
     private static final DefaultsMode FALLBACK_DEFAULTS_MODE = DefaultsMode.STANDARD;
     private static final String ANDROID_JAVA_VENDOR = "The Android Project";

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
@@ -42,11 +42,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
-import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.awscore.internal.defaultsmode.AutoDefaultsModeDiscovery;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.defaultsmode.DefaultsMode;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -76,10 +77,14 @@ public class DefaultAwsClientBuilderTest {
     @Mock
     private SdkAsyncHttpClient.Builder defaultAsyncHttpClientFactory;
 
+    @Mock
+    private AutoDefaultsModeDiscovery autoModeDiscovery;
+
     @Before
     public void setup() {
         when(defaultHttpClientBuilder.buildWithDefaults(any())).thenReturn(mock(SdkHttpClient.class));
         when(defaultAsyncHttpClientFactory.buildWithDefaults(any())).thenReturn(mock(SdkAsyncHttpClient.class));
+        when(autoModeDiscovery.discover(any())).thenReturn(DefaultsMode.IN_REGION);
     }
 
     @Test
@@ -232,7 +237,7 @@ public class DefaultAwsClientBuilderTest {
         implements AwsClientBuilder<TestClientBuilder, TestClient> {
 
         public TestClientBuilder() {
-            super(defaultHttpClientBuilder, null);
+            super(defaultHttpClientBuilder, null, autoModeDiscovery);
         }
 
         @Override
@@ -273,7 +278,7 @@ public class DefaultAwsClientBuilderTest {
         implements AwsClientBuilder<TestAsyncClientBuilder, TestAsyncClient> {
 
         public TestAsyncClientBuilder() {
-            super(defaultHttpClientBuilder, defaultAsyncHttpClientFactory);
+            super(defaultHttpClientBuilder, defaultAsyncHttpClientFactory, autoModeDiscovery);
         }
 
         @Override

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultsModeTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultsModeTest.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.awscore.internal.defaultsmode.AutoDefaultsModeDiscovery;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
-import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.defaultsmode.DefaultsMode;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -75,7 +74,7 @@ public class DefaultsModeTest {
             .build();
 
         assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(DefaultsMode.LEGACY);
-        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(client.clientConfiguration.option(DEFAULT_RETRY_MODE));
+        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(RetryMode.defaultRetryMode());
     }
 
     @Test
@@ -199,13 +198,6 @@ public class DefaultsModeTest {
         }
 
         @Override
-        protected final SdkClientConfiguration mergeInternalDefaults(SdkClientConfiguration config) {
-            return config.merge(c -> {
-                c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.ADAPTIVE);
-            });
-        }
-
-        @Override
         protected AttributeMap serviceHttpConfig() {
             return SERVICE_DEFAULTS;
         }
@@ -236,13 +228,6 @@ public class DefaultsModeTest {
         @Override
         protected String serviceName() {
             return SERVICE_NAME;
-        }
-
-        @Override
-        protected final SdkClientConfiguration mergeInternalDefaults(SdkClientConfiguration config) {
-            return config.merge(c -> {
-                c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.ADAPTIVE);
-            });
         }
 
         @Override

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultsModeTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultsModeTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.client.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.awscore.client.config.AwsAdvancedClientOption.ENABLE_DEFAULT_REGION_DETECTION;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.DEFAULTS_MODE;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.DEFAULT_RETRY_MODE;
+import static software.amazon.awssdk.core.client.config.SdkClientOption.RETRY_POLICY;
+
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.awscore.internal.defaultsmode.AutoDefaultsModeDiscovery;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.internal.defaultsmode.DefaultsModeConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.AttributeMap;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultsModeTest {
+
+    private static final AttributeMap SERVICE_DEFAULTS = AttributeMap
+        .builder()
+        .put(SdkHttpConfigurationOption.READ_TIMEOUT, Duration.ofSeconds(10))
+        .build();
+
+    private static final String ENDPOINT_PREFIX = "test";
+    private static final String SIGNING_NAME = "test";
+    private static final String SERVICE_NAME = "test";
+
+    @Mock
+    private SdkHttpClient.Builder defaultHttpClientBuilder;
+
+    @Mock
+    private SdkAsyncHttpClient.Builder defaultAsyncHttpClientBuilder;
+
+    @Mock
+    private AutoDefaultsModeDiscovery autoModeDiscovery;
+
+    @Test
+    public void defaultClient_shouldUseLegacyModeWithExistingDefaults() {
+        TestClient client = testClientBuilder()
+            .region(Region.US_WEST_2)
+            .httpClientBuilder((SdkHttpClient.Builder) serviceDefaults -> {
+                assertThat(serviceDefaults).isEqualTo(SERVICE_DEFAULTS);
+                return mock(SdkHttpClient.class);
+            })
+            .build();
+
+        assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(DefaultsMode.LEGACY);
+        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(client.clientConfiguration.option(DEFAULT_RETRY_MODE));
+    }
+
+    @Test
+    public void nonLegacyDefaultsMode_shouldApplySdkDefaultsAndHttpDefaults() {
+        DefaultsMode targetMode = DefaultsMode.IN_REGION;
+
+        TestClient client =
+            testClientBuilder().region(Region.US_WEST_1)
+                               .overrideConfiguration(o -> o.defaultsMode(targetMode))
+                               .httpClientBuilder((SdkHttpClient.Builder) serviceDefaults -> {
+                                   AttributeMap defaultHttpConfig = DefaultsModeConfiguration.defaultHttpConfig(targetMode);
+                                   AttributeMap mergedDefaults = SERVICE_DEFAULTS.merge(defaultHttpConfig);
+                                   assertThat(serviceDefaults).isEqualTo(mergedDefaults);
+                                   return mock(SdkHttpClient.class);
+                               }).build();
+
+        assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(targetMode);
+
+        AttributeMap attributes = DefaultsModeConfiguration.defaultConfig(targetMode);
+
+        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(attributes.get(DEFAULT_RETRY_MODE));
+    }
+
+    @Test
+    public void nonLegacyDefaultsModeAsyncClient_shouldApplySdkDefaultsAndHttpDefaults() {
+        DefaultsMode targetMode = DefaultsMode.IN_REGION;
+
+        TestAsyncClient client =
+            testAsyncClientBuilder().region(Region.US_WEST_1)
+                                    .overrideConfiguration(o -> o.defaultsMode(targetMode))
+                                    .httpClientBuilder((SdkHttpClient.Builder) serviceDefaults -> {
+                                        AttributeMap defaultHttpConfig = DefaultsModeConfiguration.defaultHttpConfig(targetMode);
+                                        AttributeMap mergedDefaults = SERVICE_DEFAULTS.merge(defaultHttpConfig);
+                                        assertThat(serviceDefaults).isEqualTo(mergedDefaults);
+                                        return mock(SdkHttpClient.class);
+                                    }).build();
+
+        assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(targetMode);
+
+        AttributeMap attributes = DefaultsModeConfiguration.defaultConfig(targetMode);
+
+        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(attributes.get(DEFAULT_RETRY_MODE));
+    }
+
+    @Test
+    public void clientOverrideRetryMode_shouldTakePrecedence() {
+        TestClient client =
+            testClientBuilder().region(Region.US_WEST_1)
+                               .overrideConfiguration(o -> o.defaultsMode(DefaultsMode.IN_REGION)
+                                                            .retryPolicy(RetryMode.LEGACY))
+                               .build();
+        assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(DefaultsMode.IN_REGION);
+        assertThat(client.clientConfiguration.option(RETRY_POLICY).retryMode()).isEqualTo(RetryMode.LEGACY);
+    }
+
+    @Test
+    public void autoMode_shouldResolveDefaultsMode() {
+        DefaultsMode expectedMode = DefaultsMode.IN_REGION;
+        when(autoModeDiscovery.discover(any(Region.class))).thenReturn(expectedMode);
+        TestClient client =
+            testClientBuilder().region(Region.US_WEST_1)
+                               .overrideConfiguration(o -> o.defaultsMode(DefaultsMode.AUTO))
+                               .build();
+
+        assertThat(client.clientConfiguration.option(DEFAULTS_MODE)).isEqualTo(expectedMode);
+    }
+
+    private static class TestClient {
+        private final SdkClientConfiguration clientConfiguration;
+
+        public TestClient(SdkClientConfiguration clientConfiguration) {
+            this.clientConfiguration = clientConfiguration;
+        }
+    }
+
+    private AwsClientBuilder<TestClientBuilder, TestClient> testClientBuilder() {
+        ClientOverrideConfiguration overrideConfig =
+            ClientOverrideConfiguration.builder()
+                                       .putAdvancedOption(ENABLE_DEFAULT_REGION_DETECTION, false)
+                                       .build();
+
+        return new TestClientBuilder().credentialsProvider(AnonymousCredentialsProvider.create())
+                                      .overrideConfiguration(overrideConfig);
+    }
+
+    private AwsClientBuilder<TestAsyncClientBuilder, TestAsyncClient> testAsyncClientBuilder() {
+        ClientOverrideConfiguration overrideConfig =
+            ClientOverrideConfiguration.builder()
+                                       .putAdvancedOption(ENABLE_DEFAULT_REGION_DETECTION, false)
+                                       .build();
+
+        return new TestAsyncClientBuilder().credentialsProvider(AnonymousCredentialsProvider.create())
+                                      .overrideConfiguration(overrideConfig);
+    }
+
+    private class TestClientBuilder extends AwsDefaultClientBuilder<TestClientBuilder, TestClient>
+        implements AwsClientBuilder<TestClientBuilder, TestClient> {
+
+        public TestClientBuilder() {
+            super(defaultHttpClientBuilder, defaultAsyncHttpClientBuilder, autoModeDiscovery);
+        }
+
+        @Override
+        protected TestClient buildClient() {
+            return new TestClient(super.syncClientConfiguration());
+        }
+
+        @Override
+        protected String serviceEndpointPrefix() {
+            return ENDPOINT_PREFIX;
+        }
+
+        @Override
+        protected String signingName() {
+            return SIGNING_NAME;
+        }
+
+        @Override
+        protected String serviceName() {
+            return SERVICE_NAME;
+        }
+
+        @Override
+        protected final SdkClientConfiguration mergeInternalDefaults(SdkClientConfiguration config) {
+            return config.merge(c -> {
+                c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.ADAPTIVE);
+            });
+        }
+
+        @Override
+        protected AttributeMap serviceHttpConfig() {
+            return SERVICE_DEFAULTS;
+        }
+    }
+
+    private class TestAsyncClientBuilder extends AwsDefaultClientBuilder<TestAsyncClientBuilder, TestAsyncClient>
+        implements AwsClientBuilder<TestAsyncClientBuilder, TestAsyncClient> {
+
+        public TestAsyncClientBuilder() {
+            super(defaultHttpClientBuilder, defaultAsyncHttpClientBuilder, autoModeDiscovery);
+        }
+
+        @Override
+        protected TestAsyncClient buildClient() {
+            return new TestAsyncClient(super.asyncClientConfiguration());
+        }
+
+        @Override
+        protected String serviceEndpointPrefix() {
+            return ENDPOINT_PREFIX;
+        }
+
+        @Override
+        protected String signingName() {
+            return SIGNING_NAME;
+        }
+
+        @Override
+        protected String serviceName() {
+            return SERVICE_NAME;
+        }
+
+        @Override
+        protected final SdkClientConfiguration mergeInternalDefaults(SdkClientConfiguration config) {
+            return config.merge(c -> {
+                c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.ADAPTIVE);
+            });
+        }
+
+        @Override
+        protected AttributeMap serviceHttpConfig() {
+            return SERVICE_DEFAULTS;
+        }
+    }
+
+    private static class TestAsyncClient {
+        private final SdkClientConfiguration clientConfiguration;
+
+        private TestAsyncClient(SdkClientConfiguration clientConfiguration) {
+            this.clientConfiguration = clientConfiguration;
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.java
@@ -210,7 +210,7 @@ public final class ClientOverrideConfiguration
      * @see Builder#defaultsMode(DefaultsMode)
      */
     public Optional<DefaultsMode> defaultsMode() {
-        return Optional.of(defaultsMode);
+        return Optional.ofNullable(defaultsMode);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientConfiguration.java
@@ -79,6 +79,25 @@ public final class SdkClientConfiguration
         attributes.close();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SdkClientConfiguration that = (SdkClientConfiguration) o;
+
+        return attributes.equals(that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return attributes.hashCode();
+    }
+
     public static final class Builder implements CopyableBuilder<Builder, SdkClientConfiguration> {
         private final AttributeMap.Builder attributes;
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.defaultsmode.DefaultsMode;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.metrics.MetricPublisher;
@@ -156,6 +157,11 @@ public final class SdkClientOption<T> extends ClientOption<T> {
      * @see RetryMode.Resolver#defaultRetryMode(RetryMode)
      */
     public static final SdkClientOption<RetryMode> DEFAULT_RETRY_MODE = new SdkClientOption<>(RetryMode.class);
+
+    /**
+     * Option to specify the {@link DefaultsMode}
+     */
+    public static final SdkClientOption<DefaultsMode> DEFAULTS_MODE = new SdkClientOption<>(DefaultsMode.class);
 
     private SdkClientOption(Class<T> valueClass) {
         super(valueClass);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/config/SdkClientConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/config/SdkClientConfigurationTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.client.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class SdkClientConfigurationTest {
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(SdkClientConfiguration.class)
+                      .withNonnullFields("attributes")
+                      .verify();
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/defaultsmode/DefaultsModeConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/defaultsmode/DefaultsModeConfigurationTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.core.internal.defaultsmode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import org.junit.Test;
 import software.amazon.awssdk.defaultsmode.DefaultsMode;
 import software.amazon.awssdk.internal.defaultsmode.DefaultsModeConfiguration;
@@ -25,8 +26,15 @@ import software.amazon.awssdk.utils.AttributeMap;
 public class DefaultsModeConfigurationTest {
 
     @Test
-    public void legacyMode_shouldReturnEmptyAttributeMap() {
-        assertThat(DefaultsModeConfiguration.defaultHttpConfig(DefaultsMode.LEGACY)).isEqualTo(AttributeMap.empty());
-        assertThat(DefaultsModeConfiguration.defaultConfig(DefaultsMode.LEGACY)).isEqualTo(AttributeMap.empty());
+    public void defaultConfig_shouldPresentExceptLegacyAndAuto() {
+        Arrays.stream(DefaultsMode.values()).forEach(m -> {
+            if (m == DefaultsMode.LEGACY || m == DefaultsMode.AUTO) {
+                assertThat(DefaultsModeConfiguration.defaultConfig(m)).isEqualTo(AttributeMap.empty());
+                assertThat(DefaultsModeConfiguration.defaultHttpConfig(m)).isEqualTo(AttributeMap.empty());
+            } else {
+                assertThat(DefaultsModeConfiguration.defaultConfig(m)).isNotEqualTo(AttributeMap.empty());
+                assertThat(DefaultsModeConfiguration.defaultHttpConfig(m)).isNotEqualTo(AttributeMap.empty());
+            }
+        });
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/defaultsmode/DefaultsModeConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/defaultsmode/DefaultsModeConfigurationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.defaultsmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import software.amazon.awssdk.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.internal.defaultsmode.DefaultsModeConfiguration;
+import software.amazon.awssdk.utils.AttributeMap;
+
+public class DefaultsModeConfigurationTest {
+
+    @Test
+    public void legacyMode_shouldReturnEmptyAttributeMap() {
+        assertThat(DefaultsModeConfiguration.defaultHttpConfig(DefaultsMode.LEGACY)).isEqualTo(AttributeMap.empty());
+        assertThat(DefaultsModeConfiguration.defaultConfig(DefaultsMode.LEGACY)).isEqualTo(AttributeMap.empty());
+    }
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpClient.java
@@ -70,8 +70,8 @@ public interface SdkHttpClient extends SdkAutoCloseable {
         }
 
         /**
-         * Create an {@link SdkHttpClient} with service specific defaults applied. Applying service defaults is optional
-         * and some options may not be supported by a particular implementation.
+         * Create an {@link SdkHttpClient} with service specific defaults and defaults from {@code DefaultsMode} applied.
+         * Applying service defaults is optional and some options may not be supported by a particular implementation.
          *
          * @param serviceDefaults Service specific defaults. Keys will be one of the constants defined in
          *                        {@link SdkHttpConfigurationOption}.

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/async/SdkAsyncHttpClient.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.builder.SdkBuilder;

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/defaultsmode/AsyncClientDefaultsModeTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/defaultsmode/AsyncClientDefaultsModeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.defaultsmode;
+
+import java.util.concurrent.CompletionException;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+public class AsyncClientDefaultsModeTest
+    extends ClientDefaultsModeTestSuite<ProtocolRestJsonAsyncClient, ProtocolRestJsonAsyncClientBuilder> {
+    @Override
+    protected ProtocolRestJsonAsyncClientBuilder newClientBuilder() {
+        return ProtocolRestJsonAsyncClient.builder();
+    }
+
+    @Override
+    protected AllTypesResponse callAllTypes(ProtocolRestJsonAsyncClient client) {
+        try {
+            return client.allTypes().join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+
+            throw e;
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/defaultsmode/ClientDefaultsModeTestSuite.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/defaultsmode/ClientDefaultsModeTestSuite.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.defaultsmode;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+/**
+ * Tests suites to verify {@link DefaultsMode} behavior. We currently just test SDK default configuration such as
+ * {@link RetryMode}; there is no easy way to test HTTP timeout option.
+ *
+ */
+public abstract class ClientDefaultsModeTestSuite<ClientT, BuilderT extends AwsClientBuilder<BuilderT, ClientT>> {
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(0);
+
+    @Test
+    public void legacyDefaultsMode_shouldUseLegacySetting() {
+        stubResponse();
+        ClientT client = clientBuilder().overrideConfiguration(o -> o.retryPolicy(RetryMode.LEGACY)).build();
+        callAllTypes(client);
+
+        WireMock.verify(postRequestedFor(anyUrl()).withHeader("User-Agent", containing("cfg/retry-mode/legacy")));
+    }
+
+    @Test
+    public void standardDefaultsMode_shouldApplyStandardDefaults() {
+        stubResponse();
+        ClientT client = clientBuilder().overrideConfiguration(o -> o.defaultsMode(DefaultsMode.STANDARD)).build();
+        callAllTypes(client);
+
+        WireMock.verify(postRequestedFor(anyUrl()).withHeader("User-Agent", containing("cfg/retry-mode/standard")));
+    }
+
+    @Test
+    public void retryModeOverridden_shouldTakePrecedence() {
+        stubResponse();
+        ClientT client =
+            clientBuilder().overrideConfiguration(o -> o.defaultsMode(DefaultsMode.STANDARD).retryPolicy(RetryMode.LEGACY)).build();
+        callAllTypes(client);
+
+        WireMock.verify(postRequestedFor(anyUrl()).withHeader("User-Agent", containing("cfg/retry-mode/legacy")));
+    }
+
+    private BuilderT clientBuilder() {
+        return newClientBuilder().credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                                 .region(Region.US_EAST_1)
+                                 .endpointOverride(URI.create("http://localhost:" + wireMock.port()));
+    }
+
+    protected abstract BuilderT newClientBuilder();
+
+    protected abstract AllTypesResponse callAllTypes(ClientT client);
+
+    private void verifyRequestCount(int count) {
+        verify(count, anyRequestedFor(anyUrl()));
+    }
+
+    private void stubResponse() {
+        stubFor(post(anyUrl())
+                    .willReturn(aResponse()));
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/defaultsmode/SyncClientDefaultsModeTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/defaultsmode/SyncClientDefaultsModeTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.defaultsmode;
+
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
+
+public class SyncClientDefaultsModeTest extends ClientDefaultsModeTestSuite<ProtocolRestJsonClient, ProtocolRestJsonClientBuilder> {
+    @Override
+    protected ProtocolRestJsonClientBuilder newClientBuilder() {
+        return ProtocolRestJsonClient.builder();
+    }
+
+    @Override
+    protected AllTypesResponse callAllTypes(ProtocolRestJsonClient client) {
+        return client.allTypes();
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/AttributeMap.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/AttributeMap.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 @SdkProtectedApi
 @Immutable
 public final class AttributeMap implements ToCopyableBuilder<AttributeMap.Builder, AttributeMap>, SdkAutoCloseable {
+    private static final AttributeMap EMPTY = AttributeMap.builder().build();
     private final Map<Key<?>, Object> attributes;
 
     private AttributeMap(Map<? extends Key<?>, ?> attributes) {
@@ -74,7 +75,7 @@ public final class AttributeMap implements ToCopyableBuilder<AttributeMap.Builde
     }
 
     public static AttributeMap empty() {
-        return builder().build();
+        return EMPTY;
     }
 
     public AttributeMap copy() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
- adding codegen change for `DefaultConfigurationConfiguration` which contains the default settings for each mode
- adding defaults from defaults mode to the configuration resolution chain

## Testing
added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
