### PR TITLE
Adds all fields in RequestOverrideConfiguration in toBuilder

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-c20ef41.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-c20ef41.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Adds all fields in RequestOverrideConfiguration when a builder is created from an instance"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/RequestOverrideConfiguration.java
@@ -428,6 +428,11 @@ public abstract class RequestOverrideConfiguration {
             headers(sdkRequestOverrideConfig.headers);
             rawQueryParameters(sdkRequestOverrideConfig.rawQueryParameters);
             sdkRequestOverrideConfig.apiNames.forEach(this::addApiName);
+            apiCallTimeout(sdkRequestOverrideConfig.apiCallTimeout);
+            apiCallAttemptTimeout(sdkRequestOverrideConfig.apiCallAttemptTimeout);
+            signer(sdkRequestOverrideConfig.signer().orElse(null));
+            metricPublishers(sdkRequestOverrideConfig.metricPublishers());
+            executionAttributes(sdkRequestOverrideConfig.executionAttributes());
         }
 
         @Override

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/RequestOverrideConfigurationTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/RequestOverrideConfigurationTest.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.core;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -27,15 +26,52 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 public class RequestOverrideConfigurationTest {
     private static final String HEADER = "header";
     private static final String QUERY_PARAM = "queryparam";
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(RequestOverrideConfiguration.class)
+                      .usingGetClass()
+                      .verify();
+    }
+
+    @Test
+    public void toBuilder_minimal() {
+        RequestOverrideConfiguration configuration = SdkRequestOverrideConfiguration.builder()
+                                                                                    .build();
+
+        assertThat(configuration.toBuilder().build()).usingRecursiveComparison().isEqualTo(configuration);
+    }
+
+    @Test
+    public void toBuilder_maximal() {
+        ExecutionAttribute testAttribute = new ExecutionAttribute("TestAttribute");
+        String expectedValue = "Value1";
+
+        RequestOverrideConfiguration configuration = SdkRequestOverrideConfiguration.builder()
+                .putHeader(HEADER, "foo")
+                .putRawQueryParameter(QUERY_PARAM, "foo")
+                .addApiName(a -> a.name("test1").version("1"))
+                .apiCallTimeout(Duration.ofSeconds(1))
+                .apiCallAttemptTimeout(Duration.ofSeconds(1))
+                .signer(new NoOpSigner())
+                .executionAttributes(ExecutionAttributes.builder().put(testAttribute, expectedValue).build())
+                .addMetricPublisher(mock(MetricPublisher.class))
+                .build();
+
+        assertThat(configuration.toBuilder().build()).usingRecursiveComparison().isEqualTo(configuration);
+    }
 
     @Test
     public void addingSameItemTwice_shouldOverride() {
@@ -283,5 +319,13 @@ public class RequestOverrideConfigurationTest {
         assertThat(request1Override).isEqualTo(request1Override);
         assertThat(request1Override).isEqualTo(request2Override);
         assertThat(request1Override).isNotEqualTo(null);
+    }
+
+    private static class NoOpSigner implements Signer {
+
+        @Override
+        public SdkHttpFullRequest sign(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
+            return null;
+        }
     }
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/paginators-1.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/paginators-1.json
@@ -1,0 +1,10 @@
+{
+  "pagination": {
+    "PaginatedOperationWithResultKey": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Items"
+    }
+  }
+}

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
@@ -143,6 +143,20 @@
         "requestUri":"/2016-03-11/operationWithNoInputOrOutput"
       }
     },
+    "PaginatedOperationWithResultKey": {
+      "name": "PaginatedOperationWithResultKey",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "input": {
+        "shape": "PaginatedOperationWithResultKeyRequest"
+      },
+      "output": {
+        "shape": "PaginatedOperationWithResultKeyResponse"
+      },
+      "documentation": "Some paginated operation with result_key in paginators.json file"
+    },
     "QueryParamWithoutValue":{
       "name":"QueryParamWithoutValue",
       "http":{
@@ -571,6 +585,33 @@
           "locationName":"Content-Type"
         }
       }
+    },
+    "PaginatedOperationWithResultKeyRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "MaxResults": {
+          "shape": "String",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      }
+    },
+    "PaginatedOperationWithResultKeyResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "String",
+          "documentation": "<p>Token for the next set of results</p>"
+        },
+        "Items": {
+          "shape": "ListOfSimpleStructs",
+          "documentation": "<p>Maximum number of results in a single page</p>"
+        }
+      },
+      "documentation": "<p>Response type of a single page</p>"
     },
     "PayloadStructType":{
       "type":"structure",


### PR DESCRIPTION
## Motivation and Context
When a `requestOverrideConfiguration` is modified from an existing instance all values of existing fields should be copied. For instance, `metricPublishers` was missing, leading to the paginated operations code path missing metric publishers added as a request override and no metrics are published. 

## Description
Updated the `BuilderImpl` constructor that takes a `RequestOverrideConfiguration` as an argument. 

## Testing
- Added unit tests to cover minimal and maximal cases of converting to builder and back
- Added functional test to verify usage of publishers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
