### PR TITLE
Fix rest-json marshalling for events

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ShapeModel.java
@@ -233,7 +233,11 @@ public class ShapeModel extends DocumentationModel implements HasDeprecation {
 
     public boolean hasImplicitPayloadMembers() {
         return !getUnboundMembers().isEmpty() ||
-               (isEvent() && !getUnboundEventMembers().isEmpty());
+               hasImplicitEventPayloadMembers();
+    }
+
+    public boolean hasImplicitEventPayloadMembers() {
+        return isEvent() && !getUnboundEventMembers().isEmpty();
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/transform/protocols/EventStreamJsonMarshallerSpec.java
@@ -65,6 +65,7 @@ public final class EventStreamJsonMarshallerSpec extends JsonMarshallerSpec {
                      .add(".hasExplicitPayloadMember($L)", shapeModel.isHasPayloadMember() ||
                                                            shapeModel.getExplicitEventPayloadMember() != null)
                      .add(".hasPayloadMembers($L)", shapeModel.hasPayloadMembers())
+                     .add(".hasImplicitPayloadMembers($L)", shapeModel.hasImplicitEventPayloadMembers())
                      // Adding httpMethod to avoid validation failure while creating the SdkHttpFullRequest
                      .add(".httpMethod($T.GET)", SdkHttpMethod.class)
                      .add(".hasEvent(true)")

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventonemarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventOneMarshaller implements Marshaller<EventOne> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).hasImplicitPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -34,11 +34,10 @@ public class EventOneMarshaller implements Marshaller<EventOne> {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventOne).toBuilder().putHeader(":message-type", "event")
-                    .putHeader(":event-type", eventOne.sdkEventType().toString()).putHeader(":content-type", protocolFactory.getContentType())
-                    .build();
+                    .putHeader(":event-type", eventOne.sdkEventType().toString())
+                    .putHeader(":content-type", protocolFactory.getContentType()).build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventthreemarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventThreeMarshaller implements Marshaller<EventThree> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).hasImplicitPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -41,4 +41,3 @@ public class EventThreeMarshaller implements Marshaller<EventThree> {
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/eventtwomarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class EventTwoMarshaller implements Marshaller<EventTwo> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).hasImplicitPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -34,11 +34,10 @@ public class EventTwoMarshaller implements Marshaller<EventTwo> {
             ProtocolMarshaller<SdkHttpFullRequest> protocolMarshaller = protocolFactory
                     .createProtocolMarshaller(SDK_OPERATION_BINDING);
             return protocolMarshaller.marshall(eventTwo).toBuilder().putHeader(":message-type", "event")
-                    .putHeader(":event-type", eventTwo.sdkEventType().toString()).putHeader(":content-type", protocolFactory.getContentType())
-                    .build();
+                    .putHeader(":event-type", eventTwo.sdkEventType().toString())
+                    .putHeader(":content-type", protocolFactory.getContentType()).build();
         } catch (Exception e) {
             throw SdkClientException.builder().message("Unable to marshall request to JSON: " + e.getMessage()).cause(e).build();
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventmarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventmarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class InputEventMarshaller implements Marshaller<InputEvent> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(true)
-            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).hasImplicitPayloadMembers(false).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -41,4 +41,3 @@ public class InputEventMarshaller implements Marshaller<InputEvent> {
         }
     }
 }
-

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/transform/inputeventtwomarshaller.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public class InputEventTwoMarshaller implements Marshaller<InputEventTwo> {
     private static final OperationInfo SDK_OPERATION_BINDING = OperationInfo.builder().hasExplicitPayloadMember(false)
-            .hasPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
+            .hasPayloadMembers(true).hasImplicitPayloadMembers(true).httpMethod(SdkHttpMethod.GET).hasEvent(true).build();
 
     private final BaseAwsJsonProtocolFactory protocolFactory;
 
@@ -41,4 +41,3 @@ public class InputEventTwoMarshaller implements Marshaller<InputEventTwo> {
         }
     }
 }
-

