### PR TITLE
Add reporting for release CodeBuild jobs

### DIFF
--- a/buildspecs/build.yml
+++ b/buildspecs/build.yml
@@ -16,3 +16,10 @@ phases:
           mvn package
           mvn exec:exec -P mock-tests
         fi
+    finally:
+      - mkdir -p codebuild-test-reports
+      - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;
+reports:
+  UnitTests:
+    files:
+      - 'codebuild-test-reports/**/*'

--- a/buildspecs/integ-test.yml
+++ b/buildspecs/integ-test.yml
@@ -24,3 +24,10 @@ phases:
           mvn package
           mvn exec:exec -P integ-tests
         fi
+    finally:
+      - mkdir -p codebuild-test-reports
+      - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;
+reports:
+  IntegTests:
+    files:
+      - 'codebuild-test-reports/**/*'

--- a/buildspecs/stability-test.yml
+++ b/buildspecs/stability-test.yml
@@ -8,3 +8,10 @@ phases:
   build:
     commands:
       - mvn clean install -P stability-tests -pl :stability-tests --am
+    finally:
+      - mkdir -p codebuild-test-reports
+      - find ./ -name 'TEST-*.xml' -type f -exec cp {} codebuild-test-reports/ \;
+reports:
+  StabilityTests:
+    files:
+      - 'codebuild-test-reports/**/*'


### PR DESCRIPTION


## Motivation and Context
Easier and faster identification of failed tests in builds.

## Description
Trawling through the logs looking for the tests that failed is time consuming,
especially because tests are run in parallel, making the logs harder to follow.
This uses the test result dashboarding feature from CodeBuild to make it much
easier and faster to find tests that failed during a release.


## Testing

Tested the buildspecs in personal account using the SDK v2.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
