### PR TITLE
Added support for enabling FIPS endpoints.

### DIFF
--- a/.changes/next-release/deprecation-AmazonS3Control-df756f2.json
+++ b/.changes/next-release/deprecation-AmazonS3Control-df756f2.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon S3 Control", 
+    "contributor": "", 
+    "type": "deprecation", 
+    "description": "Deprecated `S3ControlConfiguration.Builder`'s `fipsModeEnabled` in favor of the new service-standard `S3ControlClientBuilder.fipsEnabled`."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-635c382.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-635c382.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Added a new `fipsEnabled` property to every client builder, which can be used to make calls be invoked against AWS endpoints which are FIPS compliant. This can also be enabled via the `AWS_USE_FIPS_ENDPOINT` environment variable, `aws.useFipsEndpoint` system property, or the `use_fips_endpoint` profile file property."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -37,16 +37,9 @@ public class CustomizationConfig {
     private final List<ConvenienceTypeOverload> convenienceTypeOverloads = new ArrayList<>();
 
     /**
-     * Specifies the name of the client configuration class to use if a service
-     * has a specific advanced client configuration class. Null if the service
-     * does not have advanced configuration.
+     * Configuration object for service-specific configuration options.
      */
-    private String serviceSpecificClientConfigClass;
-
-    /**
-     * Whether a service has a dualstack configuration in its {@link #serviceSpecificClientConfigClass}.
-     */
-    private boolean serviceConfigHasDualstackConfig = false;
+    private ServiceConfig serviceConfig = new ServiceConfig();
 
     /**
      * Specify shapes to be renamed.
@@ -242,22 +235,6 @@ public class CustomizationConfig {
 
     public void setShapeModifiers(Map<String, ShapeModifier> shapeModifiers) {
         this.shapeModifiers = shapeModifiers;
-    }
-
-    public String getServiceSpecificClientConfigClass() {
-        return serviceSpecificClientConfigClass;
-    }
-
-    public void setServiceSpecificClientConfigClass(String serviceSpecificClientConfig) {
-        this.serviceSpecificClientConfigClass = serviceSpecificClientConfig;
-    }
-
-    public boolean getServiceConfigHasDualstackConfig() {
-        return serviceConfigHasDualstackConfig;
-    }
-
-    public void setServiceConfigHasDualstackConfig(boolean serviceConfigHasDualstackConfig) {
-        this.serviceConfigHasDualstackConfig = serviceConfigHasDualstackConfig;
     }
 
     public List<ConvenienceTypeOverload> getConvenienceTypeOverloads() {
@@ -516,5 +493,13 @@ public class CustomizationConfig {
 
     public void setDefaultRetryMode(RetryMode defaultRetryMode) {
         this.defaultRetryMode = defaultRetryMode;
+    }
+
+    public ServiceConfig getServiceConfig() {
+        return serviceConfig;
+    }
+
+    public void setServiceConfig(ServiceConfig serviceConfig) {
+        this.serviceConfig = serviceConfig;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ServiceConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ServiceConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+public class ServiceConfig {
+    /**
+     * Specifies the name of the client configuration class to use if a service
+     * has a specific advanced client configuration class. Null if the service
+     * does not have advanced configuration.
+     */
+    private String className;
+
+    /**
+     * Whether the service config has a property used to manage dualstack (should be deprecated in favor of
+     * AwsClientBuilder#dualstackEnabled).
+     */
+    private boolean hasDualstackProperty = false;
+
+    /**
+     * Whether the service config has a property used to manage FIPS (should be deprecated in favor of
+     * AwsClientBuilder#fipsEnabled).
+     */
+    private boolean hasFipsProperty = false;
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public boolean hasDualstackProperty() {
+        return hasDualstackProperty;
+    }
+
+    public void setHasDualstackProperty(boolean hasDualstackProperty) {
+        this.hasDualstackProperty = hasDualstackProperty;
+    }
+
+    public boolean hasFipsProperty() {
+        return hasFipsProperty;
+    }
+
+    public void setHasFipsProperty(boolean hasFipsProperty) {
+        this.hasFipsProperty = hasFipsProperty;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
@@ -57,7 +57,7 @@ public class BaseClientBuilderInterface implements ClassSpec {
             builder.addMethod(endpointDiscovery());
         }
 
-        if (model.getCustomizationConfig().getServiceSpecificClientConfigClass() != null) {
+        if (model.getCustomizationConfig().getServiceConfig().getClassName() != null) {
             builder.addMethod(serviceConfigurationMethod());
             builder.addMethod(serviceConfigurationConsumerBuilderMethod());
         }
@@ -91,7 +91,7 @@ public class BaseClientBuilderInterface implements ClassSpec {
 
     private MethodSpec serviceConfigurationMethod() {
         ClassName serviceConfiguration = ClassName.get(basePackage,
-                                                        model.getCustomizationConfig().getServiceSpecificClientConfigClass());
+                                                        model.getCustomizationConfig().getServiceConfig().getClassName());
         return MethodSpec.methodBuilder("serviceConfiguration")
                          .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
                          .returns(TypeVariableName.get("B"))
@@ -101,7 +101,7 @@ public class BaseClientBuilderInterface implements ClassSpec {
 
     private MethodSpec serviceConfigurationConsumerBuilderMethod() {
         ClassName serviceConfiguration = ClassName.get(basePackage,
-                                                        model.getCustomizationConfig().getServiceSpecificClientConfigClass());
+                                                        model.getCustomizationConfig().getServiceConfig().getClassName());
         TypeName consumerBuilder = ParameterizedTypeName.get(ClassName.get(Consumer.class),
                                                              serviceConfiguration.nestedClass("Builder"));
         return MethodSpec.methodBuilder("serviceConfiguration")

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -58,7 +58,16 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         } else {
             c.dualstackEnabled(config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED));
         }
-        return config.toBuilder().option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
+        if (c.fipsModeEnabled() != null) {
+            Validate.validState(
+                config.option(AwsClientOption.FIPS_ENDPOINT_ENABLED) == null,
+                "Fips has been configured on both ServiceConfiguration and the client/global level. Please limit fips configuration to one location.");
+        } else {
+            c.fipsModeEnabled(config.option(AwsClientOption.FIPS_ENDPOINT_ENABLED));
+        }
+        return config.toBuilder().option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED, c.dualstackEnabled())
+                     .option(AwsClientOption.FIPS_ENDPOINT_ENABLED, c.fipsModeEnabled())
+                     .option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors)
                      .option(SdkClientOption.RETRY_POLICY, MyServiceRetryPolicy.resolveRetryPolicy(config))
                      .option(SdkClientOption.SERVICE_CONFIGURATION, c.build()).build();
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/customization.config
@@ -4,8 +4,11 @@
     },
     "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
     "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
-    "serviceSpecificClientConfigClass": "ServiceConfiguration",
-    "serviceConfigHasDualstackConfig": true,
+    "serviceConfig": {
+      "className": "ServiceConfiguration",
+      "hasDualstackProperty": true,
+      "hasFipsProperty": true
+    },
     "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
