### PR TITLE
Added a new `dualstackEnabled` property to every client builder.

### DIFF
--- a/.changes/next-release/deprecation-AmazonS3-21b2ad3.json
+++ b/.changes/next-release/deprecation-AmazonS3-21b2ad3.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon S3", 
+    "contributor": "", 
+    "type": "deprecation", 
+    "description": "Deprecated `S3Configuration.Builder`'s `dualstackEnabled` in favor of the new service-standard `S3ClientBuilder.dualstackEnabled`."
+}

--- a/.changes/next-release/deprecation-AmazonS3Control-b22c29a.json
+++ b/.changes/next-release/deprecation-AmazonS3Control-b22c29a.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon S3 Control", 
+    "contributor": "", 
+    "type": "deprecation", 
+    "description": "Deprecated `S3ControlConfiguration.Builder`'s `dualstackEnabled` in favor of the new service-standard `S3ControlClientBuilder.dualstackEnabled`."
+}

--- a/.changes/next-release/feature-AWSSDKforJava-6255065.json
+++ b/.changes/next-release/feature-AWSSDKforJava-6255065.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Added a new `dualstackEnabled` property to every client builder, which can be used to make calls be invoked against AWS endpoints which return IPv6 records. This can also be enabled via the `AWS_USE_DUALSTACK_ENDPOINT` environment variable, `aws.useDualstackEndpoint` system property, or the `use_dualstack_endpoint` profile file property."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -42,6 +42,12 @@ public class CustomizationConfig {
      * does not have advanced configuration.
      */
     private String serviceSpecificClientConfigClass;
+
+    /**
+     * Whether a service has a dualstack configuration in its {@link #serviceSpecificClientConfigClass}.
+     */
+    private boolean serviceConfigHasDualstackConfig = false;
+
     /**
      * Specify shapes to be renamed.
      */
@@ -197,6 +203,8 @@ public class CustomizationConfig {
     
     private RetryMode defaultRetryMode;
 
+
+
     private CustomizationConfig() {
     }
 
@@ -242,6 +250,14 @@ public class CustomizationConfig {
 
     public void setServiceSpecificClientConfigClass(String serviceSpecificClientConfig) {
         this.serviceSpecificClientConfigClass = serviceSpecificClientConfig;
+    }
+
+    public boolean getServiceConfigHasDualstackConfig() {
+        return serviceConfigHasDualstackConfig;
+    }
+
+    public void setServiceConfigHasDualstackConfig(boolean serviceConfigHasDualstackConfig) {
+        this.serviceConfigHasDualstackConfig = serviceConfigHasDualstackConfig;
     }
 
     public List<ConvenienceTypeOverload> getConvenienceTypeOverloads() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -34,6 +34,7 @@ import javax.lang.model.element.Modifier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
@@ -54,6 +55,7 @@ import software.amazon.awssdk.protocols.query.interceptor.QueryParametersToBodyI
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.Validate;
 
 public class BaseClientBuilderClass implements ClassSpec {
     private final IntermediateModel model;
@@ -241,9 +243,20 @@ public class BaseClientBuilderClass implements ClassSpec {
         if (StringUtils.isNotBlank(clientConfigClassName)) {
             ClassName clientConfigClass = ClassName.bestGuess(clientConfigClassName);
             builder.addCode("$1T.Builder c = (($1T) config.option($2T.SERVICE_CONFIGURATION)).toBuilder();" +
-                            "c.profileFile(c.profileFile() != null ? c.profileFile() : config.option($2T.PROFILE_FILE))" +
-                            " .profileName(c.profileName() != null ? c.profileName() : config.option($2T.PROFILE_NAME));",
+                            "c.profileFile(c.profileFile() != null ? c.profileFile() : config.option($2T.PROFILE_FILE));" +
+                            "c.profileName(c.profileName() != null ? c.profileName() : config.option($2T.PROFILE_NAME));",
                             clientConfigClass, SdkClientOption.class);
+
+            if (model.getCustomizationConfig().getServiceConfigHasDualstackConfig()) {
+                builder.addCode("if (c.dualstackEnabled() != null) {")
+                       .addCode("    $T.validState(config.option($T.DUALSTACK_ENDPOINT_ENABLED) == null, \"Dualstack has been "
+                                + "configured on both $L and the client/global level. Please limit dualstack configuration to "
+                                + "one location.\");",
+                                Validate.class, AwsClientOption.class, clientConfigClassName)
+                       .addCode("} else {")
+                       .addCode("    c.dualstackEnabled(config.option($T.DUALSTACK_ENDPOINT_ENABLED));", AwsClientOption.class)
+                       .addCode("}");
+            }
         }
 
         // Update configuration

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
+import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
@@ -15,6 +16,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
@@ -47,8 +49,15 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         interceptors = CollectionUtils.mergeLists(interceptors, config.option(SdkClientOption.EXECUTION_INTERCEPTORS));
         ServiceConfiguration.Builder c = ((ServiceConfiguration) config.option(SdkClientOption.SERVICE_CONFIGURATION))
             .toBuilder();
-        c.profileFile(c.profileFile() != null ? c.profileFile() : config.option(SdkClientOption.PROFILE_FILE)).profileName(
-            c.profileName() != null ? c.profileName() : config.option(SdkClientOption.PROFILE_NAME));
+        c.profileFile(c.profileFile() != null ? c.profileFile() : config.option(SdkClientOption.PROFILE_FILE));
+        c.profileName(c.profileName() != null ? c.profileName() : config.option(SdkClientOption.PROFILE_NAME));
+        if (c.dualstackEnabled() != null) {
+            Validate.validState(
+                config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED) == null,
+                "Dualstack has been configured on both ServiceConfiguration and the client/global level. Please limit dualstack configuration to one location.");
+        } else {
+            c.dualstackEnabled(config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED));
+        }
         return config.toBuilder().option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
                      .option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config))
                      .option(SdkClientOption.SERVICE_CONFIGURATION, c.build()).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -5,6 +5,7 @@
     "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
     "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
     "serviceSpecificClientConfigClass": "ServiceConfiguration",
+    "serviceConfigHasDualstackConfig": true,
     "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
@@ -5,6 +5,7 @@
     "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
     "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
     "serviceSpecificClientConfigClass": "ServiceConfiguration",
+    "serviceConfigHasDualstackConfig": true,
     "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsExecutionAttribute.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsExecutionAttribute.java
