### PR TITLE
Resubmit: "[JUnit 5] Migrate to JUnit 5 Platform (with existing JUnit 4 test cases)"

### DIFF
--- a/archetypes/archetype-app-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/archetype-app-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
         <aws.java.sdk.version>${javaSdkVersion}</aws.java.sdk.version>
         <slf4j.version>1.7.28</slf4j.version>
         <graalvm.version>21.0.0</graalvm.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-app-quickstart/src/test/resources/projects/apachehttpclient/reference/pom.xml
+++ b/archetypes/archetype-app-quickstart/src/test/resources/projects/apachehttpclient/reference/pom.xml
@@ -16,7 +16,7 @@
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <slf4j.version>1.7.28</slf4j.version>
         <graalvm.version>21.0.0</graalvm.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-app-quickstart/src/test/resources/projects/apachehttpclientwithoutnativeimage/reference/pom.xml
+++ b/archetypes/archetype-app-quickstart/src/test/resources/projects/apachehttpclientwithoutnativeimage/reference/pom.xml
@@ -16,7 +16,7 @@
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <slf4j.version>1.7.28</slf4j.version>
         <graalvm.version>21.0.0</graalvm.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-app-quickstart/src/test/resources/projects/nettyclient/reference/pom.xml
+++ b/archetypes/archetype-app-quickstart/src/test/resources/projects/nettyclient/reference/pom.xml
@@ -16,7 +16,7 @@
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <slf4j.version>1.7.28</slf4j.version>
         <graalvm.version>21.0.0</graalvm.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-app-quickstart/src/test/resources/projects/urlhttpclient/reference/pom.xml
+++ b/archetypes/archetype-app-quickstart/src/test/resources/projects/urlhttpclient/reference/pom.xml
@@ -16,7 +16,7 @@
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <slf4j.version>1.7.28</slf4j.version>
         <graalvm.version>21.0.0</graalvm.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-lambda/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/archetype-lambda/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>${javaSdkVersion}</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
 #if( $httpClient == 'netty-nio-client')
         <netty.openssl.version>${nettyOpenSslVersion}</netty.openssl.version>
 #end

--- a/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/apachehttpclient/reference/pom.xml
@@ -15,7 +15,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-lambda/src/test/resources/projects/dynamodbstreamsclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/dynamodbstreamsclient/reference/pom.xml
@@ -15,7 +15,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/nettyclient/reference/pom.xml
@@ -15,7 +15,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
         <netty.openssl.version>2.0.29.Final</netty.openssl.version>
     </properties>
 

--- a/archetypes/archetype-lambda/src/test/resources/projects/urlhttpclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/urlhttpclient/reference/pom.xml
@@ -15,7 +15,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/archetypes/archetype-lambda/src/test/resources/projects/wafregionalclient/reference/pom.xml
+++ b/archetypes/archetype-lambda/src/test/resources/projects/wafregionalclient/reference/pom.xml
@@ -15,7 +15,7 @@
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <aws.java.sdk.version>2.11.0</aws.java.sdk.version>
         <aws.lambda.java.version>1.2.0</aws.lambda.java.version>
-        <junit5.version>5.4.2</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
     <dependencyManagement>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -295,9 +295,15 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit5.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit5.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -307,6 +307,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit4.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>

--- a/codegen-lite/pom.xml
+++ b/codegen-lite/pom.xml
@@ -94,8 +94,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -156,8 +156,13 @@
         </dependency>
 
         <dependency>
