### PR TITLE
Skip VersionedRecordExtension for batch writes

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtension.java
@@ -97,6 +97,10 @@ public final class VersionedRecordExtension implements DynamoDbEnhancedClientExt
             return WriteModification.builder().build();
         }
 
+        if (context.operationName() == OperationName.BATCH_WRITE_ITEM) {
+            return WriteModification.builder().build();
+        }
+
         Map<String, AttributeValue> itemToTransform = new HashMap<>(context.items());
         AttributeValue newVersionValue;
         Expression condition;

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/VersionedRecordExtensionTest.java
@@ -163,6 +163,25 @@ public class VersionedRecordExtensionTest {
         assertThat(writeModification, is(WriteModification.builder().build()));
     }
 
+    @Test
+    public void beforeWrite_returnsNoOpModification_ifOperationIsBatchWrite() {
+        FakeItem fakeItem = createUniqueFakeItem();
+        fakeItem.setVersion(13);
+        Map<String, AttributeValue> fakeItemWithInitialVersion =
+            new HashMap<>(FakeItem.getTableSchema().itemToMap(fakeItem, true));
+        fakeItemWithInitialVersion.put("version", AttributeValue.builder().n("14").build());
+
+        WriteModification result =
+            versionedRecordExtension.beforeWrite(DefaultDynamoDbExtensionContext
+                                                     .builder()
+                                                     .items(FakeItem.getTableSchema().itemToMap(fakeItem, true))
+                                                     .tableMetadata(FakeItem.getTableMetadata())
+                                                     .operationName(OperationName.BATCH_WRITE_ITEM)
+                                                     .operationContext(PRIMARY_CONTEXT).build());
+
+        assertThat(writeModification, is(WriteModification.builder().build()));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void beforeWrite_throwsIllegalArgumentException_ifVersionAttributeIsWrongType() {
         FakeItem fakeItem = createUniqueFakeItem();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Skip version checks in `VersionedRecordExtension` when the operation is known to be a batch write rather than causing the client to throw an exception IllegalArgumentException https://github.com/aws/aws-sdk-java-v2/blob/6a11ab8196ccddf4fe1bba5530c62c7f1059517a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/PutItemOperation.java#L158

Addresses https://github.com/aws/aws-sdk-java-v2/issues/2559 and allows the default DynamoDbEnhancedClient et al to behave with DynamoDBVersionAttribute as it's [documented](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBVersionAttribute.html) to behave.

> Note that for batchWrite, and by extension batchSave and batchDelete, no version checks are performed, as required by the AmazonDynamoDB.batchWriteItem(BatchWriteItemRequest) API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
