### PR TITLE
If tlsNegotiationTimeout is not configured, it will be resolved as th…

### DIFF
--- a/.changes/next-release/feature-NettyNIOHTTPClient-7eae6f4.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-7eae6f4.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "If `tlsNegotiationTimeout` is not configued, it will be set to the resolved `connectionTimeout`"
+}

--- a/.changes/next-release/feature-NettyNIOHTTPClient-7eae6f4.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-7eae6f4.json
@@ -2,5 +2,5 @@
     "category": "Netty NIO HTTP Client", 
     "contributor": "", 
     "type": "feature", 
-    "description": "If `tlsNegotiationTimeout` is not configured, it will be set to the resolved `connectionTimeout`. By default, `tlsNegotiationTimeout` is 2s instead of 10s"
+    "description": "If `tlsNegotiationTimeout` is not configured, it will be set to the resolved `connectionTimeout`. By default, `tlsNegotiationTimeout` is now 2s instead of 10s"
 }

--- a/.changes/next-release/feature-NettyNIOHTTPClient-7eae6f4.json
+++ b/.changes/next-release/feature-NettyNIOHTTPClient-7eae6f4.json
@@ -2,5 +2,5 @@
     "category": "Netty NIO HTTP Client", 
     "contributor": "", 
     "type": "feature", 
-    "description": "If `tlsNegotiationTimeout` is not configued, it will be set to the resolved `connectionTimeout`"
+    "description": "If `tlsNegotiationTimeout` is not configured, it will be set to the resolved `connectionTimeout`. By default, `tlsNegotiationTimeout` is 2s instead of 10s"
 }

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
@@ -124,6 +124,9 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
     /**
      * The maximum amount of time that a TLS handshake is allowed to take from the time the CLIENT HELLO
      * message is sent to the time the client and server have fully negotiated ciphers and exchanged keys.
+     *
+     * <p>
+     * If not specified, the default value will be the same as the resolved {@link #CONNECTION_TIMEOUT}.
      */
     public static final SdkHttpConfigurationOption<Duration> TLS_NEGOTIATION_TIMEOUT =
         new SdkHttpConfigurationOption<>("TlsNegotiationTimeout", Duration.class);
@@ -134,7 +137,7 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
     private static final Duration DEFAULT_CONNECTION_ACQUIRE_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration DEFAULT_CONNECTION_MAX_IDLE_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration DEFAULT_CONNECTION_TIME_TO_LIVE = Duration.ZERO;
-    private static final Duration DEFAULT_TLS_HANDSHAKE_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_TLS_HANDSHAKE_TIMEOUT = DEFAULT_CONNECTION_TIMEOUT;
     private static final Boolean DEFAULT_REAP_IDLE_CONNECTIONS = Boolean.TRUE;
     private static final int DEFAULT_MAX_CONNECTIONS = 50;
     private static final int DEFAULT_MAX_CONNECTION_ACQUIRES = 10_000;

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -544,7 +544,9 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         public Builder connectionTimeout(Duration timeout) {
             Validate.isPositive(timeout, "connectionTimeout");
             standardOptions.put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, timeout);
-            standardOptions.put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, timeout);
+            if (standardOptions.get(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT) == null) {
+                standardOptions.put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, timeout);
+            }
             return this;
         }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -544,6 +544,7 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         public Builder connectionTimeout(Duration timeout) {
             Validate.isPositive(timeout, "connectionTimeout");
             standardOptions.put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, timeout);
+            standardOptions.put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, timeout);
             return this;
         }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.java
@@ -544,9 +544,6 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
         public Builder connectionTimeout(Duration timeout) {
             Validate.isPositive(timeout, "connectionTimeout");
             standardOptions.put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, timeout);
-            if (standardOptions.get(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT) == null) {
-                standardOptions.put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT, timeout);
-            }
             return this;
         }
 
@@ -723,6 +720,11 @@ public final class NettyNioAsyncHttpClient implements SdkAsyncHttpClient {
 
         @Override
         public SdkAsyncHttpClient buildWithDefaults(AttributeMap serviceDefaults) {
+            if (standardOptions.get(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT) == null) {
+                standardOptions.put(SdkHttpConfigurationOption.TLS_NEGOTIATION_TIMEOUT,
+                                    standardOptions.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT));
+            }
+
             return new NettyNioAsyncHttpClient(this, standardOptions.build()
                                                                     .merge(serviceDefaults)
                                                                     .merge(NETTY_HTTP_DEFAULTS)

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -140,6 +140,13 @@ public class NettyNioAsyncHttpClientWireMockTest {
         Duration connectTimeout = Duration.ofSeconds(1);
         Duration tlsTimeout = Duration.ofSeconds(3);
         try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                                                               .tlsNegotiationTimeout(tlsTimeout)
+                                                                                               .connectionTimeout(connectTimeout)
+                                                                                               .build()) {
+            assertThat(client.configuration().tlsHandshakeTimeout()).isEqualTo(tlsTimeout);
+        }
+
+        try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
                                                                                                .connectionTimeout(connectTimeout)
                                                                                                .tlsNegotiationTimeout(tlsTimeout)
                                                                                                .build()) {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -126,6 +126,28 @@ public class NettyNioAsyncHttpClientWireMockTest {
     }
 
     @Test
+    public void noTlsTimeout_shouldResolveToConnectTimeout() {
+        Duration connectTimeout = Duration.ofSeconds(1);
+        try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                                                               .connectionTimeout(connectTimeout)
+                                                                                               .build()) {
+            assertThat(client.configuration().tlsHandshakeTimeout()).isEqualTo(connectTimeout);
+        }
+    }
+
+    @Test
+    public void tlsTimeoutConfigured_shouldHonor() {
+        Duration connectTimeout = Duration.ofSeconds(1);
+        Duration tlsTimeout = Duration.ofSeconds(3);
+        try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                                                               .connectionTimeout(connectTimeout)
+                                                                                               .tlsNegotiationTimeout(tlsTimeout)
+                                                                                               .build()) {
+            assertThat(client.configuration().tlsHandshakeTimeout()).isEqualTo(tlsTimeout);
+        }
+    }
+
+    @Test
     public void overrideConnectionIdleTimeout_shouldHonor() {
         try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
                                                                                                .connectionMaxIdleTime(Duration.ofMillis(1000))

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClientWireMockTest.java
@@ -133,6 +133,18 @@ public class NettyNioAsyncHttpClientWireMockTest {
                                                                                                .build()) {
             assertThat(client.configuration().tlsHandshakeTimeout()).isEqualTo(connectTimeout);
         }
+        Duration timeoutOverride = Duration.ofSeconds(2);
+        try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.builder()
+                                                                                               .connectionTimeout(connectTimeout)
+                                                                                               .connectionTimeout(timeoutOverride)
+                                                                                               .build()) {
+            assertThat(client.configuration().tlsHandshakeTimeout()).isEqualTo(timeoutOverride);
+        }
+
+        try (NettyNioAsyncHttpClient client = (NettyNioAsyncHttpClient) NettyNioAsyncHttpClient.create()) {
+            assertThat(client.configuration().tlsHandshakeTimeout().toMillis()).
+                isEqualTo(client.configuration().connectTimeoutMillis());
+        }
     }
 
     @Test


### PR DESCRIPTION
…e connectTimeout

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The current tlsNegotiationTimeout is too conservative. 

## Description
If `tlsNegotiationTimeout` is not configured, it will be set to the resolved `connectionTimeout`

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
