### PR TITLE
Enable BlockHound for integration tests and stability tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <netty-open-ssl-version>2.0.43.Final</netty-open-ssl-version>
         <dynamodb-local.version>1.16.0</dynamodb-local.version>
         <sqllite.version>1.0.392</sqllite.version>
+        <blockhound.version>1.0.6.RELEASE</blockhound.version>
 
         <!-- build plugin dependencies-->
         <maven.surefire.version>3.0.0-M5</maven.surefire.version>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -378,6 +378,18 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound</artifactId>
+            <version>${blockhound.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound-junit-platform</artifactId>
+            <version>${blockhound.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <artifactId>service-test-utils</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <scope>test</scope>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -42,6 +42,15 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredUsedUndeclaredDependencies>
+                        <ignoredUnusedDeclaredDependency>org.junit.jupiter:*</ignoredUnusedDeclaredDependency>
+                    </ignoredUsedUndeclaredDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -115,6 +124,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth-crt</artifactId>
             <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/BlockHoundInstalledTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/BlockHoundInstalledTest.java
@@ -52,8 +52,7 @@ import software.amazon.awssdk.utils.Logger;
  *     <li>Using BlockHound's provided {@link BlockHoundTestExecutionListener}, which will be automatically detected by the
  *     JUnit 5 platform upon initialization.</li>
  *     <li>Manually calling {@link BlockHound#install(BlockHoundIntegration...)}. This is done as part of static initialization in
- *     {@link AwsIntegrationTestBase}, as an extra precaution, and in {@link AwsTestBase} for our stability tests, which are not
- *     built upon JUnit.
+ *     {@link AwsIntegrationTestBase} and {@link AwsTestBase}, which most integration/stability tests extend.
  * </ol>
  * <p>
  * This test ensures BlockHound is correctly installed by intentionally performing a blocking operation on the Netty

--- a/services/s3/src/it/java/software/amazon/awssdk/services/BlockHoundInstalledTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/BlockHoundInstalledTest.java
@@ -22,6 +22,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -34,9 +35,30 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.blockhound.BlockHound;
 import reactor.blockhound.BlockingOperationError;
+import reactor.blockhound.integration.BlockHoundIntegration;
+import reactor.blockhound.junit.platform.BlockHoundTestExecutionListener;
+import software.amazon.awssdk.testutils.service.AwsIntegrationTestBase;
+import software.amazon.awssdk.testutils.service.AwsTestBase;
 import software.amazon.awssdk.utils.Logger;
 
+/**
+ * This test ensures that BlockHound is correctly installed for integration tests. The test is somewhat arbitrarily placed in the
+ * {@code s3} module in order to assert against the configuration of all service integration tests.
+ * <p>
+ * BlockHound is installed in one of two ways:
+ * <ol>
+ *     <li>Using BlockHound's provided {@link BlockHoundTestExecutionListener}, which will be automatically detected by the
+ *     JUnit 5 platform upon initialization.</li>
+ *     <li>Manually calling {@link BlockHound#install(BlockHoundIntegration...)}. This is done as part of static initialization in
+ *     {@link AwsIntegrationTestBase}, as an extra precaution, and in {@link AwsTestBase} for our stability tests, which are not
+ *     built upon JUnit.
+ * </ol>
+ * <p>
+ * This test ensures BlockHound is correctly installed by intentionally performing a blocking operation on the Netty
+ * {@link EventLoop} and asserting that a {@link BlockingOperationError} is thrown to forbid it.
+ */
 class BlockHoundInstalledTest {
     private static final Logger log = Logger.loggerFor(BlockHoundInstalledTest.class);
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/BlockHoundInstalledTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/BlockHoundInstalledTest.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.stability.tests;
+package software.amazon.awssdk.services;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,14 +31,14 @@ import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.blockhound.BlockingOperationError;
 import software.amazon.awssdk.utils.Logger;
 
-public class BlockHoundIntegrationTest {
-    private static final Logger log = Logger.loggerFor(BlockHoundIntegrationTest.class);
+class BlockHoundInstalledTest {
+    private static final Logger log = Logger.loggerFor(BlockHoundInstalledTest.class);
 
     AtomicReference<Throwable> throwableReference;
     CountDownLatch latch;
@@ -47,7 +47,7 @@ public class BlockHoundIntegrationTest {
     Socket clientSocket;
     Channel serverChannel;
 
-    @Before
+    @BeforeEach
     public void setup() {
         throwableReference = new AtomicReference<>();
         latch = new CountDownLatch(1);
@@ -55,7 +55,7 @@ public class BlockHoundIntegrationTest {
         workerGroup = new NioEventLoopGroup();
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         if (clientSocket != null) {
             clientSocket.close();
@@ -68,7 +68,7 @@ public class BlockHoundIntegrationTest {
     }
 
     @Test
-    public void testBlockHoundIntegration() throws Exception {
+    void testBlockHoundInstalled() throws Exception {
         ServerBootstrap bootstrap = new ServerBootstrap();
         bootstrap.group(bossGroup, workerGroup)
                  .channel(NioServerSocketChannel.class)
@@ -94,9 +94,9 @@ public class BlockHoundIntegrationTest {
 
         latch.await(5, TimeUnit.SECONDS);
         assertThat(throwableReference.get())
-            .withFailMessage("BlockHound does not appear to be successfully installed. "
-                             + "Ensure that BlockHoundTestExecutionListener is available on "
-                             + "the class path and correctly registered with JUnit: "
+            .withFailMessage("BlockHound does not appear to be successfully installed. Ensure that either BlockHound.install() "
+                             + "is called prior to all test executions or that BlockHoundTestExecutionListener is available on "
+                             + "the class path and correctly detected by JUnit: "
                              + "https://github.com/reactor/BlockHound/blob/master/docs/supported_testing_frameworks.md")
             .isInstanceOf(BlockingOperationError.class);
     }

--- a/test/service-test-utils/pom.xml
+++ b/test/service-test-utils/pom.xml
@@ -84,6 +84,18 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound</artifactId>
+            <version>${blockhound.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound-junit-platform</artifactId>
+            <version>${blockhound.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>compile</scope>
@@ -101,6 +113,7 @@
                         <ignoredUnusedDeclaredDependency>software.amazon.awssdk:test-utils:*</ignoredUnusedDeclaredDependency>
                         <ignoredUnusedDeclaredDependency>org.junit.jupiter:*</ignoredUnusedDeclaredDependency>
                         <ignoredUnusedDeclaredDependency>org.junit.vintage:*</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>io.projectreactor.tools:blockhound-junit-platform:*</ignoredUnusedDeclaredDependency>
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>

--- a/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/AwsIntegrationTestBase.java
+++ b/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/AwsIntegrationTestBase.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.testutils.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import reactor.blockhound.BlockHound;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
@@ -27,6 +28,10 @@ import software.amazon.awssdk.utils.IoUtils;
 
 public abstract class AwsIntegrationTestBase {
 
+    static {
+        BlockHound.install();
+    }
+    
     /** Default Properties Credentials file path. */
     private static final String TEST_CREDENTIALS_PROFILE_NAME = "aws-test-account";
 

--- a/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/AwsTestBase.java
+++ b/test/service-test-utils/src/main/java/software/amazon/awssdk/testutils/service/AwsTestBase.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import reactor.blockhound.BlockHound;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
@@ -30,6 +31,11 @@ import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.utils.IoUtils;
 
 public abstract class AwsTestBase {
+
+    static {
+        BlockHound.install();
+    }
+
     /** Default Properties Credentials file path. */
     private static final String TEST_CREDENTIALS_PROFILE_NAME = "aws-test-account";
 

--- a/test/stability-tests/pom.xml
+++ b/test/stability-tests/pom.xml
@@ -154,6 +154,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound</artifactId>
+            <version>${blockhound.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound-junit-platform</artifactId>
+            <version>${blockhound.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/test/stability-tests/pom.xml
+++ b/test/stability-tests/pom.xml
@@ -66,6 +66,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
             <version>${awsjavasdk.version}-PREVIEW</version>

--- a/test/stability-tests/pom.xml
+++ b/test/stability-tests/pom.xml
@@ -66,10 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
             <version>${awsjavasdk.version}-PREVIEW</version>

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/BlockHoundIntegrationTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/BlockHoundIntegrationTest.java
@@ -101,7 +101,7 @@ public class BlockHoundIntegrationTest {
             .isInstanceOf(BlockingOperationError.class);
     }
 
-    public static int getUnusedPort() throws IOException {
+    private static int getUnusedPort() throws IOException {
         try (ServerSocket socket = new ServerSocket(0)) {
             socket.setReuseAddress(true);
             return socket.getLocalPort();

--- a/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/BlockHoundIntegrationTest.java
+++ b/test/stability-tests/src/it/java/software/amazon/awssdk/stability/tests/BlockHoundIntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.stability.tests;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.blockhound.BlockingOperationError;
+import software.amazon.awssdk.utils.Logger;
+
+public class BlockHoundIntegrationTest {
+    private static final Logger log = Logger.loggerFor(BlockHoundIntegrationTest.class);
+
+    AtomicReference<Throwable> throwableReference;
+    CountDownLatch latch;
+    EventLoopGroup bossGroup;
+    EventLoopGroup workerGroup;
+    Socket clientSocket;
+    Channel serverChannel;
+
+    @Before
+    public void setup() {
+        throwableReference = new AtomicReference<>();
+        latch = new CountDownLatch(1);
+        bossGroup = new NioEventLoopGroup();
+        workerGroup = new NioEventLoopGroup();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        if (clientSocket != null) {
+            clientSocket.close();
+        }
+        if (serverChannel != null) {
+            serverChannel.close();
+        }
+        workerGroup.shutdownGracefully();
+        bossGroup.shutdownGracefully();
+    }
+
+    @Test
+    public void testBlockHoundIntegration() throws Exception {
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup)
+                 .channel(NioServerSocketChannel.class)
+                 .childHandler(new ChannelDuplexHandler() {
+                     @Override
+                     public void channelActive(ChannelHandlerContext ctx) {
+                         log.info(() -> "Preparing to sleep on the EventLoop to test if BlockHound is installed");
+                         try {
+                             Thread.sleep(1000);
+                             log.info(() -> "BlockHound does not appear to be successfully installed");
+                         } catch (Throwable t) {
+                             log.info(() -> "BlockHound is successfully installed", t);
+                             throwableReference.set(t);
+                         }
+                         latch.countDown();
+                         ctx.fireChannelActive();
+                     }
+                 });
+
+        int port = getUnusedPort();
+        serverChannel = bootstrap.bind(port).sync().channel();
+        clientSocket = new Socket("localhost", port);
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(throwableReference.get())
+            .withFailMessage("BlockHound does not appear to be successfully installed. "
+                             + "Ensure that BlockHoundTestExecutionListener is available on "
+                             + "the class path and correctly registered with JUnit: "
+                             + "https://github.com/reactor/BlockHound/blob/master/docs/supported_testing_frameworks.md")
+            .isInstanceOf(BlockingOperationError.class);
+    }
+
+    public static int getUnusedPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+}


### PR DESCRIPTION
This PR enables [BlockHound](https://github.com/reactor/BlockHound) for the SDK integration test and stability tests. BlockHound can be used to detect blocking behavior in threads that must be treated as non-blocking, like Netty's EventLoop threads.

If BlockHound detects an illegal blocking operation being performed, it will throw a BlockingOperationError. Doing so in an integration test would typically fail the integration test and allow us to investigate the behavior.

This PR enables BlockHound by leveraging BlockHound's provided [BlockHoundTestExecutionListener](https://github.com/reactor/BlockHound/blob/2071ca8dbb06eba9ffa65596f327e3182d3b9730/junit-platform/src/main/java/reactor/blockhound/junit/platform/BlockHoundTestExecutionListener.java), which uses `@AutoService` to automatically register with JUnit 5's ServiceLoader support:

https://junit.org/junit5/docs/current/user-guide/#launcher-api-listeners-custom

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