@@ -4,8 +4,11 @@
     },
     "presignersFqcn": "software.amazon.awssdk.services.acm.presign.AcmClientPresigners",
     "serviceSpecificHttpConfig": "software.amazon.MyServiceHttpConfig",
-    "serviceSpecificClientConfigClass": "ServiceConfiguration",
-    "serviceConfigHasDualstackConfig": true,
+    "serviceConfig": {
+      "className": "ServiceConfiguration",
+      "hasDualstackProperty": true,
+      "hasFipsProperty": true
+    },
     "customRetryPolicy": "software.amazon.MyServiceRetryPolicy",
     "verifiedSimpleMethods" : ["paginatedOperationWithResultKey"],
     "blacklistedSimpleMethods" : [

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
@@ -57,9 +57,9 @@ public final class AwsCredentialsProviderChain implements AwsCredentialsProvider
      * @see #builder()
      */
     private AwsCredentialsProviderChain(BuilderImpl builder) {
+        Validate.notEmpty(builder.credentialsProviders, "No credential providers were specified.");
         this.reuseLastProviderEnabled = builder.reuseLastProviderEnabled;
-        this.credentialsProviders = Collections.unmodifiableList(
-                Validate.notEmpty(builder.credentialsProviders, "No credential providers were specified."));
+        this.credentialsProviders = Collections.unmodifiableList(builder.credentialsProviders);
     }
 
     /**

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsExecutionAttribute.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsExecutionAttribute.java
@@ -39,7 +39,16 @@ public final class AwsExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<String> ENDPOINT_PREFIX = new ExecutionAttribute<>("AwsEndpointPrefix");
 
+    /**
+     * Whether dualstack endpoints were enabled for this request.
+     */
     public static final ExecutionAttribute<Boolean> DUALSTACK_ENDPOINT_ENABLED =
+        new ExecutionAttribute<>("DualstackEndpointsEnabled");
+
+    /**
+     * Whether fips endpoints were enabled for this request.
+     */
+    public static final ExecutionAttribute<Boolean> FIPS_ENDPOINT_ENABLED =
         new ExecutionAttribute<>("DualstackEndpointsEnabled");
 
     private AwsExecutionAttribute() {

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.java
@@ -81,4 +81,20 @@ public interface AwsClientBuilder<BuilderT extends AwsClientBuilder<BuilderT, Cl
      * <p>If the setting is not found in any of the locations above, 'false' will be used.
      */
     BuilderT dualstackEnabled(Boolean dualstackEndpointEnabled);
+
+    /**
+     * Configure whether the SDK should use the AWS fips endpoints.
+     *
+     * <p>If this is not specified, the SDK will attempt to determine whether the fips endpoint should be used
+     * automatically using the following logic:
+     * <ol>
+     *     <li>Check the 'aws.useFipsEndpoint' system property for 'true' or 'false'.</li>
+     *     <li>Check the 'AWS_USE_FIPS_ENDPOINT' environment variable for 'true' or 'false'.</li>
+     *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_fips_endpoint'
+     *     property set to 'true' or 'false'.</li>
+     * </ol>
+     *
+     * <p>If the setting is not found in any of the locations above, 'false' will be used.
+     */
+    BuilderT fipsEnabled(Boolean fipsEndpointEnabled);
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.awscore.client.config.AwsAdvancedClientOption;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
 import software.amazon.awssdk.awscore.endpoint.DualstackEnabledProvider;
+import software.amazon.awssdk.awscore.endpoint.FipsEnabledProvider;
 import software.amazon.awssdk.awscore.eventstream.EventStreamInitialRequestInterceptor;
 import software.amazon.awssdk.awscore.interceptor.HelpfulUnknownHostExceptionInterceptor;
 import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
@@ -144,6 +145,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                                      .option(AwsClientOption.AWS_REGION, resolveRegion(configuration))
                                      .option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED,
                                              resolveDualstackEndpointEnabled(configuration))
+                                     .option(AwsClientOption.FIPS_ENDPOINT_ENABLED, resolveFipsEndpointEnabled(configuration))
                                      .build();
 
         return configuration.toBuilder()
@@ -181,9 +183,10 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     private URI endpointFromConfig(SdkClientConfiguration config) {
         return new DefaultServiceEndpointBuilder(serviceEndpointPrefix(), DEFAULT_ENDPOINT_PROTOCOL)
             .withRegion(config.option(AwsClientOption.AWS_REGION))
-            .withProfileFile(config.option(SdkClientOption.PROFILE_FILE))
+            .withProfileFile(() -> config.option(SdkClientOption.PROFILE_FILE))
             .withProfileName(config.option(SdkClientOption.PROFILE_NAME))
             .withDualstackEnabled(config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
+            .withFipsEnabled(config.option(AwsClientOption.FIPS_ENDPOINT_ENABLED))
             .getServiceEndpoint();
     }
 
@@ -220,13 +223,13 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     private Boolean resolveDualstackEndpointEnabled(SdkClientConfiguration config) {
         return config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED) != null
                ? config.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED)
-               : dualstackEndpointFromDefaultProvider(config);
+               : resolveUseDualstackFromDefaultProvider(config);
     }
 
     /**
      * Load the dualstack endpoint setting from the default provider logic.
      */
