### PR TITLE
Salande/handle user supplied updateexpression

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/Expression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/Expression.java
@@ -186,6 +186,15 @@ public final class Expression {
         return expressionNames;
     }
 
+    /**
+     * Coalesces two complete expressions into a single expression joined by an 'AND'.
+     *
+     * @see #join(Expression, Expression, String)
+     */
+    public Expression and(Expression expression) {
+        return join(this, expression, " AND ");
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/WriteModification.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/WriteModification.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.enhanced.dynamodb.extensions;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -28,15 +29,20 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
  * <p>
  * If an additionalConditionalExpression is supplied then this condition will be coalesced with any other conditions
  * and added as a parameter to the write operation.
+ * <p>
+ * If an updateExpression is supplied then this update expression will be coalesced with any other update expressions
+ * and added as a parameter to the write operation.
  */
 @SdkPublicApi
 public final class WriteModification {
     private final Map<String, AttributeValue> transformedItem;
     private final Expression additionalConditionalExpression;
+    private final UpdateExpression updateExpression;
 
-    private WriteModification(Map<String, AttributeValue> transformedItem, Expression additionalConditionalExpression) {
-        this.transformedItem = transformedItem;
-        this.additionalConditionalExpression = additionalConditionalExpression;
+    private WriteModification(Builder builder) {
+        this.transformedItem = builder.transformedItem;
+        this.additionalConditionalExpression = builder.additionalConditionalExpression;
+        this.updateExpression = builder.updateExpression;
     }
 
     public static Builder builder() {
@@ -49,6 +55,10 @@ public final class WriteModification {
 
     public Expression additionalConditionalExpression() {
         return additionalConditionalExpression;
+    }
+
+    public UpdateExpression updateExpression() {
+        return updateExpression;
     }
 
     @Override
@@ -65,21 +75,29 @@ public final class WriteModification {
         if (transformedItem != null ? ! transformedItem.equals(that.transformedItem) : that.transformedItem != null) {
             return false;
         }
-        return additionalConditionalExpression != null ?
-            additionalConditionalExpression.equals(that.additionalConditionalExpression) :
-            that.additionalConditionalExpression == null;
+        if (additionalConditionalExpression != null ?
+                ! additionalConditionalExpression.equals(that.additionalConditionalExpression) :
+                that.additionalConditionalExpression != null) {
+            return false;
+        }
+
+        return updateExpression != null ?
+               updateExpression.equals(that.updateExpression) :
+               that.updateExpression == null;
     }
 
     @Override
     public int hashCode() {
         int result = transformedItem != null ? transformedItem.hashCode() : 0;
         result = 31 * result + (additionalConditionalExpression != null ? additionalConditionalExpression.hashCode() : 0);
+        result = 31 * result + (updateExpression != null ? updateExpression.hashCode() : 0);
         return result;
     }
 
     public static final class Builder {
         private Map<String, AttributeValue> transformedItem;
         private Expression additionalConditionalExpression;
+        private UpdateExpression updateExpression;
 
         private Builder() {
         }
@@ -94,8 +112,13 @@ public final class WriteModification {
             return this;
         }
 
+        public Builder updateExpression(UpdateExpression updateExpression) {
+            this.updateExpression = updateExpression;
+            return this;
+        }
+
         public WriteModification build() {
-            return new WriteModification(transformedItem, additionalConditionalExpression);
+            return new WriteModification(this);
         }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -115,8 +115,9 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
             if (writeModification.transformedItem() != null) {
                 transformedItem = writeModification.transformedItem();
             }
-            conditionalExpression = mergeConditionalExpressions(conditionalExpression, writeModification);
-            updateExpression = mergeUpdateExpressions(updateExpression, writeModification);
+            conditionalExpression = mergeConditionalExpressions(conditionalExpression,
+                                                                writeModification.additionalConditionalExpression());
+            updateExpression = mergeUpdateExpressions(updateExpression, writeModification.updateExpression());
         }
 
         return WriteModification.builder()
@@ -126,29 +127,26 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
                                 .build();
     }
 
-    private UpdateExpression mergeUpdateExpressions(UpdateExpression updateExpression, WriteModification writeModification) {
-        if (writeModification.updateExpression() != null) {
-            if (updateExpression == null) {
-                updateExpression = writeModification.updateExpression();
+    private UpdateExpression mergeUpdateExpressions(UpdateExpression existingExpression, UpdateExpression newExpression) {
+        if (newExpression != null) {
+            if (existingExpression == null) {
+                existingExpression = newExpression;
             } else {
-                updateExpression.mergeExpression(writeModification.updateExpression());
+                existingExpression = UpdateExpression.mergeExpressions(existingExpression, newExpression);
             }
         }
-        return updateExpression;
+        return existingExpression;
     }
 
-    private Expression mergeConditionalExpressions(Expression conditionalExpression, WriteModification writeModification) {
-        if (writeModification.additionalConditionalExpression() != null) {
-            if (conditionalExpression == null) {
-                conditionalExpression = writeModification.additionalConditionalExpression();
+    private Expression mergeConditionalExpressions(Expression existingExpression, Expression newExpression) {
+        if (newExpression != null) {
+            if (existingExpression == null) {
+                existingExpression = newExpression;
             } else {
-                conditionalExpression =
-                    Expression.join(conditionalExpression,
-                                    writeModification.additionalConditionalExpression(),
-                                    " AND ");
+                existingExpression = existingExpression.and(newExpression);
             }
         }
-        return conditionalExpression;
+        return existingExpression;
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.ReadModification;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -85,7 +86,8 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
      * Implementation of the {@link DynamoDbEnhancedClientExtension} interface that will call all the chained extensions
      * in forward order, passing the results of each one to the next and coalescing the results into a single modification.
      * Multiple conditional statements will be separated by the string " AND ". Expression values will be coalesced
-     * unless they conflict in which case an exception will be thrown.
+     * unless they conflict in which case an exception will be thrown. UpdateExpressions will be
+     * coalesced.
      *
      * @param context A {@link DynamoDbExtensionContext.BeforeWrite} context
      * @return A single {@link WriteModification} representing the coalesced results of all the chained extensions.
@@ -94,6 +96,7 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
     public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
         Map<String, AttributeValue> transformedItem = null;
         Expression conditionalExpression = null;
+        UpdateExpression updateExpression = null;
 
         for (DynamoDbEnhancedClientExtension extension : this.extensionChain) {
             Map<String, AttributeValue> itemToTransform = transformedItem == null ? context.items() : transformedItem;
@@ -112,23 +115,40 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
             if (writeModification.transformedItem() != null) {
                 transformedItem = writeModification.transformedItem();
             }
-
-            if (writeModification.additionalConditionalExpression() != null) {
-                if (conditionalExpression == null) {
-                    conditionalExpression = writeModification.additionalConditionalExpression();
-                } else {
-                    conditionalExpression =
-                        Expression.join(conditionalExpression,
-                                        writeModification.additionalConditionalExpression(),
-                                        " AND ");
-                }
-            }
+            conditionalExpression = mergeConditionalExpressions(conditionalExpression, writeModification);
+            updateExpression = mergeUpdateExpressions(updateExpression, writeModification);
         }
 
         return WriteModification.builder()
                                 .transformedItem(transformedItem)
                                 .additionalConditionalExpression(conditionalExpression)
+                                .updateExpression(updateExpression)
                                 .build();
+    }
+
+    private UpdateExpression mergeUpdateExpressions(UpdateExpression updateExpression, WriteModification writeModification) {
+        if (writeModification.updateExpression() != null) {
+            if (updateExpression == null) {
+                updateExpression = writeModification.updateExpression();
+            } else {
+                updateExpression.mergeExpression(writeModification.updateExpression());
+            }
+        }
+        return updateExpression;
+    }
+
+    private Expression mergeConditionalExpressions(Expression conditionalExpression, WriteModification writeModification) {
+        if (writeModification.additionalConditionalExpression() != null) {
+            if (conditionalExpression == null) {
+                conditionalExpression = writeModification.additionalConditionalExpression();
+            } else {
+                conditionalExpression =
+                    Expression.join(conditionalExpression,
+                                    writeModification.additionalConditionalExpression(),
+                                    " AND ");
+            }
+        }
+        return conditionalExpression;
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperation.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperation.java
@@ -15,18 +15,17 @@
 
 package software.amazon.awssdk.enhanced.dynamodb.internal.operations;
 
-import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.isNullAttributeValue;
 import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.readAndTransformSingleItem;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.update.UpdateExpressionUtils.operationExpression;
+import static software.amazon.awssdk.utils.CollectionUtils.filterMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
@@ -34,13 +33,12 @@ import software.amazon.awssdk.enhanced.dynamodb.OperationContext;
 import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
-import software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils;
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.DefaultDynamoDbExtensionContext;
-import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.UpdateBehaviorTag;
-import software.amazon.awssdk.enhanced.dynamodb.mapper.UpdateBehavior;
+import software.amazon.awssdk.enhanced.dynamodb.internal.update.UpdateExpressionConverter;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactUpdateItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedResponse;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -49,22 +47,13 @@ import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
 import software.amazon.awssdk.services.dynamodb.model.Update;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Either;
 
 @SdkInternalApi
 public class UpdateItemOperation<T>
     implements TableOperation<T, UpdateItemRequest, UpdateItemResponse, UpdateItemEnhancedResponse<T>>,
                TransactableWriteOperation<T> {
-
-    private static final Function<String, String> EXPRESSION_VALUE_KEY_MAPPER =
-        key -> ":AMZN_MAPPED_" + EnhancedClientUtils.cleanAttributeName(key);
-
-    private static final Function<String, String> EXPRESSION_KEY_MAPPER =
-        key -> "#AMZN_MAPPED_" + EnhancedClientUtils.cleanAttributeName(key);
-
-    private static final Function<String, String> CONDITIONAL_UPDATE_MAPPER =
-        key -> "if_not_exists(" + EXPRESSION_KEY_MAPPER.apply(key) + ", " +
-                EXPRESSION_VALUE_KEY_MAPPER.apply(key) + ")";
 
     private final Either<UpdateItemEnhancedRequest<T>, TransactUpdateItemEnhancedRequest<T>> request;
 
@@ -122,24 +111,35 @@ public class UpdateItemOperation<T>
 
         Collection<String> primaryKeys = tableSchema.tableMetadata().primaryKeys();
 
-        Map<String, AttributeValue> keyAttributeValues = itemMap.entrySet().stream()
-            .filter(entry -> primaryKeys.contains(entry.getKey()))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, AttributeValue> keyAttributes = filterMap(itemMap, entry -> primaryKeys.contains(entry.getKey()));
+        Map<String, AttributeValue> nonKeyAttributes = filterMap(itemMap, entry -> !primaryKeys.contains(entry.getKey()));
+
+        Expression updateExpression = generateUpdateExpressionIfExist(tableMetadata, transformation, nonKeyAttributes);
+        Expression conditionExpression = generateConditionExpressionIfExist(transformation, request);
+
+        Map<String, String> expressionNames = coalesceExpressionNames(updateExpression, conditionExpression);
+        Map<String, AttributeValue> expressionValues = coalesceExpressionValues(updateExpression, conditionExpression);
 
         UpdateItemRequest.Builder requestBuilder = UpdateItemRequest.builder()
             .tableName(operationContext.tableName())
-            .key(keyAttributeValues)
+            .key(keyAttributes)
             .returnValues(ReturnValue.ALL_NEW);
-
-        Map<String, AttributeValue> filteredAttributeValues = itemMap.entrySet().stream()
-            .filter(entry -> !primaryKeys.contains(entry.getKey()))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         if (request.left().isPresent()) {
             addPlainUpdateItemParameters(requestBuilder, request.left().get());
         }
-
-        requestBuilder = addExpressionsIfExist(transformation, filteredAttributeValues, requestBuilder, tableMetadata);
+        if (updateExpression != null) {
+            requestBuilder.updateExpression(updateExpression.expression());
+        }
+        if (conditionExpression != null) {
+            requestBuilder.conditionExpression(conditionExpression.expression());
+        }
+        if (expressionNames != null && !expressionNames.isEmpty()) {
+            requestBuilder = requestBuilder.expressionAttributeNames(expressionNames);
+        }
+        if (expressionValues != null && !expressionValues.isEmpty()) {
+            requestBuilder = requestBuilder.expressionAttributeValues(expressionValues);
+        }
 
         return requestBuilder.build();
     }
@@ -201,114 +201,43 @@ public class UpdateItemOperation<T>
                                 .build();
     }
 
-    private static Expression generateUpdateExpression(Map<String, AttributeValue> attributeValuesToUpdate,
-                                                       TableMetadata tableMetadata) {
-        // Sort the updates into 'SET' or 'REMOVE' based on null value
-        List<String> updateSetActions = new ArrayList<>();
-        List<String> updateRemoveActions = new ArrayList<>();
-
-        attributeValuesToUpdate.forEach((key, value) -> {
-            if (!isNullAttributeValue(value)) {
-                UpdateBehavior updateBehavior = UpdateBehaviorTag.resolveForAttribute(key, tableMetadata);
-                updateSetActions.add(EXPRESSION_KEY_MAPPER.apply(key) + " = " +
-                        updateExpressionMapperForBehavior(updateBehavior).apply(key));
+    private Expression generateUpdateExpressionIfExist(TableMetadata tableMetadata,
+                                                       WriteModification transformation,
+                                                       Map<String, AttributeValue> attributes) {
+        UpdateExpression updateExpression = null;
+        List<String> nonRemoveAttributes = new ArrayList<>();
+        if (transformation != null && transformation.updateExpression() != null) {
+            updateExpression = transformation.updateExpression();
+            nonRemoveAttributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        }
+        if (!attributes.isEmpty()) {
+            UpdateExpression operationUpdateExpression = operationExpression(attributes, tableMetadata, nonRemoveAttributes);
+            if (updateExpression == null) {
+                updateExpression = operationUpdateExpression;
             } else {
-                updateRemoveActions.add(EXPRESSION_KEY_MAPPER.apply(key));
+                updateExpression.mergeExpression(operationUpdateExpression);
             }
-        });
-
-        // Combine the expressions
-        List<String> updateActions = new ArrayList<>();
-
-        if (!updateSetActions.isEmpty()) {
-            updateActions.add("SET " + String.join(", ", updateSetActions));
         }
-
-        if (!updateRemoveActions.isEmpty()) {
-            updateActions.add("REMOVE " + String.join(", ", updateRemoveActions));
-        }
-
-        String updateExpression = String.join(" ", updateActions);
-
-        Map<String, AttributeValue> expressionAttributeValues =
-            attributeValuesToUpdate.entrySet()
-                                   .stream()
-                                   .filter(entry -> !isNullAttributeValue(entry.getValue()))
-                                   .collect(Collectors.toMap(
-                                       entry -> EXPRESSION_VALUE_KEY_MAPPER.apply(entry.getKey()),
-                                       Map.Entry::getValue));
-
-        Map<String, String> expressionAttributeNames =
-            attributeValuesToUpdate.keySet()
-                                   .stream()
-                                   .collect(Collectors.toMap(EXPRESSION_KEY_MAPPER, key -> key));
-
-        return Expression.builder()
-                         .expression(updateExpression)
-                         .expressionValues(Collections.unmodifiableMap(expressionAttributeValues))
-                         .expressionNames(expressionAttributeNames)
-                         .build();
+        return UpdateExpressionConverter.toExpression(updateExpression);
     }
 
-    private static Function<String, String> updateExpressionMapperForBehavior(UpdateBehavior updateBehavior) {
-        switch (updateBehavior) {
-            case WRITE_ALWAYS:
-                return EXPRESSION_VALUE_KEY_MAPPER;
-            case WRITE_IF_NOT_EXISTS:
-                return CONDITIONAL_UPDATE_MAPPER;
-            default:
-                throw new IllegalArgumentException("Unsupported update behavior '" + updateBehavior + "'");
-        }
-    }
+    private Expression generateConditionExpressionIfExist(
+            WriteModification transformation,
+            Either<UpdateItemEnhancedRequest<T>, TransactUpdateItemEnhancedRequest<T>> request) {
 
-    private UpdateItemRequest.Builder addExpressionsIfExist(WriteModification transformation,
-                                                            Map<String, AttributeValue> filteredAttributeValues,
-                                                            UpdateItemRequest.Builder requestBuilder,
-                                                            TableMetadata tableMetadata) {
-        Map<String, String> expressionNames = null;
-        Map<String, AttributeValue> expressionValues = null;
-        String conditionExpressionString = null;
+        Expression conditionExpression = null;
 
-        /* Add update expression for transformed non-key attributes if applicable */
-        if (!filteredAttributeValues.isEmpty()) {
-            Expression fullUpdateExpression = generateUpdateExpression(filteredAttributeValues, tableMetadata);
-            expressionNames = fullUpdateExpression.expressionNames();
-            expressionValues = fullUpdateExpression.expressionValues();
-            requestBuilder = requestBuilder.updateExpression(fullUpdateExpression.expression());
-        }
-
-        /* Merge in conditional expression from extension WriteModification if applicable */
         if (transformation != null && transformation.additionalConditionalExpression() != null) {
-            expressionNames =
-                Expression.joinNames(expressionNames,
-                                     transformation.additionalConditionalExpression().expressionNames());
-            expressionValues =
-                Expression.joinValues(expressionValues,
-                                      transformation.additionalConditionalExpression().expressionValues());
-            conditionExpressionString = transformation.additionalConditionalExpression().expression();
+            conditionExpression = transformation.additionalConditionalExpression();
         }
 
-        /* Merge in conditional expression from specified 'conditionExpression' if applicable */
-        Expression conditionExpression = request.map(r -> Optional.ofNullable(r.conditionExpression()),
-                                                     r -> Optional.ofNullable(r.conditionExpression()))
-                                                .orElse(null);
-        if (conditionExpression != null) {
-            expressionNames = Expression.joinNames(expressionNames, conditionExpression.expressionNames());
-            expressionValues = Expression.joinValues(expressionValues, conditionExpression.expressionValues());
-            conditionExpressionString = Expression.joinExpressions(conditionExpressionString,
-                                                                   conditionExpression.expression(), " AND ");
+        Expression operationConditionExpression = request.map(r -> Optional.ofNullable(r.conditionExpression()),
+                                                              r -> Optional.ofNullable(r.conditionExpression()))
+                                                         .orElse(null);
+        if (operationConditionExpression != null) {
+            conditionExpression = Expression.join(conditionExpression, operationConditionExpression, " AND ");
         }
-
-        // Avoiding adding empty collections that the low level SDK will propagate to DynamoDb where it causes error.
-        if (expressionNames != null && !expressionNames.isEmpty()) {
-            requestBuilder = requestBuilder.expressionAttributeNames(expressionNames);
-        }
-
-        if (expressionValues != null && !expressionValues.isEmpty()) {
-            requestBuilder = requestBuilder.expressionAttributeValues(expressionValues);
-        }
-
-        return requestBuilder.conditionExpression(conditionExpressionString);
+        return conditionExpression;
     }
 
     private UpdateItemRequest.Builder addPlainUpdateItemParameters(UpdateItemRequest.Builder requestBuilder,
@@ -316,5 +245,27 @@ public class UpdateItemOperation<T>
         requestBuilder = requestBuilder.returnConsumedCapacity(enhancedRequest.returnConsumedCapacityAsString());
         requestBuilder = requestBuilder.returnItemCollectionMetrics(enhancedRequest.returnItemCollectionMetricsAsString());
         return requestBuilder;
+    }
+
+    private static Map<String, String> coalesceExpressionNames(Expression firstExpression, Expression secondExpression) {
+        Map<String, String> expressionNames = null;
+        if (firstExpression != null && !CollectionUtils.isNullOrEmpty(firstExpression.expressionNames())) {
+            expressionNames = firstExpression.expressionNames();
+        }
+        if (secondExpression != null && !CollectionUtils.isNullOrEmpty(secondExpression.expressionNames())) {
+            expressionNames = Expression.joinNames(expressionNames, secondExpression.expressionNames());
+        }
+        return expressionNames;
+    }
+
+    private static Map<String, AttributeValue> coalesceExpressionValues(Expression firstExpression, Expression secondExpression) {
+        Map<String, AttributeValue> expressionValues = null;
+        if (firstExpression != null && !CollectionUtils.isNullOrEmpty(firstExpression.expressionValues())) {
+            expressionValues = firstExpression.expressionValues();
+        }
+        if (secondExpression != null && !CollectionUtils.isNullOrEmpty(secondExpression.expressionValues())) {
+            expressionValues = Expression.joinValues(expressionValues, secondExpression.expressionValues());
+        }
+        return expressionValues;
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.enhanced.dynamodb.internal.update;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -58,6 +58,8 @@ public final class UpdateExpressionConverter {
 
     private static final String ACTION_SEPARATOR = ", ";
     private static final String GROUP_SEPARATOR = " ";
+    private static final char DOT = '.';
+    private static final char LEFT_BRACKET = '[';
 
     private UpdateExpressionConverter() {
     }
@@ -99,6 +101,9 @@ public final class UpdateExpressionConverter {
      * @return A list of top level attribute names that have update actions associated.
      */
     public static List<String> findAttributeNames(UpdateExpression updateExpression) {
+        if (updateExpression == null) {
+            return Collections.emptyList();
+        }
         List<String> attributeNames = listPathsWithoutTokens(updateExpression);
         List<String> attributeNamesFromTokens = listAttributeNamesFromTokens(updateExpression);
         attributeNames.addAll(attributeNamesFromTokens);
@@ -142,7 +147,7 @@ public final class UpdateExpressionConverter {
     private static Map<String, AttributeValue> mergeExpressionValues(UpdateExpression expression) {
         return streamOfExpressionValues(expression)
             .reduce(Expression::joinValues)
-            .orElseGet(HashMap::new);
+            .orElseGet(Collections::emptyMap);
     }
 
     private static Stream<Map<String, AttributeValue>> streamOfExpressionValues(UpdateExpression expression) {
@@ -154,7 +159,7 @@ public final class UpdateExpressionConverter {
     private static Map<String, String> mergeExpressionNames(UpdateExpression expression) {
         return streamOfExpressionNames(expression)
             .reduce(Expression::joinNames)
-            .orElseGet(HashMap::new);
+            .orElseGet(Collections::emptyMap);
     }
 
     private static List<String> listPathsWithoutTokens(UpdateExpression expression) {
@@ -178,8 +183,9 @@ public final class UpdateExpressionConverter {
     }
 
     private static int getRemovalIndex(String attributeName) {
-        for (char c : attributeName.toCharArray()) {
-            if (c == '.' || c == '[') {
+        for (int i = 0; i < attributeName.length(); i++) {
+            char c = attributeName.charAt(i);
+            if (c == DOT || c == LEFT_BRACKET) {
                 return attributeName.indexOf(c);
             }
         }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.update;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ *
+ * In order to convert it to the format that DynamoDB accepts, the toExpression() method will create an Expression
+ * with a coalesced string representation of its actions, and the ExpressionNames and ExpressionValues maps associated
+ * with all present actions.
+ *
+ * Note: Once an Expression has been obtained, you cannot combine it with another update Expression since they can't be
+ * reliably combined using a token.
+ *
+ *
+ * Validation
+ * When an UpdateExpression is created or merged with another, the code validates the integrity of the expression to ensure
+ * a successful database update.
+ * - The same attribute MAY NOT be chosen for updates in more than one action expression. This is checked by verifying that
+ * attribute only has one representation in the AttributeNames map.
+ * - The same attribute MAY NOT have more than one value. This is checked by verifying that attribute only has one
+ * representation in the AttributeValues map.
+ */
+@SdkInternalApi
+public final class UpdateExpressionConverter {
+
+    private static final String REMOVE = "REMOVE ";
+    private static final String SET = "SET ";
+    private static final String DELETE = "DELETE ";
+    private static final String ADD = "ADD ";
+
+    private static final String ACTION_SEPARATOR = ", ";
+    private static final String GROUP_SEPARATOR = " ";
+
+    private UpdateExpressionConverter() {
+    }
+
+    /**
+     * Returns an {@link Expression} where all update actions in the UpdateExpression have been concatenated according
+     * to the rules of DDB Update Expressions, and all expression names and values have been combined into single maps,
+     * respectively.
+     *
+     * Observe that the resulting expression string should never be joined with another expression string, independently
+     * of whether it represents an update expression, conditional expression or another type of expression, since once
+     * the string is generated that update expression is the final format accepted by DDB.
+     *
+     * @return an Expression representing the concatenation of all actions in this UpdateExpression
+     */
+    public static Expression toExpression(UpdateExpression expression) {
+        if (expression == null) {
+            return null;
+        }
+        Map<String, AttributeValue> expressionValues = mergeExpressionValues(expression);
+        Map<String, String> expressionNames = mergeExpressionNames(expression);
+        List<String> groupExpressions = groupExpressions(expression);
+
+        return Expression.builder()
+                         .expression(String.join(GROUP_SEPARATOR, groupExpressions))
+                         .expressionNames(expressionNames)
+                         .expressionValues(expressionValues)
+                         .build();
+    }
+
+    /**
+     * Attempts to find the list of attribute names that will be updated for the supplied {@link UpdateExpression} by looking at
+     * the combined collection of paths and ExpressionName values. Because attribute names can be composed from nested
+     * attribute references and list references, the leftmost part will be returned if composition is detected.
+     * <p>
+     * Examples: The expression contains a {@link DeleteUpdateAction} with a path value of 'MyAttribute[1]'; the list returned
+     * will have 'MyAttribute' as an element.}
+     *
+     * @return A list of top level attribute names that have update actions associated.
+     */
+    public static List<String> findAttributeNames(UpdateExpression updateExpression) {
+        List<String> attributeNames = listPathsWithoutTokens(updateExpression);
+        List<String> attributeNamesFromTokens = listAttributeNamesFromTokens(updateExpression);
+        attributeNames.addAll(attributeNamesFromTokens);
+        return attributeNames;
+    }
+
+    private static List<String> groupExpressions(UpdateExpression expression) {
+        List<String> groupExpressions = new ArrayList<>();
+        if (!expression.setActions().isEmpty()) {
+            groupExpressions.add(SET + expression.setActions().stream()
+                                                 .map(a -> String.format("%s = %s", a.path(), a.value()))
+                                                 .collect(Collectors.joining(ACTION_SEPARATOR)));
+        }
+        if (!expression.removeActions().isEmpty()) {
+            groupExpressions.add(REMOVE + expression.removeActions().stream()
+                                                    .map(RemoveUpdateAction::path)
+                                                    .collect(Collectors.joining(ACTION_SEPARATOR)));
+        }
+        if (!expression.deleteActions().isEmpty()) {
+            groupExpressions.add(DELETE + expression.deleteActions().stream()
+                                                    .map(a -> String.format("%s %s", a.path(), a.value()))
+                                                    .collect(Collectors.joining(ACTION_SEPARATOR)));
+        }
+        if (!expression.addActions().isEmpty()) {
+            groupExpressions.add(ADD + expression.addActions().stream()
+                                                 .map(a -> String.format("%s %s", a.path(), a.value()))
+                                                 .collect(Collectors.joining(ACTION_SEPARATOR)));
+        }
+        return groupExpressions;
+    }
+
+    private static Stream<Map<String, String>> streamOfExpressionNames(UpdateExpression expression) {
+        return Stream.concat(expression.setActions().stream().map(SetUpdateAction::expressionNames),
+                             Stream.concat(expression.removeActions().stream().map(RemoveUpdateAction::expressionNames),
+                                           Stream.concat(expression.deleteActions().stream()
+                                                                   .map(DeleteUpdateAction::expressionNames),
+                                                         expression.addActions().stream()
+                                                                   .map(AddUpdateAction::expressionNames))));
+    }
+
+    private static Map<String, AttributeValue> mergeExpressionValues(UpdateExpression expression) {
+        return streamOfExpressionValues(expression)
+            .reduce(Expression::joinValues)
+            .orElseGet(HashMap::new);
+    }
+
+    private static Stream<Map<String, AttributeValue>> streamOfExpressionValues(UpdateExpression expression) {
+        return Stream.concat(expression.setActions().stream().map(SetUpdateAction::expressionValues),
+                             Stream.concat(expression.deleteActions().stream().map(DeleteUpdateAction::expressionValues),
+                                           expression.addActions().stream().map(AddUpdateAction::expressionValues)));
+    }
+
+    private static Map<String, String> mergeExpressionNames(UpdateExpression expression) {
+        return streamOfExpressionNames(expression)
+            .reduce(Expression::joinNames)
+            .orElseGet(HashMap::new);
+    }
+
+    private static List<String> listPathsWithoutTokens(UpdateExpression expression) {
+        return Stream.concat(expression.setActions().stream().map(SetUpdateAction::path),
+                             Stream.concat(expression.removeActions().stream().map(RemoveUpdateAction::path),
+                                           Stream.concat(expression.deleteActions().stream().map(DeleteUpdateAction::path),
+                                                         expression.addActions().stream().map(AddUpdateAction::path))))
+                     .map(UpdateExpressionConverter::removeNestingAndListReference)
+                     .filter(attributeName -> !attributeName.contains("#"))
+                     .collect(Collectors.toList());
+    }
+
+    private static List<String> listAttributeNamesFromTokens(UpdateExpression updateExpression) {
+        return mergeExpressionNames(updateExpression).values().stream()
+                                                     .map(UpdateExpressionConverter::removeNestingAndListReference)
+                                                     .collect(Collectors.toList());
+    }
+
+    private static String removeNestingAndListReference(String attributeName) {
+        return attributeName.substring(0, getRemovalIndex(attributeName));
+    }
+
+    private static int getRemovalIndex(String attributeName) {
+        for (char c : attributeName.toCharArray()) {
+            if (c == '.' || c == '[') {
+                return attributeName.indexOf(c);
+            }
+        }
+        return attributeName.length();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionUtils.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.update;
+
+import static software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils.isNullAttributeValue;
+import static software.amazon.awssdk.utils.CollectionUtils.filterMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils;
+import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.UpdateBehaviorTag;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.UpdateBehavior;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@SdkInternalApi
+public final class UpdateExpressionUtils {
+
+    private UpdateExpressionUtils() {
+    }
+
+    private static String keyRef(String key) {
+        return "#AMZN_MAPPED_" + EnhancedClientUtils.cleanAttributeName(key);
+    }
+
+    private static String valueRef(String value) {
+        return ":AMZN_MAPPED_" + EnhancedClientUtils.cleanAttributeName(value);
+    }
+
+    private static String ifNotExists(String key, String initValue) {
+        return "if_not_exists(" + keyRef(key) + ", " + valueRef(initValue) + ")";
+    }
+
+    public static UpdateExpression operationExpression(Map<String, AttributeValue> itemMap,
+                                                       TableMetadata tableMetadata,
+                                                       List<String> nonRemoveAttributes) {
+
+        Map<String, AttributeValue> setAttributes = filterMap(itemMap, e -> !isNullAttributeValue(e.getValue()));
+        UpdateExpression setAttributeExpression = UpdateExpression.builder()
+                                                                  .actions(setActionsFor(setAttributes, tableMetadata))
+                                                                  .build();
+
+        Map<String, AttributeValue> removeAttributes =
+            filterMap(itemMap, e -> isNullAttributeValue(e.getValue()) && !nonRemoveAttributes.contains(e.getKey()));
+
+        UpdateExpression removeAttributeExpression = UpdateExpression.builder()
+                                                                     .actions(removeActionsFor(removeAttributes))
+                                                                     .build();
+
+        setAttributeExpression.mergeExpression(removeAttributeExpression);
+        return setAttributeExpression;
+    }
+
+    private static List<SetUpdateAction> setActionsFor(Map<String, AttributeValue> attributesToSet, TableMetadata tableMetadata) {
+        return attributesToSet.entrySet()
+                              .stream()
+                              .map(entry -> setValue(entry.getKey(),
+                                                     entry.getValue(),
+                                                     UpdateBehaviorTag.resolveForAttribute(entry.getKey(), tableMetadata)))
+                              .collect(Collectors.toList());
+    }
+
+    private static List<RemoveUpdateAction> removeActionsFor(Map<String, AttributeValue> attributesToSet) {
+        return attributesToSet.entrySet()
+                              .stream()
+                              .map(entry -> remove(entry.getKey()))
+                              .collect(Collectors.toList());
+    }
+
+    private static RemoveUpdateAction remove(String attributeName) {
+        return RemoveUpdateAction.builder()
+                                 .path(keyRef(attributeName))
+                                 .expressionNames(Collections.singletonMap(keyRef(attributeName), attributeName))
+                                 .build();
+    }
+
+    private static SetUpdateAction setValue(String attributeName, AttributeValue value, UpdateBehavior updateBehavior) {
+        return SetUpdateAction.builder()
+                              .path(keyRef(attributeName))
+                              .value(behaviorBasedValue(updateBehavior).apply(attributeName))
+                              .expressionNames(expressionNamesFor(attributeName))
+                              .expressionValues(Collections.singletonMap(valueRef(attributeName), value))
+                              .build();
+    }
+
+    private static Function<String, String> behaviorBasedValue(UpdateBehavior updateBehavior) {
+        switch (updateBehavior) {
+            case WRITE_ALWAYS:
+                return v -> valueRef(v);
+            case WRITE_IF_NOT_EXISTS:
+                return k -> ifNotExists(k, k);
+            default:
+                throw new IllegalArgumentException("Unsupported update behavior '" + updateBehavior + "'");
+        }
+    }
+
+    private static Map<String, String> expressionNamesFor(String... attributeNames) {
+        return Arrays.stream(attributeNames)
+                     .collect(Collectors.toMap(UpdateExpressionUtils::keyRef, Function.identity()));
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
@@ -19,8 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkPublicApi;
-import software.amazon.awssdk.utils.CollectionUtils;
 
 /**
  * Contains sets of {@link UpdateAction} that represent the four DynamoDB update actions: SET, ADD, REMOVE and DELETE.
@@ -86,24 +87,25 @@ public final class UpdateExpression {
     }
 
     /**
-     * Merges the supplied UpdateExpression with the current
+     * Merges two UpdateExpression, returning a new
      */
-    public void mergeExpression(UpdateExpression expression) {
-        if (expression == null) {
-            return;
+    public static UpdateExpression mergeExpressions(UpdateExpression expression1, UpdateExpression expression2) {
+        if (expression1 == null) {
+            return expression2;
         }
-        if (!CollectionUtils.isNullOrEmpty(expression.removeActions)) {
-            removeActions.addAll(expression.removeActions());
+        if (expression2 == null) {
+            return expression1;
         }
-        if (!CollectionUtils.isNullOrEmpty(expression.setActions)) {
-            setActions.addAll(expression.setActions());
-        }
-        if (!CollectionUtils.isNullOrEmpty(expression.deleteActions)) {
-            deleteActions.addAll(expression.deleteActions());
-        }
-        if (!CollectionUtils.isNullOrEmpty(expression.addActions)) {
-            addActions.addAll(expression.addActions());
-        }
+        Builder builder = builder();
+        builder.removeActions = Stream.concat(expression1.removeActions.stream(),
+                                              expression2.removeActions.stream()).collect(Collectors.toList());
+        builder.setActions = Stream.concat(expression1.setActions.stream(),
+                                           expression2.setActions.stream()).collect(Collectors.toList());
+        builder.deleteActions = Stream.concat(expression1.deleteActions.stream(),
+                                              expression2.deleteActions.stream()).collect(Collectors.toList());
+        builder.addActions = Stream.concat(expression1.addActions.stream(),
+                                           expression2.addActions.stream()).collect(Collectors.toList());
+        return builder.build();
     }
 
     @Override

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
@@ -17,9 +17,11 @@ package software.amazon.awssdk.enhanced.dynamodb.extensions;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem.createUniqueFakeItem;
 
@@ -44,6 +46,12 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtensi
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.DefaultDynamoDbExtensionContext;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DefaultOperationContext;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationName;
+import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -74,21 +82,28 @@ public class ChainExtensionTest {
                  .collect(toList());
 
     @Test
-    public void beforeWrite_multipleExtensions_multipleConditions_multipleTransformations() {
+    public void beforeWrite_multipleExtensions_multipleModifications() {
         Expression expression1 = Expression.builder().expression("one").expressionValues(ATTRIBUTE_VALUES_1).build();
         Expression expression2 = Expression.builder().expression("two").expressionValues(ATTRIBUTE_VALUES_2).build();
         Expression expression3 = Expression.builder().expression("three").expressionValues(ATTRIBUTE_VALUES_3).build();
+        UpdateExpression updateExpression1 = updateExpression(removeAction("attr1"));
+        UpdateExpression updateExpression2 = updateExpression(removeAction("attr2"));
+        UpdateExpression updateExpression3 = updateExpression(removeAction("attr3"));
+
         ChainExtension extension = ChainExtension.create(mockExtension1, mockExtension2, mockExtension3);
         WriteModification writeModification1 = WriteModification.builder()
                                                                 .additionalConditionalExpression(expression1)
+                                                                .updateExpression(updateExpression1)
                                                                 .transformedItem(fakeItems.get(1))
                                                                 .build();
         WriteModification writeModification2 = WriteModification.builder()
                                                                 .additionalConditionalExpression(expression2)
+                                                                .updateExpression(updateExpression2)
                                                                 .transformedItem(fakeItems.get(2))
                                                                 .build();
         WriteModification writeModification3 = WriteModification.builder()
                                                                 .additionalConditionalExpression(expression3)
+                                                                .updateExpression(updateExpression3)
                                                                 .transformedItem(fakeItems.get(3))
                                                                 .build();
         when(mockExtension1.beforeWrite(any(DynamoDbExtensionContext.BeforeWrite.class))).thenReturn(writeModification1);
@@ -100,10 +115,14 @@ public class ChainExtensionTest {
         Map<String, AttributeValue> combinedMap = new HashMap<>(ATTRIBUTE_VALUES_1);
         combinedMap.putAll(ATTRIBUTE_VALUES_2);
         combinedMap.putAll(ATTRIBUTE_VALUES_3);
-        Expression expectedExpression =
+        Expression expectedConditionalExpression =
             Expression.builder().expression("((one) AND (two)) AND (three)").expressionValues(combinedMap).build();
+        UpdateExpression expectedUpdateExpression = updateExpression(removeAction("attr1"),
+                                                                     removeAction("attr2"),
+                                                                     removeAction("attr3"));
         assertThat(result.transformedItem(), is(fakeItems.get(3)));
-        assertThat(result.additionalConditionalExpression(), is(expectedExpression));
+        assertThat(result.additionalConditionalExpression(), is(expectedConditionalExpression));
+        assertThat(result.updateExpression(), is(expectedUpdateExpression));
 
         InOrder inOrder = Mockito.inOrder(mockExtension1, mockExtension2, mockExtension3);
         inOrder.verify(mockExtension1).beforeWrite(getWriteExtensionContext(0));
@@ -122,6 +141,7 @@ public class ChainExtensionTest {
         WriteModification result = extension.beforeWrite(getWriteExtensionContext(0));
 
         assertThat(result.additionalConditionalExpression(), is(nullValue()));
+        assertThat(result.updateExpression(), is(nullValue()));
         assertThat(result.transformedItem(), is(nullValue()));
 
         InOrder inOrder = Mockito.inOrder(mockExtension1, mockExtension2, mockExtension3);
@@ -133,11 +153,11 @@ public class ChainExtensionTest {
 
     @Test
     public void beforeWrite_multipleExtensions_singleCondition_noTransformations() {
-        Expression expression = Expression.builder().expression("one").expressionValues(ATTRIBUTE_VALUES_1).build();
+        Expression conditionalExpression = Expression.builder().expression("one").expressionValues(ATTRIBUTE_VALUES_1).build();
         ChainExtension extension = ChainExtension.create(mockExtension1, mockExtension2, mockExtension3);
         WriteModification writeModification1 = WriteModification.builder().build();
         WriteModification writeModification2 = WriteModification.builder()
-                                                                .additionalConditionalExpression(expression)
+                                                                .additionalConditionalExpression(conditionalExpression)
                                                                 .build();
         WriteModification writeModification3 = WriteModification.builder().build();
         when(mockExtension1.beforeWrite(any(DynamoDbExtensionContext.BeforeWrite.class))).thenReturn(writeModification1);
@@ -146,12 +166,12 @@ public class ChainExtensionTest {
 
         WriteModification result = extension.beforeWrite(getWriteExtensionContext(0));
 
-        Expression expectedExpression = Expression.builder()
+        Expression expectedConditionalExpression = Expression.builder()
                                                   .expression("one")
                                                   .expressionValues(ATTRIBUTE_VALUES_1)
                                                   .build();
         assertThat(result.transformedItem(), is(nullValue()));
-        assertThat(result.additionalConditionalExpression(), is(expectedExpression));
+        assertThat(result.additionalConditionalExpression(), is(expectedConditionalExpression));
 
         InOrder inOrder = Mockito.inOrder(mockExtension1, mockExtension2, mockExtension3);
         inOrder.verify(mockExtension1).beforeWrite(getWriteExtensionContext(0));
@@ -282,5 +302,37 @@ public class ChainExtensionTest {
             context.operationName(OperationName.BATCH_WRITE_ITEM);
         }
         return context.build();
+    }
+
+    private static RemoveUpdateAction removeAction(String attributeName) {
+        return RemoveUpdateAction.builder()
+                                 .path(keyRef(attributeName))
+                                 .putExpressionName(keyRef(attributeName), attributeName)
+                                 .build();
+    }
+
+    private static SetUpdateAction setAction(String attributeName, AttributeValue value) {
+        return SetUpdateAction.builder()
+                              .value(valueRef(attributeName))
+                              .putExpressionValue(valueRef(attributeName), value)
+                              .path(keyRef(attributeName))
+                              .putExpressionName(keyRef(attributeName), attributeName)
+                              .build();
+    }
+
+    private UpdateExpression updateExpression(UpdateAction... actions) {
+        return UpdateExpression.builder().actions(actions).build();
+    }
+
+    private AttributeValue string(String s) {
+        return AttributeValue.builder().s(s).build();
+    }
+
+    private static String keyRef(String key) {
+        return "#AMZN_" + key;
+    }
+
+    private static String valueRef(String value) {
+        return ":AMZN_" + value;
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
@@ -144,7 +144,6 @@ public class VersionedRecordExtensionTest {
                                                      .tableMetadata(FakeItem.getTableMetadata())
                                                      .operationContext(PRIMARY_CONTEXT).build());
 
-
         assertThat(result.transformedItem(), is(fakeItemWithInitialVersion));
     }
 
@@ -159,7 +158,6 @@ public class VersionedRecordExtensionTest {
                                                                                                                    .operationContext(PRIMARY_CONTEXT)
                                                                                                                    .tableMetadata(FakeItemWithSort.getTableMetadata())
                                                                                                                    .build());
-
         assertThat(writeModification, is(WriteModification.builder().build()));
     }
 

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/WriteModificationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/WriteModificationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.extensions;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+class WriteModificationTest {
+
+    @Test
+    void equalsHashcode() {
+        EqualsVerifier.forClass(WriteModification.class)
+                      .withPrefabValues(AttributeValue.class,
+                                        AttributeValue.builder().s("1").build(),
+                                        AttributeValue.builder().s("2").build())
+                      .verify();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/UpdateExpressionTest.java
@@ -1,0 +1,254 @@
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.RecordForUpdateExpressions;
+import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationName;
+import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.utils.CollectionUtils;
+
+public class UpdateExpressionTest extends LocalDynamoDbSyncTestBase {
+
+    private static final Long ATTRIBUTE1_INCREMENT = 5L;
+    private static final Set<String> ATTRIBUTE2_INIT_VALUE = Stream.of("YELLOW", "BLUE", "RED", "GREEN")
+                                                                   .collect(Collectors.toSet());
+    private static final Set<String> ATTRIBUTE2_DELETE = Stream.of("YELLOW", "RED").collect(Collectors.toSet());
+
+    private static final String ATTRIBUTE1 = "extensionAttribute1";
+    private static final String ATTRIBUTE2 = "extensionAttribute2";
+
+
+    private static final TableSchema<RecordForUpdateExpressions> TABLE_SCHEMA =
+            TableSchema.fromClass(RecordForUpdateExpressions.class);
+
+
+    private DynamoDbTable<RecordForUpdateExpressions> mappedTable;
+
+    private void initClientWithExtensions(DynamoDbEnhancedClientExtension... extensions) {
+        DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
+                                                                      .dynamoDbClient(getDynamoDbClient())
+                                                                      .extensions(extensions)
+                                                                      .build();
+
+        mappedTable = enhancedClient.table(getConcreteTableName("table-name"), TABLE_SCHEMA);
+        mappedTable.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+    }
+
+    @After
+    public void deleteTable() {
+        getDynamoDbClient().deleteTable(r -> r.tableName(getConcreteTableName("table-name")));
+    }
+
+    @Test
+    public void attribute1NotInPojo_notFilteredInExtension_RequestIgnoresNull() {
+        initClientWithExtensions(new NonFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+
+        mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
+
+        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
+        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionAttribute1()).isEqualTo(5L);
+    }
+
+    @Test
+    public void attribute1NotInPojo_notFilteredInExtension_IgnoreNullDefaultFalse_HandledByFilter() {
+        initClientWithExtensions(new NonFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+
+        mappedTable.updateItem(r -> r.item(record));
+
+        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
+        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionAttribute1()).isEqualTo(5L);
+    }
+
+    @Test
+    public void attribute1InPojo_notFilteredInExtension_RequestIgnoresNull_duplicateError() {
+        initClientWithExtensions(new NonFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+        record.setExtensionAttribute1(100L);
+
+        assertThatThrownBy(() ->mappedTable.updateItem(r -> r.item(record).ignoreNulls(true)))
+            .isInstanceOf(DynamoDbException.class)
+            .hasMessageContaining("Two document paths")
+            .hasMessageContaining(ATTRIBUTE1);
+    }
+
+    @Test
+    public void attribute1InPojo_notFilteredInExtension_IgnoreNullDefaultFalse_duplicateError() {
+        initClientWithExtensions(new NonFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+        record.setExtensionAttribute1(100L);
+
+        assertThatThrownBy(() ->mappedTable.updateItem(r -> r.item(record).ignoreNulls(true)))
+            .isInstanceOf(DynamoDbException.class)
+            .hasMessageContaining("Two document paths")
+            .hasMessageContaining(ATTRIBUTE1);
+    }
+
+    @Test
+    public void attribute2NotInPojo_filteredInExtension_RequestIgnoresNull() {
+        initClientWithExtensions(new FilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+        mappedTable.putItem(record);
+
+        record.setStringAttribute1("init");
+        mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
+
+        verifyAttribute2(record);
+    }
+
+    @Test
+    public void attribute2NotInPojo_filteredInExtension_IgnoreNullDefaultFalse() {
+        initClientWithExtensions(new FilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+        mappedTable.putItem(record);
+
+        record.setStringAttribute1("init");
+        mappedTable.updateItem(r -> r.item(record));
+
+        verifyAttribute2(record);
+    }
+
+    @Test
+    public void attribute2InPojo_filteredInExtension_RequestIgnoresNull_duplicateError() {
+        initClientWithExtensions(new FilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+        mappedTable.putItem(record);
+
+        record.setStringAttribute1("init");
+        record.setExtensionAttribute2(Stream.of("PURPLE").collect(Collectors.toSet()));
+        mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
+
+        verifyAttribute2(record);
+    }
+
+    @Test
+    public void attribute2InPojo_filteredInExtension_IgnoreNullDefaultFalse_duplicateError() {
+        initClientWithExtensions(new FilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecord();
+        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+        mappedTable.putItem(record);
+
+        record.setStringAttribute1("init");
+        record.setExtensionAttribute2(Stream.of("PURPLE").collect(Collectors.toSet()));
+        mappedTable.updateItem(r -> r.item(record));
+
+        verifyAttribute2(record);
+    }
+
+    @Test
+    public void multipleExtensions_RequestIgnoresNull() {
+        initClientWithExtensions(new NonFilteringUpdateExtension(), new FilteringUpdateExtension());
+        RecordForUpdateExpressions putRecord = createRecord();
+        putRecord.setExtensionAttribute1(11L);
+        putRecord.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+        mappedTable.putItem(putRecord);
+
+        RecordForUpdateExpressions record = createRecord();
+        record.setStringAttribute1("init");
+        mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
+
+        Set<String> expectedExtensionAttribute2 = Stream.of("BLUE", "GREEN").collect(Collectors.toSet());
+        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
+        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionAttribute1()).isEqualTo(16L);
+        assertThat(persistedRecord.getExtensionAttribute2()).isEqualTo(expectedExtensionAttribute2);
+    }
+
+    private void verifyAttribute2(RecordForUpdateExpressions record) {
+        Set<String> expectedExtensionAttribute2 = Stream.of("BLUE", "GREEN").collect(Collectors.toSet());
+        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
+        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionAttribute1()).isNull();
+        assertThat(persistedRecord.getExtensionAttribute2()).isEqualTo(expectedExtensionAttribute2);
+    }
+
+    private RecordForUpdateExpressions createRecord() {
+        RecordForUpdateExpressions record = new RecordForUpdateExpressions();
+        record.setId("1");
+        record.setStringAttribute1("init");
+        return record;
+    }
+
+    private static final class NonFilteringUpdateExtension implements DynamoDbEnhancedClientExtension {
+
+        @Override
+        public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
+            UpdateExpression updateExpression =
+                UpdateExpression.builder()
+                                .addAction(addToNumericAttribute(ATTRIBUTE1))
+                                .build();
+
+            return WriteModification.builder()
+                                    .updateExpression(updateExpression)
+                                    .build();
+        }
+
+        private AddUpdateAction addToNumericAttribute(String attributeName) {
+            AttributeValue actualValue = AttributeValue.builder().n(Long.toString(ATTRIBUTE1_INCREMENT)).build();
+            String valueName = ":increment";
+            return AddUpdateAction.builder()
+                                  .path(attributeName)
+                                  .value(valueName)
+                                  .putExpressionValue(valueName, actualValue)
+                                  .build();
+        }
+
+    }
+
+    private static final class FilteringUpdateExtension implements DynamoDbEnhancedClientExtension {
+
+        @Override
+        public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
+            Map<String, AttributeValue> transformedItemMap = context.items();
+
+            if ( context.operationName() == OperationName.UPDATE_ITEM) {
+                List<String> attributesToFilter = Arrays.asList(ATTRIBUTE2);
+                transformedItemMap = CollectionUtils.filterMap(transformedItemMap, e -> !attributesToFilter.contains(e.getKey()));
+            }
+            UpdateExpression updateExpression =
+                UpdateExpression.builder()
+                                .addAction(deleteFromList(ATTRIBUTE2))
+                                .build();
+
+            return WriteModification.builder()
+                                    .updateExpression(updateExpression)
+                                    .transformedItem(transformedItemMap)
+                                    .build();
+        }
+
+        private DeleteUpdateAction deleteFromList(String attributeName) {
+            AttributeValue actualValue = AttributeValue.builder().ss(ATTRIBUTE2_DELETE).build();
+            String valueName = ":toDelete";
+            return DeleteUpdateAction.builder()
+                                     .path(attributeName)
+                                     .value(valueName)
+                                     .putExpressionValue(valueName, actualValue)
+                                     .build();
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/RecordForUpdateExpressions.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/RecordForUpdateExpressions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.UpdateBehavior.WRITE_IF_NOT_EXISTS;
+
+import java.util.Set;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbUpdateBehavior;
+
+@DynamoDbBean
+public class RecordForUpdateExpressions {
+    private String id;
+    private String stringAttribute1;
+    private Long extensionAttribute1;
+    private Set<String> extensionAttribute2;
+
+    @DynamoDbPartitionKey
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @DynamoDbUpdateBehavior(WRITE_IF_NOT_EXISTS)
+    public String getStringAttribute1() {
+        return stringAttribute1;
+    }
+
+    public void setStringAttribute1(String stringAttribute1) {
+        this.stringAttribute1 = stringAttribute1;
+    }
+
+    public Long getExtensionAttribute1() {
+        return extensionAttribute1;
+    }
+
+    public void setExtensionAttribute1(Long extensionAttribute1) {
+        this.extensionAttribute1 = extensionAttribute1;
+    }
+
+    public Set<String> getExtensionAttribute2() {
+        return extensionAttribute2;
+    }
+
+    public void setExtensionAttribute2(Set<String> extensionAttribute2) {
+        this.extensionAttribute2 = extensionAttribute2;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperationTransactTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperationTransactTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.operations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem.createUniqueFakeItem;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.stringValue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.OperationContext;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactUpdateItemEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.Update;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateItemOperationTransactTest {
+    private static final String TABLE_NAME = "table-name";
+
+    @Mock
+    private DynamoDbEnhancedClientExtension mockDynamoDbEnhancedClientExtension;
+
+    @Test
+    public void generateTransactWriteItem_basicRequest() {
+        FakeItem fakeItem = createUniqueFakeItem();
+        Map<String, AttributeValue> fakeItemMap = FakeItem.getTableSchema().itemToMap(fakeItem, true);
+        UpdateItemOperation<FakeItem> updateItemOperation =
+            spy(UpdateItemOperation.create(UpdateItemEnhancedRequest.builder(FakeItem.class).item(fakeItem).build()));
+        OperationContext context = DefaultOperationContext.create(TABLE_NAME, TableMetadata.primaryIndexName());
+        String updateExpression = "update-expression";
+        Map<String, AttributeValue> attributeValues = Collections.singletonMap("key", stringValue("value1"));
+        Map<String, String> attributeNames = Collections.singletonMap("key", "value2");
+
+        UpdateItemRequest.Builder builder = ddbRequestBuilder(fakeItemMap);
+        builder.updateExpression(updateExpression);
+        builder.expressionAttributeValues(attributeValues);
+        builder.expressionAttributeNames(attributeNames);
+        UpdateItemRequest updateItemRequest = builder.build();
+
+        doReturn(updateItemRequest).when(updateItemOperation).generateRequest(any(), any(), any());
+
+        TransactWriteItem actualResult = updateItemOperation.generateTransactWriteItem(FakeItem.getTableSchema(),
+                                                                                       context,
+                                                                                       mockDynamoDbEnhancedClientExtension);
+
+        TransactWriteItem expectedResult = TransactWriteItem.builder()
+                                                            .update(Update.builder()
+                                                                          .key(fakeItemMap)
+                                                                          .tableName(TABLE_NAME)
+                                                                          .updateExpression(updateExpression)
+                                                                          .expressionAttributeNames(attributeNames)
+                                                                          .expressionAttributeValues(attributeValues)
+                                                                          .build())
+                                                            .build();
+        assertThat(actualResult, is(expectedResult));
+        verify(updateItemOperation).generateRequest(FakeItem.getTableSchema(), context, mockDynamoDbEnhancedClientExtension);
+    }
+
+    @Test
+    public void generateTransactWriteItem_conditionalRequest() {
+        FakeItem fakeItem = createUniqueFakeItem();
+        Map<String, AttributeValue> fakeItemMap = FakeItem.getTableSchema().itemToMap(fakeItem, true);
+        UpdateItemOperation<FakeItem> updateItemOperation =
+            spy(UpdateItemOperation.create(UpdateItemEnhancedRequest.builder(FakeItem.class).item(fakeItem).build()));
+        OperationContext context = DefaultOperationContext.create(TABLE_NAME, TableMetadata.primaryIndexName());
+        String updateExpression = "update-expression";
+        String conditionExpression = "condition-expression";
+        Map<String, AttributeValue> attributeValues = Collections.singletonMap("key", stringValue("value1"));
+        Map<String, String> attributeNames = Collections.singletonMap("key", "value2");
+
+        UpdateItemRequest.Builder builder = ddbRequestBuilder(fakeItemMap);
+        builder.updateExpression(updateExpression);
+        builder.expressionAttributeValues(attributeValues);
+        builder.expressionAttributeNames(attributeNames);
+        builder.conditionExpression(conditionExpression);
+        UpdateItemRequest updateItemRequest = builder.build();
+
+        doReturn(updateItemRequest).when(updateItemOperation).generateRequest(any(), any(), any());
+
+        TransactWriteItem actualResult = updateItemOperation.generateTransactWriteItem(FakeItem.getTableSchema(),
+                                                                                       context,
+                                                                                       mockDynamoDbEnhancedClientExtension);
+
+        TransactWriteItem expectedResult = TransactWriteItem.builder()
+                                                            .update(Update.builder()
+                                                                          .key(fakeItemMap)
+                                                                          .tableName(TABLE_NAME)
+                                                                          .updateExpression(updateExpression)
+                                                                          .conditionExpression(conditionExpression)
+                                                                          .expressionAttributeNames(attributeNames)
+                                                                          .expressionAttributeValues(attributeValues)
+                                                                          .build())
+                                                            .build();
+        assertThat(actualResult, is(expectedResult));
+        verify(updateItemOperation).generateRequest(FakeItem.getTableSchema(), context, mockDynamoDbEnhancedClientExtension);
+    }
+
+    @Test
+    public void generateTransactWriteItem_returnValuesOnConditionCheckFailure_generatesCorrectRequest() {
+        FakeItem fakeItem = createUniqueFakeItem();
+        Map<String, AttributeValue> fakeItemMap = FakeItem.getTableSchema().itemToMap(fakeItem, true);
+        String returnValues = "return-values";
+
+        UpdateItemOperation<FakeItem> updateItemOperation =
+            spy(UpdateItemOperation.create(TransactUpdateItemEnhancedRequest.builder(FakeItem.class)
+                                                                            .item(fakeItem)
+                                                                            .returnValuesOnConditionCheckFailure(returnValues)
+                                                                            .build()));
+        OperationContext context = DefaultOperationContext.create(TABLE_NAME, TableMetadata.primaryIndexName());
+
+        doReturn(ddbRequest(fakeItemMap, b -> {})).when(updateItemOperation).generateRequest(any(), any(), any());
+
+        TransactWriteItem actualResult = updateItemOperation.generateTransactWriteItem(FakeItem.getTableSchema(),
+                                                                                       context,
+                                                                                       mockDynamoDbEnhancedClientExtension);
+
+        TransactWriteItem expectedResult = TransactWriteItem.builder()
+                                                            .update(Update.builder()
+                                                                          .key(fakeItemMap)
+                                                                          .tableName(TABLE_NAME)
+                                                                          .returnValuesOnConditionCheckFailure(returnValues)
+                                                                          .build())
+                                                            .build();
+        assertThat(actualResult, is(expectedResult));
+        verify(updateItemOperation).generateRequest(FakeItem.getTableSchema(), context, mockDynamoDbEnhancedClientExtension);
+    }
+
+
+    private UpdateItemRequest ddbRequest(Map<String, AttributeValue> keys, Consumer<UpdateItemRequest.Builder> modify) {
+        UpdateItemRequest.Builder builder = ddbBaseRequestBuilder(keys);
+        modify.accept(builder);
+        return builder.build();
+    }
+
+    private UpdateItemRequest.Builder ddbRequestBuilder(Map<String, AttributeValue> keys) {
+        return ddbBaseRequestBuilder(keys);
+    }
+
+    private UpdateItemRequest.Builder ddbBaseRequestBuilder(Map<String, AttributeValue> keys) {
+        return UpdateItemRequest.builder().tableName(TABLE_NAME)
+                                .key(keys)
+                                .returnValues(ReturnValue.ALL_NEW);
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverterTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.update;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+
+import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+class UpdateExpressionConverterTest {
+
+    private static final String KEY_TOKEN = "#PRE_";
+    private static final String VALUE_TOKEN = ":PRE_";
+
+    @Test
+    void convert_emptyExpression() {
+        UpdateExpression updateExpression = UpdateExpression.builder().build();
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEmpty();
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    @Test
+    void convert_single_removeAction() {
+        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("REMOVE attribute1");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    @Test
+    void convert_multiple_removeAction() {
+        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", false),
+                                                             removeAction("attribute2", false));
+
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("REMOVE attribute1, attribute2");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    @Test
+    void convert_multiple_removeAction_useNameTokens() {
+        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", true),
+                                                             removeAction("attribute2", true));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, String> expectedExpressionNames = new HashMap<>();
+        expectedExpressionNames.put("#PRE_attribute1", "attribute1");
+        expectedExpressionNames.put("#PRE_attribute2", "attribute2");
+
+        assertThat(expression.expression()).isEqualTo("REMOVE #PRE_attribute1, #PRE_attribute2");
+        assertThat(expression.expressionNames()).containsExactlyEntriesOf(expectedExpressionNames);
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    @Test
+    void convert_single_setAction() {
+        UpdateExpression updateExpression = updateExpression(setAction("attribute1", string("val1"),false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("SET attribute1 = :PRE_attribute1");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsEntry(":PRE_attribute1", string("val1"));
+    }
+
+    @Test
+    void convert_multiple_setAction() {
+        UpdateExpression updateExpression = updateExpression(setAction("attribute1", string("val1"), false),
+                                                             setAction("attribute2", string("val2"), false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
+        expectedExpressionValues.put(":PRE_attribute1", string("val1"));
+        expectedExpressionValues.put(":PRE_attribute2", string("val2"));
+
+        assertThat(expression.expression()).isEqualTo("SET attribute1 = :PRE_attribute1, attribute2 = :PRE_attribute2");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
+    }
+
+    @Test
+    void convert_multiple_setAction_useNameTokens() {
+        UpdateExpression updateExpression = updateExpression(setAction("attribute1", string("val1"), true),
+                                                             setAction("attribute2", string("val2"), true));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, String> expectedExpressionNames = new HashMap<>();
+        expectedExpressionNames.put("#PRE_attribute1", "attribute1");
+        expectedExpressionNames.put("#PRE_attribute2", "attribute2");
+
+        Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
+        expectedExpressionValues.put(":PRE_attribute1", string("val1"));
+        expectedExpressionValues.put(":PRE_attribute2", string("val2"));
+
+        assertThat(expression.expression()).isEqualTo("SET #PRE_attribute1 = :PRE_attribute1, #PRE_attribute2 = :PRE_attribute2");
+        assertThat(expression.expressionNames()).containsExactlyEntriesOf(expectedExpressionNames);
+        assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
+    }
+
+    @Test
+    void convert_single_deleteAction() {
+        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"),false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("DELETE attribute1 :PRE_attribute1");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsEntry(":PRE_attribute1", string("val1"));
+    }
+
+    @Test
+    void convert_multiple_deleteAction() {
+        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), false),
+                                                             deleteAction("attribute2", string("val2"), false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
+        expectedExpressionValues.put(":PRE_attribute1", string("val1"));
+        expectedExpressionValues.put(":PRE_attribute2", string("val2"));
+
+        assertThat(expression.expression()).isEqualTo("DELETE attribute1 :PRE_attribute1, attribute2 :PRE_attribute2");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
+    }
+
+    @Test
+    void convert_multiple_deleteAction_useNameTokens() {
+        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), true),
+                                                             deleteAction("attribute2", string("val2"), true));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, String> expectedExpressionNames = new HashMap<>();
+        expectedExpressionNames.put("#PRE_attribute1", "attribute1");
+        expectedExpressionNames.put("#PRE_attribute2", "attribute2");
+
+        Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
+        expectedExpressionValues.put(":PRE_attribute1", string("val1"));
+        expectedExpressionValues.put(":PRE_attribute2", string("val2"));
+
+        assertThat(expression.expression()).isEqualTo("DELETE #PRE_attribute1 :PRE_attribute1, #PRE_attribute2 :PRE_attribute2");
+        assertThat(expression.expressionNames()).containsExactlyEntriesOf(expectedExpressionNames);
+        assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
+    }
+
+    @Test
+    void convert_single_addAction() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"),false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("ADD attribute1 :PRE_attribute1");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsEntry(":PRE_attribute1", string("val1"));
+    }
+
+    @Test
+    void convert_multiple_addAction() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), false),
+                                                             addAction("attribute2", string("val2"), false));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
+        expectedExpressionValues.put(":PRE_attribute1", string("val1"));
+        expectedExpressionValues.put(":PRE_attribute2", string("val2"));
+
+        assertThat(expression.expression()).isEqualTo("ADD attribute1 :PRE_attribute1, attribute2 :PRE_attribute2");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
+    }
+
+    @Test
+    void convert_multiple_addAction_useNameTokens() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), true),
+                                                             addAction("attribute2", string("val2"), true));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        Map<String, String> expectedExpressionNames = new HashMap<>();
+        expectedExpressionNames.put("#PRE_attribute1", "attribute1");
+        expectedExpressionNames.put("#PRE_attribute2", "attribute2");
+
+        Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
+        expectedExpressionValues.put(":PRE_attribute1", string("val1"));
+        expectedExpressionValues.put(":PRE_attribute2", string("val2"));
+
+        assertThat(expression.expression()).isEqualTo("ADD #PRE_attribute1 :PRE_attribute1, #PRE_attribute2 :PRE_attribute2");
+        assertThat(expression.expressionNames()).containsExactlyEntriesOf(expectedExpressionNames);
+        assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
+    }
+
+    @Test
+    void convert_multiple_mixedAction_useNameTokens() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), true),
+                                                             deleteAction("attribute2", string("val2"), true),
+                                                             removeAction("attribute3", true),
+                                                             setAction("attribute4", string("val4"), true),
+                                                             deleteAction("attribute5", string("val5"), true),
+                                                             setAction("attribute6", string("val6"), true),
+                                                             removeAction("attribute7", true),
+                                                             addAction("attribute8", string("val8"), true),
+                                                             removeAction("attribute9", true));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        assertThat(expression.expression()).isEqualTo(
+            "SET #PRE_attribute4 = :PRE_attribute4, #PRE_attribute6 = :PRE_attribute6 " +
+            "REMOVE #PRE_attribute3, #PRE_attribute7, #PRE_attribute9 " +
+            "DELETE #PRE_attribute2 :PRE_attribute2, #PRE_attribute5 :PRE_attribute5 " +
+            "ADD #PRE_attribute1 :PRE_attribute1, #PRE_attribute8 :PRE_attribute8"
+        );
+        assertThat(expression.expressionNames()).hasSize(9);
+        assertThat(expression.expressionValues()).hasSize(6);
+    }
+
+    @Test
+    void convert_multiple_actions_with_duplicates() {
+        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), true),
+                                                             deleteAction("attribute1", string("val2"), true));
+
+        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
+            .hasMessageContaining(":PRE_attribute1");
+    }
+
+    @Test
+    void convert_multiple_actions_with_duplicates_removes() {
+        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", true),
+                                                             removeAction("attribute1", true));
+
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("REMOVE #PRE_attribute1, #PRE_attribute1");
+        assertThat(expression.expressionNames()).hasSize(1);
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    @Test
+    void convert_multiple_actions_with_duplicates_diffact() {
+        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), true),
+                                                             addAction("attribute1", string("val2"), true));
+        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
+            .hasMessageContaining(":PRE_attribute1");
+    }
+
+    @Test
+    void findAttributeNames_emptyExpression_returnEmptyList() {
+        UpdateExpression updateExpression = UpdateExpression.builder().build();
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).isEmpty();
+    }
+
+    @Test
+    void findAttributeNames_noComposedNames_noTokens() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), false),
+                                                             deleteAction("attribute2", string("val2"), false),
+                                                             removeAction("attribute3", false),
+                                                             setAction("attribute4", string("val4"), false));
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
+    }
+
+    @Test
+    void findAttributeNames_noComposedNames_tokens() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), true),
+                                                             deleteAction("attribute2", string("val2"), true),
+                                                             removeAction("attribute3", true),
+                                                             setAction("attribute4", string("val4"), true));
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
+    }
+
+    @Test
+    void findAttributeNames_noComposedNames_duplicates() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), false),
+                                                             deleteAction("attribute1", string("val2"), true));
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute1");
+    }
+
+    @Test
+    void findAttributeNames_composedNames_noTokens() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1.#nested", string("val1"), false),
+                                                             deleteAction("attribute2.nested", string("val2"), false),
+                                                             removeAction("attribute3[1]", false),
+                                                             setAction("attribute4[1].nested", string("val4"), false));
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
+    }
+
+    @Test
+    void findAttributeNames_composedNames_tokens() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1.nested[1]", string("val1"), true),
+                                                             deleteAction("attribute2.nested", string("val2"), true),
+                                                             removeAction("attribute3[1]", true),
+                                                             setAction("attribute4[1].nested", string("val4"), true));
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
+    }
+
+    @Test
+    void findAttributeNames_composedNames_duplicates() {
+        UpdateExpression updateExpression = updateExpression(addAction("attribute1[1]", string("val1"), false),
+                                                             deleteAction("attribute1.nested", string("val2"), true));
+        List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
+        assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute1");
+    }
+
+    private static RemoveUpdateAction removeAction(String attributeName, boolean useToken) {
+        RemoveUpdateAction.Builder builder = RemoveUpdateAction.builder()
+                                                               .path(attributeName);
+        if (useToken) {
+            builder.path(keyRef(attributeName));
+            builder.putExpressionName(keyRef(attributeName), attributeName);
+        }
+        return builder.build();
+    }
+
+    private static SetUpdateAction setAction(String attributeName, AttributeValue value, boolean useToken) {
+        SetUpdateAction.Builder builder = SetUpdateAction.builder()
+                                                         .path(attributeName)
+                                                         .value(valueRef(attributeName))
+                                                         .putExpressionValue(valueRef(attributeName), value);
+        if (useToken) {
+            builder.path(keyRef(attributeName));
+            builder.putExpressionName(keyRef(attributeName), attributeName);
+        }
+        return builder.build();
+    }
+
+    private static DeleteUpdateAction deleteAction(String attributeName, AttributeValue value, boolean useToken) {
+        DeleteUpdateAction.Builder builder = DeleteUpdateAction.builder()
+                                                         .path(attributeName)
+                                                         .value(valueRef(attributeName))
+                                                         .putExpressionValue(valueRef(attributeName), value);
+        if (useToken) {
+            builder.path(keyRef(attributeName));
+            builder.putExpressionName(keyRef(attributeName), attributeName);
+        }
+        return builder.build();
+    }
+
+    private static AddUpdateAction addAction(String attributeName, AttributeValue value, boolean useToken) {
+        AddUpdateAction.Builder builder = AddUpdateAction.builder()
+                                                               .path(attributeName)
+                                                               .value(valueRef(attributeName))
+                                                               .putExpressionValue(valueRef(attributeName), value);
+        if (useToken) {
+            builder.path(keyRef(attributeName));
+            builder.putExpressionName(keyRef(attributeName), attributeName);
+        }
+        return builder.build();
+    }
+
+    private UpdateExpression updateExpression(UpdateAction... actions) {
+        return UpdateExpression.builder().actions(actions).build();
+    }
+
+    private AttributeValue string(String s) {
+        return AttributeValue.builder().s(s).build();
+    }
+
+    private static String keyRef(String key) {
+        return KEY_TOKEN + key;
+    }
+
+    private static String valueRef(String value) {
+        return VALUE_TOKEN + value;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
@@ -115,11 +115,11 @@ class UpdateExpressionTest {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
-        updateExpression.mergeExpression(null);
-        assertThat(updateExpression.removeActions()).containsExactly(removeAction);
-        assertThat(updateExpression.setActions()).containsExactly(setAction);
-        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
-        assertThat(updateExpression.addActions()).containsExactly(addAction);
+        UpdateExpression result = UpdateExpression.mergeExpressions(updateExpression, null);
+        assertThat(result.removeActions()).containsExactly(removeAction);
+        assertThat(result.setActions()).containsExactly(setAction);
+        assertThat(result.deleteActions()).containsExactly(deleteAction);
+        assertThat(result.addActions()).containsExactly(addAction);
     }
 
     @Test
@@ -127,11 +127,11 @@ class UpdateExpressionTest {
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
-        updateExpression.mergeExpression(UpdateExpression.builder().build());
-        assertThat(updateExpression.removeActions()).containsExactly(removeAction);
-        assertThat(updateExpression.setActions()).containsExactly(setAction);
-        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
-        assertThat(updateExpression.addActions()).containsExactly(addAction);
+        UpdateExpression result = UpdateExpression.mergeExpressions(updateExpression, UpdateExpression.builder().build());
+        assertThat(result.removeActions()).containsExactly(removeAction);
+        assertThat(result.setActions()).containsExactly(setAction);
+        assertThat(result.deleteActions()).containsExactly(deleteAction);
+        assertThat(result.addActions()).containsExactly(addAction);
     }
 
     @Test
@@ -144,11 +144,11 @@ class UpdateExpressionTest {
         UpdateExpression additionalExpression = UpdateExpression.builder()
                                                                 .addAction(extraRemoveAction)
                                                                 .build();
-        updateExpression.mergeExpression(additionalExpression);
-        assertThat(updateExpression.removeActions()).containsExactly(removeAction, extraRemoveAction);
-        assertThat(updateExpression.setActions()).containsExactly(setAction);
-        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction);
-        assertThat(updateExpression.addActions()).containsExactly(addAction);
+        UpdateExpression result = UpdateExpression.mergeExpressions(updateExpression, additionalExpression);
+        assertThat(result.removeActions()).containsExactly(removeAction, extraRemoveAction);
+        assertThat(result.setActions()).containsExactly(setAction);
+        assertThat(result.deleteActions()).containsExactly(deleteAction);
+        assertThat(result.addActions()).containsExactly(addAction);
     }
 
     @Test
@@ -164,11 +164,11 @@ class UpdateExpressionTest {
         UpdateExpression additionalExpression = UpdateExpression.builder()
                                                                 .actions(extraRemoveAction, extraSetAction, extraDeleteAction, extraAddAction)
                                                                 .build();
-        updateExpression.mergeExpression(additionalExpression);
-        assertThat(updateExpression.removeActions()).containsExactly(removeAction, extraRemoveAction);
-        assertThat(updateExpression.setActions()).containsExactly(setAction, extraSetAction);
-        assertThat(updateExpression.deleteActions()).containsExactly(deleteAction, extraDeleteAction);
-        assertThat(updateExpression.addActions()).containsExactly(addAction, extraAddAction);
+        UpdateExpression result = UpdateExpression.mergeExpressions(updateExpression, additionalExpression);
+        assertThat(result.removeActions()).containsExactly(removeAction, extraRemoveAction);
+        assertThat(result.setActions()).containsExactly(setAction, extraSetAction);
+        assertThat(result.deleteActions()).containsExactly(deleteAction, extraDeleteAction);
+        assertThat(result.addActions()).containsExactly(addAction, extraAddAction);
     }
 
     private static final class UnknownUpdateAction implements UpdateAction {

--- a/utils/src/main/java/software/amazon/awssdk/utils/CollectionUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CollectionUtils.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -124,8 +125,34 @@ public final class CollectionUtils {
         return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue);
     }
 
+    /**
+     * Transforms the values of a map to another map with the same keys, using the supplied function.
+     *
+     * @param inputMap the input map
+     * @param mapper the function used to transform the map values
+     * @param <K> the key type
+     * @param <VInT> the value type for the input map
+     * @param <VOutT> the value type for the output map
+     * @return a map
+     */
     public static <K, VInT, VOutT> Map<K, VOutT> mapValues(Map<K, VInT> inputMap, Function<VInT, VOutT> mapper) {
         return inputMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> mapper.apply(e.getValue())));
+    }
+
+    /**
+     * Filters a map based on a condition
+     *
+     * @param map the input map
+     * @param condition the predicate to filter on
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return the filtered map
+     */
+    public static <K, V> Map<K, V> filterMap(Map<K, V> map, Predicate<Map.Entry<K, V>> condition) {
+        return map.entrySet()
+                  .stream()
+                  .filter(condition)
+                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**

--- a/utils/src/main/java/software/amazon/awssdk/utils/CollectionUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CollectionUtils.java
@@ -43,6 +43,10 @@ public final class CollectionUtils {
         return map == null || map.isEmpty();
     }
 
+    public static boolean isNotEmpty(Map<?, ?> map) {
+        return map != null && !map.isEmpty();
+    }
+
     /**
      * Returns a new list containing the second list appended to the first list.
      */


### PR DESCRIPTION
## Motivation and Context
While the UpdateExpression API is already defined, this PR updates the extension framework API to accept UpdateExpressions as part of a WriteModification, allowing extension users to create their own UpdateExpression. 

## Description
Behind the scenes, the UpdateItemOperation now merges an UpdateExpression from extensions with a locally generated UpdateExpression representing the request POJO/item. Internal code generates an Expression from an UpdateExpression. 

### Chained extensions
If there are multiple extensions which create UpdateExpression, these will be sequentially merged into one resulting UpdateExpression. The merge is a basic additive function which adds actions for the respective types, and won't detect duplicates. 

### Generating UpdateExpression for request item
The request item UpdateExpression contain only SET and REMOVE actions. REMOVE actions are filtered by attributes that have been detected as being updated through the extension framework; see more below.

### IgnoreNulls and Collisions
There is a disconnect between update expressions generated from the request item and update expressions generated using extensions: extensions are loaded at client creation time and address schema level information, while requests are at object instance level. Inner workings of the enhanced client in general and the update item operation in particular make it hard for users to understand the full effect of calling the updateItem operation whilst having extensions that operate on update expressions loaded. 

`IgnoreNull` is a setting at the request level that tells the enhanced client to not remove attributes that the user hasn't explicitly set on their POJO. It's false by default, which means that the client will create REMOVE statements for all attributes not set on the POJO. This happens behind the scenes. If an extension creates an update expression touching such an attribute, the call to DDB will fail because the expression contains TWO actions for the same attribute: the one from the extension + the silent REMOVE. It's a very confusing experience, especially for users who are writing the request but may not even be aware of the extension

Remedy: A utility function attempts to parse the attribute names from extension expressions and use them to filter out NUL attributes from the POJO. 

Other collisions are not handled by the code. Examples are attributes that are set on the POJO and in extensions, as well as collisions between extensions. DDB will throw an error. 

Alternative modifications:
- No help for the user. No filtering; requests MUST set ignoreNull to true in order to escape the silent duplication
- Also apply filtering to POJO SETs 
- Apply filtering when merging extensions

## Testing
Unit and functional testing against DDB local.