### PR TITLE
[JUnit 5] Migrate some parameterized tests to JUnit 5

### DIFF
--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/Ec2MetadataConfigProviderEndpointModeTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/internal/Ec2MetadataConfigProviderEndpointModeTest.java
@@ -16,112 +16,104 @@
 package software.amazon.awssdk.auth.credentials.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.function.Supplier;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
-@RunWith(Parameterized.class)
 public class Ec2MetadataConfigProviderEndpointModeTest {
     private static final String TEST_PROFILES_PATH_PREFIX = "/software/amazon/awssdk/auth/credentials/internal/ec2metadataconfigprovider/";
     private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
     private static final String CUSTOM_PROFILE = "myprofile";
 
-    @Parameterized.Parameter
-    public TestCase testCase;
+    public static Stream<Arguments> testData() {
+        return Stream.of(
+            arguments(null, null, null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV4, null),
+            arguments("ipv4", null, null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV4, null),
+            arguments("IPv4", null, null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV4, null),
+            arguments("ipv6", null, null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments("IPv6", null, null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments("Ipv99", null, null, null, null, null, IllegalArgumentException.class),
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+            arguments(null, "ipv4", null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV4, null),
+            arguments(null, "IPv4", null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV4, null),
+            arguments(null, "ipv6", null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments(null, "IPv6", null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments(null, "Ipv99", null, null, null, null, IllegalArgumentException.class),
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Iterable<Object> testCases() {
-        return Arrays.asList(
-                new TestCase().expectedEndpointMode(null).expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV4),
+            arguments(null, null, TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv6", null, null,
+                      Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments(null, null, TEST_PROFILES_PATH_PREFIX + "endpoint_mode_invalidValue", null, null, null,
+                      IllegalArgumentException.class),
 
-                new TestCase().envEndpointMode("ipv4").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV4),
-                new TestCase().envEndpointMode("IPv4").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV4),
-                new TestCase().envEndpointMode("ipv6").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().envEndpointMode("IPv6").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().envEndpointMode("Ipv99").expectedException(IllegalArgumentException.class),
+            // System property takes highest precedence
+            arguments("ipv4", "ipv6", null, null, null, Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments(null, "ipv6", TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv4", null, null,
+                      Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
 
-                new TestCase().systemPropertyEndpointMode("ipv4").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV4),
-                new TestCase().systemPropertyEndpointMode("IPv4").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV4),
-                new TestCase().systemPropertyEndpointMode("ipv6").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().systemPropertyEndpointMode("IPv6").expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().systemPropertyEndpointMode("Ipv99").expectedException(IllegalArgumentException.class),
+            // env var has higher precedence than shared config
+            arguments("ipv6", null, TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv4", null, null,
+                      Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
 
-                new TestCase().sharedConfigFile(TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv6")
-                        .expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().sharedConfigFile(TEST_PROFILES_PATH_PREFIX + "endpoint_mode_invalidValue")
-                        .expectedException(IllegalArgumentException.class),
-
-                // System property takes highest precedence
-                new TestCase().systemPropertyEndpointMode("ipv6").envEndpointMode("ipv4")
-                        .expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().systemPropertyEndpointMode("ipv6").sharedConfigFile(TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv4")
-                        .expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-
-                // env var has higher precedence than shared config
-                new TestCase().envEndpointMode("ipv6").sharedConfigFile(TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv4")
-                        .expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-
-                // Test custom profile supplier and custom profile name
-                new TestCase().sharedConfigFile(TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv6_custom_profile")
-                        .customProfileName(CUSTOM_PROFILE).expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6),
-                new TestCase().customProfileFile(Ec2MetadataConfigProviderEndpointModeTest::customProfileFile)
-                        .customProfileName(CUSTOM_PROFILE).expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode.IPV6)
+            // Test custom profile supplier and custom profile name
+            arguments(null, null, TEST_PROFILES_PATH_PREFIX + "endpoint_mode_ipv6_custom_profile", null, CUSTOM_PROFILE,
+                      Ec2MetadataConfigProvider.EndpointMode.IPV6, null),
+            arguments(null, null, null, customProfileFile(), CUSTOM_PROFILE, Ec2MetadataConfigProvider.EndpointMode.IPV6, null)
         );
     }
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    @AfterEach
+    public void cleanup() {
         ENVIRONMENT_VARIABLE_HELPER.reset();
         System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE.property());
+    }
 
-        if (testCase.envEndpointMode != null) {
+    @ParameterizedTest
+    @MethodSource("testData")
+    void resolvesCorrectEndpointMode(String envEndpointMode,
+                                     String systemPropertyEndpointMode,
+                                     String sharedConfigFile,
+                                     ProfileFile customProfileFile,
+                                     String customProfileName,
+                                     Ec2MetadataConfigProvider.EndpointMode expectedEndpointMode,
+                                     Class<? extends Throwable> expectedException) {
+        if (envEndpointMode != null) {
             ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE.environmentVariable(),
-                    testCase.envEndpointMode);
+                                            envEndpointMode);
         }
 
-        if (testCase.systemPropertyEndpointMode != null) {
+        if (systemPropertyEndpointMode != null) {
             System.setProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE.property(),
-                    testCase.systemPropertyEndpointMode);
+                               systemPropertyEndpointMode);
         }
-        if (testCase.sharedConfigFile != null) {
+        if (sharedConfigFile != null) {
             ENVIRONMENT_VARIABLE_HELPER.set(ProfileFileSystemSetting.AWS_CONFIG_FILE.environmentVariable(),
-                    getTestFilePath(testCase.sharedConfigFile));
+                                            getTestFilePath(sharedConfigFile));
         }
 
-        if (testCase.expectedException != null) {
-            thrown.expect(testCase.expectedException);
-        }
-    }
-
-    @After
-    public void teardown() {
-        ENVIRONMENT_VARIABLE_HELPER.reset();
-        System.clearProperty(SdkSystemSetting.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE.property());
-    }
-
-    @Test
-    public void resolvesCorrectEndpointMode() {
         Ec2MetadataConfigProvider configProvider = Ec2MetadataConfigProvider.builder()
-                .profileFile(testCase.customProfileFile)
-                .profileName(testCase.customProfileName)
-                .build();
+                                                                            .profileFile(customProfileFile == null ? null :
+                                                                                         () -> customProfileFile)
+                                                                            .profileName(customProfileName)
+                                                                            .build();
 
-        assertThat(configProvider.getEndpointMode()).isEqualTo(testCase.expectedEndpointMode);
+        if (expectedException != null) {
+            assertThatThrownBy(configProvider::getEndpointMode).isInstanceOf(expectedException);
+        } else {
+            assertThat(configProvider.getEndpointMode()).isEqualTo(expectedEndpointMode);
+        }
     }
 
     private static String getTestFilePath(String testFile) {
@@ -136,66 +128,5 @@ public class Ec2MetadataConfigProviderEndpointModeTest {
                 .type(ProfileFile.Type.CONFIGURATION)
                 .content(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
                 .build();
-    }
-
-    private static class TestCase {
-        private String envEndpointMode;
-        private String systemPropertyEndpointMode;
-
-        private String sharedConfigFile;
-
-        private Supplier<ProfileFile> customProfileFile;
-
-        private String customProfileName;
-
-        private Ec2MetadataConfigProvider.EndpointMode expectedEndpointMode;
-        private Class<? extends Throwable> expectedException;
-
-        public TestCase envEndpointMode(String envEndpointMode) {
-            this.envEndpointMode = envEndpointMode;
-            return this;
-        }
-        public TestCase systemPropertyEndpointMode(String systemPropertyEndpointMode) {
-            this.systemPropertyEndpointMode = systemPropertyEndpointMode;
-            return this;
-        }
-
-        public TestCase sharedConfigFile(String sharedConfigFile) {
-            this.sharedConfigFile = sharedConfigFile;
-            return this;
-        }
-
-        public TestCase customProfileFile(Supplier<ProfileFile> customProfileFile) {
-            this.customProfileFile = customProfileFile;
-            return this;
-        }
-
-        private TestCase customProfileName(String customProfileName) {
-            this.customProfileName = customProfileName;
-            return this;
-        }
-
-        public TestCase expectedEndpointMode(Ec2MetadataConfigProvider.EndpointMode expectedEndpointMode) {
-            this.expectedEndpointMode = expectedEndpointMode;
-            return this;
-        }
-
-        public TestCase expectedException(Class<? extends Throwable> expectedException) {
-            this.expectedException = expectedException;
-            return this;
-        }
-
-        @Override
-        public String toString() {
-            return "TestCase{" +
-                    "envEndpointMode='" + envEndpointMode + '\'' +
-                    ", systemPropertyEndpointMode='" + systemPropertyEndpointMode + '\'' +
-                    ", sharedConfigFile='" + sharedConfigFile + '\'' +
-                    ", customProfileFile=" + customProfileFile +
-                    ", customProfileName='" + customProfileName + '\'' +
-                    ", expectedEndpointMode=" + expectedEndpointMode +
-                    ", expectedException=" + expectedException +
-                    '}';
-        }
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStageTest.java
@@ -43,11 +43,10 @@ public class MergeCustomHeadersStageTest {
     // with modifications:
     // removed: accept-ranges, if-match, if-none-match, vary since it looks like they're defined as lists
     public static Stream<String> singleHeaders() {
-        return Stream.of("age", "authorization",
-                         "content-length", "content-location", "content-md5", "content-range", "content-type",
-                         "date", "etag", "expires", "from", "host", "if-modified-since", "if-range",
-                         "if-unmodified-since", "last-modified", "location", "max-forwards",
-                         "proxy-authorization", "range", "referer", "retry-after", "server", "user-agent");
+        return Stream.of("age", "authorization", "content-length", "content-location", "content-md5", "content-range",
+                         "content-type", "date", "etag", "expires", "from", "host", "if-modified-since", "if-range",
+                         "if-unmodified-since", "last-modified", "location", "max-forwards", "proxy-authorization", "range",
+                         "referer", "retry-after", "server", "user-agent");
     }
 
     @ParameterizedTest

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MergeCustomHeadersStageTest.java
@@ -16,18 +16,15 @@
 package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkRequestOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -40,28 +37,22 @@ import software.amazon.awssdk.core.internal.http.timers.ClientExecutionAndReques
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import utils.ValidSdkObjects;
 
-@RunWith(Parameterized.class)
 public class MergeCustomHeadersStageTest {
     // List of headers that may appear only once in a request; i.e. is not a list of values.
-    // Taken from https://github.com/apache/httpcomponents-client/blob/81c1bc4dc3ca5a3134c5c60e8beff08be2fd8792/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java#L69-L85 with modifications:
+    // Taken from https://github.com/apache/httpcomponents-client/blob/81c1bc4dc3ca5a3134c5c60e8beff08be2fd8792/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java#L69-L85
+    // with modifications:
     // removed: accept-ranges, if-match, if-none-match, vary since it looks like they're defined as lists
-    private static final Set<String> SINGLE_HEADERS = Stream.of("age", "authorization",
-            "content-length", "content-location", "content-md5", "content-range", "content-type",
-            "date", "etag", "expires", "from", "host", "if-modified-since", "if-range",
-            "if-unmodified-since", "last-modified", "location", "max-forwards",
-            "proxy-authorization", "range", "referer", "retry-after", "server", "user-agent")
-            .collect(Collectors.toSet());
-
-    @Parameterized.Parameters(name = "Header = {0}")
-    public static Collection<Object> data() {
-        return Arrays.asList(SINGLE_HEADERS.toArray(new Object[0]));
+    public static Stream<String> singleHeaders() {
+        return Stream.of("age", "authorization",
+                         "content-length", "content-location", "content-md5", "content-range", "content-type",
+                         "date", "etag", "expires", "from", "host", "if-modified-since", "if-range",
+                         "if-unmodified-since", "last-modified", "location", "max-forwards",
+                         "proxy-authorization", "range", "referer", "retry-after", "server", "user-agent");
     }
 
-    @Parameterized.Parameter
-    public String singleHeaderName;
-
-    @Test
-    public void singleHeader_inMarshalledRequest_overriddenOnClient() throws Exception {
+    @ParameterizedTest
+    @MethodSource("singleHeaders")
+    void singleHeader_inMarshalledRequest_overriddenOnClient(String singleHeaderName) throws Exception {
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
 
         RequestExecutionContext ctx = requestContext(NoopTestRequest.builder().build());
@@ -82,8 +73,9 @@ public class MergeCustomHeadersStageTest {
         assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("client");
     }
 
-    @Test
-    public void singleHeader_inMarshalledRequest_overriddenOnRequest() throws Exception {
+    @ParameterizedTest
+    @MethodSource("singleHeaders")
+    void singleHeader_inMarshalledRequest_overriddenOnRequest(String singleHeaderName) throws Exception {
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
         requestBuilder.putHeader(singleHeaderName, "marshaller");
 
@@ -104,8 +96,9 @@ public class MergeCustomHeadersStageTest {
         assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request");
     }
 
-    @Test
-    public void singleHeader_inClient_overriddenOnRequest() throws Exception {
+    @ParameterizedTest
+    @MethodSource("singleHeaders")
+    void singleHeader_inClient_overriddenOnRequest(String singleHeaderName) throws Exception {
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
 
         RequestExecutionContext ctx = requestContext(NoopTestRequest.builder()
@@ -127,8 +120,9 @@ public class MergeCustomHeadersStageTest {
         assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request");
     }
 
-    @Test
-    public void singleHeader_inMarshalledRequest_inClient_inRequest() throws Exception {
+    @ParameterizedTest
+    @MethodSource("singleHeaders")
+    void singleHeader_inMarshalledRequest_inClient_inRequest(String singleHeaderName) throws Exception {
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
         requestBuilder.putHeader(singleHeaderName, "marshaller");
 
@@ -151,8 +145,9 @@ public class MergeCustomHeadersStageTest {
         assertThat(requestBuilder.headers().get(singleHeaderName)).containsExactly("request");
     }
 
-    @Test
-    public void singleHeader_inRequestAsList_keepsMultipleValues() throws Exception {
+    @ParameterizedTest
+    @MethodSource("singleHeaders")
+    void singleHeader_inRequestAsList_keepsMultipleValues(String singleHeaderName) throws Exception {
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder();
         requestBuilder.putHeader(singleHeaderName, "marshaller");
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryModeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryModeTest.java
@@ -17,66 +17,61 @@ package software.amazon.awssdk.core.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.Callable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.Validate;
 
-@RunWith(Parameterized.class)
 public class RetryModeTest {
     private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
 
-    @Parameterized.Parameter
-    public TestData testData;
-
-    @Parameterized.Parameters
-    public static Collection<Object> data() {
-        return Arrays.asList(new Object[] {
+    public static Stream<Arguments> testData() {
+        return Stream.of(
             // Test defaults
-            new TestData(null, null, null, null, RetryMode.LEGACY),
-            new TestData(null, null, "PropertyNotSet", null, RetryMode.LEGACY),
+            arguments(null, null, null, null, RetryMode.LEGACY),
+            arguments(null, null, "PropertyNotSet", null, RetryMode.LEGACY),
 
             // Test resolution
-            new TestData("legacy", null, null, null, RetryMode.LEGACY),
-            new TestData("standard", null, null, null, RetryMode.STANDARD),
-            new TestData("adaptive", null, null, null, RetryMode.ADAPTIVE),
-            new TestData("lEgAcY", null, null, null, RetryMode.LEGACY),
-            new TestData("sTanDaRd", null, null, null, RetryMode.STANDARD),
-            new TestData("aDaPtIvE", null, null, null, RetryMode.ADAPTIVE),
+            arguments("legacy", null, null, null, RetryMode.LEGACY),
+            arguments("standard", null, null, null, RetryMode.STANDARD),
+            arguments("adaptive", null, null, null, RetryMode.ADAPTIVE),
+            arguments("lEgAcY", null, null, null, RetryMode.LEGACY),
+            arguments("sTanDaRd", null, null, null, RetryMode.STANDARD),
+            arguments("aDaPtIvE", null, null, null, RetryMode.ADAPTIVE),
 
             // Test precedence
-            new TestData("standard", "legacy", "PropertySetToLegacy", RetryMode.LEGACY, RetryMode.STANDARD),
-            new TestData("standard", null, null, RetryMode.LEGACY, RetryMode.STANDARD),
-            new TestData(null, "standard", "PropertySetToLegacy", RetryMode.LEGACY, RetryMode.STANDARD),
-            new TestData(null, "standard", null, RetryMode.LEGACY, RetryMode.STANDARD),
-            new TestData(null, null, "PropertySetToStandard", RetryMode.LEGACY, RetryMode.STANDARD),
-            new TestData(null, null, null, RetryMode.STANDARD, RetryMode.STANDARD),
+            arguments("standard", "legacy", "PropertySetToLegacy", RetryMode.LEGACY, RetryMode.STANDARD),
+            arguments("standard", null, null, RetryMode.LEGACY, RetryMode.STANDARD),
+            arguments(null, "standard", "PropertySetToLegacy", RetryMode.LEGACY, RetryMode.STANDARD),
+            arguments(null, "standard", null, RetryMode.LEGACY, RetryMode.STANDARD),
+            arguments(null, null, "PropertySetToStandard", RetryMode.LEGACY, RetryMode.STANDARD),
+            arguments(null, null, null, RetryMode.STANDARD, RetryMode.STANDARD),
 
             // Test invalid values
-            new TestData("wrongValue", null, null, null, IllegalStateException.class),
-            new TestData(null, "wrongValue", null, null, IllegalStateException.class),
-            new TestData(null, null, "PropertySetToUnsupportedValue", null, IllegalStateException.class),
+            arguments("wrongValue", null, null, null, IllegalStateException.class),
+            arguments(null, "wrongValue", null, null, IllegalStateException.class),
+            arguments(null, null, "PropertySetToUnsupportedValue", null, IllegalStateException.class),
 
             // Test capitalization standardization
-            new TestData("sTaNdArD", null, null, null, RetryMode.STANDARD),
-            new TestData(null, "sTaNdArD", null, null, RetryMode.STANDARD),
-            new TestData(null, null, "PropertyMixedCase", null, RetryMode.STANDARD),
-            });
+            arguments("sTaNdArD", null, null, null, RetryMode.STANDARD),
+            arguments(null, "sTaNdArD", null, null, RetryMode.STANDARD),
+            arguments(null, null, "PropertyMixedCase", null, RetryMode.STANDARD)
+        );
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void methodSetup() {
         ENVIRONMENT_VARIABLE_HELPER.reset();
         System.clearProperty(SdkSystemSetting.AWS_RETRY_MODE.property());
@@ -84,50 +79,38 @@ public class RetryModeTest {
         System.clearProperty(ProfileFileSystemSetting.AWS_CONFIG_FILE.property());
     }
 
-    @Test
-    public void differentCombinationOfConfigs_shouldResolveCorrectly() throws Exception {
-        if (testData.envVarValue != null) {
-            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_RETRY_MODE.environmentVariable(), testData.envVarValue);
+    @ParameterizedTest
+    @MethodSource("testData")
+    void differentCombinationOfConfigs_shouldResolveCorrectly(String systemProperty,
+                                                              String envVarValue,
+                                                              String configFile,
+                                                              RetryMode defaultMode,
+                                                              Object expected) throws Exception {
+        if (envVarValue != null) {
+            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_RETRY_MODE.environmentVariable(), envVarValue);
         }
 
-        if (testData.systemProperty != null) {
-            System.setProperty(SdkSystemSetting.AWS_RETRY_MODE.property(), testData.systemProperty);
+        if (systemProperty != null) {
+            System.setProperty(SdkSystemSetting.AWS_RETRY_MODE.property(), systemProperty);
         }
 
-        if (testData.configFile != null) {
-            String diskLocationForFile = diskLocationForConfig(testData.configFile);
+        if (configFile != null) {
+            String diskLocationForFile = diskLocationForConfig(configFile);
             Validate.isTrue(Files.isReadable(Paths.get(diskLocationForFile)), diskLocationForFile + " is not readable.");
             System.setProperty(ProfileFileSystemSetting.AWS_PROFILE.property(), "default");
             System.setProperty(ProfileFileSystemSetting.AWS_CONFIG_FILE.property(), diskLocationForFile);
         }
 
-        Callable<RetryMode> result = RetryMode.resolver().defaultRetryMode(testData.defaultMode)::resolve;
-        if (testData.expected instanceof Class<?>) {
-            Class<?> expectedClassType = (Class<?>) testData.expected;
+        Callable<RetryMode> result = RetryMode.resolver().defaultRetryMode(defaultMode)::resolve;
+        if (expected instanceof Class<?>) {
+            Class<?> expectedClassType = (Class<?>) expected;
             assertThatThrownBy(result::call).isInstanceOf(expectedClassType);
         } else {
-            assertThat(result.call()).isEqualTo(testData.expected);
+            assertThat(result.call()).isEqualTo(expected);
         }
     }
 
     private String diskLocationForConfig(String configFileName) {
         return getClass().getResource(configFileName).getFile();
-    }
-
-
-    private static class TestData {
-        private final String envVarValue;
-        private final String systemProperty;
-        private final String configFile;
-        private final RetryMode defaultMode;
-        private final Object expected;
-
-        TestData(String systemProperty, String envVarValue, String configFile, RetryMode defaultMode, Object expected) {
-            this.envVarValue = envVarValue;
-            this.systemProperty = systemProperty;
-            this.configFile = configFile;
-            this.defaultMode = defaultMode;
-            this.expected = expected;
-        }
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyMaxRetriesTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/RetryPolicyMaxRetriesTest.java
@@ -17,60 +17,55 @@ package software.amazon.awssdk.core.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.Validate;
 
-@RunWith(Parameterized.class)
 public class RetryPolicyMaxRetriesTest {
     private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
 
-    @Parameterized.Parameter
-    public TestData testData;
-
-    @Parameterized.Parameters
-    public static Collection<Object> data() {
-        return Arrays.asList(new Object[] {
+    public static Stream<Arguments> testData() {
+        return Stream.of(
             // Test defaults
-            new TestData(null, null, null, null, null, 3),
-            new TestData(null, null, null, null, "PropertyNotSet", 3),
+            arguments(null, null, null, null, null, 3),
+            arguments(null, null, null, null, "PropertyNotSet", 3),
 
             // Test precedence
-            new TestData("9", "2", "standard", "standard", "PropertySetToStandard", 8),
-            new TestData(null, "9", "standard", "standard", "PropertySetToStandard", 8),
-            new TestData(null, null, "standard", "standard", "PropertySetToStandard", 2),
-            new TestData(null, null, null, "standard", "PropertySetToStandard", 2),
-            new TestData(null, null, null, null, "PropertySetToStandard", 2),
+            arguments("9", "2", "standard", "standard", "PropertySetToStandard", 8),
+            arguments(null, "9", "standard", "standard", "PropertySetToStandard", 8),
+            arguments(null, null, "standard", "standard", "PropertySetToStandard", 2),
+            arguments(null, null, null, "standard", "PropertySetToStandard", 2),
+            arguments(null, null, null, null, "PropertySetToStandard", 2),
 
             // Test invalid values
-            new TestData("wrongValue", null, null, null, null, null),
-            new TestData(null, "wrongValue", null, null, null, null),
-            new TestData(null, null, "wrongValue", null, null, null),
-            new TestData(null, null, null, "wrongValue", null, null),
-            new TestData(null, null, null, null, "PropertySetToUnsupportedValue", null),
-            });
+            arguments("wrongValue", null, null, null, null, null),
+            arguments(null, "wrongValue", null, null, null, null),
+            arguments(null, null, "wrongValue", null, null, null),
+            arguments(null, null, null, "wrongValue", null, null),
+            arguments(null, null, null, null, "PropertySetToUnsupportedValue", null)
+        );
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void classSetup() {
         // If this caches any values, make sure it's cached with the default (non-modified) configuration.
         RetryPolicy.defaultRetryPolicy();
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void methodSetup() {
         ENVIRONMENT_VARIABLE_HELPER.reset();
         System.clearProperty(SdkSystemSetting.AWS_MAX_ATTEMPTS.property());
@@ -79,62 +74,45 @@ public class RetryPolicyMaxRetriesTest {
         System.clearProperty(ProfileFileSystemSetting.AWS_CONFIG_FILE.property());
     }
 
-    @Test
-    public void differentCombinationOfConfigs_shouldResolveCorrectly() {
-        if (testData.attemptCountEnvVarValue != null) {
-            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_MAX_ATTEMPTS.environmentVariable(), testData.attemptCountEnvVarValue);
+    @ParameterizedTest
+    @MethodSource("testData")
+    void differentCombinationOfConfigs_shouldResolveCorrectly(String attemptCountSystemProperty,
+                                                              String attemptCountEnvVarValue,
+                                                              String systemProperty,
+                                                              String envVarValue,
+                                                              String configFile,
+                                                              Integer expected) {
+        if (attemptCountEnvVarValue != null) {
+            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_MAX_ATTEMPTS.environmentVariable(), attemptCountEnvVarValue);
         }
 
-        if (testData.attemptCountSystemProperty != null) {
-            System.setProperty(SdkSystemSetting.AWS_MAX_ATTEMPTS.property(), testData.attemptCountSystemProperty);
+        if (attemptCountSystemProperty != null) {
+            System.setProperty(SdkSystemSetting.AWS_MAX_ATTEMPTS.property(), attemptCountSystemProperty);
         }
 
-        if (testData.envVarValue != null) {
-            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_RETRY_MODE.environmentVariable(), testData.envVarValue);
+        if (envVarValue != null) {
+            ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_RETRY_MODE.environmentVariable(), envVarValue);
         }
 
-        if (testData.systemProperty != null) {
-            System.setProperty(SdkSystemSetting.AWS_RETRY_MODE.property(), testData.systemProperty);
+        if (systemProperty != null) {
+            System.setProperty(SdkSystemSetting.AWS_RETRY_MODE.property(), systemProperty);
         }
 
-        if (testData.configFile != null) {
-            String diskLocationForFile = diskLocationForConfig(testData.configFile);
+        if (configFile != null) {
+            String diskLocationForFile = diskLocationForConfig(configFile);
             Validate.isTrue(Files.isReadable(Paths.get(diskLocationForFile)), diskLocationForFile + " is not readable.");
             System.setProperty(ProfileFileSystemSetting.AWS_PROFILE.property(), "default");
             System.setProperty(ProfileFileSystemSetting.AWS_CONFIG_FILE.property(), diskLocationForFile);
         }
 
-        if (testData.expected == null) {
+        if (expected == null) {
             assertThatThrownBy(() -> RetryPolicy.forRetryMode(RetryMode.defaultRetryMode())).isInstanceOf(RuntimeException.class);
         } else {
-            assertThat(RetryPolicy.forRetryMode(RetryMode.defaultRetryMode()).numRetries()).isEqualTo(testData.expected);
+            assertThat(RetryPolicy.forRetryMode(RetryMode.defaultRetryMode()).numRetries()).isEqualTo(expected);
         }
     }
 
     private String diskLocationForConfig(String configFileName) {
         return getClass().getResource(configFileName).getFile();
-    }
-
-    private static class TestData {
-        private final String attemptCountSystemProperty;
-        private final String attemptCountEnvVarValue;
-        private final String envVarValue;
-        private final String systemProperty;
-        private final String configFile;
-        private final Integer expected;
-
-        TestData(String attemptCountSystemProperty,
-                 String attemptCountEnvVarValue,
-                 String retryModeSystemProperty,
-                 String retryModeEnvVarValue,
-                 String configFile,
-                 Integer expected) {
-            this.attemptCountSystemProperty = attemptCountSystemProperty;
-            this.attemptCountEnvVarValue = attemptCountEnvVarValue;
-            this.envVarValue = retryModeEnvVarValue;
-            this.systemProperty = retryModeSystemProperty;
-            this.configFile = configFile;
-            this.expected = expected;
-        }
     }
 }


### PR DESCRIPTION
JUnit 4 -> 5 migrations are often done in a 3-step process:

1. Update dependencies to JUnit 5, including the vintage module, causing all tests to leverage the new JUnit 5 Platform
2. Incrementally migrate JUnit 4 tests to JUnit 5 tests
3. Once no JUnit 4 usage remains, remove the dependency on the vintage module

This PR continues step 2 by migrating some parameterized tests to JUnit 5.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
