### PR TITLE
Add pretty-format support to LoggingMetricPublisher

### DIFF
--- a/.changes/next-release/feature-MetricsSPI-9675089.json
+++ b/.changes/next-release/feature-MetricsSPI-9675089.json
@@ -1,0 +1,6 @@
+{
+    "category": "Metrics", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Add pretty-format support to LoggingMetricPublisher"
+}

--- a/core/metrics-spi/pom.xml
+++ b/core/metrics-spi/pom.xml
@@ -57,6 +57,16 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/LoggingMetricPublisher.java
+++ b/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/LoggingMetricPublisher.java
@@ -136,12 +136,12 @@ public final class LoggingMetricPublisher implements MetricPublisher {
 
     private void logPretty(String guid, MetricCollection metrics, int indent) {
         // Pre-determine metric key-value-pairs so that we can calculate the necessary padding
-        List<String> kvps = new ArrayList<>();
+        List<String> metricValues = new ArrayList<>();
         metrics.forEach(m -> {
-            kvps.add(String.format("%s=%s", m.metric().name(), m.value()));
+            metricValues.add(String.format("%s=%s", m.metric().name(), m.value()));
         });
 
-        int maxLen = getMaxLen(kvps);
+        int maxLen = getMaxLen(metricValues);
 
         // MetricCollection name
         LOGGER.log(logLevel, () -> String.format("[%s]%s %s",
@@ -156,11 +156,11 @@ public final class LoggingMetricPublisher implements MetricPublisher {
                                                  repeat("─", maxLen + 2)));
 
         // Metric key-value-pairs
-        kvps.forEach(kvp -> LOGGER.log(logLevel, () -> {
+        metricValues.forEach(metric -> LOGGER.log(logLevel, () -> {
             return String.format("[%s]%s │ %s │",
                                  guid,
                                  repeat(" ", indent),
-                                 pad(kvp, maxLen));
+                                 pad(metric, maxLen));
         }));
 
         // Close box

--- a/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/LoggingMetricPublisher.java
+++ b/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/LoggingMetricPublisher.java
@@ -15,27 +15,173 @@
 
 package software.amazon.awssdk.metrics;
 
+import static software.amazon.awssdk.utils.StringUtils.repeat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
 
 /**
- * An implementation of {@link MetricPublisher} that writes all published metrics to the logs at the INFO level under the
- * {@code software.amazon.awssdk.metrics.LoggingMetricPublisher} namespace.
+ * An implementation of {@link MetricPublisher} that logs all published metrics under the {@code
+ * software.amazon.awssdk.metrics.LoggingMetricPublisher} namespace.
+ * <p>
+ * {@link LoggingMetricPublisher} can be configured with a {@link Level} to control the log level at which metrics are recorded
+ * and a {@link Format} to control the format that metrics are printed in.
+ * <p>
+ * {@link Format#PLAIN} can be used to print all metrics on a single line. E.g.,
+ * <pre>
+ * Metrics published: MetricCollection(name=ApiCall, metrics=[MetricRecord(metric=MarshallingDuration, value=PT0.000202197S),
+ * MetricRecord(metric=RetryCount, value=0), MetricRecord(metric=ApiCallSuccessful, value=true),
+ * MetricRecord(metric=OperationName, value=HeadObject), MetricRecord(metric=ApiCallDuration, value=PT0.468369S),
+ * MetricRecord(metric=CredentialsFetchDuration, value=PT0.000003191S), MetricRecord(metric=ServiceId, value=S3)],
+ * children=[MetricCollection(name=ApiCallAttempt, metrics=[MetricRecord(metric=SigningDuration, value=PT0.000667268S),
+ * MetricRecord(metric=ServiceCallDuration, value=PT0.460529977S), MetricRecord(metric=AwsExtendedRequestId,
+ * value=jY/Co5Ge6WjRYk78kGOYQ4Z/CqUBr6pAAPZtexgOQR3Iqs3QP0OfZz3fDraQiXtmx7eXCZ4sbO0=), MetricRecord(metric=HttpStatusCode,
+ * value=200), MetricRecord(metric=BackoffDelayDuration, value=PT0S), MetricRecord(metric=AwsRequestId, value=6SJ82R65SADHX098)],
+ * children=[MetricCollection(name=HttpClient, metrics=[MetricRecord(metric=AvailableConcurrency, value=0),
+ * MetricRecord(metric=LeasedConcurrency, value=0), MetricRecord(metric=ConcurrencyAcquireDuration, value=PT0.230757S),
+ * MetricRecord(metric=PendingConcurrencyAcquires, value=0), MetricRecord(metric=MaxConcurrency, value=50),
+ * MetricRecord(metric=HttpClientName, value=NettyNio)], children=[])])])
+ * </pre>
+ * {@link Format#PRETTY} can be used to print metrics over multiple lines in a readable fashion suitable for debugging. E.g.,
+ * <pre>
+ * [18e5092e] ApiCall
+ * [18e5092e] ┌────────────────────────────────────────┐
+ * [18e5092e] │ MarshallingDuration=PT0.000227427S     │
+ * [18e5092e] │ RetryCount=0                           │
+ * [18e5092e] │ ApiCallSuccessful=true                 │
+ * [18e5092e] │ OperationName=HeadObject               │
+ * [18e5092e] │ ApiCallDuration=PT0.541751S            │
+ * [18e5092e] │ CredentialsFetchDuration=PT0.00000306S │
+ * [18e5092e] │ ServiceId=S3                           │
+ * [18e5092e] └────────────────────────────────────────┘
+ * [18e5092e]     ApiCallAttempt
+ * [18e5092e]     ┌───────────────────────────────────────────────────────────────────────────────────────────────────┐
+ * [18e5092e]     │ SigningDuration=PT0.000974924S                                                                    │
+ * [18e5092e]     │ ServiceCallDuration=PT0.531462375S                                                                │
+ * [18e5092e]     │ AwsExtendedRequestId=eGfwjV3mSwQZQD4YxHLswYguvhQoGcDTkr2jRvpio37a6QmhWd18C8wagC8LkBzzcnOOKoMuiXw= │
+ * [18e5092e]     │ HttpStatusCode=200                                                                                │
+ * [18e5092e]     │ BackoffDelayDuration=PT0S                                                                         │
+ * [18e5092e]     │ AwsRequestId=ED46TP7NN62DDG4Q                                                                     │
+ * [18e5092e]     └───────────────────────────────────────────────────────────────────────────────────────────────────┘
+ * [18e5092e]         HttpClient
+ * [18e5092e]         ┌────────────────────────────────────────┐
+ * [18e5092e]         │ AvailableConcurrency=0                 │
+ * [18e5092e]         │ LeasedConcurrency=0                    │
+ * [18e5092e]         │ ConcurrencyAcquireDuration=PT0.235851S │
+ * [18e5092e]         │ PendingConcurrencyAcquires=0           │
+ * [18e5092e]         │ MaxConcurrency=50                      │
+ * [18e5092e]         │ HttpClientName=NettyNio                │
+ * [18e5092e]         └────────────────────────────────────────┘
+ * </pre>
+ * Note that the output format may be subject to small changes in future versions and should not be relied upon as a strict public
+ * contract.
  */
 @SdkPublicApi
 public final class LoggingMetricPublisher implements MetricPublisher {
-    private static final Logger LOGGER = Logger.loggerFor(LoggingMetricPublisher.class);
 
-    private LoggingMetricPublisher() {
+    public enum Format {
+        PLAIN,
+        PRETTY
     }
 
+    private static final Logger LOGGER = Logger.loggerFor(LoggingMetricPublisher.class);
+    private static final Integer PRETTY_INDENT_SIZE = 4;
+
+    private final Level logLevel;
+    private final Format format;
+
+    private LoggingMetricPublisher(Level logLevel, Format format) {
+        this.logLevel = Validate.notNull(logLevel, "logLevel");
+        this.format = Validate.notNull(format, "format");
+    }
+
+    /**
+     * Create a {@link LoggingMetricPublisher} with the default configuration of {@link Level#INFO} and {@link Format#PLAIN}.
+     */
     public static LoggingMetricPublisher create() {
-        return new LoggingMetricPublisher();
+        return new LoggingMetricPublisher(Level.INFO, Format.PLAIN);
+    }
+
+    /**
+     * Create a {@link LoggingMetricPublisher} with a custom {@link Format} and log {@link Level}.
+     *
+     * @param logLevel the SLF4J log level to log metrics with
+     * @param format   the format to print the metrics with (see class-level documentation for examples)
+     */
+    public static LoggingMetricPublisher create(Level logLevel, Format format) {
+        return new LoggingMetricPublisher(logLevel, format);
     }
 
     @Override
-    public void publish(MetricCollection metricCollection) {
-        LOGGER.info(() -> "Metrics published: " + metricCollection);
+    public void publish(MetricCollection metrics) {
+        if (!LOGGER.isLoggingLevelEnabled(logLevel)) {
+            return;
+        }
+        switch (format) {
+            case PLAIN:
+                LOGGER.log(logLevel, () -> "Metrics published: " + metrics);
+                break;
+            case PRETTY:
+                logPretty(Integer.toHexString(metrics.hashCode()), metrics, 0);
+                break;
+            default:
+                throw new IllegalStateException("Unsupported format: " + format);
+        }
+    }
+
+    private void logPretty(String guid, MetricCollection metrics, int indent) {
+        // Pre-determine metric key-value-pairs so that we can calculate the necessary padding
+        List<String> kvps = new ArrayList<>();
+        metrics.forEach(m -> {
+            kvps.add(String.format("%s=%s", m.metric().name(), m.value()));
+        });
+
+        int maxLen = getMaxLen(kvps);
+
+        // MetricCollection name
+        LOGGER.log(logLevel, () -> String.format("[%s]%s %s",
+                                                 guid,
+                                                 repeat(" ", indent),
+                                                 metrics.name()));
+
+        // Open box
+        LOGGER.log(logLevel, () -> String.format("[%s]%s ┌%s┐",
+                                                 guid,
+                                                 repeat(" ", indent),
+                                                 repeat("─", maxLen + 2)));
+
+        // Metric key-value-pairs
+        kvps.forEach(kvp -> LOGGER.log(logLevel, () -> {
+            return String.format("[%s]%s │ %s │",
+                                 guid,
+                                 repeat(" ", indent),
+                                 pad(kvp, maxLen));
+        }));
+
+        // Close box
+        LOGGER.log(logLevel, () -> String.format("[%s]%s └%s┘",
+                                                 guid,
+                                                 repeat(" ", indent),
+                                                 repeat("─", maxLen + 2)));
+
+        // Recursively repeat for any children
+        metrics.children().forEach(child -> logPretty(guid, child, indent + PRETTY_INDENT_SIZE));
+    }
+
+    private static int getMaxLen(List<String> strings) {
+        int maxLen = 0;
+        for (String str : strings) {
+            maxLen = Math.max(maxLen, str.length());
+        }
+        return maxLen;
+    }
+
+    private static String pad(String str, int length) {
+        return str + repeat(" ", length - str.length());
     }
 
     @Override

--- a/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/LoggingMetricPublisher.java
+++ b/core/metrics-spi/src/main/java/software/amazon/awssdk/metrics/LoggingMetricPublisher.java
@@ -126,7 +126,8 @@ public final class LoggingMetricPublisher implements MetricPublisher {
                 LOGGER.log(logLevel, () -> "Metrics published: " + metrics);
                 break;
             case PRETTY:
-                logPretty(Integer.toHexString(metrics.hashCode()), metrics, 0);
+                String guid = Integer.toHexString(metrics.hashCode());
+                logPretty(guid, metrics, 0);
                 break;
             default:
                 throw new IllegalStateException("Unsupported format: " + format);

--- a/core/metrics-spi/src/test/java/software/amazon/awssdk/metrics/LoggingMetricPublisherTest.java
+++ b/core/metrics-spi/src/test/java/software/amazon/awssdk/metrics/LoggingMetricPublisherTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.metrics;
+
+import static org.apache.log4j.Level.ALL;
+import static org.apache.log4j.Level.DEBUG;
+import static org.apache.log4j.Level.INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+import software.amazon.awssdk.metrics.LoggingMetricPublisher.Format;
+import software.amazon.awssdk.metrics.internal.DefaultMetricCollection;
+import software.amazon.awssdk.metrics.internal.DefaultMetricRecord;
+import software.amazon.awssdk.testutils.LogCaptor;
+
+class LoggingMetricPublisherTest {
+    private static final SdkMetric<Integer> TEST_METRIC =
+        SdkMetric.create("LoggingMetricPublisherTest", Integer.class, MetricLevel.INFO, MetricCategory.CORE);
+
+    @Test
+    void testDefaultConfiguration() {
+        MetricCollection qux = metrics("qux");
+        MetricCollection baz = metrics("baz");
+        MetricCollection bar = metrics("bar", baz);
+        MetricCollection foo = metrics("foo", bar, qux);
+
+        LoggingMetricPublisher publisher = LoggingMetricPublisher.create();
+        publisher.publish(foo);
+
+        try (LogCaptor logCaptor = new LogCaptor.DefaultLogCaptor(ALL)) {
+            publisher.publish(foo);
+            List<LoggingEvent> events = logCaptor.loggedEvents();
+            assertLogged(events, INFO, "Metrics published: %s", foo);
+            assertThat(events).isEmpty();
+        }
+    }
+
+    @Test
+    void testPrettyFormat() {
+        MetricCollection qux = metrics("qux");
+        MetricCollection baz = metrics("baz");
+        MetricCollection bar = metrics("bar", baz);
+        MetricCollection foo = metrics("foo", bar, qux);
+        String guid = Integer.toHexString(foo.hashCode());
+
+        LoggingMetricPublisher publisher = LoggingMetricPublisher.create(Level.DEBUG, Format.PRETTY);
+        publisher.publish(foo);
+
+        try (LogCaptor logCaptor = new LogCaptor.DefaultLogCaptor(ALL)) {
+            publisher.publish(foo);
+            List<LoggingEvent> events = logCaptor.loggedEvents();
+            assertLogged(events, DEBUG, "[%s] foo", guid);
+            assertLogged(events, DEBUG, "[%s] ┌──────────────────────────────┐", guid);
+            assertLogged(events, DEBUG, "[%s] │ LoggingMetricPublisherTest=1 │", guid);
+            assertLogged(events, DEBUG, "[%s] │ LoggingMetricPublisherTest=2 │", guid);
+            assertLogged(events, DEBUG, "[%s] │ LoggingMetricPublisherTest=3 │", guid);
+            assertLogged(events, DEBUG, "[%s] └──────────────────────────────┘", guid);
+            assertLogged(events, DEBUG, "[%s]     bar", guid);
+            assertLogged(events, DEBUG, "[%s]     ┌──────────────────────────────┐", guid);
+            assertLogged(events, DEBUG, "[%s]     │ LoggingMetricPublisherTest=1 │", guid);
+            assertLogged(events, DEBUG, "[%s]     │ LoggingMetricPublisherTest=2 │", guid);
+            assertLogged(events, DEBUG, "[%s]     │ LoggingMetricPublisherTest=3 │", guid);
+            assertLogged(events, DEBUG, "[%s]     └──────────────────────────────┘", guid);
+            assertLogged(events, DEBUG, "[%s]         baz", guid);
+            assertLogged(events, DEBUG, "[%s]         ┌──────────────────────────────┐", guid);
+            assertLogged(events, DEBUG, "[%s]         │ LoggingMetricPublisherTest=1 │", guid);
+            assertLogged(events, DEBUG, "[%s]         │ LoggingMetricPublisherTest=2 │", guid);
+            assertLogged(events, DEBUG, "[%s]         │ LoggingMetricPublisherTest=3 │", guid);
+            assertLogged(events, DEBUG, "[%s]         └──────────────────────────────┘", guid);
+            assertLogged(events, DEBUG, "[%s]     qux", guid);
+            assertLogged(events, DEBUG, "[%s]     ┌──────────────────────────────┐", guid);
+            assertLogged(events, DEBUG, "[%s]     │ LoggingMetricPublisherTest=1 │", guid);
+            assertLogged(events, DEBUG, "[%s]     │ LoggingMetricPublisherTest=2 │", guid);
+            assertLogged(events, DEBUG, "[%s]     │ LoggingMetricPublisherTest=3 │", guid);
+            assertLogged(events, DEBUG, "[%s]     └──────────────────────────────┘", guid);
+            assertThat(events).isEmpty();
+        }
+    }
+
+    private static MetricCollection metrics(String name, MetricCollection... children) {
+        Integer[] values = {1, 2, 3};
+        Map<SdkMetric<?>, List<MetricRecord<?>>> recordMap = new HashMap<>();
+        List<MetricRecord<?>> records =
+            Stream.of(values).map(v -> new DefaultMetricRecord<>(TEST_METRIC, v)).collect(Collectors.toList());
+        recordMap.put(TEST_METRIC, records);
+        return new DefaultMetricCollection(name, recordMap, Arrays.asList(children));
+    }
+
+    private static void assertLogged(List<LoggingEvent> events, org.apache.log4j.Level level, String message, Object... args) {
+        LoggingEvent event = events.remove(0);
+        assertThat(event.getLevel()).isEqualTo(level);
+        assertThat(event.getMessage()).isEqualTo(String.format(message, args));
+    }
+}

--- a/core/metrics-spi/src/test/resources/log4j.properties
+++ b/core/metrics-spi/src/test/resources/log4j.properties
@@ -1,0 +1,33 @@
+#
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+log4j.rootLogger=INFO, A1
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+
+# Print the date in ISO 8601 format
+log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+# Adjust to see more / less logging
+#log4j.logger.com.amazonaws.ec2=DEBUG
+
+# HttpClient 3 Wire Logging
+#log4j.logger.httpclient.wire=DEBUG
+
+# HttpClient 4 Wire Logging
+#log4j.logger.org.apache.http.wire=DEBUG
+#log4j.logger.org.apache.http=DEBUG
+#log4j.logger.org.apache.http.wire=WARN
+#log4j.logger.software.amazon.awssdk=DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,7 @@
                         <ignoredUsedUndeclaredDependency>org.hamcrest:*</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.testng:testng</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.mockito:*</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>org.junit.jupiter:*</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.junit.platform:*</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>org.opentest4j:*</ignoredUsedUndeclaredDependency>
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/Logger.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/Logger.java
@@ -185,6 +185,34 @@ public final class Logger {
     }
 
     /**
+     * Log a message at the given log level (if it is enabled).
+     *
+     * @param logLevel the SLF4J log level
+     * @param msg      supplier for the log message
+     */
+    public void log(Level logLevel, Supplier<String> msg) {
+        switch (logLevel) {
+            case TRACE:
+                trace(msg);
+                break;
+            case DEBUG:
+                debug(msg);
+                break;
+            case INFO:
+                info(msg);
+                break;
+            case WARN:
+                warn(msg);
+                break;
+            case ERROR:
+                error(msg);
+                break;
+            default:
+                throw new IllegalStateException("Unsupported log level: " + logLevel);
+        }
+    }
+
+    /**
      * Static factory to get a logger instance for a given class
      * @param clz - class to get the logger for
      * @return a Logger instance

--- a/utils/src/main/java/software/amazon/awssdk/utils/Logger.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/Logger.java
@@ -19,6 +19,7 @@ import static software.amazon.awssdk.utils.StringUtils.lowerCase;
 
 import java.util.function.Supplier;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 
 @SdkProtectedApi
@@ -135,6 +136,28 @@ public final class Logger {
     public void trace(Supplier<String> msg, Throwable throwable) {
         if (log.isTraceEnabled()) {
             log.trace(msg.get(), throwable);
+        }
+    }
+
+    /**
+     * Determines if the provided log-level is enabled.
+     * @param logLevel the SLF4J log level enum
+     * @return whether that level is enabled
+     */
+    public boolean isLoggingLevelEnabled(Level logLevel) {
+        switch (logLevel) {
+            case TRACE:
+                return log.isTraceEnabled();
+            case DEBUG:
+                return log.isDebugEnabled();
+            case INFO:
+                return log.isInfoEnabled();
+            case WARN:
+                return log.isWarnEnabled();
+            case ERROR:
+                return log.isErrorEnabled();
+            default:
+                throw new IllegalStateException("Unsupported log level: " + logLevel);
         }
     }
 


### PR DESCRIPTION
LoggingMetricPublisher provides a convenient way to emit and inspect metrics via standard logging. The default log format is concise and perhaps difficult to read when looking for particular values. For users that wish to log metrics purely for debugging purposes, we should offer a more readable and user-friendly format. This PR introduces `PLAIN` and `PRETTY` format options to LoggingMetricPublisher.

`PLAIN` example (default/original behavior):

```
Metrics published: MetricCollection(name=ApiCall, metrics=[MetricRecord(metric=MarshallingDuration, value=PT0.000202197S),
MetricRecord(metric=RetryCount, value=0), MetricRecord(metric=ApiCallSuccessful, value=true),
MetricRecord(metric=OperationName, value=HeadObject), MetricRecord(metric=ApiCallDuration, value=PT0.468369S),
MetricRecord(metric=CredentialsFetchDuration, value=PT0.000003191S), MetricRecord(metric=ServiceId, value=S3)],
children=[MetricCollection(name=ApiCallAttempt, metrics=[MetricRecord(metric=SigningDuration, value=PT0.000667268S),
MetricRecord(metric=ServiceCallDuration, value=PT0.460529977S), MetricRecord(metric=AwsExtendedRequestId,
value=jY/Co5Ge6WjRYk78kGOYQ4Z/CqUBr6pAAPZtexgOQR3Iqs3QP0OfZz3fDraQiXtmx7eXCZ4sbO0=), MetricRecord(metric=HttpStatusCode,
value=200), MetricRecord(metric=BackoffDelayDuration, value=PT0S), MetricRecord(metric=AwsRequestId, value=6SJ82R65SADHX098)],
children=[MetricCollection(name=HttpClient, metrics=[MetricRecord(metric=AvailableConcurrency, value=0),
MetricRecord(metric=LeasedConcurrency, value=0), MetricRecord(metric=ConcurrencyAcquireDuration, value=PT0.230757S),
MetricRecord(metric=PendingConcurrencyAcquires, value=0), MetricRecord(metric=MaxConcurrency, value=50),
MetricRecord(metric=HttpClientName, value=NettyNio)], children=[])])])
```

`PRETTY` example (new format option):

```
[18e5092e] ApiCall
[18e5092e] ┌────────────────────────────────────────┐
[18e5092e] │ MarshallingDuration=PT0.000227427S     │
[18e5092e] │ RetryCount=0                           │
[18e5092e] │ ApiCallSuccessful=true                 │
[18e5092e] │ OperationName=HeadObject               │
[18e5092e] │ ApiCallDuration=PT0.541751S            │
[18e5092e] │ CredentialsFetchDuration=PT0.00000306S │
[18e5092e] │ ServiceId=S3                           │
[18e5092e] └────────────────────────────────────────┘
[18e5092e]     ApiCallAttempt
[18e5092e]     ┌───────────────────────────────────────────────────────────────────────────────────────────────────┐
[18e5092e]     │ SigningDuration=PT0.000974924S                                                                    │
[18e5092e]     │ ServiceCallDuration=PT0.531462375S                                                                │
[18e5092e]     │ AwsExtendedRequestId=eGfwjV3mSwQZQD4YxHLswYguvhQoGcDTkr2jRvpio37a6QmhWd18C8wagC8LkBzzcnOOKoMuiXw= │
[18e5092e]     │ HttpStatusCode=200                                                                                │
[18e5092e]     │ BackoffDelayDuration=PT0S                                                                         │
[18e5092e]     │ AwsRequestId=ED46TP7NN62DDG4Q                                                                     │
[18e5092e]     └───────────────────────────────────────────────────────────────────────────────────────────────────┘
[18e5092e]         HttpClient
[18e5092e]         ┌────────────────────────────────────────┐
[18e5092e]         │ AvailableConcurrency=0                 │
[18e5092e]         │ LeasedConcurrency=0                    │
[18e5092e]         │ ConcurrencyAcquireDuration=PT0.235851S │
[18e5092e]         │ PendingConcurrencyAcquires=0           │
[18e5092e]         │ MaxConcurrency=50                      │
[18e5092e]         │ HttpClientName=NettyNio                │
[18e5092e]         └────────────────────────────────────────┘
```

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
