### PR TITLE
UpdateExpression API

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateAction.java
@@ -15,9 +15,11 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import java.util.Collections;
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.Validate;
 
@@ -45,6 +47,7 @@ import software.amazon.awssdk.utils.Validate;
  * }
  * </pre>
  */
+@SdkPublicApi
 public final class AddUpdateAction implements UpdateAction {
 
     private final String path;
@@ -52,11 +55,11 @@ public final class AddUpdateAction implements UpdateAction {
     private final Map<String, String> expressionNames;
     private final Map<String, AttributeValue> expressionValues;
 
-    public AddUpdateAction(Builder builder) {
+    private AddUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
-        this.expressionValues = Validate.paramNotNull(builder.expressionValues, "expressionValues");
-        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+        this.expressionValues = unmodifiableMap(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
+        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
     }
 
     /**
@@ -77,11 +80,11 @@ public final class AddUpdateAction implements UpdateAction {
     }
 
     public Map<String, String> expressionNames() {
-        return Collections.unmodifiableMap(expressionNames);
+        return expressionNames;
     }
 
     public Map<String, AttributeValue> expressionValues() {
-        return Collections.unmodifiableMap(expressionValues);
+        return expressionValues;
     }
 
     @Override
@@ -145,8 +148,11 @@ public final class AddUpdateAction implements UpdateAction {
         }
 
         /**
-         * The 'expression values' token map that maps from value references (expression attribute values) to DynamoDB
-         * AttributeValues. The value reference should always start with ':' (colon).
+         * Sets the 'expression values' token map that maps from value references (expression attribute values) to 
+         * DynamoDB AttributeValues, overriding any existing values. 
+         * The value reference should always start with ':' (colon).
+         *
+         * @see #putExpressionValue(String, AttributeValue)
          */
         public Builder expressionValues(Map<String, AttributeValue> expressionValues) {
             this.expressionValues = expressionValues == null ? null : new HashMap<>(expressionValues);
@@ -156,7 +162,7 @@ public final class AddUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the 'expression values' token map.
          *
-         * @see #expressionValues
+         * @see #expressionValues(Map)
          */
         public Builder putExpressionValue(String key, AttributeValue value) {
             if (this.expressionValues == null) {
@@ -168,12 +174,11 @@ public final class AddUpdateAction implements UpdateAction {
         }
 
         /**
-         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
-         * token ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
-         * to real attribute name.
-         *
-         * @param expressionNames
-         * @return
+         * Sets the optional 'expression names' token map, overriding any existing values. Use if the attribute 
+         * references in the path expression are token ('expression attribute names') prepended with the 
+         * '#' (pound) sign. It should map from token name to real attribute name.
+         * 
+         * @see #putExpressionName(String, String) 
          */
         public Builder expressionNames(Map<String, String> expressionNames) {
             this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
@@ -183,7 +188,7 @@ public final class AddUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the optional 'expression names' token map.
          *
-         * @see #expressionNames
+         * @see #expressionNames(Map) 
          */
         public Builder putExpressionName(String key, String value) {
             if (this.expressionNames == null) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateAction.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A representation of a single {@link UpdateExpression} ADD action.
+ * <p>
+ * At a minimum, this action must contain a path string referencing the attribute that should be acted upon and a value string
+ * referencing the value to be added to the attribute. The value should be substituted with tokens using the
+ * ':value_token' syntax and values associated with the token must be explicitly added to the expressionValues map.
+ * Consult the DynamoDB UpdateExpression documentation for details on this action.
+ * <p>
+ * Optionally, attribute names can be substituted with tokens using the '#name_token' syntax. If tokens are used in the
+ * expression then the names associated with those tokens must be explicitly added to the expressionNames map
+ * that is also stored on this object.
+ * <p>
+ * Example:-
+ * <pre>
+ * {@code
+ * AddUpdateAction addAction = AddUpdateAction.builder()
+ *                                            .path("#a")
+ *                                            .value(":b")
+ *                                            .putExpressionName("#a", "attributeA")
+ *                                            .putExpressionValue(":b", myAttributeValue)
+ *                                            .build();
+ * }
+ * </pre>
+ */
+public final class AddUpdateAction implements UpdateAction {
+
+    private final String path;
+    private final String value;
+    private final Map<String, String> expressionNames;
+    private final Map<String, AttributeValue> expressionValues;
+
+    public AddUpdateAction(Builder builder) {
+        this.path = Validate.paramNotNull(builder.path, "path");
+        this.value = Validate.paramNotNull(builder.value, "value");
+        this.expressionValues = Validate.paramNotNull(builder.expressionValues, "expressionValues");
+        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+    }
+
+    /**
+     * Constructs a new builder for {@link AddUpdateAction}.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public Map<String, String> expressionNames() {
+        return Collections.unmodifiableMap(expressionNames);
+    }
+
+    public Map<String, AttributeValue> expressionValues() {
+        return Collections.unmodifiableMap(expressionValues);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AddUpdateAction that = (AddUpdateAction) o;
+
+        if (path != null ? ! path.equals(that.path) : that.path != null) {
+            return false;
+        }
+        if (value != null ? ! value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        if (expressionValues != null ? ! expressionValues.equals(that.expressionValues) :
+            that.expressionValues != null) {
+            return false;
+        }
+        return expressionNames != null ? expressionNames.equals(that.expressionNames) : that.expressionNames == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path != null ? path.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (expressionValues != null ? expressionValues.hashCode() : 0);
+        result = 31 * result + (expressionNames != null ? expressionNames.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * A builder for {@link AddUpdateAction}
+     */
+    public static final class Builder {
+
+        private String path;
+        private String value;
+        private Map<String, String> expressionNames;
+        private Map<String, AttributeValue> expressionValues;
+
+        /**
+         * A string expression representing the attribute to be acted upon
+         */
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * A string expression representing the value used in the action. The value must be represented as an
+         * expression attribute value token.
+         */
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        /**
+         * The 'expression values' token map that maps from value references (expression attribute values) to DynamoDB
+         * AttributeValues. The value reference should always start with ':' (colon).
+         */
+        public Builder expressionValues(Map<String, AttributeValue> expressionValues) {
+            this.expressionValues = expressionValues == null ? null : new HashMap<>(expressionValues);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the 'expression values' token map.
+         *
+         * @see #expressionValues
+         */
+        public Builder putExpressionValue(String key, AttributeValue value) {
+            if (this.expressionValues == null) {
+                this.expressionValues = new HashMap<>();
+            }
+
+            this.expressionValues.put(key, value);
+            return this;
+        }
+
+        /**
+         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
+         * token ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
+         * to real attribute name.
+         *
+         * @param expressionNames
+         * @return
+         */
+        public Builder expressionNames(Map<String, String> expressionNames) {
+            this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the optional 'expression names' token map.
+         *
+         * @see #expressionNames
+         */
+        public Builder putExpressionName(String key, String value) {
+            if (this.expressionNames == null) {
+                this.expressionNames = new HashMap<>();
+            }
+            this.expressionNames.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds an {@link AddUpdateAction} based on the values stored in this builder.
+         */
+        public AddUpdateAction build() {
+            return new AddUpdateAction(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateAction.java
@@ -15,8 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import static java.util.Collections.unmodifiableMap;
-
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -58,8 +57,12 @@ public final class AddUpdateAction implements UpdateAction {
     private AddUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
-        this.expressionValues = unmodifiableMap(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
-        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+        this.expressionValues = wrapSecure(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
+        this.expressionNames = wrapSecure(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+    }
+
+    private static <T, U> Map<T, U> wrapSecure(Map<T, U> map) {
+        return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateAction.java
@@ -15,9 +15,11 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import java.util.Collections;
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.Validate;
 
@@ -45,6 +47,7 @@ import software.amazon.awssdk.utils.Validate;
  * }
  * </pre>
  */
+@SdkPublicApi
 public final class DeleteUpdateAction implements UpdateAction {
 
     private final String path;
@@ -55,8 +58,8 @@ public final class DeleteUpdateAction implements UpdateAction {
     private DeleteUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
-        this.expressionValues = Validate.paramNotNull(builder.expressionValues, "expressionValues");
-        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+        this.expressionValues = unmodifiableMap(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
+        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
     }
 
     /**
@@ -77,11 +80,11 @@ public final class DeleteUpdateAction implements UpdateAction {
     }
 
     public Map<String, String> expressionNames() {
-        return Collections.unmodifiableMap(expressionNames);
+        return expressionNames;
     }
 
     public Map<String, AttributeValue> expressionValues() {
-        return Collections.unmodifiableMap(expressionValues);
+        return expressionValues;
     }
 
     @Override
@@ -145,8 +148,11 @@ public final class DeleteUpdateAction implements UpdateAction {
         }
 
         /**
-         * The 'expression values' token map that maps from value references (expression attribute values) to DynamoDB
-         * AttributeValues. The value reference should always start with ':' (colon).
+         * Sets the 'expression values' token map that maps from value references (expression attribute values) to
+         * DynamoDB AttributeValues, overriding any existing values.
+         * The value reference should always start with ':' (colon).
+         *
+         * @see #putExpressionValue(String, AttributeValue)
          */
         public Builder expressionValues(Map<String, AttributeValue> expressionValues) {
             this.expressionValues = expressionValues == null ? null : new HashMap<>(expressionValues);
@@ -156,7 +162,7 @@ public final class DeleteUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the 'expression values' token map.
          *
-         * @see #expressionValues
+         * @see #expressionValues(Map)
          */
         public Builder putExpressionValue(String key, AttributeValue value) {
             if (this.expressionValues == null) {
@@ -168,12 +174,11 @@ public final class DeleteUpdateAction implements UpdateAction {
         }
 
         /**
-         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
-         * token ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
-         * to real attribute name.
+         * Sets the optional 'expression names' token map, overriding any existing values. Use if the attribute
+         * references in the path expression are token ('expression attribute names') prepended with the
+         * '#' (pound) sign. It should map from token name to real attribute name.
          *
-         * @param expressionNames
-         * @return
+         * @see #putExpressionName(String, String)
          */
         public Builder expressionNames(Map<String, String> expressionNames) {
             this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
@@ -183,7 +188,7 @@ public final class DeleteUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the optional 'expression names' token map.
          *
-         * @see #expressionNames
+         * @see #expressionNames(Map)
          */
         public Builder putExpressionName(String key, String value) {
             if (this.expressionNames == null) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateAction.java
@@ -15,8 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import static java.util.Collections.unmodifiableMap;
-
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -58,8 +57,12 @@ public final class DeleteUpdateAction implements UpdateAction {
     private DeleteUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
-        this.expressionValues = unmodifiableMap(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
-        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+        this.expressionValues = wrapSecure(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
+        this.expressionNames = wrapSecure(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+    }
+
+    private static <T, U> Map<T, U> wrapSecure(Map<T, U> map) {
+        return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateAction.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A representation of a single {@link UpdateExpression} DELETE action.
+ * <p>
+ * At a minimum, this action must contain a path string referencing the attribute that should be acted upon and a value string
+ * referencing the value (subset) to be removed from the attribute. The value should be substituted with tokens using the
+ * ':value_token' syntax and values associated with the token must be explicitly added to the expressionValues map.
+ * Consult the DynamoDB UpdateExpression documentation for details on this action.
+ * <p>
+ * Optionally, attribute names can be substituted with tokens using the '#name_token' syntax. If tokens are used in the
+ * expression then the names associated with those tokens must be explicitly added to the expressionNames map
+ * that is also stored on this object.
+ * <p>
+ * Example:-
+ * <pre>
+ * {@code
+ * DeleteUpdateAction deleteAction = DeleteUpdateAction.builder()
+ *                                                     .path("#a")
+ *                                                     .value(":b")
+ *                                                     .putExpressionName("#a", "attributeA")
+ *                                                     .putExpressionValue(":b", myAttributeValue)
+ *                                                     .build();
+ * }
+ * </pre>
+ */
+public final class DeleteUpdateAction implements UpdateAction {
+
+    private final String path;
+    private final String value;
+    private final Map<String, String> expressionNames;
+    private final Map<String, AttributeValue> expressionValues;
+
+    private DeleteUpdateAction(Builder builder) {
+        this.path = Validate.paramNotNull(builder.path, "path");
+        this.value = Validate.paramNotNull(builder.value, "value");
+        this.expressionValues = Validate.paramNotNull(builder.expressionValues, "expressionValues");
+        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+    }
+
+    /**
+     * Constructs a new builder for {@link DeleteUpdateAction}.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public Map<String, String> expressionNames() {
+        return Collections.unmodifiableMap(expressionNames);
+    }
+
+    public Map<String, AttributeValue> expressionValues() {
+        return Collections.unmodifiableMap(expressionValues);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DeleteUpdateAction that = (DeleteUpdateAction) o;
+
+        if (path != null ? ! path.equals(that.path) : that.path != null) {
+            return false;
+        }
+        if (value != null ? ! value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        if (expressionValues != null ? ! expressionValues.equals(that.expressionValues) :
+            that.expressionValues != null) {
+            return false;
+        }
+        return expressionNames != null ? expressionNames.equals(that.expressionNames) : that.expressionNames == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path != null ? path.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (expressionValues != null ? expressionValues.hashCode() : 0);
+        result = 31 * result + (expressionNames != null ? expressionNames.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * A builder for {@link DeleteUpdateAction}
+     */
+    public static final class Builder {
+
+        private String path;
+        private String value;
+        private Map<String, String> expressionNames;
+        private Map<String, AttributeValue> expressionValues;
+
+        /**
+         * A string expression representing the attribute to be acted upon
+         */
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * A string expression representing the value used in the action. The value must be represented as an
+         * expression attribute value token.
+         */
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        /**
+         * The 'expression values' token map that maps from value references (expression attribute values) to DynamoDB
+         * AttributeValues. The value reference should always start with ':' (colon).
+         */
+        public Builder expressionValues(Map<String, AttributeValue> expressionValues) {
+            this.expressionValues = expressionValues == null ? null : new HashMap<>(expressionValues);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the 'expression values' token map.
+         *
+         * @see #expressionValues
+         */
+        public Builder putExpressionValue(String key, AttributeValue value) {
+            if (this.expressionValues == null) {
+                this.expressionValues = new HashMap<>();
+            }
+
+            this.expressionValues.put(key, value);
+            return this;
+        }
+
+        /**
+         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
+         * token ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
+         * to real attribute name.
+         *
+         * @param expressionNames
+         * @return
+         */
+        public Builder expressionNames(Map<String, String> expressionNames) {
+            this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the optional 'expression names' token map.
+         *
+         * @see #expressionNames
+         */
+        public Builder putExpressionName(String key, String value) {
+            if (this.expressionNames == null) {
+                this.expressionNames = new HashMap<>();
+            }
+            this.expressionNames.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds an {@link DeleteUpdateAction} based on the values stored in this builder.
+         */
+        public DeleteUpdateAction build() {
+            return new DeleteUpdateAction(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
@@ -15,10 +15,12 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import static java.util.Collections.unmodifiableMap;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.cleanAttributeName;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Validate;
 
@@ -50,7 +52,11 @@ public final class RemoveUpdateAction implements UpdateAction {
 
     private RemoveUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
-        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+        this.expressionNames = wrapSecure(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+    }
+
+    private static <T, U> Map<T, U> wrapSecure(Map<T, U> map) {
+        return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
@@ -15,10 +15,11 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -41,6 +42,7 @@ import software.amazon.awssdk.utils.Validate;
  * }
  * </pre>
  */
+@SdkPublicApi
 public final class RemoveUpdateAction implements UpdateAction {
 
     private final String path;
@@ -48,7 +50,7 @@ public final class RemoveUpdateAction implements UpdateAction {
 
     private RemoveUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
-        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
     }
 
     /**
@@ -65,7 +67,7 @@ public final class RemoveUpdateAction implements UpdateAction {
     }
 
     public Map<String, String> expressionNames() {
-        return Collections.unmodifiableMap(expressionNames);
+        return expressionNames;
     }
 
     @Override
@@ -109,9 +111,11 @@ public final class RemoveUpdateAction implements UpdateAction {
         }
 
         /**
-         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
-         * tokens ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
-         * to real attribute name.
+         * Sets the optional 'expression names' token map, overriding any existing values. Use if the attribute
+         * references in the path expression are token ('expression attribute names') prepended with the
+         * '#' (pound) sign. It should map from token name to real attribute name.
+         *
+         * @see #putExpressionName(String, String)
          */
         public Builder expressionNames(Map<String, String> expressionNames) {
             this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
@@ -121,7 +125,7 @@ public final class RemoveUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the optional 'expression names' token map.
          *
-         * @see #expressionNames
+         * @see #expressionNames(Map)
          */
         public Builder putExpressionName(String key, String value) {
             if (this.expressionNames == null) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
@@ -15,12 +15,9 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.cleanAttributeName;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.UnaryOperator;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Validate;
 

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateAction.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A representation of a single {@link UpdateExpression} REMOVE action.
+ * <p>
+ * At a minimum, this action must contain a path string referencing the attribute that should be removed when applying this
+ * action. Consult the DynamoDB UpdateExpression documentation for details on this action.
+ * <p>
+ * Optionally, attribute names can be substituted with tokens using the '#name_token' syntax. If tokens are used in the
+ * expression then the names associated with those tokens must be explicitly added to the expressionNames map
+ * that is also stored on this object.
+ * <p>
+ * Example:-
+ * <pre>
+ * {@code
+ * RemoveUpdateAction removeAction = RemoveUpdateAction.builder()
+ *                                                     .path("#a")
+ *                                                     .putExpressionName("#a", "attributeA")
+ *                                                     .build();
+ * }
+ * </pre>
+ */
+public final class RemoveUpdateAction implements UpdateAction {
+
+    private final String path;
+    private final Map<String, String> expressionNames;
+
+    private RemoveUpdateAction(Builder builder) {
+        this.path = Validate.paramNotNull(builder.path, "path");
+        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+    }
+
+    /**
+     * Constructs a new builder for {@link RemoveUpdateAction}.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public Map<String, String> expressionNames() {
+        return Collections.unmodifiableMap(expressionNames);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RemoveUpdateAction that = (RemoveUpdateAction) o;
+
+        if (path != null ? ! path.equals(that.path) : that.path != null) {
+            return false;
+        }
+        return expressionNames != null ? expressionNames.equals(that.expressionNames) : that.expressionNames == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path != null ? path.hashCode() : 0;
+        result = 31 * result + (expressionNames != null ? expressionNames.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * A builder for {@link RemoveUpdateAction}
+     */
+    public static final class Builder {
+
+        private String path;
+        private Map<String, String> expressionNames;
+
+        /**
+         * A string expression representing the attribute to remove
+         */
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
+         * tokens ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
+         * to real attribute name.
+         */
+        public Builder expressionNames(Map<String, String> expressionNames) {
+            this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the optional 'expression names' token map.
+         *
+         * @see #expressionNames
+         */
+        public Builder putExpressionName(String key, String value) {
+            if (this.expressionNames == null) {
+                this.expressionNames = new HashMap<>();
+            }
+            this.expressionNames.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds an {@link RemoveUpdateAction} based on the values stored in this builder.
+         */
+        public RemoveUpdateAction build() {
+            return new RemoveUpdateAction(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateAction.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * A representation of a single {@link UpdateExpression} SET action.
+ * <p>
+ * At a minimum, this action must contain a path string referencing the attribute that should be acted upon and a value string
+ * referencing the value to set or change.
+ * <p>
+ * The value string may contain just an operand, or operands combined with '+' or '-'. Furthermore, an operand can be a
+ * reference to a specific value or a function. All references to values should be substituted with tokens using the
+ * ':value_token' syntax and values associated with the token must be explicitly added to the expressionValues map.
+ * Consult the DynamoDB UpdateExpression documentation for details on this action.
+ * <p>
+ * Optionally, attribute names can be substituted with tokens using the '#name_token' syntax. If tokens are used in the
+ * expression then the names associated with those tokens must be explicitly added to the expressionNames map
+ * that is also stored on this object.
+ * <p>
+ * Example:-
+ * <pre>
+ * {@code
+ * //Simply setting the value of 'attributeA' to 'myAttributeValue'
+ * SetUpdateAction setAction1 = SetUpdateAction.builder()
+ *                                             .path("#a")
+ *                                             .value(":b")
+ *                                             .putExpressionName("#a", "attributeA")
+ *                                             .putExpressionValue(":b", myAttributeValue)
+ *                                             .build();
+ *
+ * //Increasing the value of 'attributeA' with 'delta' if it already exists, otherwise sets it to 'startValue'
+ * SetUpdateAction setAction2 = SetUpdateAction.builder()
+ *                                             .path("#a")
+ *                                             .value("if_not_exists(#a, :startValue) + :delta")
+ *                                             .putExpressionName("#a", "attributeA")
+ *                                             .putExpressionValue(":delta", myNumericAttributeValue1)
+ *                                             .putExpressionValue(":startValue", myNumericAttributeValue2)
+ *                                             .build();
+ * }
+ * </pre>
+ */
+public final class SetUpdateAction implements UpdateAction {
+
+    private final String path;
+    private final String value;
+    private final Map<String, String> expressionNames;
+    private final Map<String, AttributeValue> expressionValues;
+
+    private SetUpdateAction(Builder builder) {
+        this.path = Validate.paramNotNull(builder.path, "path");
+        this.value = Validate.paramNotNull(builder.value, "value");
+        this.expressionValues = Validate.paramNotNull(builder.expressionValues, "expressionValues");
+        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+    }
+
+    /**
+     * Constructs a new builder for {@link SetUpdateAction}.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public Map<String, String> expressionNames() {
+        return Collections.unmodifiableMap(expressionNames);
+    }
+
+    public Map<String, AttributeValue> expressionValues() {
+        return Collections.unmodifiableMap(expressionValues);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SetUpdateAction that = (SetUpdateAction) o;
+
+        if (path != null ? ! path.equals(that.path) : that.path != null) {
+            return false;
+        }
+        if (value != null ? ! value.equals(that.value) : that.value != null) {
+            return false;
+        }
+        if (expressionValues != null ? ! expressionValues.equals(that.expressionValues) :
+            that.expressionValues != null) {
+            return false;
+        }
+        return expressionNames != null ? expressionNames.equals(that.expressionNames) : that.expressionNames == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path != null ? path.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (expressionValues != null ? expressionValues.hashCode() : 0);
+        result = 31 * result + (expressionNames != null ? expressionNames.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * A builder for {@link DeleteUpdateAction}
+     */
+    public static final class Builder {
+
+        private String path;
+        private String value;
+        private Map<String, String> expressionNames;
+        private Map<String, AttributeValue> expressionValues;
+
+        /**
+         * A string expression representing the attribute to be acted upon
+         */
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * A string expression representing the value used in the action. The value must be represented as an
+         * expression attribute value token.
+         */
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        /**
+         * The 'expression values' token map that maps from value references (expression attribute values) to DynamoDB
+         * AttributeValues. The value reference should always start with ':' (colon).
+         */
+        public Builder expressionValues(Map<String, AttributeValue> expressionValues) {
+            this.expressionValues = expressionValues == null ? null : new HashMap<>(expressionValues);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the 'expression values' token map.
+         *
+         * @see #expressionValues
+         */
+        public Builder putExpressionValue(String key, AttributeValue value) {
+            if (this.expressionValues == null) {
+                this.expressionValues = new HashMap<>();
+            }
+
+            this.expressionValues.put(key, value);
+            return this;
+        }
+
+        /**
+         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
+         * token ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
+         * to real attribute name.
+         *
+         * @param expressionNames
+         * @return
+         */
+        public Builder expressionNames(Map<String, String> expressionNames) {
+            this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
+            return this;
+        }
+
+        /**
+         * Adds a single element to the optional 'expression names' token map.
+         *
+         * @see #expressionNames
+         */
+        public Builder putExpressionName(String key, String value) {
+            if (this.expressionNames == null) {
+                this.expressionNames = new HashMap<>();
+            }
+            this.expressionNames.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds an {@link SetUpdateAction} based on the values stored in this builder.
+         */
+        public SetUpdateAction build() {
+            return new SetUpdateAction(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateAction.java
@@ -15,9 +15,11 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import java.util.Collections;
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.Validate;
 
@@ -58,6 +60,7 @@ import software.amazon.awssdk.utils.Validate;
  * }
  * </pre>
  */
+@SdkPublicApi
 public final class SetUpdateAction implements UpdateAction {
 
     private final String path;
@@ -68,8 +71,8 @@ public final class SetUpdateAction implements UpdateAction {
     private SetUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
-        this.expressionValues = Validate.paramNotNull(builder.expressionValues, "expressionValues");
-        this.expressionNames = builder.expressionNames != null ? builder.expressionNames : new HashMap<>();
+        this.expressionValues = unmodifiableMap(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
+        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
     }
 
     /**
@@ -90,11 +93,11 @@ public final class SetUpdateAction implements UpdateAction {
     }
 
     public Map<String, String> expressionNames() {
-        return Collections.unmodifiableMap(expressionNames);
+        return expressionNames;
     }
 
     public Map<String, AttributeValue> expressionValues() {
-        return Collections.unmodifiableMap(expressionValues);
+        return expressionValues;
     }
 
     @Override
@@ -158,8 +161,11 @@ public final class SetUpdateAction implements UpdateAction {
         }
 
         /**
-         * The 'expression values' token map that maps from value references (expression attribute values) to DynamoDB
-         * AttributeValues. The value reference should always start with ':' (colon).
+         * Sets the 'expression values' token map that maps from value references (expression attribute values) to
+         * DynamoDB AttributeValues, overriding any existing values.
+         * The value reference should always start with ':' (colon).
+         *
+         * @see #putExpressionValue(String, AttributeValue)
          */
         public Builder expressionValues(Map<String, AttributeValue> expressionValues) {
             this.expressionValues = expressionValues == null ? null : new HashMap<>(expressionValues);
@@ -169,7 +175,7 @@ public final class SetUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the 'expression values' token map.
          *
-         * @see #expressionValues
+         * @see #expressionValues(Map)
          */
         public Builder putExpressionValue(String key, AttributeValue value) {
             if (this.expressionValues == null) {
@@ -181,12 +187,11 @@ public final class SetUpdateAction implements UpdateAction {
         }
 
         /**
-         * Optional 'expression names' token map, to be used if the attribute references in the path expression are
-         * token ('expression attribute names') prepended with the '#' (pound) sign. It should map from token name
-         * to real attribute name.
+         * Sets the optional 'expression names' token map, overriding any existing values. Use if the attribute
+         * references in the path expression are token ('expression attribute names') prepended with the
+         * '#' (pound) sign. It should map from token name to real attribute name.
          *
-         * @param expressionNames
-         * @return
+         * @see #putExpressionName(String, String)
          */
         public Builder expressionNames(Map<String, String> expressionNames) {
             this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
@@ -196,7 +201,7 @@ public final class SetUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the optional 'expression names' token map.
          *
-         * @see #expressionNames
+         * @see #expressionNames(Map)
          */
         public Builder putExpressionName(String key, String value) {
             if (this.expressionNames == null) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateAction.java
@@ -15,8 +15,7 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import static java.util.Collections.unmodifiableMap;
-
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -71,8 +70,12 @@ public final class SetUpdateAction implements UpdateAction {
     private SetUpdateAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
-        this.expressionValues = unmodifiableMap(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
-        this.expressionNames = unmodifiableMap(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+        this.expressionValues = wrapSecure(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
+        this.expressionNames = wrapSecure(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
+    }
+
+    private static <T, U> Map<T, U> wrapSecure(Map<T, U> map) {
+        return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * An update action represents a part of an {@link UpdateExpression}
+ */
+public interface UpdateAction {
+
+    // String expression();
+    //
+    // Map<String, String> expressionNames();
+    //
+    // Map<String, AttributeValue> expressionValues();
+
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateAction.java
@@ -15,18 +15,12 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
-import java.util.Map;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
  * An update action represents a part of an {@link UpdateExpression}
  */
+@SdkPublicApi
 public interface UpdateAction {
-
-    // String expression();
-    //
-    // Map<String, String> expressionNames();
-    //
-    // Map<String, AttributeValue> expressionValues();
 
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Contains sets of {@link UpdateAction} that represent the four DynamoDB update actions: SET, ADD, REMOVE and DELETE.
+ * <p>
+ * Use this class to build an immutable UpdateExpression with one or more UpdateAction. An UpdateExpression may be merged
+ * with another. When two UpdateExpression are merged, the actions of each group of UpdateAction, should they exist, are
+ * combined; all SET actions from each expression are concatenated, all REMOVE actions etc.
+ * <p>
+ * DynamoDb Enhanced will convert the UpdateExpression to a format readable by DynamoDb,
+ * <p>
+ * Examples of adding actions for attributes directly:
+ * <pre>
+ * {@code
+ * RemoveUpdateAction removeAction = ...
+ * List<SetUpdateAction> setActions = ...
+ * UpdateExpression.builder()
+ *                 .addAction(removeAction)
+ *                 .actions(setActions)
+ *                 .build();
+ * }
+ * </pre>
+ *
+ * See respective subtype of {@link UpdateAction}, for example {@link SetUpdateAction}, for details on creating that action.
+ */
+@SdkPublicApi
+public final class UpdateExpression {
+
+    private final Collection<RemoveUpdateAction> removeActions;
+    private final Collection<SetUpdateAction> setActions;
+    private final Collection<DeleteUpdateAction> deleteActions;
+    private final Collection<AddUpdateAction> addActions;
+
+    private UpdateExpression(Builder builder) {
+        this.removeActions = builder.removeActions != null ? builder.removeActions : new ArrayList<>();
+        this.setActions = builder.setActions != null ? builder.setActions : new ArrayList<>();
+        this.deleteActions = builder.deleteActions != null ? builder.deleteActions : new ArrayList<>();
+        this.addActions = builder.addActions != null ? builder.addActions : new ArrayList<>();
+    }
+
+    /**
+     * Constructs a new builder for {@link UpdateExpression}.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Collection<RemoveUpdateAction> removeActions() {
+        return Collections.unmodifiableCollection(removeActions);
+    }
+
+    public Collection<SetUpdateAction> setActions() {
+        return Collections.unmodifiableCollection(setActions);
+    }
+
+    public Collection<DeleteUpdateAction> deleteActions() {
+        return Collections.unmodifiableCollection(deleteActions);
+    }
+
+    public Collection<AddUpdateAction> addActions() {
+        return Collections.unmodifiableCollection(addActions);
+    }
+
+    /**
+     * Merges the supplied UpdateExpression with the current
+     */
+    public void mergeExpression(UpdateExpression expression) {
+        if (expression == null) {
+            return;
+        }
+        removeActions.addAll(expression.removeActions());
+        setActions.addAll(expression.setActions());
+        deleteActions.addAll(expression.deleteActions());
+        addActions.addAll(expression.addActions());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        UpdateExpression that = (UpdateExpression) o;
+
+        if (removeActions != null ? ! removeActions.equals(that.removeActions) : that.removeActions != null) {
+            return false;
+        }
+        if (setActions != null ? ! setActions.equals(that.setActions) : that.setActions != null) {
+            return false;
+        }
+        if (deleteActions != null ? ! deleteActions.equals(that.deleteActions) : that.deleteActions != null) {
+            return false;
+        }
+        return addActions != null ? addActions.equals(that.addActions) : that.addActions == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = removeActions != null ? removeActions.hashCode() : 0;
+        result = 31 * result + (setActions != null ? setActions.hashCode() : 0);
+        result = 31 * result + (deleteActions != null ? deleteActions.hashCode() : 0);
+        result = 31 * result + (addActions != null ? addActions.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * A builder for {@link UpdateExpression}
+     */
+    public static final class Builder {
+
+        private Collection<RemoveUpdateAction> removeActions;
+        private Collection<SetUpdateAction> setActions;
+        private Collection<DeleteUpdateAction> deleteActions;
+        private Collection<AddUpdateAction> addActions;
+
+        private Builder() {
+        }
+
+        /**
+         * Add an action of type {@link RemoveUpdateAction}
+         */
+        public Builder addAction(RemoveUpdateAction action) {
+            if (this.removeActions == null) {
+                this.removeActions = new ArrayList<>();
+            }
+            removeActions.add(action);
+            return this;
+        }
+
+        /**
+         * Add an action of type {@link SetUpdateAction}
+         */
+        public Builder addAction(SetUpdateAction action) {
+            if (this.setActions == null) {
+                this.setActions = new ArrayList<>();
+            }
+            setActions.add(action);
+            return this;
+        }
+
+        /**
+         * Add an action of type {@link DeleteUpdateAction}
+         */
+        public Builder addAction(DeleteUpdateAction action) {
+            if (this.deleteActions == null) {
+                this.deleteActions = new ArrayList<>();
+            }
+            deleteActions.add(action);
+            return this;
+        }
+
+        /**
+         * Add an action of type {@link AddUpdateAction}
+         */
+        public Builder addAction(AddUpdateAction action) {
+            if (this.addActions == null) {
+                this.addActions = new ArrayList<>();
+            }
+            addActions.add(action);
+            return this;
+        }
+
+        /**
+         * Adds a collection of {@link UpdateAction} of any subtype to the builder. Calling this operation
+         * repeatedly will add the new collection to existing items and not overwrite them.
+         */
+        public Builder actions(Collection<UpdateAction> actions) {
+            addActions(actions);
+            return this;
+        }
+
+        /**
+         * Adds a collection of {@link UpdateAction} of any subtype to the builder. Calling this operation
+         * repeatedly will add the new collection to existing items and not overwrite them.
+         */
+        public Builder actions(UpdateAction... actions) {
+            actions(Arrays.asList(actions));
+            return this;
+        }
+
+        /**
+         * Builds an {@link UpdateExpression} based on the values stored in this builder.
+         */
+        public UpdateExpression build() {
+            return new UpdateExpression(this);
+        }
+
+        private void addActions(Collection<UpdateAction> actions) {
+            if (actions != null) {
+                actions.forEach(this::assignAction);
+            }
+        }
+
+        private void assignAction(UpdateAction action) {
+            if (action instanceof RemoveUpdateAction) {
+                addAction((RemoveUpdateAction) action);
+            } else if (action instanceof SetUpdateAction) {
+                addAction((SetUpdateAction) action);
+            } else if (action instanceof DeleteUpdateAction) {
+                addAction((DeleteUpdateAction) action);
+            } else if (action instanceof AddUpdateAction) {
+                addAction((AddUpdateAction) action);
+            } else {
+                throw new IllegalArgumentException("Do not recognize this UpdateAction");
+            }
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
@@ -31,14 +31,14 @@ import software.amazon.awssdk.utils.CollectionUtils;
  * <p>
  * DynamoDb Enhanced will convert the UpdateExpression to a format readable by DynamoDb,
  * <p>
- * Examples of adding actions for attributes directly:
+ * Example:-
  * <pre>
  * {@code
  * RemoveUpdateAction removeAction = ...
- * List<SetUpdateAction> setActions = ...
+ * SetUpdateAction setAction = ...
  * UpdateExpression.builder()
  *                 .addAction(removeAction)
- *                 .actions(setActions)
+ *                 .addAction(setAction)
  *                 .build();
  * }
  * </pre>
@@ -70,19 +70,19 @@ public final class UpdateExpression {
     }
 
     public List<RemoveUpdateAction> removeActions() {
-        return Collections.unmodifiableList(removeActions);
+        return Collections.unmodifiableList(new ArrayList<>(removeActions));
     }
 
     public List<SetUpdateAction> setActions() {
-        return Collections.unmodifiableList(setActions);
+        return Collections.unmodifiableList(new ArrayList<>(setActions));
     }
 
     public List<DeleteUpdateAction> deleteActions() {
-        return Collections.unmodifiableList(deleteActions);
+        return Collections.unmodifiableList(new ArrayList<>(deleteActions));
     }
 
     public List<AddUpdateAction> addActions() {
-        return Collections.unmodifiableList(addActions);
+        return Collections.unmodifiableList(new ArrayList<>(addActions));
     }
 
     /**
@@ -192,7 +192,7 @@ public final class UpdateExpression {
         }
 
         /**
-         * Adds a lsit of {@link UpdateAction} of any subtype to the builder, overwriting any previous values.
+         * Adds a list of {@link UpdateAction} of any subtype to the builder, overwriting any previous values.
          */
         public Builder actions(UpdateAction... actions) {
             actions(Arrays.asList(actions));

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.utils.CollectionUtils;
 
 /**
  * Contains sets of {@link UpdateAction} that represent the four DynamoDB update actions: SET, ADD, REMOVE and DELETE.
@@ -53,10 +54,10 @@ public final class UpdateExpression {
     private final List<AddUpdateAction> addActions;
 
     private UpdateExpression(Builder builder) {
-        this.removeActions = builder.removeActions != null ? builder.removeActions : new ArrayList<>();
-        this.setActions = builder.setActions != null ? builder.setActions : new ArrayList<>();
-        this.deleteActions = builder.deleteActions != null ? builder.deleteActions : new ArrayList<>();
-        this.addActions = builder.addActions != null ? builder.addActions : new ArrayList<>();
+        this.removeActions = builder.removeActions;
+        this.setActions = builder.setActions;
+        this.deleteActions = builder.deleteActions;
+        this.addActions = builder.addActions;
     }
 
     /**
@@ -91,10 +92,18 @@ public final class UpdateExpression {
         if (expression == null) {
             return;
         }
-        removeActions.addAll(expression.removeActions());
-        setActions.addAll(expression.setActions());
-        deleteActions.addAll(expression.deleteActions());
-        addActions.addAll(expression.addActions());
+        if (!CollectionUtils.isNullOrEmpty(expression.removeActions)) {
+            removeActions.addAll(expression.removeActions());
+        }
+        if (!CollectionUtils.isNullOrEmpty(expression.setActions)) {
+            setActions.addAll(expression.setActions());
+        }
+        if (!CollectionUtils.isNullOrEmpty(expression.deleteActions)) {
+            deleteActions.addAll(expression.deleteActions());
+        }
+        if (!CollectionUtils.isNullOrEmpty(expression.addActions)) {
+            addActions.addAll(expression.addActions());
+        }
     }
 
     @Override
@@ -134,10 +143,10 @@ public final class UpdateExpression {
      */
     public static final class Builder {
 
-        private List<RemoveUpdateAction> removeActions;
-        private List<SetUpdateAction> setActions;
-        private List<DeleteUpdateAction> deleteActions;
-        private List<AddUpdateAction> addActions;
+        private List<RemoveUpdateAction> removeActions = new ArrayList<>();
+        private List<SetUpdateAction> setActions = new ArrayList<>();
+        private List<DeleteUpdateAction> deleteActions = new ArrayList<>();
+        private List<AddUpdateAction> addActions = new ArrayList<>();
 
         private Builder() {
         }
@@ -146,9 +155,6 @@ public final class UpdateExpression {
          * Add an action of type {@link RemoveUpdateAction}
          */
         public Builder addAction(RemoveUpdateAction action) {
-            if (this.removeActions == null) {
-                this.removeActions = new ArrayList<>();
-            }
             removeActions.add(action);
             return this;
         }
@@ -157,9 +163,6 @@ public final class UpdateExpression {
          * Add an action of type {@link SetUpdateAction}
          */
         public Builder addAction(SetUpdateAction action) {
-            if (this.setActions == null) {
-                this.setActions = new ArrayList<>();
-            }
             setActions.add(action);
             return this;
         }
@@ -168,9 +171,6 @@ public final class UpdateExpression {
          * Add an action of type {@link DeleteUpdateAction}
          */
         public Builder addAction(DeleteUpdateAction action) {
-            if (this.deleteActions == null) {
-                this.deleteActions = new ArrayList<>();
-            }
             deleteActions.add(action);
             return this;
         }
@@ -179,25 +179,20 @@ public final class UpdateExpression {
          * Add an action of type {@link AddUpdateAction}
          */
         public Builder addAction(AddUpdateAction action) {
-            if (this.addActions == null) {
-                this.addActions = new ArrayList<>();
-            }
             addActions.add(action);
             return this;
         }
 
         /**
-         * Adds a list of {@link UpdateAction} of any subtype to the builder. Calling this operation
-         * repeatedly will add the new list to existing items and not overwrite them.
+         * Adds a list of {@link UpdateAction} of any subtype to the builder, overwriting any previous values.
          */
-        public Builder actions(List<UpdateAction> actions) {
-            addActions(actions);
+        public Builder actions(List<? extends UpdateAction> actions) {
+            replaceActions(actions);
             return this;
         }
 
         /**
-         * Adds a lsit of {@link UpdateAction} of any subtype to the builder. Calling this operation
-         * repeatedly will add the new list to existing items and not overwrite them.
+         * Adds a lsit of {@link UpdateAction} of any subtype to the builder, overwriting any previous values.
          */
         public Builder actions(UpdateAction... actions) {
             actions(Arrays.asList(actions));
@@ -211,8 +206,12 @@ public final class UpdateExpression {
             return new UpdateExpression(this);
         }
 
-        private void addActions(List<UpdateAction> actions) {
+        private void replaceActions(List<? extends UpdateAction> actions) {
             if (actions != null) {
+                this.removeActions = new ArrayList<>();
+                this.setActions = new ArrayList<>();
+                this.deleteActions = new ArrayList<>();
+                this.addActions = new ArrayList<>();
                 actions.forEach(this::assignAction);
             }
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
@@ -17,8 +17,8 @@ package software.amazon.awssdk.enhanced.dynamodb.update;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
 /**
@@ -47,10 +47,10 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
 @SdkPublicApi
 public final class UpdateExpression {
 
-    private final Collection<RemoveUpdateAction> removeActions;
-    private final Collection<SetUpdateAction> setActions;
-    private final Collection<DeleteUpdateAction> deleteActions;
-    private final Collection<AddUpdateAction> addActions;
+    private final List<RemoveUpdateAction> removeActions;
+    private final List<SetUpdateAction> setActions;
+    private final List<DeleteUpdateAction> deleteActions;
+    private final List<AddUpdateAction> addActions;
 
     private UpdateExpression(Builder builder) {
         this.removeActions = builder.removeActions != null ? builder.removeActions : new ArrayList<>();
@@ -68,20 +68,20 @@ public final class UpdateExpression {
         return new Builder();
     }
 
-    public Collection<RemoveUpdateAction> removeActions() {
-        return Collections.unmodifiableCollection(removeActions);
+    public List<RemoveUpdateAction> removeActions() {
+        return Collections.unmodifiableList(removeActions);
     }
 
-    public Collection<SetUpdateAction> setActions() {
-        return Collections.unmodifiableCollection(setActions);
+    public List<SetUpdateAction> setActions() {
+        return Collections.unmodifiableList(setActions);
     }
 
-    public Collection<DeleteUpdateAction> deleteActions() {
-        return Collections.unmodifiableCollection(deleteActions);
+    public List<DeleteUpdateAction> deleteActions() {
+        return Collections.unmodifiableList(deleteActions);
     }
 
-    public Collection<AddUpdateAction> addActions() {
-        return Collections.unmodifiableCollection(addActions);
+    public List<AddUpdateAction> addActions() {
+        return Collections.unmodifiableList(addActions);
     }
 
     /**
@@ -134,10 +134,10 @@ public final class UpdateExpression {
      */
     public static final class Builder {
 
-        private Collection<RemoveUpdateAction> removeActions;
-        private Collection<SetUpdateAction> setActions;
-        private Collection<DeleteUpdateAction> deleteActions;
-        private Collection<AddUpdateAction> addActions;
+        private List<RemoveUpdateAction> removeActions;
+        private List<SetUpdateAction> setActions;
+        private List<DeleteUpdateAction> deleteActions;
+        private List<AddUpdateAction> addActions;
 
         private Builder() {
         }
@@ -187,17 +187,17 @@ public final class UpdateExpression {
         }
 
         /**
-         * Adds a collection of {@link UpdateAction} of any subtype to the builder. Calling this operation
-         * repeatedly will add the new collection to existing items and not overwrite them.
+         * Adds a list of {@link UpdateAction} of any subtype to the builder. Calling this operation
+         * repeatedly will add the new list to existing items and not overwrite them.
          */
-        public Builder actions(Collection<UpdateAction> actions) {
+        public Builder actions(List<UpdateAction> actions) {
             addActions(actions);
             return this;
         }
 
         /**
-         * Adds a collection of {@link UpdateAction} of any subtype to the builder. Calling this operation
-         * repeatedly will add the new collection to existing items and not overwrite them.
+         * Adds a lsit of {@link UpdateAction} of any subtype to the builder. Calling this operation
+         * repeatedly will add the new list to existing items and not overwrite them.
          */
         public Builder actions(UpdateAction... actions) {
             actions(Arrays.asList(actions));
@@ -211,7 +211,7 @@ public final class UpdateExpression {
             return new UpdateExpression(this);
         }
 
-        private void addActions(Collection<UpdateAction> actions) {
+        private void addActions(List<UpdateAction> actions) {
             if (actions != null) {
                 actions.forEach(this::assignAction);
             }
@@ -227,7 +227,8 @@ public final class UpdateExpression {
             } else if (action instanceof AddUpdateAction) {
                 addAction((AddUpdateAction) action);
             } else {
-                throw new IllegalArgumentException("Do not recognize this UpdateAction");
+                throw new IllegalArgumentException(
+                    String.format("Do not recognize UpdateAction: %s", action.getClass()));
             }
         }
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateActionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class AddUpdateActionTest {
+
+    private static final String PATH = "path string";
+    private static final String VALUE = "value string";
+    private static final String VALUE_TOKEN = ":valueToken";
+    private static final String ATTRIBUTE_TOKEN = "#attributeToken";
+    private static final String ATTRIBUTE_NAME = "attribute1";
+    private static final AttributeValue NUMERIC_VALUE = AttributeValue.builder().n("5").build();
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(AddUpdateAction.class)
+                      .usingGetClass()
+                      .withPrefabValues(AttributeValue.class,
+                                        AttributeValue.builder().s("1").build(),
+                                        AttributeValue.builder().s("2").build())
+                      .verify();
+    }
+
+    @Test
+    public void build_minimal() {
+        AddUpdateAction action = AddUpdateAction.builder()
+                                                .path(PATH)
+                                                .value(VALUE)
+                                                .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
+                                                .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.value()).isEqualTo(VALUE);
+        assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
+        assertThat(action.expressionNames()).isEmpty();
+    }
+
+    @Test
+    public void build_maximal() {
+        AddUpdateAction action = AddUpdateAction.builder()
+                                                .path(PATH)
+                                                .value(VALUE)
+                                                .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                                .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                                .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.value()).isEqualTo(VALUE);
+        assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
+        assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/AddUpdateActionTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-public class AddUpdateActionTest {
+class AddUpdateActionTest {
 
     private static final String PATH = "path string";
     private static final String VALUE = "value string";
@@ -32,7 +32,7 @@ public class AddUpdateActionTest {
     private static final AttributeValue NUMERIC_VALUE = AttributeValue.builder().n("5").build();
 
     @Test
-    public void equalsHashcode() {
+    void equalsHashcode() {
         EqualsVerifier.forClass(AddUpdateAction.class)
                       .usingGetClass()
                       .withPrefabValues(AttributeValue.class,
@@ -42,7 +42,7 @@ public class AddUpdateActionTest {
     }
 
     @Test
-    public void build_minimal() {
+    void build_minimal() {
         AddUpdateAction action = AddUpdateAction.builder()
                                                 .path(PATH)
                                                 .value(VALUE)
@@ -55,7 +55,7 @@ public class AddUpdateActionTest {
     }
 
     @Test
-    public void build_maximal() {
+    void build_maximal() {
         AddUpdateAction action = AddUpdateAction.builder()
                                                 .path(PATH)
                                                 .value(VALUE)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateActionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class DeleteUpdateActionTest {
+
+    private static final String PATH = "path string";
+    private static final String VALUE = "value string";
+    private static final String VALUE_TOKEN = ":valueToken";
+    private static final String ATTRIBUTE_TOKEN = "#attributeToken";
+    private static final String ATTRIBUTE_NAME = "attribute1";
+    private static final AttributeValue NUMERIC_VALUE = AttributeValue.builder().n("5").build();
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(DeleteUpdateAction.class)
+                      .usingGetClass()
+                      .withPrefabValues(AttributeValue.class,
+                                        AttributeValue.builder().s("1").build(),
+                                        AttributeValue.builder().s("2").build())
+                      .verify();
+    }
+
+    @Test
+    public void build_minimal() {
+        DeleteUpdateAction action = DeleteUpdateAction.builder()
+                                                      .path(PATH)
+                                                      .value(VALUE)
+                                                      .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
+                                                      .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.value()).isEqualTo(VALUE);
+        assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
+        assertThat(action.expressionNames()).isEmpty();
+    }
+
+    @Test
+    public void build_maximal() {
+        DeleteUpdateAction action = DeleteUpdateAction.builder()
+                                                      .path(PATH)
+                                                      .value(VALUE)
+                                                      .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                                      .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                                      .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.value()).isEqualTo(VALUE);
+        assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
+        assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteUpdateActionTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-public class DeleteUpdateActionTest {
+class DeleteUpdateActionTest {
 
     private static final String PATH = "path string";
     private static final String VALUE = "value string";
@@ -32,7 +32,7 @@ public class DeleteUpdateActionTest {
     private static final AttributeValue NUMERIC_VALUE = AttributeValue.builder().n("5").build();
 
     @Test
-    public void equalsHashcode() {
+    void equalsHashcode() {
         EqualsVerifier.forClass(DeleteUpdateAction.class)
                       .usingGetClass()
                       .withPrefabValues(AttributeValue.class,
@@ -42,7 +42,7 @@ public class DeleteUpdateActionTest {
     }
 
     @Test
-    public void build_minimal() {
+    void build_minimal() {
         DeleteUpdateAction action = DeleteUpdateAction.builder()
                                                       .path(PATH)
                                                       .value(VALUE)
@@ -55,7 +55,7 @@ public class DeleteUpdateActionTest {
     }
 
     @Test
-    public void build_maximal() {
+    void build_maximal() {
         DeleteUpdateAction action = DeleteUpdateAction.builder()
                                                       .path(PATH)
                                                       .value(VALUE)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateActionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class RemoveUpdateActionTest {
+
+    private static final String PATH = "path string";
+    private static final String ATTRIBUTE_TOKEN = "#attributeToken";
+    private static final String ATTRIBUTE_NAME = "attribute1";
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(RemoveUpdateAction.class)
+                      .usingGetClass()
+                      .verify();
+    }
+
+    @Test
+    public void build_minimal() {
+        RemoveUpdateAction action = RemoveUpdateAction.builder()
+                                                      .path(PATH)
+                                                      .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.expressionNames()).isEmpty();
+    }
+
+    @Test
+    public void build_maximal() {
+        RemoveUpdateAction action = RemoveUpdateAction.builder()
+                                                      .path(PATH)
+                                                      .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                                      .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveUpdateActionTest.java
@@ -21,21 +21,21 @@ import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-public class RemoveUpdateActionTest {
+class RemoveUpdateActionTest {
 
     private static final String PATH = "path string";
     private static final String ATTRIBUTE_TOKEN = "#attributeToken";
     private static final String ATTRIBUTE_NAME = "attribute1";
 
     @Test
-    public void equalsHashcode() {
+    void equalsHashcode() {
         EqualsVerifier.forClass(RemoveUpdateAction.class)
                       .usingGetClass()
                       .verify();
     }
 
     @Test
-    public void build_minimal() {
+    void build_minimal() {
         RemoveUpdateAction action = RemoveUpdateAction.builder()
                                                       .path(PATH)
                                                       .build();
@@ -44,7 +44,7 @@ public class RemoveUpdateActionTest {
     }
 
     @Test
-    public void build_maximal() {
+    void build_maximal() {
         RemoveUpdateAction action = RemoveUpdateAction.builder()
                                                       .path(PATH)
                                                       .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateActionTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-public class SetUpdateActionTest {
+class SetUpdateActionTest {
 
     private static final String PATH = "path string";
     private static final String VALUE = "value string";
@@ -32,7 +32,7 @@ public class SetUpdateActionTest {
     private static final AttributeValue NUMERIC_VALUE = AttributeValue.builder().n("5").build();
 
     @Test
-    public void equalsHashcode() {
+    void equalsHashcode() {
         EqualsVerifier.forClass(SetUpdateAction.class)
                       .usingGetClass()
                       .withPrefabValues(AttributeValue.class,
@@ -42,7 +42,7 @@ public class SetUpdateActionTest {
     }
 
     @Test
-    public void build_minimal() {
+    void build_minimal() {
         SetUpdateAction action = SetUpdateAction.builder()
                                                 .path(PATH)
                                                 .value(VALUE)
@@ -55,7 +55,7 @@ public class SetUpdateActionTest {
     }
 
     @Test
-    public void build_maximal() {
+    void build_maximal() {
         SetUpdateAction action = SetUpdateAction.builder()
                                                 .path(PATH)
                                                 .value(VALUE)

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/SetUpdateActionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class SetUpdateActionTest {
+
+    private static final String PATH = "path string";
+    private static final String VALUE = "value string";
+    private static final String VALUE_TOKEN = ":valueToken";
+    private static final String ATTRIBUTE_TOKEN = "#attributeToken";
+    private static final String ATTRIBUTE_NAME = "attribute1";
+    private static final AttributeValue NUMERIC_VALUE = AttributeValue.builder().n("5").build();
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(SetUpdateAction.class)
+                      .usingGetClass()
+                      .withPrefabValues(AttributeValue.class,
+                                        AttributeValue.builder().s("1").build(),
+                                        AttributeValue.builder().s("2").build())
+                      .verify();
+    }
+
+    @Test
+    public void build_minimal() {
+        SetUpdateAction action = SetUpdateAction.builder()
+                                                .path(PATH)
+                                                .value(VALUE)
+                                                .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
+                                                .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.value()).isEqualTo(VALUE);
+        assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
+        assertThat(action.expressionNames()).isEmpty();
+    }
+
+    @Test
+    public void build_maximal() {
+        SetUpdateAction action = SetUpdateAction.builder()
+                                                .path(PATH)
+                                                .value(VALUE)
+                                                .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                                .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                                .build();
+        assertThat(action.path()).isEqualTo(PATH);
+        assertThat(action.value()).isEqualTo(VALUE);
+        assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
+        assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
@@ -16,12 +16,13 @@
 package software.amazon.awssdk.enhanced.dynamodb.update;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-public class UpdateExpressionTest {
+class UpdateExpressionTest {
 
     private static final AttributeValue VAL = AttributeValue.builder().n("5").build();
 
@@ -43,7 +44,7 @@ public class UpdateExpressionTest {
                                                                     .build();
 
     @Test
-    public void equalsHashcode() {
+    void equalsHashcode() {
         EqualsVerifier.forClass(UpdateExpression.class)
                       .withPrefabValues(AttributeValue.class,
                                         AttributeValue.builder().s("1").build(),
@@ -52,7 +53,7 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void build_minimal() {
+    void build_minimal() {
         UpdateExpression updateExpression = UpdateExpression.builder().build();
         assertThat(updateExpression.removeActions()).isEmpty();
         assertThat(updateExpression.setActions()).isEmpty();
@@ -61,7 +62,7 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void build_maximal_single() {
+    void build_maximal_single() {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .addAction(removeAction)
                                                             .addAction(setAction)
@@ -75,7 +76,7 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void build_maximal_plural() {
+    void build_maximal_plural() {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
@@ -86,7 +87,14 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void merge_null_expression() {
+    void unknown_action_generates_error() {
+        assertThatThrownBy(() -> UpdateExpression.builder().actions(new UnknownUpdateAction()).build())
+            .hasMessageContaining("Do not recognize UpdateAction")
+            .hasMessageContaining("UnknownUpdateAction");
+    }
+
+    @Test
+    void merge_null_expression() {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
@@ -98,7 +106,7 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void merge_empty_expression() {
+    void merge_empty_expression() {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
@@ -110,7 +118,7 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void merge_expression_with_one_action_type() {
+    void merge_expression_with_one_action_type() {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
@@ -127,7 +135,7 @@ public class UpdateExpressionTest {
     }
 
     @Test
-    public void merge_expression_with_all_action_types() {
+    void merge_expression_with_all_action_types() {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
@@ -144,5 +152,9 @@ public class UpdateExpressionTest {
         assertThat(updateExpression.setActions()).containsExactly(setAction, extraSetAction);
         assertThat(updateExpression.deleteActions()).containsExactly(deleteAction, extraDeleteAction);
         assertThat(updateExpression.addActions()).containsExactly(addAction, extraAddAction);
+    }
+
+    private static final class UnknownUpdateAction implements UpdateAction {
+
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
@@ -18,6 +18,8 @@ package software.amazon.awssdk.enhanced.dynamodb.update;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -80,7 +82,22 @@ class UpdateExpressionTest {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
+
         assertThat(updateExpression.removeActions()).containsExactly(removeAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction);
+    }
+
+    @Test
+    void build_plural_is_not_additive() {
+        List<RemoveUpdateAction> removeActions = Arrays.asList(removeAction, removeAction);
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .actions(removeActions)
+                                                            .actions(setAction, deleteAction, addAction)
+                                                            .build();
+
+        assertThat(updateExpression.removeActions()).isEmpty();
         assertThat(updateExpression.setActions()).containsExactly(setAction);
         assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
         assertThat(updateExpression.addActions()).containsExactly(addAction);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class UpdateExpressionTest {
+
+    private static final AttributeValue VAL = AttributeValue.builder().n("5").build();
+
+    private static final RemoveUpdateAction removeAction = RemoveUpdateAction.builder().path("").build();
+    private static final SetUpdateAction setAction = SetUpdateAction.builder()
+                                                                    .path("")
+                                                                    .value("")
+                                                                    .putExpressionValue("", VAL)
+                                                                    .build();
+    private static final DeleteUpdateAction deleteAction = DeleteUpdateAction.builder()
+                                                                             .path("")
+                                                                             .value("")
+                                                                             .putExpressionValue("", VAL)
+                                                                             .build();
+    private static final AddUpdateAction addAction = AddUpdateAction.builder()
+                                                                    .path("")
+                                                                    .value("")
+                                                                    .putExpressionValue("", VAL)
+                                                                    .build();
+
+    @Test
+    public void equalsHashcode() {
+        EqualsVerifier.forClass(UpdateExpression.class)
+                      .withPrefabValues(AttributeValue.class,
+                                        AttributeValue.builder().s("1").build(),
+                                        AttributeValue.builder().s("2").build())
+                      .verify();
+    }
+
+    @Test
+    public void build_minimal() {
+        UpdateExpression updateExpression = UpdateExpression.builder().build();
+        assertThat(updateExpression.removeActions()).isEmpty();
+        assertThat(updateExpression.setActions()).isEmpty();
+        assertThat(updateExpression.deleteActions()).isEmpty();
+        assertThat(updateExpression.addActions()).isEmpty();
+    }
+
+    @Test
+    public void build_maximal_single() {
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .addAction(removeAction)
+                                                            .addAction(setAction)
+                                                            .addAction(deleteAction)
+                                                            .addAction(addAction)
+                                                            .build();
+        assertThat(updateExpression.removeActions()).containsExactly(removeAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction);
+    }
+
+    @Test
+    public void build_maximal_plural() {
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .actions(removeAction, setAction, deleteAction, addAction)
+                                                            .build();
+        assertThat(updateExpression.removeActions()).containsExactly(removeAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction);
+    }
+
+    @Test
+    public void merge_null_expression() {
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .actions(removeAction, setAction, deleteAction, addAction)
+                                                            .build();
+        updateExpression.mergeExpression(null);
+        assertThat(updateExpression.removeActions()).containsExactly(removeAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction);
+    }
+
+    @Test
+    public void merge_empty_expression() {
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .actions(removeAction, setAction, deleteAction, addAction)
+                                                            .build();
+        updateExpression.mergeExpression(UpdateExpression.builder().build());
+        assertThat(updateExpression.removeActions()).containsExactly(removeAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction);
+    }
+
+    @Test
+    public void merge_expression_with_one_action_type() {
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .actions(removeAction, setAction, deleteAction, addAction)
+                                                            .build();
+
+        RemoveUpdateAction extraRemoveAction = RemoveUpdateAction.builder().path("a").build();
+        UpdateExpression additionalExpression = UpdateExpression.builder()
+                                                                .addAction(extraRemoveAction)
+                                                                .build();
+        updateExpression.mergeExpression(additionalExpression);
+        assertThat(updateExpression.removeActions()).containsExactly(removeAction, extraRemoveAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction);
+    }
+
+    @Test
+    public void merge_expression_with_all_action_types() {
+        UpdateExpression updateExpression = UpdateExpression.builder()
+                                                            .actions(removeAction, setAction, deleteAction, addAction)
+                                                            .build();
+
+        RemoveUpdateAction extraRemoveAction = RemoveUpdateAction.builder().path("a").build();
+        SetUpdateAction extraSetAction = SetUpdateAction.builder().path("").value("").putExpressionValue("", VAL).build();
+        DeleteUpdateAction extraDeleteAction = DeleteUpdateAction.builder().path("").value("").putExpressionValue("", VAL).build();
+        AddUpdateAction extraAddAction = AddUpdateAction.builder().path("").value("").putExpressionValue("", VAL).build();
+        UpdateExpression additionalExpression = UpdateExpression.builder()
+                                                                .actions(extraRemoveAction, extraSetAction, extraDeleteAction, extraAddAction)
+                                                                .build();
+        updateExpression.mergeExpression(additionalExpression);
+        assertThat(updateExpression.removeActions()).containsExactly(removeAction, extraRemoveAction);
+        assertThat(updateExpression.setActions()).containsExactly(setAction, extraSetAction);
+        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction, extraDeleteAction);
+        assertThat(updateExpression.addActions()).containsExactly(addAction, extraAddAction);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
In order to support DynamoDB UpdateExpressions we need a representation of these concepts in the public API. 

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html

## Description
Adding a set of classes to represent UpdateExpression actions, and an UpdateExpression class to contain them. See separate design document for motivation and architecture.

## Testing
Unit tested. 