-    private Boolean dualstackEndpointFromDefaultProvider(SdkClientConfiguration config) {
+    private Boolean resolveUseDualstackFromDefaultProvider(SdkClientConfiguration config) {
         ProfileFile profileFile = config.option(SdkClientOption.PROFILE_FILE);
         String profileName = config.option(SdkClientOption.PROFILE_NAME);
         return DualstackEnabledProvider.builder()
@@ -235,6 +238,29 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
                                        .build()
                                        .isDualstackEnabled()
                                        .orElse(null);
+    }
+
+    /**
+     * Resolve whether a dualstack endpoint should be used for this client.
+     */
+    private Boolean resolveFipsEndpointEnabled(SdkClientConfiguration config) {
+        return config.option(AwsClientOption.FIPS_ENDPOINT_ENABLED) != null
+               ? config.option(AwsClientOption.FIPS_ENDPOINT_ENABLED)
+               : resolveUseFipsFromDefaultProvider(config);
+    }
+
+    /**
+     * Load the dualstack endpoint setting from the default provider logic.
+     */
+    private Boolean resolveUseFipsFromDefaultProvider(SdkClientConfiguration config) {
+        ProfileFile profileFile = config.option(SdkClientOption.PROFILE_FILE);
+        String profileName = config.option(SdkClientOption.PROFILE_NAME);
+        return FipsEnabledProvider.builder()
+                                  .profileFile(() -> profileFile)
+                                  .profileName(profileName)
+                                  .build()
+                                  .isFipsEnabled()
+                                  .orElse(null);
     }
 
     /**
@@ -286,6 +312,16 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
 
     public final void setDualstackEnabled(Boolean dualstackEndpointEnabled) {
         dualstackEnabled(dualstackEndpointEnabled);
+    }
+
+    @Override
+    public BuilderT fipsEnabled(Boolean dualstackEndpointEnabled) {
+        clientConfiguration.option(AwsClientOption.FIPS_ENDPOINT_ENABLED, dualstackEndpointEnabled);
+        return thisBuilder();
+    }
+
+    public final void setFipsEnabled(Boolean fipsEndpointEnabled) {
+        fipsEnabled(fipsEndpointEnabled);
     }
 
     @Override

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/config/AwsClientOption.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/config/AwsClientOption.java
@@ -47,6 +47,12 @@ public final class AwsClientOption<T> extends ClientOption<T> {
     public static final AwsClientOption<Boolean> DUALSTACK_ENDPOINT_ENABLED = new AwsClientOption<>(Boolean.class);
 
     /**
+     * Whether the SDK should resolve fips endpoints instead of default endpoints. See
+     * {@link AwsClientBuilder#fipsEnabled(Boolean)}.
+     */
+    public static final ClientOption<Boolean> FIPS_ENDPOINT_ENABLED = new AwsClientOption<>(Boolean.class);
+
+    /**
      * Scope name to use during signing of a request.
      */
     public static final AwsClientOption<String> SERVICE_SIGNING_NAME = new AwsClientOption<>(String.class);

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/FipsEnabledProvider.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/endpoint/FipsEnabledProvider.java
@@ -19,22 +19,21 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkSystemSetting;
-import software.amazon.awssdk.profiles.Profile;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * A resolver for the default value of whether the SDK should use dualstack endpoints. This checks environment variables,
- * system properties and the profile file for the relevant configuration options when {@link #isDualstackEnabled()} is invoked.
+ * A resolver for the default value of whether the SDK should use fips endpoints. This checks environment variables,
+ * system properties and the profile file for the relevant configuration options when {@link #isFipsEnabled()} is invoked.
  */
 @SdkProtectedApi
-public class DualstackEnabledProvider {
+public class FipsEnabledProvider {
     private final Supplier<ProfileFile> profileFile;
     private final String profileName;
 
-    private DualstackEnabledProvider(Builder builder) {
+    private FipsEnabledProvider(Builder builder) {
         this.profileFile = Validate.paramNotNull(builder.profileFile, "profileFile");
         this.profileName = builder.profileName;
     }
@@ -47,17 +46,15 @@ public class DualstackEnabledProvider {
      * Returns true when dualstack should be used, false when dualstack should not be used, and empty when there is no global
      * dualstack configuration.
      */
-    public Optional<Boolean> isDualstackEnabled() {
-        Optional<Boolean> setting = SdkSystemSetting.AWS_USE_DUALSTACK_ENDPOINT.getBooleanValue();
+    public Optional<Boolean> isFipsEnabled() {
+        Optional<Boolean> setting = SdkSystemSetting.AWS_USE_FIPS_ENDPOINT.getBooleanValue();
         if (setting.isPresent()) {
             return setting;
         }
 
-        ProfileFile profileFile = this.profileFile.get();
-        Optional<Profile> profile = profileFile
-            .profile(profileName());
-        return profile
-                          .flatMap(p -> p.booleanProperty(ProfileProperty.USE_DUALSTACK_ENDPOINT));
+        return profileFile.get()
+                          .profile(profileName())
+                          .flatMap(p -> p.booleanProperty(ProfileProperty.USE_FIPS_ENDPOINT));
     }
 
     private String profileName() {
@@ -81,8 +78,8 @@ public class DualstackEnabledProvider {
             return this;
         }
 
-        public DualstackEnabledProvider build() {
-            return new DualstackEnabledProvider(this);
+        public FipsEnabledProvider build() {
+            return new FipsEnabledProvider(this);
         }
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
@@ -84,6 +84,8 @@ public final class AwsExecutionContextBuilder {
             .putAttribute(SdkExecutionAttribute.PROFILE_NAME, clientConfig.option(SdkClientOption.PROFILE_NAME))
             .putAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED,
                           clientConfig.option(AwsClientOption.DUALSTACK_ENDPOINT_ENABLED))
+            .putAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED,
+                          clientConfig.option(AwsClientOption.FIPS_ENDPOINT_ENABLED))
             .putAttribute(SdkExecutionAttribute.OPERATION_NAME, executionParams.getOperationName())
             .putAttribute(SdkExecutionAttribute.CLIENT_ENDPOINT, clientConfig.option(SdkClientOption.ENDPOINT))
             .putAttribute(SdkExecutionAttribute.ENDPOINT_OVERRIDDEN, clientConfig.option(SdkClientOption.ENDPOINT_OVERRIDDEN))

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/presigner/SdkPresigner.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/presigner/SdkPresigner.java
@@ -92,6 +92,22 @@ public interface SdkPresigner extends SdkAutoCloseable {
         Builder dualstackEnabled(Boolean dualstackEnabled);
 
         /**
+         * Configure whether the SDK should use the AWS fips endpoint.
+         *
+         * <p>If this is not specified, the SDK will attempt to determine whether the fips endpoint should be used
+         * automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.useFipsEndpoint' system property for 'true' or 'false'.</li>
+         *     <li>Check the 'AWS_USE_FIPS_ENDPOINT' environment variable for 'true' or 'false'.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_fips_endpoint'
+         *     property set to 'true' or 'false'.</li>
+         * </ol>
+         *
+         * <p>If the setting is not found in any of the locations above, 'false' will be used.
+         */
+        Builder fipsEnabled(Boolean fipsEnabled);
+
+        /**
          * Configure an endpoint that should be used in the pre-signed requests. This will override the endpoint that is usually
          * determined by the {@link #region(Region)} and {@link #dualstackEnabled(Boolean)} settings.
          */

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileProperty.java
@@ -123,6 +123,8 @@ public final class ProfileProperty {
 
     public static final String USE_DUALSTACK_ENDPOINT = "use_dualstack_endpoint";
 
+    public static final String USE_FIPS_ENDPOINT = "use_fips_endpoint";
+
     public static final String EC2_METADATA_SERVICE_ENDPOINT_MODE = "ec2_metadata_service_endpoint_mode";
 
     public static final String EC2_METADATA_SERVICE_ENDPOINT = "ec2_metadata_service_endpoint";

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -174,6 +174,11 @@ public enum SdkSystemSetting implements SystemSetting {
      */
     AWS_USE_DUALSTACK_ENDPOINT("aws.useDualstackEndpoint", null),
 
+    /**
+     * Defines whether fips endpoints should be resolved during default endpoint resolution instead of non-fips endpoints.
+     */
+    AWS_USE_FIPS_ENDPOINT("aws.useFipsEndpoint", null),
+
     ;
 
     private final String systemProperty;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/builder/SdkDefaultClientBuilder.java
@@ -353,10 +353,14 @@ public abstract class SdkDefaultClientBuilder<B extends SdkClientBuilder<B, C>, 
 
     @Override
     public final B endpointOverride(URI endpointOverride) {
-        Validate.paramNotNull(endpointOverride, "endpointOverride");
-        Validate.paramNotNull(endpointOverride.getScheme(), "The URI scheme of endpointOverride");
-        clientConfiguration.option(SdkClientOption.ENDPOINT, endpointOverride);
-        clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN, true);
+        if (endpointOverride == null) {
+            clientConfiguration.option(SdkClientOption.ENDPOINT, null);
+            clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN, false);
+        } else {
+            Validate.paramNotNull(endpointOverride.getScheme(), "The URI scheme of endpointOverride");
+            clientConfiguration.option(SdkClientOption.ENDPOINT, endpointOverride);
+            clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN, true);
+        }
         return thisBuilder();
     }
 

--- a/services/docdb/src/main/java/software/amazon/awssdk/services/docdb/internal/RdsPresignInterceptor.java
+++ b/services/docdb/src/main/java/software/amazon/awssdk/services/docdb/internal/RdsPresignInterceptor.java
@@ -162,9 +162,10 @@ public abstract class RdsPresignInterceptor<T extends DocDbRequest> implements E
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, Protocol.HTTPS.toString())
             .withRegion(region)
-            .withProfileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
+            .withProfileFile(() -> attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
             .withProfileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
             .withDualstackEnabled(attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+            .withFipsEnabled(attributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
             .getServiceEndpoint();
     }
 }

--- a/services/docdb/src/test/java/software/amazon/awssdk/services/docdb/internal/PresignRequestHandlerTest.java
+++ b/services/docdb/src/test/java/software/amazon/awssdk/services/docdb/internal/PresignRequestHandlerTest.java
@@ -38,8 +38,10 @@ import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.docdb.model.CopyDbClusterSnapshotRequest;
 import software.amazon.awssdk.services.docdb.model.DocDbRequest;
@@ -162,7 +164,9 @@ public class PresignRequestHandlerTest {
 
     private ExecutionAttributes executionAttributes() {
         return new ExecutionAttributes().putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, CREDENTIALS)
-                .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION);
+                                        .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION)
+                                        .putAttribute(SdkExecutionAttribute.PROFILE_FILE, ProfileFile.defaultProfileFile())
+                                        .putAttribute(SdkExecutionAttribute.PROFILE_NAME, "default");
     }
 
     private CopyDbClusterSnapshotRequest makeTestRequest() {

--- a/services/neptune/src/main/java/software/amazon/awssdk/services/neptune/internal/RdsPresignInterceptor.java
+++ b/services/neptune/src/main/java/software/amazon/awssdk/services/neptune/internal/RdsPresignInterceptor.java
@@ -164,9 +164,10 @@ public abstract class RdsPresignInterceptor<T extends NeptuneRequest> implements
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, Protocol.HTTPS.toString())
                 .withRegion(region)
-                .withProfileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
+                .withProfileFile(() -> attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
                 .withProfileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
                 .withDualstackEnabled(attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+                .withFipsEnabled(attributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
                 .getServiceEndpoint();
     }
 }

--- a/services/neptune/src/test/java/software/amazon/awssdk/services/neptune/internal/PresignRequestHandlerTest.java
+++ b/services/neptune/src/test/java/software/amazon/awssdk/services/neptune/internal/PresignRequestHandlerTest.java
@@ -24,8 +24,10 @@ import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.neptune.model.CopyDbClusterSnapshotRequest;
 import software.amazon.awssdk.services.neptune.model.NeptuneRequest;
@@ -158,7 +160,9 @@ public class PresignRequestHandlerTest {
 
     private ExecutionAttributes executionAttributes() {
         return new ExecutionAttributes().putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, CREDENTIALS)
-                .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION);
+                                        .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION)
+                                        .putAttribute(SdkExecutionAttribute.PROFILE_FILE, ProfileFile.defaultProfileFile())
+                                        .putAttribute(SdkExecutionAttribute.PROFILE_NAME, "default");
     }
 
     private CopyDbClusterSnapshotRequest makeTestRequest() {

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.awscore.AwsExecutionAttribute;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
 import software.amazon.awssdk.awscore.endpoint.DualstackEnabledProvider;
+import software.amazon.awssdk.awscore.endpoint.FipsEnabledProvider;
 import software.amazon.awssdk.awscore.presigner.PresignRequest;
 import software.amazon.awssdk.awscore.presigner.PresignedRequest;
 import software.amazon.awssdk.core.ClientType;
@@ -73,6 +74,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     private final AwsCredentialsProvider credentialsProvider;
     private final URI endpointOverride;
     private final Boolean dualstackEnabled;
+    private final Boolean fipsEnabled;
 
     private DefaultPollyPresigner(BuilderImpl builder) {
         this.profileFile = ProfileFile.defaultProfileFile();
@@ -96,6 +98,13 @@ public final class DefaultPollyPresigner implements PollyPresigner {
                                                                                            .build()
                                                                                            .isDualstackEnabled()
                                                                                            .orElse(false);
+        this.fipsEnabled = builder.fipsEnabled != null ? builder.fipsEnabled
+                                                       : FipsEnabledProvider.builder()
+                                                                            .profileFile(() -> profileFile)
+                                                                            .profileName(profileName)
+                                                                            .build()
+                                                                            .isFipsEnabled()
+                                                                            .orElse(false);
     }
 
     public Region region() {
@@ -236,9 +245,10 @@ public final class DefaultPollyPresigner implements PollyPresigner {
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, "https")
                 .withRegion(region())
-                .withProfileFile(profileFile)
+                .withProfileFile(() -> profileFile)
                 .withProfileName(profileName)
                 .withDualstackEnabled(dualstackEnabled)
+                .withFipsEnabled(fipsEnabled)
                 .getServiceEndpoint();
     }
 
@@ -247,6 +257,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
         private AwsCredentialsProvider credentialsProvider;
         private URI endpointOverride;
         private Boolean dualstackEnabled;
+        private Boolean fipsEnabled;
 
         @Override
         public Builder region(Region region) {
@@ -263,6 +274,12 @@ public final class DefaultPollyPresigner implements PollyPresigner {
         @Override
         public Builder dualstackEnabled(Boolean dualstackEnabled) {
             this.dualstackEnabled = dualstackEnabled;
+            return this;
+        }
+
+        @Override
+        public Builder fipsEnabled(Boolean fipsEnabled) {
+            this.fipsEnabled = fipsEnabled;
             return this;
         }
 

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/presigner/PollyPresigner.java
@@ -167,6 +167,9 @@ public interface PollyPresigner extends SdkPresigner {
         Builder dualstackEnabled(Boolean dualstackEnabled);
 
         @Override
+        Builder fipsEnabled(Boolean fipsEnabled);
+
+        @Override
         Builder endpointOverride(URI endpointOverride);
 
         @Override

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/internal/RdsPresignInterceptor.java
@@ -162,9 +162,10 @@ public abstract class RdsPresignInterceptor<T extends RdsRequest> implements Exe
 
         return new DefaultServiceEndpointBuilder(SERVICE_NAME, Protocol.HTTPS.toString())
             .withRegion(region)
-            .withProfileFile(attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
+            .withProfileFile(() -> attributes.getAttribute(SdkExecutionAttribute.PROFILE_FILE))
             .withProfileName(attributes.getAttribute(SdkExecutionAttribute.PROFILE_NAME))
             .withDualstackEnabled(attributes.getAttribute(AwsExecutionAttribute.DUALSTACK_ENDPOINT_ENABLED))
+            .withFipsEnabled(attributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
             .getServiceEndpoint();
     }
 }

--- a/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
+++ b/services/rds/src/test/java/software/amazon/awssdk/services/rds/internal/PresignRequestHandlerTest.java
@@ -37,8 +37,10 @@ import software.amazon.awssdk.core.Protocol;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.model.CopyDbSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.RdsRequest;
@@ -162,7 +164,9 @@ public class PresignRequestHandlerTest {
 
     private ExecutionAttributes executionAttributes() {
         return new ExecutionAttributes().putAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS, CREDENTIALS)
-                                        .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION);
+                                        .putAttribute(AwsSignerExecutionAttribute.SIGNING_REGION, DESTINATION_REGION)
+                                        .putAttribute(SdkExecutionAttribute.PROFILE_FILE, ProfileFile.defaultProfileFile())
+                                        .putAttribute(SdkExecutionAttribute.PROFILE_NAME, "default");
     }
 
     private CopyDbSnapshotRequest makeTestRequest() {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointResolverContext.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointResolverContext.java
@@ -17,9 +17,11 @@ package software.amazon.awssdk.services.s3.internal.endpoints;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
@@ -34,6 +36,7 @@ public final class S3EndpointResolverContext {
     private final S3Configuration serviceConfiguration;
     private final URI endpointOverride;
     private final boolean disableHostPrefixInjection;
+    private final boolean fipsEnabled;
 
     private S3EndpointResolverContext(Builder builder) {
         this.request = builder.request;
@@ -42,6 +45,7 @@ public final class S3EndpointResolverContext {
         this.serviceConfiguration = builder.serviceConfiguration;
         this.endpointOverride = builder.endpointOverride;
         this.disableHostPrefixInjection = builder.disableHostPrefixInjection;
+        this.fipsEnabled = builder.fipsEnabled != null ? builder.fipsEnabled : false;
     }
 
     public static Builder builder() {
@@ -62,6 +66,10 @@ public final class S3EndpointResolverContext {
 
     public S3Configuration serviceConfiguration() {
         return serviceConfiguration;
+    }
+
+    public boolean fipsEnabled() {
+        return fipsEnabled;
     }
 
     public URI endpointOverride() {
@@ -98,6 +106,7 @@ public final class S3EndpointResolverContext {
         hashCode = 31 * hashCode + Objects.hashCode(serviceConfiguration());
         hashCode = 31 * hashCode + Objects.hashCode(endpointOverride());
         hashCode = 31 * hashCode + Objects.hashCode(isDisableHostPrefixInjection());
+        hashCode = 31 * hashCode + Boolean.hashCode(fipsEnabled());
         return hashCode;
     }
 
@@ -106,7 +115,8 @@ public final class S3EndpointResolverContext {
                         .request(request)
                         .originalRequest(originalRequest)
                         .region(region)
-                        .serviceConfiguration(serviceConfiguration);
+                        .serviceConfiguration(serviceConfiguration)
+                        .fipsEnabled(fipsEnabled);
     }
 
     public static final class Builder {
@@ -116,6 +126,9 @@ public final class S3EndpointResolverContext {
         private S3Configuration serviceConfiguration;
         private URI endpointOverride;
         private boolean disableHostPrefixInjection;
+        private Boolean fipsEnabled;
+        private Supplier<ProfileFile> profileFile;
+        private String profileName;
 
         private Builder() {
         }
@@ -147,6 +160,11 @@ public final class S3EndpointResolverContext {
 
         public Builder disableHostPrefixInjection(boolean disableHostPrefixInjection) {
             this.disableHostPrefixInjection = disableHostPrefixInjection;
+            return this;
+        }
+
+        public Builder fipsEnabled(Boolean fipsEnabled) {
+            this.fipsEnabled = fipsEnabled;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtils.java
@@ -74,11 +74,15 @@ public final class S3EndpointUtils {
     /**
      * @return The endpoint for an S3 accelerate enabled operation. S3 accelerate has a single global endpoint.
      */
-    public static URI accelerateEndpoint(S3Configuration serviceConfiguration, String domain, String protocol) {
-        if (serviceConfiguration.dualstackEnabled()) {
-            return toUri(protocol, "s3-accelerate.dualstack." + domain);
-        }
+    public static URI accelerateEndpoint(String domain, String protocol) {
         return toUri(protocol, "s3-accelerate." + domain);
+    }
+
+    /**
+     * @return The endpoint for an S3 accelerate enabled operation. S3 accelerate has a single global endpoint.
+     */
+    public static URI accelerateDualstackEndpoint(String domain, String protocol) {
+        return toUri(protocol, "s3-accelerate.dualstack." + domain);
     }
 
     /**
@@ -93,6 +97,22 @@ public final class S3EndpointUtils {
      */
     public static URI dualstackEndpoint(String id, String domain, String protocol) {
         String serviceEndpoint = String.format("%s.%s.%s.%s", "s3", "dualstack", id, domain);
+        return toUri(protocol, serviceEndpoint);
+    }
+
+    /**
+     * @return fips endpoint from given protocol and region metadata
+     */
+    public static URI fipsEndpoint(String id, String domain, String protocol) {
+        String serviceEndpoint = String.format("%s.%s.%s", "s3-fips", id, domain);
+        return toUri(protocol, serviceEndpoint);
+    }
+
+    /**
+     * @return dual stack + fips endpoint from given protocol and region metadata
+     */
+    public static URI fipsDualstackEndpoint(String id, String domain, String protocol) {
+        String serviceEndpoint = String.format("%s.%s.%s.%s", "s3-fips", "dualstack", id, domain);
         return toUri(protocol, serviceEndpoint);
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/EndpointAddressInterceptor.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/handlers/EndpointAddressInterceptor.java
@@ -55,6 +55,7 @@ public final class EndpointAddressInterceptor implements ExecutionInterceptor {
                                      .region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION))
                                      .endpointOverride(endpointOverride)
                                      .serviceConfiguration(serviceConfiguration)
+                                     .fipsEnabled(executionAttributes.getAttribute(AwsExecutionAttribute.FIPS_ENDPOINT_ENABLED))
                                      .disableHostPrefixInjection(disableHostPrefixInjection)
                                      .build();
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultS3Presigner.java
@@ -193,9 +193,10 @@ public final class DefaultS3Presigner extends DefaultSdkPresigner implements S3P
         } else {
             URI defaultEndpoint = new DefaultServiceEndpointBuilder(SERVICE_NAME, "https")
                 .withRegion(region())
-                .withProfileFile(profileFile())
+                .withProfileFile(this::profileFile)
                 .withProfileName(profileName())
                 .withDualstackEnabled(serviceConfiguration.dualstackEnabled())
+                .withFipsEnabled(fipsEnabled())
                 .getServiceEndpoint();
             return SdkClientConfiguration.builder()
                                          .option(SdkClientOption.ENDPOINT, defaultEndpoint)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultSdkPresigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/signing/DefaultSdkPresigner.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.endpoint.DualstackEnabledProvider;
+import software.amazon.awssdk.awscore.endpoint.FipsEnabledProvider;
 import software.amazon.awssdk.awscore.presigner.SdkPresigner;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
@@ -42,6 +43,7 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
     private final URI endpointOverride;
     private final AwsCredentialsProvider credentialsProvider;
     private final Boolean dualstackEnabled;
+    private final boolean fipsEnabled;
 
     protected DefaultSdkPresigner(Builder<?> b) {
         this.profileFile = ProfileFile.defaultProfileFile();
@@ -64,6 +66,13 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
                                                                                      .build()
                                                                                      .isDualstackEnabled()
                                                                                      .orElse(null);
+        this.fipsEnabled = b.fipsEnabled != null ? b.fipsEnabled
+                                                 : FipsEnabledProvider.builder()
+                                                                      .profileFile(() -> profileFile)
+                                                                      .profileName(profileName)
+                                                                      .build()
+                                                                      .isFipsEnabled()
+                                                                      .orElse(false);
     }
 
     protected ProfileFile profileFile() {
@@ -86,6 +95,10 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
         return dualstackEnabled;
     }
 
+    protected boolean fipsEnabled() {
+        return fipsEnabled;
+    }
+
     protected URI endpointOverride() {
         return endpointOverride;
     }
@@ -104,6 +117,7 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
         private Region region;
         private AwsCredentialsProvider credentialsProvider;
         private Boolean dualstackEnabled;
+        private Boolean fipsEnabled;
         private URI endpointOverride;
 
         protected Builder() {
@@ -124,6 +138,12 @@ public abstract class DefaultSdkPresigner implements SdkPresigner {
         @Override
         public B dualstackEnabled(Boolean dualstackEnabled) {
             this.dualstackEnabled = dualstackEnabled;
+            return thisBuilder();
+        }
+
+        @Override
+        public B fipsEnabled(Boolean fipsEnabled) {
+            this.fipsEnabled = fipsEnabled;
             return thisBuilder();
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/presigner/S3Presigner.java
@@ -533,6 +533,9 @@ public interface S3Presigner extends SdkPresigner {
         Builder dualstackEnabled(Boolean dualstackEnabled);
 
         @Override
+        Builder fipsEnabled(Boolean dualstackEnabled);
+
+        @Override
         Builder endpointOverride(URI endpointOverride);
 
         @Override

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -113,8 +113,10 @@
       ]
     }
   },
-  "serviceSpecificClientConfigClass": "S3Configuration",
-  "serviceConfigHasDualstackConfig": true,
+  "serviceConfig": {
+    "className": "S3Configuration",
+    "hasDualstackProperty": true
+  },
   "attachPayloadTraitToMember": {
     "GetBucketLocationOutput": "LocationConstraint"
   },

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideEndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideEndpointResolutionTest.java
@@ -65,6 +65,7 @@ public class EndpointOverrideEndpointResolutionTest {
         this.s3Client = S3Client.builder()
                                 .region(testCase.clientRegion)
                                 .dualstackEnabled(testCase.clientDualstackEnabled)
+                                .fipsEnabled(testCase.clientFipsEnabled)
                                 .credentialsProvider(StaticCredentialsProvider.create(
                                     AwsBasicCredentials.create("dummy-key", "dummy-secret")))
                                 .endpointOverride(testCase.endpointUrl)
@@ -79,11 +80,13 @@ public class EndpointOverrideEndpointResolutionTest {
                                       .endpointOverride(testCase.endpointUrl)
                                       .serviceConfiguration(testCase.s3Configuration)
                                       .dualstackEnabled(testCase.clientDualstackEnabled)
+                                      .fipsEnabled(testCase.clientFipsEnabled)
                                       .build();
         this.s3Utilities = S3Utilities.builder()
                                       .region(testCase.clientRegion)
                                       .s3Configuration(testCase.s3Configuration)
                                       .dualstackEnabled(testCase.clientDualstackEnabled)
+                                      .fipsEnabled(testCase.clientFipsEnabled)
                                       .build();
 
         this.getObjectRequest = testCase.getObjectBucketName == null
@@ -330,6 +333,12 @@ public class EndpointOverrideEndpointResolutionTest {
                                 .setClientRegion(Region.US_WEST_2)
                                 .setExpectedException(IllegalArgumentException.class));
 
+        cases.add(new TestCase().setCaseName("outposts access point with fips enabled via client builder calling cross-region")
+                                .setGetObjectBucketName("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint")
+                                .setClientFipsEnabled(true)
+                                .setClientRegion(Region.US_EAST_1)
+                                .setExpectedException(IllegalArgumentException.class));
+
         cases.add(new TestCase().setCaseName("mrap access point with arn region enabled")
                                 .setGetObjectBucketName("arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap")
                                 .setEndpointUrl("https://accesspoint.vpce-123-abc.s3-global.vpce.amazonaws.com")
@@ -353,6 +362,7 @@ public class EndpointOverrideEndpointResolutionTest {
         private Region expectedSigningRegion;
         private Class<? extends RuntimeException> expectedException;
         private Boolean clientDualstackEnabled;
+        private Boolean clientFipsEnabled;
 
         public TestCase setCaseName(String caseName) {
             this.caseName = caseName;
@@ -383,6 +393,11 @@ public class EndpointOverrideEndpointResolutionTest {
 
         public TestCase setClientDualstackEnabled(Boolean dualstackEnabled) {
             this.clientDualstackEnabled = dualstackEnabled;
+            return this;
+        }
+
+        public TestCase setClientFipsEnabled(Boolean fipsEnabled) {
+            this.clientFipsEnabled = fipsEnabled;
             return this;
         }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3BucketEndpointResolverTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3BucketEndpointResolverTest.java
@@ -80,14 +80,6 @@ public class S3BucketEndpointResolverTest {
     }
 
     @Test
-    public void dualstackEnabled_shouldConvertToDualstackEndpoint() {
-        verifyEndpoint("http", "http://s3.dualstack.us-east-1.amazonaws.com",
-                       S3Configuration.builder().dualstackEnabled(true));
-        verifyEndpoint("https", "https://s3.dualstack.us-east-1.amazonaws.com",
-                       S3Configuration.builder().dualstackEnabled(true));
-    }
-
-    @Test
     public void accelerateEnabled_ListBucketRequest_shouldNotConvertToAccelerateEndpoint() {
         verifyAccelerateDisabledOperationsEndpointNotConverted(ListBucketsRequest.builder().build());
     }
@@ -100,29 +92,6 @@ public class S3BucketEndpointResolverTest {
     @Test
     public void accelerateEnabled_DeleteBucketRequest_shouldNotConvertToAccelerateEndpoint() {
         verifyAccelerateDisabledOperationsEndpointNotConverted(DeleteBucketRequest.builder().build());
-    }
-
-    @Test
-    public void virtualStyle_shouldConvertToDnsEndpoint() {
-        verifyVirtualStyleConvertDnsEndpoint("https");
-        verifyVirtualStyleConvertDnsEndpoint("http");
-    }
-
-    private void verifyVirtualStyleConvertDnsEndpoint(String protocol) {
-        String bucketName = "test-bucket";
-        String key = "test-key";
-        URI customUri = URI.create(String.format("%s://s3-test.com/%s/%s", protocol, bucketName, key));
-        URI expectedUri = URI.create(String.format("%s://%s.s3.dualstack.us-east-1.amazonaws.com/%s", protocol,
-                                                   bucketName, key));
-        S3EndpointResolverContext context = S3EndpointResolverContext.builder()
-                                                                     .request(InterceptorTestUtils.sdkHttpRequest(customUri))
-                                                                     .originalRequest(ListObjectsV2Request.builder().bucket(bucketName).build())
-                                                                     .region(Region.US_EAST_1)
-                                                                     .serviceConfiguration(S3Configuration.builder().dualstackEnabled(true).build())
-                                                                     .build();
-        ConfiguredS3SdkHttpRequest sdkHttpFullRequest = endpointResolver.applyEndpointConfiguration(context);
-
-        assertThat(sdkHttpFullRequest.sdkHttpRequest().getUri()).isEqualTo(expectedUri);
     }
 
     private void verifyAccelerateDisabledOperationsEndpointNotConverted(SdkRequest request) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/endpoints/S3EndpointUtilsTest.java
@@ -58,14 +58,10 @@ public class S3EndpointUtilsTest {
 
     @Test
     public void accelerateEndpoint() {
-        assertThat(S3EndpointUtils.accelerateEndpoint(S3Configuration.builder().build(),
-                                                      "domain",
-                                                      "https"))
+        assertThat(S3EndpointUtils.accelerateEndpoint("domain", "https"))
             .isEqualTo(URI.create("https://s3-accelerate.domain"));
 
-        assertThat(S3EndpointUtils.accelerateEndpoint(S3Configuration.builder().dualstackEnabled(true).build(),
-                                                      "domain",
-                                                      "https"))
+        assertThat(S3EndpointUtils.accelerateDualstackEndpoint("domain", "https"))
             .isEqualTo(URI.create("https://s3-accelerate.dualstack.domain"));
     }
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/OutpostAccessPointArnEndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/OutpostAccessPointArnEndpointResolutionTest.java
@@ -73,9 +73,31 @@ public class OutpostAccessPointArnEndpointResolutionTest {
     }
 
     @Test
+    public void outpostArn_dualstackEnabledViaClient_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().dualstackEnabled(true).build();
+        String outpostArn = "arn:aws:s3-outposts:ap-south-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint";
+
+        assertThatThrownBy(() -> s3Client.listObjects(ListObjectsRequest.builder().bucket(outpostArn).build()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("dualstack");
+    }
+
+    @Test
     public void outpostArn_fipsRegion_throwsIllegalArgumentException() throws Exception {
         mockHttpClient.stubNextResponse(mockListObjectsResponse());
         S3Client s3Client = clientBuilder().region(Region.of("fips-us-east-1")).serviceConfiguration(S3Configuration.builder().dualstackEnabled(false).build()).build();
+        String outpostArn = "arn:aws:s3-outposts:us-east-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint";
+
+        assertThatThrownBy(() -> s3Client.listObjects(ListObjectsRequest.builder().bucket(outpostArn).build()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("FIPS");
+    }
+
+    @Test
+    public void outpostArn_fipsEnabled_throwsIllegalArgumentException() throws Exception {
+        mockHttpClient.stubNextResponse(mockListObjectsResponse());
+        S3Client s3Client = clientBuilder().region(Region.US_EAST_1).fipsEnabled(true).build();
         String outpostArn = "arn:aws:s3-outposts:us-east-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint";
 
         assertThatThrownBy(() -> s3Client.listObjects(ListObjectsRequest.builder().bucket(outpostArn).build()))

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/S3ObjectLambdaEndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/resource/S3ObjectLambdaEndpointResolutionTest.java
@@ -206,6 +206,16 @@ public class S3ObjectLambdaEndpointResolutionTest {
     }
 
     @Test
+    public void objectLambdaArn_fips_resolveEndpointCorrectly() {
+        URI expectedEndpoint = URI.create("myol-123456789012.s3-object-lambda-fips.us-west-2.amazonaws.com");
+        S3Client s3Client = clientBuilder().fipsEnabled(true).build();
+        String objectLambdaArn = "arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/myol";
+
+        s3Client.getObject(GetObjectRequest.builder().bucket(objectLambdaArn).key("obj").build());
+        assertEndpointMatches(mockHttpClient.getLastRequest(), expectedEndpoint);
+    }
+
+    @Test
     public void objectLambdaArn_crossRegion_useArnRegionTrue_resolveEndpointCorrectly() {
         URI expectedEndpoint = URI.create("myol-123456789012.s3-object-lambda.us-east-1.amazonaws.com");
         S3Client s3Client = clientBuilder().serviceConfiguration(S3Configuration.builder()

--- a/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/S3ControlConfiguration.java
+++ b/services/s3control/src/main/java/software/amazon/awssdk/services/s3control/S3ControlConfiguration.java
@@ -147,7 +147,10 @@ public final class S3ControlConfiguration implements ServiceConfiguration,
          * </p>
          *
          * @see S3ControlConfiguration#fipsModeEnabled().
+         * @deprecated This has been deprecated in favor of {@link S3ControlClientBuilder#fipsEnabled(Boolean)}. If both are
+         * set, an exception will be thrown.
          */
+        @Deprecated
         Builder fipsModeEnabled(Boolean fipsModeEnabled);
 
         /**

--- a/services/s3control/src/main/resources/codegen-resources/customization.config
+++ b/services/s3control/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,9 @@
 {
-    "serviceSpecificClientConfigClass": "S3ControlConfiguration",
-    "serviceConfigHasDualstackConfig": true,
+    "serviceConfig": {
+      "className": "S3ControlConfiguration",
+      "hasDualstackProperty": true,
+      "hasFipsProperty": true
+    },
     "customResponseMetadata": {
         "EXTENDED_REQUEST_ID": "x-amz-id-2",
         "REQUEST_ID": "x-amz-request-id"

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/EndpointVariantResolutionTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/EndpointVariantResolutionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.in;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.Validate;
+
+public class EndpointVariantResolutionTest {
+    @Test
+    public void dualstackEndpointResolution() {
+        EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+        try {
+            clientBuilder(interceptor).dualstackEnabled(true).build().allTypes();
+        } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+            // Expected
+        }
+
+        assertThat(interceptor.endpoints())
+            .singleElement()
+            .isEqualTo("https://customresponsemetadata.us-west-2.api.aws/2016-03-11/allTypes");
+    }
+
+    @Test
+    public void fipsEndpointResolution() {
+        EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+        try {
+            clientBuilder(interceptor).fipsEnabled(true).build().allTypes();
+        } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+            // Expected
+        }
+
+        assertThat(interceptor.endpoints())
+            .singleElement()
+            .isEqualTo("https://customresponsemetadata-fips.us-west-2.amazonaws.com/2016-03-11/allTypes");
+    }
+
+    @Test
+    public void dualstackFipsEndpointResolution() {
+        EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+        try {
+            clientBuilder(interceptor).dualstackEnabled(true).fipsEnabled(true).build().allTypes();
+        } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+            // Expected
+        }
+
+        assertThat(interceptor.endpoints())
+            .singleElement()
+            .isEqualTo("https://customresponsemetadata-fips.us-west-2.api.aws/2016-03-11/allTypes");
+    }
+
+    private ProtocolRestJsonClientBuilder clientBuilder(EndpointCapturingInterceptor interceptor) {
+        return ProtocolRestJsonClient.builder()
+                                     .region(Region.US_WEST_2)
+                                     .credentialsProvider(AnonymousCredentialsProvider.create())
+                                     .overrideConfiguration(c -> c.addExecutionInterceptor(interceptor));
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/FipsEndpointTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/FipsEndpointTest.java
@@ -1,0 +1,161 @@
+package software.amazon.awssdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileProperty;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClientBuilder;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.Validate;
+
+@RunWith(Parameterized.class)
+public class FipsEndpointTest {
+    @Parameterized.Parameter
+    public TestCase testCase;
+
+    @Test
+    public void resolvesCorrectEndpoint() {
+        String systemPropertyBeforeTest = System.getProperty(SdkSystemSetting.AWS_USE_FIPS_ENDPOINT.property());
+        EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
+
+        try {
+            ProtocolRestJsonClientBuilder builder =
+                ProtocolRestJsonClient.builder()
+                                      .region(Region.US_WEST_2)
+                                      .credentialsProvider(AnonymousCredentialsProvider.create());
+
+            if (testCase.clientSetting != null) {
+                builder.fipsEnabled(testCase.clientSetting);
+            }
+
+            if (testCase.systemPropSetting != null) {
+                System.setProperty(SdkSystemSetting.AWS_USE_FIPS_ENDPOINT.property(), testCase.systemPropSetting);
+            }
+
+            if (testCase.envVarSetting != null) {
+                helper.set(SdkSystemSetting.AWS_USE_FIPS_ENDPOINT.environmentVariable(), testCase.envVarSetting);
+            }
+
+            ProfileFile.Builder profileFile = ProfileFile.builder().type(ProfileFile.Type.CONFIGURATION);
+
+            if (testCase.profileSetting != null) {
+                profileFile.content(new StringInputStream("[default]\n" +
+                                                          ProfileProperty.USE_FIPS_ENDPOINT + " = " + testCase.profileSetting));
+            } else {
+                profileFile.content(new StringInputStream(""));
+            }
+
+            EndpointCapturingInterceptor interceptor = new EndpointCapturingInterceptor();
+
+            builder.overrideConfiguration(c -> c.defaultProfileFile(profileFile.build())
+                                                .defaultProfileName("default")
+                                                .addExecutionInterceptor(interceptor));
+
+            if (testCase instanceof SuccessCase) {
+                ProtocolRestJsonClient client = builder.build();
+
+                try {
+                    client.allTypes();
+                } catch (EndpointCapturingInterceptor.CaptureCompletedException e) {
+                    // Expected
+                }
+
+                boolean expectedFipsEnabled = ((SuccessCase) testCase).expectedValue;
+                String expectedEndpoint = expectedFipsEnabled
+                                          ? "https://customresponsemetadata-fips.us-west-2.amazonaws.com/2016-03-11/allTypes"
+                                          : "https://customresponsemetadata.us-west-2.amazonaws.com/2016-03-11/allTypes";
+                assertThat(interceptor.endpoints()).singleElement().isEqualTo(expectedEndpoint);
+            } else {
+                FailureCase failure = Validate.isInstanceOf(FailureCase.class, testCase, "Unexpected test case type.");
+                assertThatThrownBy(builder::build).hasMessageContaining(failure.exceptionMessage);
+            }
+
+        } finally {
+            if (systemPropertyBeforeTest != null) {
+                System.setProperty(SdkSystemSetting.AWS_USE_FIPS_ENDPOINT.property(), systemPropertyBeforeTest);
+            } else {
+                System.clearProperty(SdkSystemSetting.AWS_USE_FIPS_ENDPOINT.property());
+            }
+            helper.reset();
+        }
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<TestCase> testCases() {
+        return Arrays.asList(new SuccessCase(true, "false", "false", "false", true, "Client highest priority (true)"),
+                             new SuccessCase(false, "true", "true", "true", false, "Client highest priority (false)"),
+                             new SuccessCase(null, "true", "false", "false", true, "System property second priority (true)"),
+                             new SuccessCase(null, "false", "true", "true", false, "System property second priority (false)"),
+                             new SuccessCase(null, null, "true", "false", true, "Env var third priority (true)"),
+                             new SuccessCase(null, null, "false", "true", false, "Env var third priority (false)"),
+                             new SuccessCase(null, null, null, "true", true, "Profile last priority (true)"),
+                             new SuccessCase(null, null, null, "false", false, "Profile last priority (false)"),
+                             new SuccessCase(null, null, null, null, false, "Default is false."),
+                             new SuccessCase(null, "tRuE", null, null, true, "System property is not case sensitive."),
+                             new SuccessCase(null, null, "tRuE", null, true, "Env var is not case sensitive."),
+                             new SuccessCase(null, null, null, "tRuE", true, "Profile property is not case sensitive."),
+                             new FailureCase(null, "FOO", null, null, "FOO", "Invalid system property values fail."),
+                             new FailureCase(null, null, "FOO", null, "FOO", "Invalid env var values fail."),
+                             new FailureCase(null, null, null, "FOO", "FOO", "Invalid profile values fail."));
+    }
+
+    public static class TestCase {
+        private final Boolean clientSetting;
+        private final String envVarSetting;
+        private final String systemPropSetting;
+        private final String profileSetting;
+        private final String caseName;
+
+        public TestCase(Boolean clientSetting, String systemPropSetting, String envVarSetting, String profileSetting,
+                        String caseName) {
+            this.clientSetting = clientSetting;
+            this.envVarSetting = envVarSetting;
+            this.systemPropSetting = systemPropSetting;
+            this.profileSetting = profileSetting;
+            this.caseName = caseName;
+        }
+
+        @Override
+        public String toString() {
+            return caseName;
+        }
+    }
+
+    public static class SuccessCase extends TestCase {
+        private final boolean expectedValue;
+
+        public SuccessCase(Boolean clientSetting,
+                           String systemPropSetting,
+                           String envVarSetting,
+                           String profileSetting,
+                           boolean expectedValue,
+                           String caseName) {
+            super(clientSetting, systemPropSetting, envVarSetting, profileSetting, caseName);
+            this.expectedValue = expectedValue;
+        }
+    }
+
+    private static class FailureCase extends TestCase {
+        private final String exceptionMessage;
+
+        public FailureCase(Boolean clientSetting,
+                           String systemPropSetting,
+                           String envVarSetting,
+                           String profileSetting,
+                           String exceptionMessage,
+                           String caseName) {
+            super(clientSetting, systemPropSetting, envVarSetting, profileSetting, caseName);
+            this.exceptionMessage = exceptionMessage;
+        }
+    }
+}


### PR DESCRIPTION
This option can be used to make calls be invoked against FIPS-compliant AWS endpoints. This can also be enabled via the AWS_USE_FIPS_ENDPOINT environment variable, aws.useFipsEndpoint system property, or the use_fips_endpoint profile file property.

1. This builds on top of #2808 and #2818
2. This replaces (deprecates) the existing "fipsModeEnabled" option in the S3ControlConfiguration.