### PR TITLE
Add "ConcurrencyAcquireDuration" metric for apache-client

### DIFF
--- a/.changes/next-release/feature-ApacheHTTPClient-2ecc813.json
+++ b/.changes/next-release/feature-ApacheHTTPClient-2ecc813.json
@@ -1,0 +1,6 @@
+{
+    "category": "Apache HTTP Client", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Add \"ConcurrencyAcquireDuration\" metric for apache-client"
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/HttpMetric.java
@@ -109,15 +109,13 @@ public final class HttpMetric {
      * The time taken to acquire a channel from the connection pool.
      *
      * <p>For HTTP/1 operations, a channel is equivalent to a TCP connection. For HTTP/2 operations, a channel is equivalent to
-     * an HTTP/2 stream channel. For both protocols, the time to acquire a new concurrency permit may include the following:
+     * an HTTP/2 stream channel. For both protocols, the time to acquire a new channel may include the following:
      * <ol>
      *     <li>Awaiting a concurrency permit, as restricted by the client's max concurrency configuration.</li>
      *     <li>The time to establish a new connection, depending on whether an existing connection is available in the pool or
      *     not.</li>
      *     <li>The time taken to perform a TLS handshake/negotiation, if TLS is enabled.</li>
      * </ol>
-     *
-     * <p>Note: This metric is currently only supported in 'netty-nio-client'.
      */
     public static final SdkMetric<Duration> CONCURRENCY_ACQUIRE_DURATION =
         metric("ConcurrencyAcquireDuration", Duration.class, MetricLevel.INFO);

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -23,6 +23,7 @@ import static software.amazon.awssdk.http.HttpMetric.HTTP_CLIENT_NAME;
 import static software.amazon.awssdk.http.HttpMetric.LEASED_CONCURRENCY;
 import static software.amazon.awssdk.http.HttpMetric.MAX_CONCURRENCY;
 import static software.amazon.awssdk.http.HttpMetric.PENDING_CONCURRENCY_ACQUIRES;
+import static software.amazon.awssdk.http.apache.internal.conn.ClientConnectionRequestFactory.THREAD_LOCAL_REQUEST_METRIC_COLLECTOR;
 import static software.amazon.awssdk.utils.NumericUtils.saturatedCast;
 
 import java.io.IOException;
@@ -81,7 +82,6 @@ import software.amazon.awssdk.http.apache.internal.ApacheHttpRequestConfig;
 import software.amazon.awssdk.http.apache.internal.DefaultConfiguration;
 import software.amazon.awssdk.http.apache.internal.SdkProxyRoutePlanner;
 import software.amazon.awssdk.http.apache.internal.conn.ClientConnectionManagerFactory;
-import software.amazon.awssdk.http.apache.internal.conn.ClientConnectionRequestFactory;
 import software.amazon.awssdk.http.apache.internal.conn.IdleConnectionReaper;
 import software.amazon.awssdk.http.apache.internal.conn.SdkConnectionKeepAliveStrategy;
 import software.amazon.awssdk.http.apache.internal.conn.SdkTlsSocketFactory;
@@ -252,12 +252,12 @@ public final class ApacheHttpClient implements SdkHttpClient {
 
     private HttpExecuteResponse execute(HttpRequestBase apacheRequest, MetricCollector metricCollector) throws IOException {
         HttpClientContext localRequestContext = ApacheUtils.newClientContext(requestConfig.proxyConfiguration());
-        ClientConnectionRequestFactory.THREAD_LOCAL_REQUEST_METRIC_COLLECTOR.set(metricCollector);
+        THREAD_LOCAL_REQUEST_METRIC_COLLECTOR.set(metricCollector);
         try {
             HttpResponse httpResponse = httpClient.execute(apacheRequest, localRequestContext);
             return createResponse(httpResponse, apacheRequest);
         } finally {
-            ClientConnectionRequestFactory.THREAD_LOCAL_REQUEST_METRIC_COLLECTOR.remove();
+            THREAD_LOCAL_REQUEST_METRIC_COLLECTOR.remove();
         }
     }
 

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionManagerFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionManagerFactory.java
@@ -65,46 +65,47 @@ public final class ClientConnectionManagerFactory {
     private static class DelegatingHttpClientConnectionManager implements HttpClientConnectionManager {
 
         private final HttpClientConnectionManager delegate;
-    
+
         protected DelegatingHttpClientConnectionManager(HttpClientConnectionManager delegate) {
             this.delegate = delegate;
         }
-    
+
         @Override
         public ConnectionRequest requestConnection(HttpRoute route, Object state) {
             return delegate.requestConnection(route, state);
         }
-    
+
         @Override
         public void releaseConnection(HttpClientConnection conn, Object newState, long validDuration, TimeUnit timeUnit) {
             delegate.releaseConnection(conn, newState, validDuration, timeUnit);
         }
-    
+
         @Override
-        public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context) throws IOException {
+        public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context)
+            throws IOException {
             delegate.connect(conn, route, connectTimeout, context);
         }
-    
+
         @Override
         public void upgrade(HttpClientConnection conn, HttpRoute route, HttpContext context) throws IOException {
             delegate.upgrade(conn, route, context);
         }
-    
+
         @Override
         public void routeComplete(HttpClientConnection conn, HttpRoute route, HttpContext context) throws IOException {
             delegate.routeComplete(conn, route, context);
         }
-    
+
         @Override
         public void closeIdleConnections(long idletime, TimeUnit timeUnit) {
             delegate.closeIdleConnections(idletime, timeUnit);
         }
-    
+
         @Override
         public void closeExpiredConnections() {
             delegate.closeExpiredConnections();
         }
-    
+
         @Override
         public void shutdown() {
             delegate.shutdown();

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionManagerFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionManagerFactory.java
@@ -82,7 +82,7 @@ public final class ClientConnectionManagerFactory {
 
         @Override
         public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context)
-            throws IOException {
+                throws IOException {
             delegate.connect(conn, route, connectTimeout, context);
         }
 

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionRequestFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionRequestFactory.java
@@ -87,8 +87,8 @@ public final class ClientConnectionRequestFactory {
         }
 
         @Override
-        public HttpClientConnection get(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException,
-                                                                                ConnectionPoolTimeoutException {
+        public HttpClientConnection get(long timeout, TimeUnit timeUnit)
+                throws InterruptedException, ExecutionException, ConnectionPoolTimeoutException {
             return delegate.get(timeout, timeUnit);
         }
 

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionRequestFactory.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionRequestFactory.java
@@ -79,19 +79,19 @@ public final class ClientConnectionRequestFactory {
      * Delegates all methods to {@link ConnectionRequest}. Subclasses can override select methods to change behavior.
      */
     private static class DelegatingConnectionRequest implements ConnectionRequest {
-    
+
         private final ConnectionRequest delegate;
 
         private DelegatingConnectionRequest(ConnectionRequest delegate) {
             this.delegate = delegate;
         }
-    
+
         @Override
         public HttpClientConnection get(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException,
                                                                                 ConnectionPoolTimeoutException {
             return delegate.get(timeout, timeUnit);
         }
-    
+
         @Override
         public boolean cancel() {
             return delegate.cancel();

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheMetricsTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheMetricsTest.java
@@ -79,7 +79,7 @@ public class ApacheMetricsTest {
 
         MetricCollection collection = collector.collect();
 
-        assertThat(collection.metricValues(CONCURRENCY_ACQUIRE_DURATION).get(0)).isPositive();
+        assertThat(collection.metricValues(CONCURRENCY_ACQUIRE_DURATION)).isNotEmpty();
     }
 
     private HttpExecuteResponse makeRequestWithMetrics(SdkHttpClient httpClient, MetricCollector metricCollector) throws IOException {

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheMetricsTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheMetricsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.apache;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.HttpMetric.CONCURRENCY_ACQUIRE_DURATION;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+
+public class ApacheMetricsTest {
+    private static WireMockServer wireMockServer;
+    private SdkHttpClient client;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+    }
+
+    @Before
+    public void methodSetup() {
+        wireMockServer.stubFor(any(urlMatching(".*")).willReturn(aResponse().withStatus(200).withBody("{}")));
+    }
+
+    @AfterClass
+    public static void teardown() throws IOException {
+        wireMockServer.stop();
+    }
+
+    @After
+    public void methodTeardown() {
+        if (client != null) {
+            client.close();
+        }
+        client = null;
+    }
+
+    @Test
+    public void defaultTlsKeyManagersProviderIsSystemPropertyProvider() throws IOException {
+        client = ApacheHttpClient.create();
+        MetricCollector collector = MetricCollector.create("test");
+        makeRequestWithMetrics(client, collector);
+
+        MetricCollection collection = collector.collect();
+
+        assertThat(collection.metricValues(CONCURRENCY_ACQUIRE_DURATION).get(0)).isPositive();
+    }
+
+    private HttpExecuteResponse makeRequestWithMetrics(SdkHttpClient httpClient, MetricCollector metricCollector) throws IOException {
+        SdkHttpRequest httpRequest = SdkHttpFullRequest.builder()
+                                                       .method(SdkHttpMethod.GET)
+                                                       .protocol("http")
+                                                       .host("localhost:" + wireMockServer.port())
+                                                       .build();
+
+        HttpExecuteRequest request = HttpExecuteRequest.builder()
+                                                       .request(httpRequest)
+                                                       .metricCollector(metricCollector)
+                                                       .build();
+
+        return httpClient.prepareRequest(request).call();
+    }
+}

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheMetricsTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheMetricsTest.java
@@ -72,7 +72,7 @@ public class ApacheMetricsTest {
     }
 
     @Test
-    public void defaultTlsKeyManagersProviderIsSystemPropertyProvider() throws IOException {
+    public void concurrencyAcquireDurationIsRecorded() throws IOException {
         client = ApacheHttpClient.create();
         MetricCollector collector = MetricCollector.create("test");
         makeRequestWithMetrics(client, collector);

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionManagerFactoryTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/conn/ClientConnectionManagerFactoryTest.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.http.apache.internal.conn;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpClientConnection;
@@ -72,8 +70,7 @@ public class ClientConnectionManagerFactoryTest {
 
     @Test
     public void wrapOnce() {
-        HttpClientConnectionManager wrapped = ClientConnectionManagerFactory.wrap(noop);
-        assertTrue(wrapped instanceof Wrapped);
+        ClientConnectionManagerFactory.wrap(noop);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The time taken to acquire a new channel from a channel pool can be both non-trivial and highly variable, depending upon whether a new connection needs to be established, and depending upon the overhead of new connection establishment (including TLS handshakes).

The same metric was recently added for netty-nio-client: https://github.com/aws/aws-sdk-java-v2/pull/2903

Ideally we would avoid the use of `ThreadLocal`, but the Apache interfaces make it very difficult to expose a request-level `MetricsCollector` to the connection acquire call. While we can easily wrap a `HttpClientConnectionManager` to include metrics, the `HttpClientConnectionManager`, is declared at the Apache-client-level, meaning we would need to create (not just wrap) a new Apache client instance for every request. Apache offers the `HttpContext` class to help propagate arbitrary attributes, but the context object is not exposed to [HttpClientConnectionManager#requestConnection](https://www.javadoc.io/static/org.apache.httpcomponents/httpclient/4.5.4/org/apache/http/conn/HttpClientConnectionManager.html#requestConnection(org.apache.http.conn.routing.HttpRoute,%20java.lang.Object)) or [ConnectionRequest#get](https://www.javadoc.io/static/org.apache.httpcomponents/httpclient/4.5.4/org/apache/http/conn/ConnectionRequest.html#get(long,%20java.util.concurrent.TimeUnit)). To lease & establish new connection, Apache calls `requestConnection`/`connect`. To lease an already-established connection, Apache calls only `requestConnection`. And only `connect` is given the context object.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license