@@ -39,6 +39,9 @@ public final class AwsExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<String> ENDPOINT_PREFIX = new ExecutionAttribute<>("AwsEndpointPrefix");
 
+    public static final ExecutionAttribute<Boolean> DUALSTACK_ENDPOINT_ENABLED =
+        new ExecutionAttribute<>("DualstackEndpointsEnabled");
+
     private AwsExecutionAttribute() {
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.java
@@ -51,7 +51,6 @@ public interface AwsClientBuilder<BuilderT extends AwsClientBuilder<BuilderT, Cl
      */
     BuilderT credentialsProvider(AwsCredentialsProvider credentialsProvider);
 
-
     /**
      * Configure the region with which the SDK should communicate.
      *
@@ -62,6 +61,24 @@ public interface AwsClientBuilder<BuilderT extends AwsClientBuilder<BuilderT, Cl
      *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the region.</li>
      *     <li>If running in EC2, check the EC2 metadata service for the region.</li>
      * </ol>
+     *
+     * <p>If the region is not found in any of the locations above, an exception will be thrown at {@link #build()} time.
      */
     BuilderT region(Region region);
+
+    /**
+     * Configure whether the SDK should use the AWS dualstack endpoint.
+     *
+     * <p>If this is not specified, the SDK will attempt to determine whether the dualstack endpoint should be used
+     * automatically using the following logic:
+     * <ol>
+     *     <li>Check the 'aws.useDualstackEndpoint' system property for 'true' or 'false'.</li>
+     *     <li>Check the 'AWS_USE_DUALSTACK_ENDPOINT' environment variable for 'true' or 'false'.</li>
+     *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_dualstack_endpoint'
+     *     property set to 'true' or 'false'.</li>
+     * </ol>
+     *
+     * <p>If the setting is not found in any of the locations above, 'false' will be used.
+     */
+    BuilderT dualstackEnabled(Boolean dualstackEndpointEnabled);
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.client.config.AwsAdvancedClientOption;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
+import software.amazon.awssdk.awscore.endpoint.DualstackEnabledProvider;
 import software.amazon.awssdk.awscore.eventstream.EventStreamInitialRequestInterceptor;
 import software.amazon.awssdk.awscore.interceptor.HelpfulUnknownHostExceptionInterceptor;
 import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
@@ -141,6 +142,8 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
 
         configuration = configuration.toBuilder()
                                      .option(AwsClientOption.AWS_REGION, resolveRegion(configuration))
+                                     .option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED,
+                                             resolveDualstackEndpointEnabled(configuration))
                                      .build();
 
         return configuration.toBuilder()
@@ -180,6 +183,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
             .withRegion(config.option(AwsClientOption.AWS_REGION))
             .withProfileFile(config.option(SdkClientOption.PROFILE_FILE))
             .withProfileName(config.option(SdkClientOption.PROFILE_NAME))
+            .withDualstackEnabled(config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
             .getServiceEndpoint();
     }
 
@@ -208,6 +212,29 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                                             .profileName(profileName)
                                             .build()
                                             .getRegion();
