### PR TITLE
Fix to correctly set TokenBucket capacity when requested amount greater than capacity

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-66cf80a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-66cf80a.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix to set TokenBucket capacity correctly when requested amount greater than capacity"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/RateLimitingTokenBucket.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/RateLimitingTokenBucket.java
@@ -185,15 +185,14 @@ public class RateLimitingTokenBucket {
      * @return The unfulfilled amount.
      */
     double tryAcquireCapacity(double amount) {
+        double result;
         if (amount <= currentCapacity) {
-            currentCapacity = currentCapacity - amount;
-            amount = 0;
+            result = 0;
         } else {
-            amount = amount - currentCapacity;
-            currentCapacity = 0;
+            result = amount - currentCapacity;
         }
-
-        return amount;
+        currentCapacity = currentCapacity - amount;
+        return result;
     }
 
     private void initialize() {
@@ -347,9 +346,10 @@ public class RateLimitingTokenBucket {
 
     /**
      * Sleep for a given amount of seconds.
+     *
      * @param seconds The amount of time to sleep in seconds.
      */
-    private static void sleep(double seconds) {
+    void sleep(double seconds) {
         long millisToSleep = (long) (seconds * 1000);
         try {
             Thread.sleep(millisToSleep);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/retry/RateLimitingTokenBucketTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/retry/RateLimitingTokenBucketTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.internal.retry;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
@@ -66,6 +67,8 @@ public class RateLimitingTokenBucketTest {
         long elapsed = System.nanoTime() - a;
 
         assertThat(acquired).isTrue();
+        assertThat(tb.getCurrentCapacity()).isNegative();
+        assertThat(tb.getCurrentCapacity()).isEqualTo(-1.0);
         assertThat(Duration.ofNanos(elapsed).getSeconds()).isEqualTo(1);
     }
 
@@ -96,6 +99,53 @@ public class RateLimitingTokenBucketTest {
         tb.setCurrentCapacity(5.0);
 
         assertThat(tb.tryAcquireCapacity(5.0)).isZero();
+        assertThat(tb.getCurrentCapacity()).isZero();
+    }
+
+    @Test
+    public void tryAcquireCapacity_amountGreaterThanCapacity_returnsNonZero() {
+        RateLimitingTokenBucket tb = new RateLimitingTokenBucket();
+        tb.setCurrentCapacity(5.0);
+
+        assertThat(tb.tryAcquireCapacity(8.0)).isEqualTo(3);
+        assertThat(tb.getCurrentCapacity()).isNegative();
+        assertThat(tb.getCurrentCapacity()).isEqualTo(-3);
+    }
+
+
+    @Test
+    public void acquire_amountGreaterThanNonZeroPositiveCapacity_setsNegativeCapacity() {
+        RateLimitingTokenBucket tb = Mockito.spy(new RateLimitingTokenBucket());
+
+        // stub out sleep , since we do not actually want to wait for sleep time
+        Mockito.doAnswer(invocationOnMock -> null).when(tb).sleep(2);
+
+        tb.setFillRate(1.0);
+        tb.setCurrentCapacity(1.0);
+        tb.enable();
+
+        boolean acquired = tb.acquire(3.0);
+        assertThat(acquired).isTrue();
+        assertThat(tb.getCurrentCapacity()).isNegative();
+        assertThat(tb.getCurrentCapacity()).isEqualTo(-2.0);
+    }
+
+    @Test
+    public void acquire_amountGreaterThanNegativeCapacity_setsNegativeCapacity() {
+        RateLimitingTokenBucket tb = Mockito.spy(new RateLimitingTokenBucket());
+
+        // stub out sleep , since we do not actually want to wait for sleep time
+        Mockito.doAnswer(invocationOnMock -> null).when(tb).sleep(3);
+
+        tb.setFillRate(1.0);
+        tb.setCurrentCapacity(-1.0);
+        tb.enable();
+
+        boolean acquired = tb.acquire(2.0);
+
+        assertThat(acquired).isTrue();
+        assertThat(tb.getCurrentCapacity()).isNegative();
+        assertThat(tb.getCurrentCapacity()).isEqualTo(-3.0);
     }
 
     @Test


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

When the requested number of tokens is greater than the current available tokens, the code sets the capacity to `0` and then sleeps the required amount of time to accumulate the remaining amount; however that amount slept is not reflected in the last recorded refill time of the bucket. Refilling the bucket is time based, and each call to `acquire()` refills the bucket, using the difference between the current time and the last recorded refill time. In this case, the next call to `refill()` will the bucket with more tokens than intended.




## Description
Rather than setting the amount fo `0`, we should just let it go into the negative.

```
_TokenBucketAcquire(amount)
  # Client side throttling is not enabled until we see a throttling error.
  if not enabled
    return

  _TokenBucketRefill()
  # Next see if we have enough capacity for the requested amount.
  if amount <= current_capacity
    current_capacity = current_capacity - amount
  else
    sleep((amount - current_capacity) / fill_rate)
    current_capacity = current_capacity - amount
  return

```



## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junit

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