--- a/test/protocol-tests/src/main/resources/codegen-resources/restjson/contenttype/service-2.json
+++ b/test/protocol-tests/src/main/resources/codegen-resources/restjson/contenttype/service-2.json
@@ -51,6 +51,15 @@
         "requestUri": "no-payload"
       },
       "input": {"shape": "NoPayloadPostRequest"}
+    },
+    "TestEventStream": {
+       "name": "TestEventStream",
+      "http": {
+        "method": "POST",
+        "requestUri": "eventstream"
+      },
+      "input": {"shape": "TestEventStreamRequest"}
+     
     }
   },
   "shapes":{
@@ -163,6 +172,101 @@
       },
       "documentation":"<p> The request structure for a blob payload request. </p>",
       "payload":"data"
+    },
+    "TestEventStreamRequest": {
+      "type": "structure",
+      "required": [
+        "InputEventStream"
+      ],
+      "members": {
+        "InputEventStream": {
+          "shape": "InputEventStream"
+        }
+      },
+      "payload":"InputEventStream"
+    },
+    "InputEventStream": {
+      "type": "structure",
+      "members": {
+        "BlobAndHeadersEvent": {
+          "shape": "BlobAndHeadersEvent"
+        },
+        "HeadersOnlyEvent": {
+          "shape": "HeadersOnlyEvent"
+        },
+        "ImplicitPayloadAndHeadersEvent": {
+          "shape": "ImplicitPayloadAndHeadersEvent"
+        }
+      },
+      "eventstream": true
+    },
+    "BlobAndHeadersEvent": {
+      "type": "structure",
+      "members": {
+        "BlobPayloadMember": {
+          "shape":"BlobPayloadMember",
+          "eventpayload":true
+        },
+        "HeaderMember": {
+          "shape": "String",
+          "eventheader": true
+        }
+      },
+      "event": true
+    },
+    "ImplicitPayloadAndHeadersEvent": {
+      "type": "structure",
+      "members": {
+        "StringMember": {
+          "shape":"String"
+        },
+        "HeaderMember": {
+          "shape": "String",
+          "eventheader": true
+        }
+      },
+      "event": true
+    },
+    "HeadersOnlyEvent": {
+      "type": "structure",
+      "members": {
+        "HeaderMember": {
+          "shape": "String",
+          "eventheader": true
+        }
+      },
+      "event": true
+    },
+    "BlobPayloadMember":{"type":"blob"},
+    "EventStream": {
+      "type": "structure",
+      "members": {
+        "EventOne": {
+          "shape": "EventOne"
+        },
+        "EventTwo": {
+          "shape": "EventTwo"
+        }
+      },
+      "eventstream": true
+    },
+    "EventOne": {
+      "type": "structure",
+      "members": {
+        "Foo": {
+          "shape": "String"
+        }
+      },
+      "event": true
+    },
+    "EventTwo": {
+      "type": "structure",
+      "members": {
+        "Bar": {
+          "shape": "String"
+        }
+      },
+      "event": true
     }
   }
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/RestJsonEventStreamProtocolTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/RestJsonEventStreamProtocolTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.protocol.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocol;
+import software.amazon.awssdk.protocols.json.AwsJsonProtocolFactory;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.BlobAndHeadersEvent;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.HeadersOnlyEvent;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.ImplicitPayloadAndHeadersEvent;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.InputEventStream;
+
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.model.ProtocolRestJsonContentTypeException;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.BlobAndHeadersEventMarshaller;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.HeadersOnlyEventMarshaller;
+import software.amazon.awssdk.services.protocolrestjsoncontenttype.transform.ImplicitPayloadAndHeadersEventMarshaller;
+
+public class RestJsonEventStreamProtocolTest {
+    private static final String EVENT_CONTENT_TYPE_HEADER = ":content-type";
+
+    @Test
+    public void implicitPayloadAndHeaders_payloadMemberPresent() {
+        ImplicitPayloadAndHeadersEventMarshaller marshaller = new ImplicitPayloadAndHeadersEventMarshaller(protocolFactory());
+
+        ImplicitPayloadAndHeadersEvent event = InputEventStream.implicitPayloadAndHeadersEventBuilder()
+                                                               .stringMember("hello rest-json")
+                                                               .headerMember("hello rest-json")
+                                                               .build();
+
+        SdkHttpFullRequest marshalledEvent = marshaller.marshall(event);
+
+        assertThat(marshalledEvent.headers().get(EVENT_CONTENT_TYPE_HEADER)).containsExactly("application/json");
+
+        String content = contentAsString(marshalledEvent);
+        assertThat(content).isEqualTo("{\"StringMember\":\"hello rest-json\"}");
+    }
+
+    @Test
+    public void implicitPayloadAndHeaders_payloadMemberNotPresent() {
+        ImplicitPayloadAndHeadersEventMarshaller marshaller = new ImplicitPayloadAndHeadersEventMarshaller(protocolFactory());
+
+        ImplicitPayloadAndHeadersEvent event = InputEventStream.implicitPayloadAndHeadersEventBuilder()
+                                                               .headerMember("hello rest-json")
+                                                               .build();
+
+        SdkHttpFullRequest marshalledEvent = marshaller.marshall(event);
+
+        assertThat(marshalledEvent.headers().get(EVENT_CONTENT_TYPE_HEADER)).containsExactly("application/json");
+
+        String content = contentAsString(marshalledEvent);
+        assertThat(content).isEqualTo("{}");
+    }
+
+    @Test
+    public void blobAndHeadersEvent() {
+        BlobAndHeadersEventMarshaller marshaller = new BlobAndHeadersEventMarshaller(protocolFactory());
+
+        BlobAndHeadersEvent event = InputEventStream.blobAndHeadersEventBuilder()
+                                                    .headerMember("hello rest-json")
+                                                    .blobPayloadMember(SdkBytes.fromUtf8String("hello rest-json"))
+                                                    .build();
+
+        SdkHttpFullRequest marshalledEvent = marshaller.marshall(event);
+
+        assertThat(marshalledEvent.headers().get(EVENT_CONTENT_TYPE_HEADER)).containsExactly("application/octet-stream");
+
+        String content = contentAsString(marshalledEvent);
+        assertThat(content).isEqualTo("hello rest-json");
+    }
+
+    @Test
+    public void headersOnly() {
+        HeadersOnlyEventMarshaller marshaller = new HeadersOnlyEventMarshaller(protocolFactory());
+
+        HeadersOnlyEvent event = InputEventStream.headersOnlyEventBuilder()
+                                                               .headerMember("hello rest-json")
+                                                               .build();
+
+        SdkHttpFullRequest marshalledEvent = marshaller.marshall(event);
+
+        assertThat(marshalledEvent.headers().keySet()).doesNotContain(EVENT_CONTENT_TYPE_HEADER);
+
+        String content = contentAsString(marshalledEvent);
+        assertThat(content).isEqualTo("");
+    }
+
+    private static AwsJsonProtocolFactory protocolFactory() {
+        return AwsJsonProtocolFactory.builder()
+                                     .clientConfiguration(
+                                         SdkClientConfiguration.builder()
+                                                               .option(SdkClientOption.ENDPOINT,
+                                                                       URI.create("https://test.aws.com"))
+                                                               .build())
+                                     .defaultServiceExceptionSupplier(ProtocolRestJsonContentTypeException::builder)
+                                     .protocol(AwsJsonProtocol.REST_JSON)
+                                     .protocolVersion("1.1")
+                                     .build();
+    }
+
+    private static String contentAsString(SdkHttpFullRequest request) {
+        return request.contentStreamProvider()
+                      .map(ContentStreamProvider::newStream)
+                      .map(s -> SdkBytes.fromInputStream(s).asString(StandardCharsets.UTF_8))
+                      .orElse(null);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Bug fix.

## Description
Correctly propagate the existence of implicit event members down to the
marshaller.


## Testing
- New unit tests
- ~~Running~~ integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