+    }
+
+    /**
+     * Resolve whether a dualstack endpoint should be used for this client.
+     */
+    private Boolean resolveDualstackEndpointEnabled(SdkClientConfiguration config) {
+        return config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED) != null
+               ? config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED)
+               : dualstackEndpointFromDefaultProvider(config);
+    }
+
+    /**
+     * Load the dualstack endpoint setting from the default provider logic.
+     */
+    private Boolean dualstackEndpointFromDefaultProvider(SdkClientConfiguration config) {
+        ProfileFile profileFile = config.option(SdkClientOption.PROFILE_FILE);
+        String profileName = config.option(SdkClientOption.PROFILE_NAME);
+        return DualstackEnabledProvider.builder()
+                                       .profileFile(() -> profileFile)
+                                       .profileName(profileName)
+                                       .build()
+                                       .isDualstackEnabled()
+                                       .orElse(null);
     }
 
     /**
@@ -249,6 +276,16 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
 
     public final void setRegion(Region region) {
         region(region);
+    }
+
+    @Override
+    public BuilderT dualstackEnabled(Boolean dualstackEndpointEnabled) {
+        clientConfiguration.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED, dualstackEndpointEnabled);
+        return thisBuilder();
+    }
+
+    public final void setDualstackEnabled(Boolean dualstackEndpointEnabled) {
+        dualstackEnabled(dualstackEndpointEnabled);
     }
 
     @Override

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/config/AwsClientOption.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/config/AwsClientOption.java
@@ -41,6 +41,12 @@ public final class AwsClientOption<T> extends ClientOption<T> {
     public static final AwsClientOption<Region> SIGNING_REGION = new AwsClientOption<>(Region.class);
 
     /**
+     * Whether the SDK should resolve dualstack endpoints instead of default endpoints. See
+     * {@link AwsClientBuilder#dualstackEnabled(Boolean)}.
+     */
+    public static final AwsClientOption<Boolean> DUALSTACK_ENDPOINT_ENABLED = new AwsClientOption<>(Boolean.class);
+
+    /**
      * Scope name to use during signing of a request.
      */
     public static final AwsClientOption<String> SERVICE_SIGNING_NAME = new AwsClientOption<>(String.class);

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/DualstackEnabledProvider.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/DualstackEnabledProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.awscore.endpoint;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A resolver for the default value of whether the SDK should use dualstack endpoints. This checks environment variables,
+ * system properties and the profile file for the relevant configuration options when {@link #isDualstackEnabled()} is invoked.
+ */
+@SdkProtectedApi
+public class DualstackEnabledProvider {
+    private final Supplier<ProfileFile> profileFile;
+    private final String profileName;
+
+    private DualstackEnabledProvider(Builder builder) {
+        this.profileFile = Validate.paramNotNull(builder.profileFile, "profileFile");
+        this.profileName = builder.profileName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns true when dualstack should be used, false when dualstack should not be used, and empty when there is no global
+     * dualstack configuration.
+     */
+    public Optional<Boolean> isDualstackEnabled() {
+        Optional<Boolean> setting = SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.getBooleanValue();
+        if (setting.isPresent()) {
+            return setting;
+        }
+
+        return profileFile.get()
+                          .profile(profileName())
+                          .flatMap(p -> p.booleanProperty(ProfileProperty.USE_DUALSTACK_ENDPOINT));
+    }
+
+    private String profileName() {
+        return profileName != null ? profileName : ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+    }
+
+    public static final class Builder {
+        private Supplier<ProfileFile> profileFile = ProfileFile::defaultProfileFile;
+        private String profileName;
+
+        private Builder() {
+        }
+
+        public Builder profileFile(Supplier<ProfileFile> profileFile) {
+            this.profileFile = profileFile;
+            return this;
+        }
+
+        public Builder profileName(String profileName) {
+            this.profileName = profileName;
+            return this;
+        }
+
+        public DualstackEnabledProvider build() {
+            return new DualstackEnabledProvider(this);
+        }
+    }
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
@@ -80,6 +80,10 @@ public final class AwsExecutionContextBuilder {
             .putAttribute(SdkInternalExecutionAttribute.HAS_INITIAL_REQUEST_EVENT, executionParams.hasInitialRequestEvent())
             .putAttribute(SdkExecutionAttribute.CLIENT_TYPE, clientConfig.option(SdkClientOption.CLIENT_TYPE))
             .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfig.option(SdkClientOption.SERVICE_NAME))
+            .putAttribute(SdkExecutionAttribute.PROFILE_FILE, clientConfig.option(SdkClientOption.PROFILE_FILE))
+            .putAttribute(SdkExecutionAttribute.PROFILE_NAME, clientConfig.option(SdkClientOption.PROFILE_NAME))
+            .putAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED,
+                          clientConfig.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
             .putAttribute(SdkExecutionAttribute.OPERATION_NAME, executionParams.getOperationName())
             .putAttribute(SdkExecutionAttribute.CLIENT_ENDPOINT, clientConfig.option(SdkClientOption.ENDPOINT))
             .putAttribute(SdkExecutionAttribute.ENDPOINT_OVERRIDDEN, clientConfig.option(SdkClientOption.ENDPOINT_OVERRIDDEN))

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/presigner/SdkPresigner.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/presigner/SdkPresigner.java
@@ -18,9 +18,7 @@ package software.amazon.awssdk.awscore.presigner;
 import java.net.URI;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
@@ -43,22 +41,59 @@ public interface SdkPresigner extends SdkAutoCloseable {
     @SdkPublicApi
     interface Builder {
         /**
-         * Configure the region that should be used for request signing.
-         * <p/>
-         * If this is not set, the {@link DefaultAwsRegionProviderChain} will be consulted to determine the region.
+         * Configure the region for which the requests should be signed.
+         *
+         * <p>If this is not specified, the SDK will attempt to identify the endpoint automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.region' system property for the region.</li>
+         *     <li>Check the 'AWS_REGION' environment variable for the region.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the region.</li>
+         *     <li>If running in EC2, check the EC2 metadata service for the region.</li>
+         * </ol>
+         *
+         * <p>If the region is not found in any of the locations above, an exception will be thrown at {@link #build()}
+         * time.
          */
         Builder region(Region region);
 
         /**
          * Configure the credentials that should be used for request signing.
-         * <p/>
-         * If this is not set, the {@link DefaultCredentialsProvider} will be used.
+         *
+         * <p>The default provider will attempt to identify the credentials automatically using the following checks:
+         * <ol>
+         *   <li>Java System Properties - <code>aws.accessKeyId</code> and <code>aws.secretKey</code></li>
+         *   <li>Environment Variables - <code>AWS_ACCESS_KEY_ID</code> and <code>AWS_SECRET_ACCESS_KEY</code></li>
+         *   <li>Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI</li>
+         *   <li>Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+         *   environment variable is set and security manager has permission to access the variable.</li>
+         *   <li>Instance profile credentials delivered through the Amazon EC2 metadata service</li>
+         * </ol>
+         *
+         * <p>If the credentials are not found in any of the locations above, an exception will be thrown at {@link #build()}
+         * time.
+         * </p>
          */
         Builder credentialsProvider(AwsCredentialsProvider credentialsProvider);
 
         /**
+         * Configure whether the SDK should use the AWS dualstack endpoint.
+         *
+         * <p>If this is not specified, the SDK will attempt to determine whether the dualstack endpoint should be used
+         * automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.useDualstackEndpoint' system property for 'true' or 'false'.</li>
+         *     <li>Check the 'AWS_USE_DUALSTACK_ENDPOINT' environment variable for 'true' or 'false'.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_dualstack_endpoint'
+         *     property set to 'true' or 'false'.</li>
+         * </ol>
+         *
+         * <p>If the setting is not found in any of the locations above, 'false' will be used.
+         */
+        Builder dualstackEnabled(Boolean dualstackEnabled);
+
+        /**
          * Configure an endpoint that should be used in the pre-signed requests. This will override the endpoint that is usually
-         * determined by the {@link #region(Region)}.
+         * determined by the {@link #region(Region)} and {@link #dualstackEnabled(Boolean)} settings.
          */
         Builder endpointOverride(URI endpointOverride);
 

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/Profile.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.SystemSetting;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
@@ -78,6 +79,29 @@ public final class Profile implements ToCopyableBuilder<Profile.Builder, Profile
      */
     public Optional<String> property(String propertyKey) {
         return Optional.ofNullable(properties.get(propertyKey));
+    }
+
+    /**
+     * Retrieve a specific property from this profile, and convert it to a boolean using the same algorithm as
+     * {@link SystemSetting#getBooleanValue()}.
+     *
+     * @param propertyKey The name of the property to retrieve.
+     * @return The boolean value of the property, if configured.
+     * @throws IllegalStateException If the property is set, but it is not boolean.
+     */
+    public Optional<Boolean> booleanProperty(String propertyKey) {
+        return property(propertyKey).map(property -> parseBooleanProperty(propertyKey, property));
+    }
+
+    private Boolean parseBooleanProperty(String propertyKey, String property) {
+        if (property.equalsIgnoreCase("true")) {
+            return true;
+        } else if (property.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        throw new IllegalStateException("Profile property '" + propertyKey + "' must be set to 'true', 'false' or unset, but "
+                                        + "was set to '" + property + "'.");
     }
 
     /**

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -121,6 +121,8 @@ public final class ProfileProperty {
      */
     public static final String SSO_START_URL = "sso_start_url";
 
+    public static final String USE_DUALSTACK_ENDPOINT = "use_dualstack_endpoint";
+
     public static final String EC2_METADATA_SERVICE_ENDPOINT_MODE = "ec2_metadata_service_endpoint_mode";
 
     public static final String EC2_METADATA_SERVICE_ENDPOINT = "ec2_metadata_service_endpoint";

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -168,6 +168,12 @@ public enum SdkSystemSetting implements SystemSetting {
      */
     AWS_MAX_ATTEMPTS("aws.maxAttempts", null),
 
+    /**
+     * Defines whether dualstack endpoints should be resolved during default endpoint resolution instead of non-dualstack
+     * endpoints.
+     */
+    AWS_USE_DUALSTACK_ENDPOINT("aws.useDualstackEndpoint", null),
+
     ;
 
     private final String systemProperty;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkExecutionAttribute.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.profiles.ProfileFile;
 
 /**
  * Contains attributes attached to the execution. This information is available to {@link ExecutionInterceptor}s and
@@ -71,6 +72,10 @@ public class SdkExecutionAttribute {
      * If the client signer value has been overridden.
      */
     public static final ExecutionAttribute<Boolean> SIGNER_OVERRIDDEN = new ExecutionAttribute<>("SignerOverridden");
+
+    public static final ExecutionAttribute<ProfileFile> PROFILE_FILE = new ExecutionAttribute<>("ProfileFile");
+
+    public static final ExecutionAttribute<String> PROFILE_NAME = new ExecutionAttribute<>("ProfileName");
 
     protected SdkExecutionAttribute() {
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -182,7 +182,9 @@ public abstract class BaseClientHandler {
             .putAttribute(InternalCoreExecutionAttribute.EXECUTION_ATTEMPT, 1)
             .putAttribute(SdkExecutionAttribute.SERVICE_CONFIG,
                           clientConfiguration.option(SdkClientOption.SERVICE_CONFIGURATION))
-            .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfiguration.option(SdkClientOption.SERVICE_NAME));
+            .putAttribute(SdkExecutionAttribute.SERVICE_NAME, clientConfiguration.option(SdkClientOption.SERVICE_NAME))
+            .putAttribute(SdkExecutionAttribute.PROFILE_FILE, clientConfiguration.option(SdkClientOption.PROFILE_FILE))
+            .putAttribute(SdkExecutionAttribute.PROFILE_NAME, clientConfiguration.option(SdkClientOption.PROFILE_NAME));
 
         ExecutionInterceptorChain interceptorChain =
             new ExecutionInterceptorChain(clientConfiguration.option(SdkClientOption.EXECUTION_INTERCEPTORS));

--- a/services/docdb/pom.xml
+++ b/services/docdb/pom.xml
@@ -56,5 +56,10 @@
             <artifactId>aws-query-protocol</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/services/docdb/src/main/java/software/amazon/awssdk/services/docdb/internal/RdsPresignInterceptor.java
+++ b/services/docdb/src/main/java/software/amazon/awssdk/services/docdb/internal/RdsPresignInterceptor.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
 import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -105,7 +107,7 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
 
         String destinationRegion = executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION).id();
 
-        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME);
+        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME, executionAttributes);
         SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
@@ -148,7 +150,7 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
         return signer.presign(request, presignerParams);
     }
 
-    private URI createEndpoint(String regionName, String serviceName) {
+    private URI createEndpoint(String regionName, String serviceName, ExecutionAttributes attributes) {
         Region region = Region.of(regionName);
 
         if (region == null) {
@@ -159,7 +161,10 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
         }
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, Protocol.HTTPS.toString())
-                .withRegion(region)
-                .getServiceEndpoint();
+            .withRegion(region)
+            .withProfileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
+            .withProfileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
+            .withDualstackEnabled(attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+            .getServiceEndpoint();
     }
 }

--- a/services/neptune/pom.xml
+++ b/services/neptune/pom.xml
@@ -56,5 +56,10 @@
             <artifactId>aws-query-protocol</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/services/neptune/src/main/java/software/amazon/awssdk/services/neptune/internal/RdsPresignInterceptor.java
+++ b/services/neptune/src/main/java/software/amazon/awssdk/services/neptune/internal/RdsPresignInterceptor.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
 import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -107,7 +109,7 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
 
         String destinationRegion = executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION).id();
 
-        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME);
+        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME, executionAttributes);
         SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
@@ -150,7 +152,7 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
         return signer.presign(request, presignerParams);
     }
 
