### PR TITLE
Enable & fix inspection: Object instantiation inside `equals()` or `hashCode()`

### DIFF
--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -5,5 +5,6 @@
       <option name="ignoreObjectMethods" value="false" />
       <option name="ignoreAnonymousClassMethods" value="false" />
     </inspection_tool>
+    <inspection_tool class="ObjectInstantiationInEqualsHashCode" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/document/internal/BooleanDocument.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/document/internal/BooleanDocument.java
@@ -17,7 +17,6 @@ package software.amazon.awssdk.core.document.internal;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkNumber;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/document/internal/BooleanDocument.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/document/internal/BooleanDocument.java
@@ -138,11 +138,11 @@ public final class BooleanDocument implements Document {
             return false;
         }
         BooleanDocument that = (BooleanDocument) o;
-        return Objects.equals(value, that.value);
+        return value == that.value;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(value);
+        return Boolean.hashCode(value);
     }
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullResponse.java
@@ -91,7 +91,7 @@ class DefaultSdkHttpFullResponse implements SdkHttpFullResponse, Serializable {
             return false;
         }
         DefaultSdkHttpFullResponse that = (DefaultSdkHttpFullResponse) o;
-        return Objects.equals(statusCode, that.statusCode) &&
+        return (statusCode == that.statusCode) &&
                Objects.equals(statusText, that.statusText) &&
                Objects.equals(headers, that.headers);
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointResolverContext.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointResolverContext.java
@@ -86,7 +86,7 @@ public final class S3EndpointResolverContext {
                Objects.equals(originalRequest, that.originalRequest) &&
                Objects.equals(region, that.region) &&
                Objects.equals(serviceConfiguration, that.serviceConfiguration) &&
-               Objects.equals(disableHostPrefixInjection, that.disableHostPrefixInjection);
+               (disableHostPrefixInjection == that.disableHostPrefixInjection);
     }
 
     @Override


### PR DESCRIPTION
Reports construction of (temporary) new objects inside equals(),
hashCode(), compareTo(), and Comparator.compare() methods.

Besides constructor invocations, new objects can also be created by
autoboxing or iterator creation inside a foreach statement. This can
cause performance problems, for example, when objects are added to a Set
 or Map, where these methods will be called often.

The inspection will not report when the objects are created in a throw
or assert statement.

Example:

```
  class Person {
    private String name;
    private int age;

    public boolean equals(Object o) {
      return Arrays.equals(new Object[] {name, age}, new Object[] {((Foo)o).name, ((Foo)o).age});
    }

    public int hashCode() {
      return (name + age).hashCode();
    }
  }
```

In this example, two additional arrays are created inside equals(),
usages of age field require boxing, and name + age implicitly creates a
new string.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
