### PR TITLE
Add "ConcurrencyAcquireDuration" metric for netty-nio-client

### DIFF
--- a/.changes/next-release/feature-NettyNIOHTTPClient-b9f6080.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-b9f6080.json
@@ -2,5 +2,5 @@
     "category": "Netty NIO HTTP Client", 
     "contributor": "", 
     "type": "feature", 
-    "description": "Add \"ChannelAcquireDuration\" metric for netty-nio-client"
+    "description": "Add \"ConcurrencyAcquireDuration\" metric for netty-nio-client"
 }

--- a/.changes/next-release/feature-NettyNIOHTTPClient-b9f6080.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-b9f6080.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Add \"ChannelAcquireDuration\" metric for netty-nio-client"
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http;
 
+import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.metrics.MetricCategory;
 import software.amazon.awssdk.metrics.MetricLevel;
@@ -103,6 +104,19 @@ public final class HttpMetric {
      */
     public static final SdkMetric<Integer> HTTP_STATUS_CODE =
         metric("HttpStatusCode", Integer.class, MetricLevel.TRACE);
+
+    /**
+     * The time taken to acquire a channel from the channel pool.
+     *
+     * <p>For HTTP/1 operations, a channel is equivalent to a TCP connection. For HTTP/2 operations, a channel is equivalent to
+     * an HTTP/2 stream channel. For both protocols, the time to acquire a new channel may or may not involve establishing a new
+     * connection, depending on whether an existing channel is available in the pool or not. New connection establishment time may
+     * also include TLS handshake time, if TLS is enabled.
+     *
+     * <p>Note: This metric is currently only supported in 'netty-nio-client'.
+     */
+    public static final SdkMetric<Duration> CHANNEL_ACQUIRE_DURATION =
+        metric("ChannelAcquireDuration", Duration.class, MetricLevel.INFO);
 
     private HttpMetric() {
     }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
@@ -106,17 +106,21 @@ public final class HttpMetric {
         metric("HttpStatusCode", Integer.class, MetricLevel.TRACE);
 
     /**
-     * The time taken to acquire a channel from the channel pool.
+     * The time taken to acquire a channel from the connection pool.
      *
      * <p>For HTTP/1 operations, a channel is equivalent to a TCP connection. For HTTP/2 operations, a channel is equivalent to
-     * an HTTP/2 stream channel. For both protocols, the time to acquire a new channel may or may not involve establishing a new
-     * connection, depending on whether an existing channel is available in the pool or not. New connection establishment time may
-     * also include TLS handshake time, if TLS is enabled.
+     * an HTTP/2 stream channel. For both protocols, the time to acquire a new concurrency permit may include the following:
+     * <ol>
+     *     <li>Awaiting a concurrency permit, as restricted by the client's max concurrency configuration.</li>
+     *     <li>The time to establish a new connection, depending on whether an existing connection is available in the pool or
+     *     not.</li>
+     *     <li>The time taken to perform a TLS handshake/negotiation, if TLS is enabled.</li>
+     * </ol>
      *
      * <p>Note: This metric is currently only supported in 'netty-nio-client'.
      */
-    public static final SdkMetric<Duration> CHANNEL_ACQUIRE_DURATION =
-        metric("ChannelAcquireDuration", Duration.class, MetricLevel.INFO);
+    public static final SdkMetric<Duration> CONCURRENCY_ACQUIRE_DURATION =
+        metric("ConcurrencyAcquireDuration", Duration.class, MetricLevel.INFO);
 
     private HttpMetric() {
     }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
-import static software.amazon.awssdk.http.HttpMetric.CHANNEL_ACQUIRE_DURATION;
+import static software.amazon.awssdk.http.HttpMetric.CONCURRENCY_ACQUIRE_DURATION;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTE_FUTURE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTION_ID_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.IN_USE;
@@ -100,7 +100,7 @@ public final class NettyRequestExecutor {
     private void acquireChannel(Promise<Channel> channelFuture) {
         NettyRequestMetrics.ifMetricsAreEnabled(context.metricCollector(), metrics -> {
             measureTimeTaken(channelFuture, duration -> {
-                metrics.reportMetric(CHANNEL_ACQUIRE_DURATION, duration);
+                metrics.reportMetric(CONCURRENCY_ACQUIRE_DURATION, duration);
             });
         });
         context.channelPool().acquire(channelFuture);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/Http2MetricsTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/Http2MetricsTest.java
@@ -86,7 +86,7 @@ public class Http2MetricsTest {
             assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY)).containsExactly(0);
-            assertThat(metrics.metricValues(HttpMetric.CHANNEL_ACQUIRE_DURATION).get(0)).isPositive();
+            assertThat(metrics.metricValues(HttpMetric.CONCURRENCY_ACQUIRE_DURATION).get(0)).isPositive();
             // The stream window doesn't get initialized with the connection
             // initial setting and the update appears to be asynchronous so
             // this may be the default window size just based on when the
@@ -114,7 +114,7 @@ public class Http2MetricsTest {
             assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0)).isIn(0, 2, 3);
-            assertThat(metrics.metricValues(HttpMetric.CHANNEL_ACQUIRE_DURATION).get(0)).isPositive();
+            assertThat(metrics.metricValues(HttpMetric.CONCURRENCY_ACQUIRE_DURATION).get(0)).isPositive();
             // The stream window doesn't get initialized with the connection
             // initial setting and the update appears to be asynchronous so
             // this may be the default window size just based on when the

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/Http2MetricsTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/Http2MetricsTest.java
@@ -86,6 +86,7 @@ public class Http2MetricsTest {
             assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY)).containsExactly(0);
+            assertThat(metrics.metricValues(HttpMetric.CHANNEL_ACQUIRE_DURATION).get(0)).isPositive();
             // The stream window doesn't get initialized with the connection
             // initial setting and the update appears to be asynchronous so
             // this may be the default window size just based on when the
@@ -113,6 +114,7 @@ public class Http2MetricsTest {
             assertThat(metrics.metricValues(HttpMetric.LEASED_CONCURRENCY).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).get(0)).isBetween(0, 1);
             assertThat(metrics.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).get(0)).isIn(0, 2, 3);
+            assertThat(metrics.metricValues(HttpMetric.CHANNEL_ACQUIRE_DURATION).get(0)).isPositive();
             // The stream window doesn't get initialized with the connection
             // initial setting and the update appears to be asynchronous so
             // this may be the default window size just based on when the


### PR DESCRIPTION
The time taken to acquire a new channel from a channel pool can be both
non-trivial and highly variable, depending upon whether a new connection
needs to be established, and depending upon the overhead of new
connection establishment (including TLS handshakes). Due to the high
variability, having an explicit metric can be helpful to give a better
picture of latency sources in impacted requests.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
