### PR TITLE
[Default Configuration Part 4]: Add tlsNegotiationTimeout

### DIFF
--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsLoader.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsLoader.java
@@ -40,7 +40,6 @@ public final class DefaultsLoader {
 
     static {
         UNSUPPORTED_OPTIONS.add("stsRegionalEndpoints");
-        UNSUPPORTED_OPTIONS.add("tlsNegotiationTimeoutInMillis");
     }
 
     private DefaultsLoader() {

--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsModeConfigurationGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/defaultsmode/DefaultsModeConfigurationGenerator.java
@@ -49,15 +49,23 @@ public class DefaultsModeConfigurationGenerator implements PoetClass {
     private static final String HTTP_DEFAULTS_VAR_SUFFIX = "_HTTP_DEFAULTS";
     private static final Map<String, OptionMetadata> CONFIGURATION_MAPPING = new HashMap<>();
     private static final Map<String, OptionMetadata> HTTP_CONFIGURATION_MAPPING = new HashMap<>();
+    private static final String CONNECT_TIMEOUT_IN_MILLIS = "connectTimeoutInMillis";
+    private static final String TLS_NEGOTIATION_TIMEOUT_IN_MILLIS = "tlsNegotiationTimeoutInMillis";
+
     private final String basePackage;
     private final String defaultsModeBase;
     private final DefaultConfiguration configuration;
 
     static {
-        HTTP_CONFIGURATION_MAPPING.put("connectTimeoutInMillis",
+        HTTP_CONFIGURATION_MAPPING.put(CONNECT_TIMEOUT_IN_MILLIS,
                                        new OptionMetadata(ClassName.get("java.time", "Duration"),
                                                           ClassName.get("software.amazon.awssdk.http",
                                                                         "SdkHttpConfigurationOption", "CONNECTION_TIMEOUT")));
+        HTTP_CONFIGURATION_MAPPING.put(TLS_NEGOTIATION_TIMEOUT_IN_MILLIS,
+                                       new OptionMetadata(ClassName.get("java.time", "Duration"),
+                                                          ClassName.get("software.amazon.awssdk.http",
+                                                                        "SdkHttpConfigurationOption",
+                                                                        "TLS_NEGOTIATION_TIMEOUT")));
         CONFIGURATION_MAPPING.put("retryMode", new OptionMetadata(ClassName.get("software.amazon.awssdk.core.retry", "RetryMode"
         ), ClassName.get("software.amazon.awssdk.core.client.config", "SdkClientOption", "DEFAULT_RETRY_MODE")));
     }
@@ -179,7 +187,8 @@ public class DefaultsModeConfigurationGenerator implements PoetClass {
     private void httpAttributeMapBuilder(String option, String value, CodeBlock.Builder attributeBuilder) {
         OptionMetadata optionMetadata = HTTP_CONFIGURATION_MAPPING.get(option);
         switch (option) {
-            case "connectTimeoutInMillis":
+            case CONNECT_TIMEOUT_IN_MILLIS:
+            case TLS_NEGOTIATION_TIMEOUT_IN_MILLIS:
                 attributeBuilder.add(".put($T, $T.ofMillis($N))", optionMetadata.attribute, optionMetadata.type, value);
                 break;
             default:

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode-configuration.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode-configuration.java
@@ -20,25 +20,29 @@ public final class DefaultsModeConfiguration {
                                                                       .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD).build();
 
     private static final AttributeMap STANDARD_HTTP_DEFAULTS = AttributeMap.builder()
-                                                                           .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(2000)).build();
+                                                                           .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(2000))
+                                                                           .put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, Duration.ofMillis(2000)).build();
 
     private static final AttributeMap MOBILE_DEFAULTS = AttributeMap.builder()
                                                                     .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.ADAPTIVE).build();
 
     private static final AttributeMap MOBILE_HTTP_DEFAULTS = AttributeMap.builder()
-                                                                         .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(10000)).build();
+                                                                         .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(10000))
+                                                                         .put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, Duration.ofMillis(11000)).build();
 
     private static final AttributeMap CROSS_REGION_DEFAULTS = AttributeMap.builder()
                                                                           .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD).build();
 
     private static final AttributeMap CROSS_REGION_HTTP_DEFAULTS = AttributeMap.builder()
-                                                                               .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(2800)).build();
+                                                                               .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(2800))
+                                                                               .put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, Duration.ofMillis(2800)).build();
 
     private static final AttributeMap IN_REGION_DEFAULTS = AttributeMap.builder()
                                                                        .put(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD).build();
 
     private static final AttributeMap IN_REGION_HTTP_DEFAULTS = AttributeMap.builder()
-                                                                            .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(1000)).build();
+                                                                            .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, Duration.ofMillis(1000))
+                                                                            .put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, Duration.ofMillis(1000)).build();
 
     private static final AttributeMap LEGACY_DEFAULTS = AttributeMap.empty();
 

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/defaultsmode/defaults-mode.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.utils.internal.EnumUtils;
  * <li>retryMode: PLACEHOLDER</li>
  * <li>s3UsEast1RegionalEndpoints: PLACEHOLDER</li>
  * <li>connectTimeoutInMillis: PLACEHOLDER</li>
+ * <li>tlsNegotiationTimeoutInMillis: PLACEHOLDER</li>
  * </ul>
  * <p>
  * All options above can be configured by users, and the overridden value will take precedence.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`tlsNegotiationTimeout` is supported in one of the http clients as part of #2806 

## Description
Support tlsNegotiationTimeout in default configuration

## Testing
Updated generated files


