### PR TITLE
Enable & fix inspection: `equals()` called on enum value

### DIFF
--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="AWS Java SDK 2.0" />
+    <inspection_tool class="EqualsCalledOnEnumConstant" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreObjectMethods" value="false" />
       <option name="ignoreAnonymousClassMethods" value="false" />

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -54,7 +54,7 @@ final class AddOperations {
     }
 
     private static boolean isAuthenticated(Operation op) {
-        return op.getAuthtype() == null || !op.getAuthtype().equals(AuthType.NONE);
+        return op.getAuthtype() == null || op.getAuthtype() != AuthType.NONE;
     }
 
     private static String getOperationDocumentation(final Output output, final Shape outputShape) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -450,6 +450,6 @@ public class JsonProtocolSpec implements ProtocolSpec {
     }
 
     private boolean isRestJson(IntermediateModel model) {
-        return Protocol.REST_JSON.equals(model.getMetadata().getProtocol());
+        return model.getMetadata().getProtocol() == Protocol.REST_JSON;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/ProtocolSpec.java
@@ -128,7 +128,7 @@ public interface ProtocolSpec {
             builder.add(".requiresLength(true)");
         }
 
-        if (AuthType.V4_UNSIGNED_BODY.equals(opModel.getAuthType())) {
+        if (opModel.getAuthType() == AuthType.V4_UNSIGNED_BODY) {
             builder.add(".transferEncoding(true)");
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApplyUserAgentStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/ApplyUserAgentStage.java
@@ -138,11 +138,11 @@ public class ApplyUserAgentStage implements MutableRequestToRequestPipeline {
     }
 
     private String clientName(ClientType clientType) {
-        if (clientType.equals(ClientType.SYNC)) {
+        if (clientType == ClientType.SYNC) {
             return clientConfig.option(SdkClientOption.SYNC_HTTP_CLIENT).clientName();
         }
 
-        if (clientType.equals(ClientType.ASYNC)) {
+        if (clientType == ClientType.ASYNC) {
             return clientConfig.option(SdkClientOption.ASYNC_HTTP_CLIENT).clientName();
         }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -208,7 +208,7 @@ public final class NettyRequestExecutor {
         }
 
         pipeline.addLast(LastHttpContentHandler.create());
-        if (Protocol.HTTP2.equals(protocol)) {
+        if (protocol == Protocol.HTTP2) {
             pipeline.addLast(FlushOnReadHandler.getInstance());
         }
         pipeline.addLast(new HttpStreamsClientHandler());

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -227,7 +227,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
 
                 private Subscription resolveSubscription(Subscription subscription) {
                     // For HTTP2 we send a RST_STREAM frame on cancel to stop the service from sending more data
-                    if (Protocol.HTTP2.equals(ChannelAttributeKey.getProtocolNow(channelContext.channel()))) {
+                    if (ChannelAttributeKey.getProtocolNow(channelContext.channel()) == Protocol.HTTP2) {
                         return new Http2ResetSendingSubscription(channelContext, subscription);
                     } else {
                         return subscription;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProvider.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/SslContextProvider.java
@@ -70,7 +70,7 @@ public final class SslContextProvider {
      * /SslUtils.java
      */
     private List<String> getCiphers() {
-        return protocol.equals(Protocol.HTTP2) ? Http2SecurityUtil.CIPHERS : null;
+        return protocol == Protocol.HTTP2 ? Http2SecurityUtil.CIPHERS : null;
     }
 
     private TrustManagerFactory getTrustManager(NettyConfiguration configuration) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -77,7 +77,7 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
         @Override
         public Consumer<StaticTableMetadata.Builder> modifyMetadata(String attributeName,
                                                                     AttributeValueType attributeValueType) {
-            if (!AttributeValueType.N.equals(attributeValueType)) {
+            if (attributeValueType != AttributeValueType.N) {
                 throw new IllegalArgumentException(String.format(
                     "Attribute '%s' of type %s is not a suitable type to be used as a version attribute. Only type 'N' " +
                         "is supported.", attributeName, attributeValueType.name()));

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadata.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/StaticTableMetadata.java
@@ -301,7 +301,7 @@ public final class StaticTableMetadata implements TableMetadata {
         public Builder markAttributeAsKey(String attributeName, AttributeValueType attributeValueType) {
             KeyAttributeMetadata existing = keyAttributes.get(attributeName);
 
-            if (existing != null && !existing.attributeValueType().equals(attributeValueType)) {
+            if (existing != null && existing.attributeValueType() != attributeValueType) {
                 throw new IllegalArgumentException("Attempt to mark an attribute as a key with a different "
                                                    + "AttributeValueType than one that has already been recorded.");
             }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3CrtDataPublisher.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3CrtDataPublisher.java
@@ -91,16 +91,16 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
 
     private void notifyErrorIfNeeded(Subscriber<? super ByteBuffer> subscriber) {
         Event event = buffer.peek();
-        if (event != null && event.type().equals(EventType.ERROR)) {
+        if (event != null && event.type() == EventType.ERROR) {
             isDone = true;
             subscriber.onError(((ErrorEvent) event).error());
         }
     }
 
     private boolean isTerminalEvent(Event event) {
-        return event.type().equals(EventType.ERROR) ||
-               event.type().equals(EventType.COMPLETE) ||
-               event.type().equals(EventType.CANCEL);
+        return event.type() == EventType.ERROR ||
+               event.type() == EventType.COMPLETE ||
+               event.type() == EventType.CANCEL;
     }
 
     private void handleTerminalEvent(Event event) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumsEnabledValidator.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumsEnabledValidator.java
@@ -98,7 +98,7 @@ public final class ChecksumsEnabledValidator {
 
         ClientType actualClientType = executionAttributes.getAttribute(SdkExecutionAttribute.CLIENT_TYPE);
 
-        if (!expectedClientType.equals(actualClientType)) {
+        if (expectedClientType != actualClientType) {
             return false;
         }
 

--- a/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/PayloadSigningInterceptor.java
+++ b/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/internal/interceptors/PayloadSigningInterceptor.java
@@ -34,7 +34,7 @@ public class PayloadSigningInterceptor implements ExecutionInterceptor {
     public Optional<RequestBody> modifyHttpContent(Context.ModifyHttpRequest context,
                                                    ExecutionAttributes executionAttributes) {
         executionAttributes.putAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING, true);
-        if (!context.requestBody().isPresent() && context.httpRequest().method().equals(SdkHttpMethod.POST)) {
+        if (!context.requestBody().isPresent() && context.httpRequest().method() == SdkHttpMethod.POST) {
             return Optional.of(RequestBody.fromBytes(new byte[0]));
         }
 

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkResultProcessor.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/BenchmarkResultProcessor.java
@@ -166,7 +166,7 @@ class BenchmarkResultProcessor {
             return true;
         }
 
-        return Objects.equals(current.getMode(), baseline.getMode());
+        return current.getMode() == baseline.getMode();
     }
 
     private String serializeResult(List<SdkBenchmarkResult> currentData) {


### PR DESCRIPTION
Reports `equals()` calls on enum constants.

Such calls can be replaced by an identity comparison (`==`) because two
enum constants are equal only when they have the same identity.

A quick-fix is available to change the call to a comparison.

Example:

```
boolean foo(MyEnum value) {
  return value.equals(MyEnum.FOO);
}
```

After the quick-fix is applied:

```
boolean foo(MyEnum value) {
  return value == MyEnum.FOO;
}
```

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
