### PR TITLE
Enable & fix inspection: Explicit argument can be lambda

### DIFF
--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="AWS Java SDK 2.0" />
+    <inspection_tool class="ExplicitArgumentCanBeLambda" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreObjectMethods" value="false" />
       <option name="ignoreAnonymousClassMethods" value="false" />

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileLocation.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileLocation.java
@@ -45,8 +45,8 @@ public final class ProfileFileLocation {
     public static Path configurationFilePath() {
         return resolveProfileFilePath(
             ProfileFileSystemSetting.AWS_CONFIG_FILE.getStringValue()
-                                                    .orElse(Paths.get(userHomeDirectory(),
-                                                                      ".aws", "config").toString()));
+                                                    .orElseGet(() -> Paths.get(userHomeDirectory(),
+                                                                               ".aws", "config").toString()));
     }
 
     /**
@@ -57,8 +57,8 @@ public final class ProfileFileLocation {
     public static Path credentialsFilePath() {
         return resolveProfileFilePath(
             ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.getStringValue()
-                                                                .orElse(Paths.get(userHomeDirectory(),
-                                                                                  ".aws", "credentials").toString()));
+                                                                .orElseGet(() -> Paths.get(userHomeDirectory(),
+                                                                                           ".aws", "credentials").toString()));
     }
 
     /**

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/ProfileFileReader.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/internal/ProfileFileReader.java
@@ -284,7 +284,7 @@ public final class ProfileFileReader {
                      .mapToInt(line::indexOf)
                      .filter(location -> location >= 0)
                      .min()
-                     .orElse(line.length());
+                     .orElseGet(line::length);
     }
 
     private static boolean isEmptyLine(String line) {

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/AwsXmlErrorUnmarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/AwsXmlErrorUnmarshaller.java
@@ -172,7 +172,7 @@ public final class AwsXmlErrorUnmarshaller {
      */
     private String getRequestId(SdkHttpFullResponse response, XmlElement document) {
         XmlElement requestId = document.getOptionalElementByName("RequestId")
-                                       .orElse(document.getElementByName("RequestID"));
+                                       .orElseGet(() -> document.getElementByName("RequestID"));
         return requestId != null ?
                requestId.textContent() :
                matchRequestIdHeaders(response);

--- a/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/QueryProtocolUnmarshaller.java
+++ b/core/protocols/aws-query-protocol/src/main/java/software/amazon/awssdk/protocols/query/internal/unmarshall/QueryProtocolUnmarshaller.java
@@ -69,7 +69,7 @@ public final class QueryProtocolUnmarshaller implements XmlErrorUnmarshaller {
 
     public <TypeT extends SdkPojo> Pair<TypeT, Map<String, String>> unmarshall(SdkPojo sdkPojo,
                                                                                SdkHttpFullResponse response) {
-        XmlElement document = response.content().map(XmlDomParser::parse).orElse(XmlElement.empty());
+        XmlElement document = response.content().map(XmlDomParser::parse).orElseGet(XmlElement::empty);
         XmlElement resultRoot = hasResultWrapper ? document.getFirstChild() : document;
         return Pair.of(unmarshall(sdkPojo, resultRoot, response), parseMetadata(document));
     }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SystemPropertyTlsKeyManagersProvider.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SystemPropertyTlsKeyManagersProvider.java
@@ -75,7 +75,7 @@ public final class SystemPropertyTlsKeyManagersProvider extends AbstractFileStor
 
     private static String getKeyStoreType() {
         return SystemSettingUtils.resolveSetting(SSL_KEY_STORE_TYPE)
-                .orElse(KeyStore.getDefaultType());
+                .orElseGet(KeyStore::getDefaultType);
     }
 
     private static Optional<String> getKeyStorePassword() {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/SdkEventLoopGroup.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/SdkEventLoopGroup.java
@@ -126,8 +126,9 @@ public final class SdkEventLoopGroup {
     private EventLoopGroup resolveEventLoopGroup(DefaultBuilder builder) {
         int numThreads = Optional.ofNullable(builder.numberOfThreads).orElse(0);
         ThreadFactory threadFactory = Optional.ofNullable(builder.threadFactory)
-                                              .orElse(new ThreadFactoryBuilder().threadNamePrefix("aws-java-sdk-NettyEventLoop")
-                                                                                .build());
+                                              .orElseGet(() -> new ThreadFactoryBuilder()
+                                                  .threadNamePrefix("aws-java-sdk-NettyEventLoop")
+                                                  .build());
         return new NioEventLoopGroup(numThreads, threadFactory);
         /*
         Need to investigate why epoll is raising channel inactive after successful response that causes

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/CrtErrorHandler.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/CrtErrorHandler.java
@@ -53,7 +53,7 @@ public class CrtErrorHandler {
         Exception exception = crtS3RuntimeExceptionOptional
                 .filter(CrtErrorHandler::isErrorDetailsAvailable)
                 .map(e -> getServiceSideException(e))
-                .orElse(SdkClientException.create(crtRuntimeException.getMessage(), crtRuntimeException));
+                .orElseGet(() -> SdkClientException.create(crtRuntimeException.getMessage(), crtRuntimeException));
         return exception;
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/TransferManagerConfiguration.java
@@ -77,19 +77,19 @@ public class TransferManagerConfiguration implements SdkAutoCloseable {
     public boolean resolveUploadDirectoryRecursive(UploadDirectoryRequest request) {
         return request.overrideConfiguration()
                       .flatMap(UploadDirectoryOverrideConfiguration::recursive)
-                      .orElse(options.get(UPLOAD_DIRECTORY_RECURSIVE));
+                      .orElseGet(() -> options.get(UPLOAD_DIRECTORY_RECURSIVE));
     }
 
     public boolean resolveUploadDirectoryFollowSymbolicLinks(UploadDirectoryRequest request) {
         return request.overrideConfiguration()
                       .flatMap(UploadDirectoryOverrideConfiguration::followSymbolicLinks)
-                      .orElse(options.get(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS));
+                      .orElseGet(() -> options.get(UPLOAD_DIRECTORY_FOLLOW_SYMBOLIC_LINKS));
     }
 
     public int resolveUploadDirectoryMaxDepth(UploadDirectoryRequest request) {
         return request.overrideConfiguration()
                       .flatMap(UploadDirectoryOverrideConfiguration::maxDepth)
-                      .orElse(options.get(UPLOAD_DIRECTORY_MAX_DEPTH));
+                      .orElseGet(() -> options.get(UPLOAD_DIRECTORY_MAX_DEPTH));
     }
 
     @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingAsyncRequestBody.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/checksums/ChecksumCalculatingAsyncRequestBody.java
@@ -35,8 +35,8 @@ public class ChecksumCalculatingAsyncRequestBody implements AsyncRequestBody {
     public ChecksumCalculatingAsyncRequestBody(SdkHttpRequest request, AsyncRequestBody wrapped, SdkChecksum sdkChecksum) {
         this.contentLength = request.firstMatchingHeader("Content-Length")
                                     .map(Long::parseLong)
-                                    .orElse(wrapped.contentLength()
-                                                   .orElse(null));
+                                    .orElseGet(() -> wrapped.contentLength()
+                                                            .orElse(null));
         this.wrapped = wrapped;
         this.sdkChecksum = sdkChecksum;
     }


### PR DESCRIPTION
Reports method calls that accept a non-trivial expression and can be replaced with an equivalent method call which accepts a lambda instead.

Converting an expression to a lambda ensures that the expression won't be evaluated if it's not used inside the method. For example, `optional.orElse(createDefaultValue())` can be converted to `optional.orElseGet(this::createDefaultValue)`.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
