### PR TITLE
Enable & fix inspection: Single character string argument in `String.indexOf()` call

### DIFF
--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="AWS Java SDK 2.0" />
+    <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreObjectMethods" value="false" />
       <option name="ignoreAnonymousClassMethods" value="false" />

--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/emitters/UnusedImportRemover.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/emitters/UnusedImportRemover.java
@@ -62,7 +62,7 @@ public class UnusedImportRemover implements CodeTransformer {
     }
 
     private boolean isNotReferenced(String contentWithoutImports, String importToCheck) {
-        String symbol = importToCheck.substring(importToCheck.lastIndexOf(".") + 1);
+        String symbol = importToCheck.substring(importToCheck.lastIndexOf('.') + 1);
         return !Pattern.compile(String.format("\\b%s\\b", symbol)).matcher(contentWithoutImports).find();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/UnusedImportRemover.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/UnusedImportRemover.java
@@ -62,7 +62,7 @@ public class UnusedImportRemover implements CodeTransformer {
     }
 
     private boolean isNotReferenced(String contentWithoutImports, String importToCheck) {
-        String symbol = importToCheck.substring(importToCheck.lastIndexOf(".") + 1);
+        String symbol = importToCheck.substring(importToCheck.lastIndexOf('.') + 1);
         return !Pattern.compile(String.format("\\b%s\\b", symbol)).matcher(contentWithoutImports).find();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DocumentationUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/internal/DocumentationUtils.java
@@ -72,8 +72,8 @@ public final class DocumentationUtils {
         }
 
         if (documentation.startsWith("<")) {
-            int startTagIndex = documentation.indexOf(">");
-            int closingTagIndex = documentation.lastIndexOf("<");
+            int startTagIndex = documentation.indexOf('>');
+            int closingTagIndex = documentation.lastIndexOf('<');
             if (closingTagIndex > startTagIndex) {
                 documentation = stripHtmlTags(documentation.substring(startTagIndex + 1, closingTagIndex));
             } else {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ListModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/ListModel.java
@@ -125,7 +125,7 @@ public class ListModel {
     }
 
     public String getSimpleType() {
-        int startIndex = memberType.lastIndexOf(".");
+        int startIndex = memberType.lastIndexOf('.');
         return memberType.substring(startIndex + 1);
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/VariableModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/VariableModel.java
@@ -64,7 +64,7 @@ public class VariableModel extends DocumentationModel {
 
     public String getSimpleType() {
         if (variableType.contains(".")) {
-            return variableType.substring(variableType.lastIndexOf(".") + 1);
+            return variableType.substring(variableType.lastIndexOf('.') + 1);
         }
         return variableType;
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/PoetUtils.java
@@ -98,8 +98,8 @@ public final class PoetUtils {
     }
 
     public static ClassName classNameFromFqcn(String fqcn) {
-        String basePath = fqcn.substring(0, fqcn.lastIndexOf("."));
-        String className = fqcn.substring(fqcn.lastIndexOf(".") + 1);
+        String basePath = fqcn.substring(0, fqcn.lastIndexOf('.'));
+        String className = fqcn.substring(fqcn.lastIndexOf('.') + 1);
         return ClassName.get(basePath, className);
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -389,7 +389,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
 
     private ClassName baseExceptionClassName(IntermediateModel model) {
         String exceptionPath = model.getSdkModeledExceptionBaseFqcn()
-                                    .substring(0, model.getSdkModeledExceptionBaseFqcn().lastIndexOf("."));
+                                    .substring(0, model.getSdkModeledExceptionBaseFqcn().lastIndexOf('.'));
 
         return ClassName.get(exceptionPath, model.getSdkModeledExceptionBaseClassName());
     }

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonErrorCodeParser.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/unmarshall/JsonErrorCodeParser.java
@@ -124,7 +124,7 @@ public class JsonErrorCodeParser implements ErrorCodeParser {
             return null;
         }
         String code = errorCodeField.text();
-        int separator = code.lastIndexOf("#");
+        int separator = code.lastIndexOf('#');
         return code.substring(separator + 1);
     }
 }

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/ProtocolUtils.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/ProtocolUtils.java
@@ -62,13 +62,13 @@ public final class ProtocolUtils {
 
         String resourcePath = uriResourcePath;
 
-        int index = resourcePath.indexOf("?");
+        int index = resourcePath.indexOf('?');
         if (index != -1) {
             String queryString = resourcePath.substring(index + 1);
             resourcePath = resourcePath.substring(0, index);
 
             for (String s : queryString.split("[;&]")) {
-                index = s.indexOf("=");
+                index = s.indexOf('=');
                 if (index != -1) {
                     request.putRawQueryParameter(s.substring(0, index), s.substring(index + 1));
                 } else {

--- a/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
+++ b/services/glacier/src/main/java/software/amazon/awssdk/services/glacier/internal/GlacierExecutionInterceptor.java
@@ -66,7 +66,7 @@ public final class GlacierExecutionInterceptor implements ExecutionInterceptor {
         String end = range.substring(range.indexOf('-') + 1);
 
         if (end.contains("/")) {
-            end = end.substring(0, end.indexOf("/"));
+            end = end.substring(0, end.indexOf('/'));
         }
 
         return Long.parseLong(end) - Long.parseLong(start) + 1;

--- a/services/route53/src/main/java/software/amazon/awssdk/services/route53/internal/Route53IdInterceptor.java
+++ b/services/route53/src/main/java/software/amazon/awssdk/services/route53/internal/Route53IdInterceptor.java
@@ -252,7 +252,7 @@ public final class Route53IdInterceptor implements ExecutionInterceptor {
             return null;
         }
 
-        int lastIndex = s.lastIndexOf("/");
+        int lastIndex = s.lastIndexOf('/');
         if (lastIndex > 0) {
             return s.substring(lastIndex + 1);
         }

--- a/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/asserts/marshalling/UriAssertion.java
+++ b/test/protocol-tests-core/src/main/java/software/amazon/awssdk/protocol/asserts/marshalling/UriAssertion.java
@@ -41,6 +41,6 @@ public class UriAssertion extends MarshallingAssertion {
     }
 
     private String removeTrailingSlash(String str) {
-        return (str.endsWith("/")) ? str.substring(0, str.lastIndexOf("/")) : str;
+        return (str.endsWith("/")) ? str.substring(0, str.lastIndexOf('/')) : str;
     }
 }


### PR DESCRIPTION
Reports single character strings being used as an argument in String.indexOf() and String.lastIndexOf() calls.

A quick-fix is suggested to replace such string literals with equivalent character literals, gaining some performance enhancement.

Example:

```
  return s.indexOf("x");
```

After the quick-fix is applied:

```
  return s.indexOf('x');
```

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