-            <artifactId>junit</artifactId>
-            <groupId>junit</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/arns/pom.xml
+++ b/core/arns/pom.xml
@@ -44,8 +44,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/auth-crt/pom.xml
+++ b/core/auth-crt/pom.xml
@@ -69,8 +69,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/auth/pom.xml
+++ b/core/auth/pom.xml
@@ -73,8 +73,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/aws-core/pom.xml
+++ b/core/aws-core/pom.xml
@@ -85,8 +85,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/json-utils/pom.xml
+++ b/core/json-utils/pom.xml
@@ -57,8 +57,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/metrics-spi/pom.xml
+++ b/core/metrics-spi/pom.xml
@@ -33,8 +33,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/protocols/aws-cbor-protocol/pom.xml
+++ b/core/protocols/aws-cbor-protocol/pom.xml
@@ -57,8 +57,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/protocols/aws-json-protocol/pom.xml
+++ b/core/protocols/aws-json-protocol/pom.xml
@@ -72,8 +72,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/protocols/aws-query-protocol/pom.xml
+++ b/core/protocols/aws-query-protocol/pom.xml
@@ -62,8 +62,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/protocols/aws-xml-protocol/pom.xml
+++ b/core/protocols/aws-xml-protocol/pom.xml
@@ -67,8 +67,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/protocols/protocol-core/pom.xml
+++ b/core/protocols/protocol-core/pom.xml
@@ -53,8 +53,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/regions/pom.xml
+++ b/core/regions/pom.xml
@@ -64,8 +64,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -72,8 +72,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http-client-spi/pom.xml
+++ b/http-client-spi/pom.xml
@@ -61,8 +61,13 @@
             <version>${reactive-streams.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http-clients/apache-client/pom.xml
+++ b/http-clients/apache-client/pom.xml
@@ -64,8 +64,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http-clients/aws-crt-client/pom.xml
+++ b/http-clients/aws-crt-client/pom.xml
@@ -84,8 +84,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http-clients/netty-nio-client/pom.xml
+++ b/http-clients/netty-nio-client/pom.xml
@@ -119,8 +119,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/http-clients/url-connection-client/pom.xml
+++ b/http-clients/url-connection-client/pom.xml
@@ -51,8 +51,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/metric-publishers/cloudwatch-metric-publisher/src/test/java/software/amazon/awssdk/metrics/publishers/cloudwatch/CloudWatchMetricPublisherTest.java
+++ b/metric-publishers/cloudwatch-metric-publisher/src/test/java/software/amazon/awssdk/metrics/publishers/cloudwatch/CloudWatchMetricPublisherTest.java
@@ -74,7 +74,7 @@ public class CloudWatchMetricPublisherTest {
         Thread.currentThread().interrupt();
         publisher.close();
         assertThat(publisher.isShutdown()).isTrue();
-        assertThat(Thread.interrupted()).isTrue(); // Clear interrupt flag
+        Thread.interrupted(); // Clear interrupt flag
     }
 
     @Test

--- a/metric-publishers/pom.xml
+++ b/metric-publishers/pom.xml
@@ -52,8 +52,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>
+        <junit4.version>4.13.2</junit4.version> <!-- Used to resolve conflicts in transitive dependencies -->
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
         <mockito2.version>2.28.2</mockito2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,7 @@
         <awscrt.version>0.15.8</awscrt.version>
 
         <!--Test dependencies -->
-        <junit.version>4.13.1</junit.version>
-        <junit5.version>5.7.1</junit5.version>
+        <junit5.version>5.8.1</junit5.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
         <mockito2.version>2.28.2</mockito2.version>
@@ -132,10 +131,10 @@
         <sqllite.version>1.0.392</sqllite.version>
 
         <!-- build plugin dependencies-->
-        <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
@@ -433,6 +432,8 @@
                     <ignoredUnusedDeclaredDependencies>
                         <!-- TODO: fix this when we've re-merged with netty-reactive-streams -->
                         <ignoredUnusedDeclaredDependency>com.typesafe.netty:*</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.junit.jupiter:*</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.junit.vintage:*</ignoredUnusedDeclaredDependency>
                         <ignoredUnusedDeclaredDependency>software.amazon.awssdk:aws-sdk-java</ignoredUnusedDeclaredDependency>
                         <!-- Declared by the codegen maven plugins (lite and normal). Not used directly but used to override a transitive dependecy -->
                         <ignoredUnusedDeclaredDependency>org.codehaus.plexus:plexus-utils</ignoredUnusedDeclaredDependency>

--- a/services-custom/dynamodb-enhanced/pom.xml
+++ b/services-custom/dynamodb-enhanced/pom.xml
@@ -67,6 +67,9 @@
                         <!--Ignore used undeclared test dependencies -->
                         <ignoredUsedUndeclaredDependency>software.amazon.awssdk:dynamodb-enhanced</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.hamcrest:*</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>org.junit.jupiter:*</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>org.junit.vintage:*</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>junit:junit::*</ignoredUsedUndeclaredDependency>
                     </ignoredUsedUndeclaredDependencies>
                 </configuration>
             </plugin>
@@ -145,8 +148,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -119,8 +119,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>junit</artifactId>
-            <groupId>junit</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services/sts/pom.xml
+++ b/services/sts/pom.xml
@@ -75,8 +75,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test/codegen-generated-classes-test/pom.xml
+++ b/test/codegen-generated-classes-test/pom.xml
@@ -118,8 +118,13 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test/http-client-tests/pom.xml
+++ b/test/http-client-tests/pom.xml
@@ -66,7 +66,12 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/test/http-client-tests/pom.xml
+++ b/test/http-client-tests/pom.xml
@@ -59,9 +59,14 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <artifactId>junit</artifactId>
-            <groupId>junit</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/test/protocol-tests-core/pom.xml
+++ b/test/protocol-tests-core/pom.xml
@@ -108,7 +108,12 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/test/protocol-tests-core/pom.xml
+++ b/test/protocol-tests-core/pom.xml
@@ -101,9 +101,14 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -123,8 +123,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test/region-testing/pom.xml
+++ b/test/region-testing/pom.xml
@@ -62,8 +62,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test/service-test-utils/pom.xml
+++ b/test/service-test-utils/pom.xml
@@ -69,8 +69,13 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <artifactId>junit</artifactId>
-            <groupId>junit</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -89,6 +94,8 @@
                     <ignoredUnusedDeclaredDependencies>
                         <!-- nice to have this pulled in so that service tests have these in scope -->
                         <ignoredUnusedDeclaredDependency>software.amazon.awssdk:test-utils:*</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.junit.jupiter:*</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.junit.vintage:*</ignoredUnusedDeclaredDependency>
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>

--- a/test/service-test-utils/pom.xml
+++ b/test/service-test-utils/pom.xml
@@ -79,6 +79,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>compile</scope>

--- a/test/stability-tests/pom.xml
+++ b/test/stability-tests/pom.xml
@@ -97,12 +97,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>test-utils</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>junit</artifactId>
-                    <groupId>junit</groupId>
-                </exclusion>
-            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -156,12 +150,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit5.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>

--- a/test/test-utils/pom.xml
+++ b/test/test-utils/pom.xml
@@ -73,6 +73,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/test/test-utils/pom.xml
+++ b/test/test-utils/pom.xml
@@ -63,8 +63,13 @@
         </dependency>
 
         <dependency>
-            <artifactId>junit</artifactId>
-            <groupId>junit</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -55,8 +55,13 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This resubmits the changes in https://github.com/aws/aws-sdk-java-v2/pull/2850 by undoing the revert performed in commit adc2072756a516ba450af512ad79bb7471ed7549. The previous change failed for integration tests. This PR resubmits the same changes and will be used for tracking any necessary fixes in the integration tests.

Previous builds were failing due to errors like:

```
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
[ERROR] TestEngine with ID 'junit-vintage' failed to discover tests
[ERROR]     at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:733)
```

This appears to have been due to having conflicting version of junit4 pulled in from different transitive dependencies. Specifying the version to use in the top-level pom's `dependencyManagement`, and making sure the version was consistent with the version pulled in by `junit-vintage-engine` appears to have resolved this issue.