### PR TITLE
feat: Enable `StsWebIdentityCredentialsProvider` to be given a custom `httpClient`

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
@@ -62,7 +62,7 @@ public class WebIdentityTokenFileCredentialsProvider implements AwsCredentialsPr
                                                     .webIdentityTokenFile(webIdentityTokenFile)
                                                     .build();
 
-            credentialsProvider = WebIdentityCredentialsUtils.factory().create(credentialProperties);
+            credentialsProvider = WebIdentityCredentialsUtils.factory(builder.httpClient).create(credentialProperties);
         } catch (RuntimeException e) {
             // If we couldn't load the credentials provider for some reason, save an exception describing why. This exception
             // will only be raised on calls to getCredentials. We don't want to raise an exception here because it may be
@@ -117,6 +117,11 @@ public class WebIdentityTokenFileCredentialsProvider implements AwsCredentialsPr
         Builder webIdentityTokenFile(Path webIdentityTokenFile);
 
         /**
+         * Define the HTTP client used by the token provider.
+         */
+        Builder httpClient(SdkHttpClient httpClient);
+
+        /**
          * Create a {@link WebIdentityTokenFileCredentialsProvider} using the configuration applied to this builder.
          */
         WebIdentityTokenFileCredentialsProvider build();
@@ -126,6 +131,7 @@ public class WebIdentityTokenFileCredentialsProvider implements AwsCredentialsPr
         private String roleArn;
         private String roleSessionName;
         private Path webIdentityTokenFile;
+        private SdkHttpClient httpClient;
 
         BuilderImpl() {
         }
@@ -158,6 +164,16 @@ public class WebIdentityTokenFileCredentialsProvider implements AwsCredentialsPr
 
         public void setWebIdentityTokenFile(Path webIdentityTokenFile) {
             webIdentityTokenFile(webIdentityTokenFile);
+        }
+
+        @Override
+        public Builder httpClient(SdkHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        public void setHttpClient(SdkHttpClient httpClient) {
+            httpClient(httpClient);
         }
 
         @Override

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/WebIdentityCredentialsUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/WebIdentityCredentialsUtils.java
@@ -40,11 +40,11 @@ public final class WebIdentityCredentialsUtils {
      *
      * @return WebIdentityTokenCredentialsProviderFactory
      */
-    public static WebIdentityTokenCredentialsProviderFactory factory() {
+    public static WebIdentityTokenCredentialsProviderFactory factory(SdkHttpClient httpClient) {
         try {
             Class<?> stsCredentialsProviderFactory = ClassLoaderHelper.loadClass(STS_WEB_IDENTITY_CREDENTIALS_PROVIDER_FACTORY,
                     WebIdentityCredentialsUtils.class);
-            return (WebIdentityTokenCredentialsProviderFactory) stsCredentialsProviderFactory.getConstructor().newInstance();
+            return (WebIdentityTokenCredentialsProviderFactory) stsCredentialsProviderFactory.getConstructor().newInstance(httpClient);
         } catch (ClassNotFoundException e) {
             String message = "To use web identity tokens, the 'sts' service module must be on the class path.";
             log.warn(() -> message);


### PR DESCRIPTION
This enables to provide a custom `SdkHttpClient` to the web identity token file provider.

## Motivation and Context

Running a Quarkus application in EKS, the application authenticates itself to AWS services with the `WebIdentityTokenFileCredentialsProvider`. For some reason, I can't get Quarkus to recognise the available HTTP client when built with the "native" profile so have to explicitly given the `httpClient` to the AWS clients. However, it doesn't work with this authentication provider because we can't give it our own HTTP client.

## Description

This allows to pass down the `httpClient` from `WebIdentityTokenFileCredentialsProvider` to the STS client.

## Testing

- [ ] TODO.

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