-    private URI createEndpoint(String regionName, String serviceName) {
+    private URI createEndpoint(String regionName, String serviceName, ExecutionAttributes attributes) {
         Region region = Region.of(regionName);
 
         if (region == null) {
@@ -162,6 +164,9 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, Protocol.HTTPS.toString())
                 .withRegion(region)
+                .withProfileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
+                .withProfileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
+                .withDualstackEnabled(attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
                 .getServiceEndpoint();
     }
 }

--- a/services/polly/pom.xml
+++ b/services/polly/pom.xml
@@ -56,5 +56,10 @@
             <artifactId>protocol-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
+import software.amazon.awssdk.awscore.endpoint.DualstackEnabledProvider;
 import software.amazon.awssdk.awscore.presigner.PresignRequest;
 import software.amazon.awssdk.awscore.presigner.PresignedRequest;
 import software.amazon.awssdk.core.ClientType;
@@ -45,10 +46,10 @@ import software.amazon.awssdk.core.signer.Presigner;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
-import software.amazon.awssdk.regions.providers.LazyAwsRegionProvider;
 import software.amazon.awssdk.services.polly.internal.presigner.model.transform.SynthesizeSpeechRequestMarshaller;
 import software.amazon.awssdk.services.polly.model.PollyRequest;
 import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
@@ -64,21 +65,37 @@ import software.amazon.awssdk.utils.Validate;
 public final class DefaultPollyPresigner implements PollyPresigner {
     private static final String SIGNING_NAME = "polly";
     private static final String SERVICE_NAME = "polly";
-    private static final AwsRegionProvider DEFAULT_REGION_PROVIDER =
-            new LazyAwsRegionProvider(DefaultAwsRegionProviderChain::new);
-    private static final AwsCredentialsProvider DEFAULT_CREDENTIALS_PROVIDER =
-            DefaultCredentialsProvider.create();
     private static final Aws4Signer DEFAULT_SIGNER = Aws4Signer.create();
 
+    private final ProfileFile profileFile;
+    private final String profileName;
     private final Region region;
     private final AwsCredentialsProvider credentialsProvider;
     private final URI endpointOverride;
+    private final Boolean dualstackEnabled;
 
     private DefaultPollyPresigner(BuilderImpl builder) {
-        this.region = builder.region != null ? builder.region : DEFAULT_REGION_PROVIDER.getRegion();
-        this.credentialsProvider = builder.credentialsProvider != null
-                ? builder.credentialsProvider : DEFAULT_CREDENTIALS_PROVIDER;
+        this.profileFile = ProfileFile.defaultProfileFile();
+        this.profileName = ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+        this.region = builder.region != null ? builder.region
+                                             : DefaultAwsRegionProviderChain.builder()
+                                                                            .profileFile(() -> profileFile)
+                                                                            .profileName(profileName)
+                                                                            .build()
+                                                                            .getRegion();
+        this.credentialsProvider = builder.credentialsProvider != null ? builder.credentialsProvider
+                                                                       : DefaultCredentialsProvider.builder()
+                                                                                                   .profileFile(profileFile)
+                                                                                                   .profileName(profileName)
+                                                                                                   .build();
         this.endpointOverride = builder.endpointOverride;
+        this.dualstackEnabled = builder.dualstackEnabled != null ? builder.dualstackEnabled
+                                                                 : DualstackEnabledProvider.builder()
+                                                                                           .profileFile(() -> profileFile)
+                                                                                           .profileName(profileName)
+                                                                                           .build()
+                                                                                           .isDualstackEnabled()
+                                                                                           .orElse(false);
     }
 
     public Region region() {
@@ -219,6 +236,9 @@ public final class DefaultPollyPresigner implements PollyPresigner {
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, "https")
                 .withRegion(region())
+                .withProfileFile(profileFile)
+                .withProfileName(profileName)
+                .withDualstackEnabled(dualstackEnabled)
                 .getServiceEndpoint();
     }
 
@@ -226,6 +246,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
         private Region region;
         private AwsCredentialsProvider credentialsProvider;
         private URI endpointOverride;
+        private Boolean dualstackEnabled;
 
         @Override
         public Builder region(Region region) {
@@ -236,6 +257,12 @@ public final class DefaultPollyPresigner implements PollyPresigner {
         @Override
         public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
             this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        @Override
+        public Builder dualstackEnabled(Boolean dualstackEnabled) {
+            this.dualstackEnabled = dualstackEnabled;
             return this;
         }
 

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
@@ -164,6 +164,9 @@ public interface PollyPresigner extends SdkPresigner {
         Builder credentialsProvider(AwsCredentialsProvider credentialsProvider);
 
         @Override
+        Builder dualstackEnabled(Boolean dualstackEnabled);
+
+        @Override
         Builder endpointOverride(URI endpointOverride);
 
         @Override

--- a/services/rds/pom.xml
+++ b/services/rds/pom.xml
@@ -56,5 +56,10 @@
             <artifactId>protocol-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
 import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
 import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.SdkRequest;
@@ -32,6 +33,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -105,7 +107,7 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
 
         String destinationRegion = executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION).id();
 
-        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME);
+        URI endpoint = createEndpoint(sourceRegion, SERVICE_NAME, executionAttributes);
         SdkHttpFullRequest.Builder marshalledRequest = presignableRequest.marshall().toBuilder().uri(endpoint);
 
         SdkHttpFullRequest requestToPresign =
@@ -148,7 +150,7 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
         return signer.presign(request, presignerParams);
     }
 
-    private URI createEndpoint(String regionName, String serviceName) {
+    private URI createEndpoint(String regionName, String serviceName, ExecutionAttributes attributes) {
         Region region = Region.of(regionName);
 
         if (region == null) {
@@ -159,7 +161,10 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
         }
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, Protocol.HTTPS.toString())
-                .withRegion(region)
-                .getServiceEndpoint();
+            .withRegion(region)
+            .withProfileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
+            .withProfileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
+            .withDualstackEnabled(attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+            .getServiceEndpoint();
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.s3.internal.FieldWithDefault;
 import software.amazon.awssdk.services.s3.internal.settingproviders.DisableMultiRegionProviderChain;
 import software.amazon.awssdk.services.s3.internal.settingproviders.UseArnRegionProviderChain;
 import software.amazon.awssdk.services.s3.model.PutBucketAccelerateConfigurationRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
@@ -225,8 +226,11 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
          * Dualstack endpoints are disabled by default.
          * </p>
          *
-         * @see S3Configuration#dualstackEnabled().
+         * @deprecated This option has been replaced with {@link S3ClientBuilder#dualstackEnabled(Boolean)} and
+         * {@link S3Presigner.Builder#dualstackEnabled(Boolean)}. If both this and one of those options are set, an exception
+         * will be thrown.
          */
+        @Deprecated
         Builder dualstackEnabled(Boolean dualstackEnabled);
 
         Boolean accelerateModeEnabled();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -99,9 +99,6 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
     private static final Logger log = Logger.loggerFor(DefaultS3Presigner.class);
 
     private static final AwsS3V4Signer DEFAULT_SIGNER = AwsS3V4Signer.create();
-    private static final S3Configuration DEFAULT_S3_CONFIGURATION = S3Configuration.builder()
-                                                                                   .checksumValidationEnabled(false)
-                                                                                   .build();
     private static final String SERVICE_NAME = "s3";
     private static final String SIGNING_NAME = "s3";
 
@@ -118,12 +115,29 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
     private DefaultS3Presigner(Builder b) {
         super(b);
 
-        this.serviceConfiguration = b.serviceConfiguration != null ? b.serviceConfiguration : DEFAULT_S3_CONFIGURATION;
+        S3Configuration serviceConfiguration = b.serviceConfiguration != null ? b.serviceConfiguration :
+                                                S3Configuration.builder()
+                                                               .profileFile(profileFile())
+                                                               .profileName(profileName())
+                                                               .checksumValidationEnabled(false)
+                                                               .build();
+        S3Configuration.Builder serviceConfigBuilder = serviceConfiguration.toBuilder();
+
         if (serviceConfiguration.checksumValidationEnabled()) {
             log.debug(() -> "The provided S3Configuration has ChecksumValidationEnabled set to true. Please note that "
                            + "the pre-signed request can't be executed using a web browser if checksum validation is enabled.");
         }
 
+        if (dualstackEnabled() != null && serviceConfigBuilder.dualstackEnabled() != null) {
+            throw new IllegalStateException("Dualstack has been configured in both S3Configuration and at the "
+                                            + "presigner/global level. Please limit dualstack configuration to one location.");
+        }
+
+        if (dualstackEnabled() != null) {
+            serviceConfigBuilder.dualstackEnabled(dualstackEnabled());
+        }
+
+        this.serviceConfiguration = serviceConfigBuilder.build();
 
         this.clientInterceptors = initializeInterceptors();
 
@@ -177,8 +191,12 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
                                          .option(SdkClientOption.ENDPOINT_OVERRIDDEN, true)
                                          .build();
         } else {
-            URI defaultEndpoint = new DefaultServiceEndpointBuilder(SERVICE_NAME, "https").withRegion(region())
-                                                                                          .getServiceEndpoint();
+            URI defaultEndpoint = new DefaultServiceEndpointBuilder(SERVICE_NAME, "https")
+                .withRegion(region())
+                .withProfileFile(profileFile())
+                .withProfileName(profileName())
+                .withDualstackEnabled(serviceConfiguration.dualstackEnabled())
+                .getServiceEndpoint();
             return SdkClientConfiguration.builder()
                                          .option(SdkClientOption.ENDPOINT, defaultEndpoint)
                                          .build();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultSdkPresigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultSdkPresigner.java
@@ -19,11 +19,12 @@ import java.net.URI;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.awscore.endpoint.DualstackEnabledProvider;
 import software.amazon.awssdk.awscore.presigner.SdkPresigner;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
-import software.amazon.awssdk.regions.providers.LazyAwsRegionProvider;
 import software.amazon.awssdk.utils.IoUtils;
 
 /**
@@ -35,19 +36,42 @@ import software.amazon.awssdk.utils.IoUtils;
  */
 @SdkInternalApi
 public abstract class DefaultSdkPresigner implements SdkPresigner {
-    private static final AwsRegionProvider DEFAULT_REGION_PROVIDER =
-            new LazyAwsRegionProvider(DefaultAwsRegionProviderChain::new);
-    private static final AwsCredentialsProvider DEFAULT_CREDENTIALS_PROVIDER =
-        DefaultCredentialsProvider.create();
-
+    private final ProfileFile profileFile;
+    private final String profileName;
     private final Region region;
     private final URI endpointOverride;
     private final AwsCredentialsProvider credentialsProvider;
+    private final Boolean dualstackEnabled;
 
     protected DefaultSdkPresigner(Builder<?> b) {
-        this.region = b.region != null ? b.region : DEFAULT_REGION_PROVIDER.getRegion();
-        this.credentialsProvider = b.credentialsProvider != null ? b.credentialsProvider : DEFAULT_CREDENTIALS_PROVIDER;
+        this.profileFile = ProfileFile.defaultProfileFile();
+        this.profileName = ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow();
+        this.region = b.region != null ? b.region : DefaultAwsRegionProviderChain.builder()
+                                                                                 .profileFile(() -> profileFile)
+                                                                                 .profileName(profileName)
+                                                                                 .build()
+                                                                                 .getRegion();
+        this.credentialsProvider = b.credentialsProvider != null ? b.credentialsProvider
+                                                                 : DefaultCredentialsProvider.builder()
+                                                                                             .profileFile(profileFile)
+                                                                                             .profileName(profileName)
+                                                                                             .build();
         this.endpointOverride = b.endpointOverride;
+        this.dualstackEnabled = b.dualstackEnabled != null ? b.dualstackEnabled
+                                                           : DualstackEnabledProvider.builder()
+                                                                                     .profileFile(() -> profileFile)
+                                                                                     .profileName(profileName)
+                                                                                     .build()
+                                                                                     .isDualstackEnabled()
+                                                                                     .orElse(null);
+    }
+
+    protected ProfileFile profileFile() {
+        return profileFile;
+    }
+
+    protected String profileName() {
+        return profileName;
     }
 
     protected Region region() {
@@ -56,6 +80,10 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
 
     protected AwsCredentialsProvider credentialsProvider() {
         return credentialsProvider;
+    }
+
+    protected Boolean dualstackEnabled() {
+        return dualstackEnabled;
     }
 
     protected URI endpointOverride() {
@@ -75,6 +103,7 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
         implements SdkPresigner.Builder {
         private Region region;
         private AwsCredentialsProvider credentialsProvider;
+        private Boolean dualstackEnabled;
         private URI endpointOverride;
 
         protected Builder() {
@@ -89,6 +118,12 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
         @Override
         public B credentialsProvider(AwsCredentialsProvider credentialsProvider) {
             this.credentialsProvider = credentialsProvider;
+            return thisBuilder();
+        }
+
+        @Override
+        public B dualstackEnabled(Boolean dualstackEnabled) {
+            this.dualstackEnabled = dualstackEnabled;
             return thisBuilder();
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -530,6 +530,9 @@ public interface S3Presigner extends SdkPresigner {
         Builder credentialsProvider(AwsCredentialsProvider credentialsProvider);
 
         @Override
+        Builder dualstackEnabled(Boolean dualstackEnabled);
+
+        @Override
         Builder endpointOverride(URI endpointOverride);
 
         @Override

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -114,6 +114,7 @@
     }
   },
   "serviceSpecificClientConfigClass": "S3Configuration",
+  "serviceConfigHasDualstackConfig": true,
   "attachPayloadTraitToMember": {
     "GetBucketLocationOutput": "LocationConstraint"
   },

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3UtilitiesTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3UtilitiesTest.java
@@ -159,6 +159,35 @@ public class S3UtilitiesTest {
     }
 
     @Test
+    public void testWithAccelerateAndDualStackViaClientEnabled() throws MalformedURLException {
+        S3Utilities utilities = S3Client.builder()
+                                        .credentialsProvider(dummyCreds())
+                                        .region(Region.US_WEST_2)
+                                        .serviceConfiguration(S3Configuration.builder()
+                                                                             .accelerateModeEnabled(true)
+                                                                             .build())
+                                        .dualstackEnabled(true)
+                                        .build()
+                                        .utilities();
+
+        assertThat(utilities.getUrl(requestWithSpecialCharacters())
+                            .toExternalForm())
+            .isEqualTo("https://foo-bucket.s3-accelerate.dualstack.amazonaws.com/key%20with%40spaces");
+    }
+
+    @Test
+    public void testWithDualStackViaUtilitiesBuilderEnabled() throws MalformedURLException {
+        S3Utilities utilities = S3Utilities.builder()
+                                           .region(Region.US_WEST_2)
+                                           .dualstackEnabled(true)
+                                           .build();
+
+        assertThat(utilities.getUrl(requestWithSpecialCharacters())
+                            .toExternalForm())
+            .isEqualTo("https://foo-bucket.s3.dualstack.us-west-2.amazonaws.com/key%20with%40spaces");
+    }
+
+    @Test
     public void testAsync() throws MalformedURLException {
         assertThat(utilitiesFromAsyncClient.getUrl(requestWithoutSpaces())
                                            .toExternalForm())

--- a/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/S3ControlConfiguration.java
+++ b/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/S3ControlConfiguration.java
@@ -131,7 +131,10 @@ public final class S3ControlConfiguration implements ServiceConfiguration,
          * </p>
          *
          * @see S3ControlConfiguration#dualstackEnabled().
+         * @deprecated This option has been replaced with {@link S3ControlClientBuilder#dualstackEnabled(Boolean)}. If both are
+         * set, an exception will be thrown.
          */
+        @Deprecated
         Builder dualstackEnabled(Boolean dualstackEnabled);
 
         Boolean fipsModeEnabled();

--- a/services/s3control/src/main/resources/codegen-resources/customization.config
+++ b/services/s3control/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,6 @@
 {
     "serviceSpecificClientConfigClass": "S3ControlConfiguration",
+    "serviceConfigHasDualstackConfig": true,
     "customResponseMetadata": {
         "EXTENDED_REQUEST_ID": "x-amz-id-2",
         "REQUEST_ID": "x-amz-request-id"

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/EndpointOverrideEndpointResolutionTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/EndpointOverrideEndpointResolutionTest.java
@@ -67,6 +67,7 @@ public class EndpointOverrideEndpointResolutionTest {
                            .endpointOverride(testCase.endpointUrl)
                            .serviceConfiguration(testCase.s3ControlConfiguration)
                            .httpClient(mockHttpClient)
+                           .dualstackEnabled(testCase.clientDualstackEnabled)
                            .overrideConfiguration(c -> c.putAdvancedOption(SdkAdvancedClientOption.SIGNER, mockSigner))
                            .build();
 
@@ -199,10 +200,17 @@ public class EndpointOverrideEndpointResolutionTest {
                                 .setExpectedSigningServiceName("s3-outposts")
                                 .setExpectedSigningRegion(Region.US_WEST_2));
 
-        cases.add(new TestCase().setCaseName("get-access-point by access point name with dualstack")
+        cases.add(new TestCase().setCaseName("get-access-point by access point name with dualstack via service config")
                                 .setGetAccessPointRequest(r -> r.name("apname").accountId("123456789012"))
                                 .setEndpointUrl("https://beta.example.com")
                                 .setS3ControlConfiguration(c -> c.dualstackEnabled(true))
+                                .setClientRegion(Region.US_WEST_2)
+                                .setExpectedException(IllegalArgumentException.class));
+
+        cases.add(new TestCase().setCaseName("get-access-point by access point name with dualstack via client builder")
+                                .setGetAccessPointRequest(r -> r.name("apname").accountId("123456789012"))
+                                .setEndpointUrl("https://beta.example.com")
+                                .setClientDualstackEnabled(true)
                                 .setClientRegion(Region.US_WEST_2)
                                 .setExpectedException(IllegalArgumentException.class));
 
@@ -242,6 +250,7 @@ public class EndpointOverrideEndpointResolutionTest {
         private String expectedSigningServiceName;
         private Region expectedSigningRegion;
         private Class<? extends RuntimeException> expectedException;
+        private Boolean clientDualstackEnabled;
 
         public TestCase setCaseName(String caseName) {
             this.caseName = caseName;
@@ -283,6 +292,11 @@ public class EndpointOverrideEndpointResolutionTest {
 
         public TestCase setClientRegion(Region clientRegion) {
             this.clientRegion = clientRegion;
+            return this;
+        }
+
+        public TestCase setClientDualstackEnabled(Boolean clientDualstackEnabled) {
+            this.clientDualstackEnabled = clientDualstackEnabled;
             return this;
         }
 

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/EndpointResolutionTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/EndpointResolutionTest.java
@@ -1,0 +1,17 @@
+package software.amazon.awssdk.services.s3control;
+
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+public class EndpointResolutionTest {
+    @Test(expected = IllegalStateException.class)
+    public void duplicateDualstackSettings_throwsException() {
+        S3ControlClient.builder()
+                       .region(Region.US_WEST_2)
+                       .credentialsProvider(AnonymousCredentialsProvider.create())
+                       .dualstackEnabled(true)
+                       .serviceConfiguration(c -> c.dualstackEnabled(true))
+                       .build();
+    }
+}

--- a/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/functionaltests/arns/S3OutpostAccessPointArnTest.java
+++ b/services/s3control/src/test/java/software/amazon/awssdk/services/s3control/internal/functionaltests/arns/S3OutpostAccessPointArnTest.java
@@ -68,8 +68,20 @@ public class S3OutpostAccessPointArnTest extends S3ControlWireMockTestBase {
         s3ControlForTest.getAccessPoint(b -> b.name(outpostArn));
     }
 
+    @Test
     public void dualstackEnabled_shouldThrowException() {
         S3ControlClient s3ControlForTest = buildClientCustom().serviceConfiguration(b -> b.dualstackEnabled(true)).build();
+
+        String outpostArn = "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint";
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Dual stack");
+        s3ControlForTest.getAccessPoint(b -> b.name(outpostArn));
+    }
+
+    @Test
+    public void dualstackEnabledViaClient_shouldThrowException() {
+        S3ControlClient s3ControlForTest = buildClientCustom().dualstackEnabled(true).build();
 
         String outpostArn = "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint";
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/DualstackEndpointTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/DualstackEndpointTest.java
@@ -1,0 +1,161 @@
+package software.amazon.awssdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.Validate;
+
+@RunWith(Parameterized.class)
+public class DualstackEndpointTest {
+    @Parameterized.Parameter
+    public TestCase testCase;
+
+    @Test
+    public void resolvesCorrectEndpoint() {
+        String systemPropertyBeforeTest = System.getProperty(SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.property());
+        EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
+
+        try {
+            ProtocolRestJsonClientBuilder builder =
+                ProtocolRestJsonClient.builder()
+                                      .region(Region.US_WEST_2)
+                                      .credentialsProvider(AnonymousCredentialsProvider.create());
+
+            if (testCase.clientSetting != null) {
+                builder.dualstackEnabled(testCase.clientSetting);
+            }
+
+            if (testCase.systemPropSetting != null) {
+                System.setProperty(SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.property(), testCase.systemPropSetting);
+            }
+
+            if (testCase.envVarSetting != null) {
+                helper.set(SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.environmentVariable(), testCase.envVarSetting);
+            }
+
+            ProfileFile.Builder profileFile = ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION);
+
+            if (testCase.profileSetting != null) {
+                profileFile.content(new StringInputStream("[default]\n" +
+                                                          ProfileProperty.USE_DUALSTACK_ENDPOINT + " = " + testCase.profileSetting));
+            } else {
+                profileFile.content(new StringInputStream(""));
+            }
+
+            EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+
+            builder.overrideConfiguration(c -> c.defaultProfileFile(profileFile.build())
+                                                .defaultProfileName("default")
+                                                .addExecutionInterceptor(interceptor));
+
+            if (testCase instanceof SuccessCase) {
+                ProtocolRestJsonClient client = builder.build();
+
+                try {
+                    client.allTypes();
+                } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+                    // Expected
+                }
+
+                boolean expectedDualstackEnabled = ((SuccessCase) testCase).expectedValue;
+                String expectedEndpoint = expectedDualstackEnabled
+                                          ? "https://customresponsemetadata.us-west-2.api.aws/2016-03-11/allTypes"
+                                          : "https://customresponsemetadata.us-west-2.amazonaws.com/2016-03-11/allTypes";
+                assertThat(interceptor.endpoints()).singleElement().isEqualTo(expectedEndpoint);
+            } else {
+                FailureCase failure = Validate.isInstanceOf(FailureCase.class, testCase, "Unexpected test case type.");
+                assertThatThrownBy(builder::build).hasMessageContaining(failure.exceptionMessage);
+            }
+
+        } finally {
+            if (systemPropertyBeforeTest != null) {
+                System.setProperty(SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.property(), systemPropertyBeforeTest);
+            } else {
+                System.clearProperty(SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.property());
+            }
+            helper.reset();
+        }
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<TestCase> testCases() {
+        return Arrays.asList(new SuccessCase(true, "false", "false", "false", true, "Client highest priority (true)"),
+                             new SuccessCase(false, "true", "true", "true", false, "Client highest priority (false)"),
+                             new SuccessCase(null, "true", "false", "false", true, "System property second priority (true)"),
+                             new SuccessCase(null, "false", "true", "true", false, "System property second priority (false)"),
+                             new SuccessCase(null, null, "true", "false", true, "Env var third priority (true)"),
+                             new SuccessCase(null, null, "false", "true", false, "Env var third priority (false)"),
+                             new SuccessCase(null, null, null, "true", true, "Profile last priority (true)"),
+                             new SuccessCase(null, null, null, "false", false, "Profile last priority (false)"),
+                             new SuccessCase(null, null, null, null, false, "Default is false."),
+                             new SuccessCase(null, "tRuE", null, null, true, "System property is not case sensitive."),
+                             new SuccessCase(null, null, "tRuE", null, true, "Env var is not case sensitive."),
+                             new SuccessCase(null, null, null, "tRuE", true, "Profile property is not case sensitive."),
+                             new FailureCase(null, "FOO", null, null, "FOO", "Invalid system property values fail."),
+                             new FailureCase(null, null, "FOO", null, "FOO", "Invalid env var values fail."),
+                             new FailureCase(null, null, null, "FOO", "FOO", "Invalid profile values fail."));
+    }
+
+    public static class TestCase {
+        private final Boolean clientSetting;
+        private final String envVarSetting;
+        private final String systemPropSetting;
+        private final String profileSetting;
+        private final String caseName;
+
+        public TestCase(Boolean clientSetting, String systemPropSetting, String envVarSetting, String profileSetting,
+                        String caseName) {
+            this.clientSetting = clientSetting;
+            this.envVarSetting = envVarSetting;
+            this.systemPropSetting = systemPropSetting;
+            this.profileSetting = profileSetting;
+            this.caseName = caseName;
+        }
+
+        @Override
+        public String toString() {
+            return caseName;
+        }
+    }
+
+    public static class SuccessCase extends TestCase {
+        private final boolean expectedValue;
+
+        public SuccessCase(Boolean clientSetting,
+                           String systemPropSetting,
+                           String envVarSetting,
+                           String profileSetting,
+                           boolean expectedValue,
+                           String caseName) {
+            super(clientSetting, systemPropSetting, envVarSetting, profileSetting, caseName);
+            this.expectedValue = expectedValue;
+        }
+    }
+
+    private static class FailureCase extends TestCase {
+        private final String exceptionMessage;
+
+        public FailureCase(Boolean clientSetting,
+                           String systemPropSetting,
+                           String envVarSetting,
+                           String profileSetting,
+                           String exceptionMessage,
+                           String caseName) {
+            super(clientSetting, systemPropSetting, envVarSetting, profileSetting, caseName);
+            this.exceptionMessage = exceptionMessage;
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/EndpointCapturingInterceptor.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/EndpointCapturingInterceptor.java
@@ -1,0 +1,29 @@
+package software.amazon.awssdk.services;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+public class EndpointCapturingInterceptor implements ExecutionInterceptor {
+    private final List<String> endpoints = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public void beforeTransmission(Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
+        endpoints.add(context.httpRequest().getUri().toString());
+        throw new CaptureCompletedException();
+    }
+
+    public List<String> endpoints() {
+        return endpoints;
+    }
+
+    private void reset() {
+        endpoints.clear();
+    }
+
+    public class CaptureCompletedException extends RuntimeException {
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/SystemSettingUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/SystemSettingUtils.java
@@ -106,4 +106,6 @@ public final class SystemSettingUtils {
         throw new IllegalStateException("Environment variable '" + setting.environmentVariable() + "' or system property '" +
                                         setting.property() + "' was defined as '" + value + "', but should be 'false' or 'true'");
     }
+
+
 }


### PR DESCRIPTION
This option can be used to make calls be invoked against AWS endpoints which return IPv6 records. This can also be enabled via the `AWS_USE_DUALSTACK_ENDPOINT` environment variable, `aws.useDualstackEndpoint` system property, or the `use_dualstack_endpoint` profile file property:

1. This PR builds on top of the 'endpoint variants' #2808, by specifying the DUALSTACK endpoint variant whenever the customer requests dualstack to be enabled.
2. May of the file changes in this PR are addressing the fact that we already have service configuration for enabling dualstack for S3 and S3 control. These existing options have been deprecated in favor of the new option that works for all services.
3. There are also a lot of changes because this is the first time we're reading the profile file during endpoint resolution, outside of S3, so that information had to be piped through in all places we're resolving endpoints.