### PR TITLE
Don't redirect credentials subprocesses' stderr

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
@@ -185,7 +185,8 @@ public final class ProcessCredentialsProvider implements AwsCredentialsProvider,
      * Execute the external process to retrieve credentials.
      */
     private String executeCommand() throws IOException, InterruptedException {
-        ProcessBuilder processBuilder = new ProcessBuilder(command);
+        ProcessBuilder processBuilder = new ProcessBuilder(command)
+            .redirectError(Redirect.INHERIT);
 
         ByteArrayOutputStream commandOutput = new ByteArrayOutputStream();
 

--- a/core/auth/src/test/resources/resources/process/linux-credentials-script.sh
+++ b/core/auth/src/test/resources/resources/process/linux-credentials-script.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+>&2 echo "$0 called for credentials"
 echo '{';
 echo '"Version": 1,';
 echo "\"AccessKeyId\": \"$1\",";

--- a/core/auth/src/test/resources/resources/process/windows-credentials-script.bat
+++ b/core/auth/src/test/resources/resources/process/windows-credentials-script.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
+ECHO %0 called for credentials 1>&2
 SET input=%1
 ECHO {
 ECHO "Version": 1,


### PR DESCRIPTION
## Motivation and Context

At ~Square~ ~Cash~ Block, we have custom tools to synchronise our AWS / IAM credentials. Every role we have access to uses a `credential_process` to retrieve the requisite secrets.

However, we've recently gated many of our profiles behind a process of [dual control](https://csrc.nist.gov/glossary/term/dual_control). The helper executed by the `credential_process` stanza prints instructions for the dual control process to standard error.

The profile credentials provider, as currently implemented, hides that output.

This PR redirects stderr output to wherever the parent process sends its output. (inherits error output)

## Description
Very minor; change the `ProcessBuilder` to inherit its redirection of the error stream.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
