### PR TITLE
Validate that the response content-length header matches what the ser…

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-55b282f.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-55b282f.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Verify that the content-length header matches the content returned by the service."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -70,6 +70,9 @@ public final class ChannelAttributeKey {
     public static final AttributeKey<Http2FrameStream> HTTP2_FRAME_STREAM = NettyUtils.getOrCreateAttributeKey(
         "aws.http.nio.netty.async.http2FrameStream");
 
+    public static final AttributeKey<ChannelDiagnostics> CHANNEL_DIAGNOSTICS = NettyUtils.getOrCreateAttributeKey(
+        "aws.http.nio.netty.async.channelDiagnostics");
+
     /**
      * {@link AttributeKey} to keep track of whether we should close the connection after this request
      * has completed.
@@ -87,6 +90,12 @@ public final class ChannelAttributeKey {
 
     static final AttributeKey<Boolean> RESPONSE_COMPLETE_KEY = NettyUtils.getOrCreateAttributeKey(
         "aws.http.nio.netty.async.responseComplete");
+
+    static final AttributeKey<Long> RESPONSE_CONTENT_LENGTH = NettyUtils.getOrCreateAttributeKey(
+        "aws.http.nio.netty.async.responseContentLength");
+
+    static final AttributeKey<Long> RESPONSE_DATA_READ = NettyUtils.getOrCreateAttributeKey(
+        "aws.http.nio.netty.async.responseDataRead");
 
     /**
      * {@link AttributeKey} to keep track of whether we have received the {@link LastHttpContent}.

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelDiagnostics.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelDiagnostics.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal;
+
+import io.netty.channel.Channel;
+import java.time.Duration;
+import java.time.Instant;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.ToString;
+
+/**
+ * Diagnostic information that may be useful to help with debugging during error scenarios.
+ */
+@SdkInternalApi
+public class ChannelDiagnostics {
+    private final Channel channel;
+    private final Instant channelCreationTime;
+    private int requestCount = 0;
+
+    public ChannelDiagnostics(Channel channel) {
+        this.channel = channel;
+        this.channelCreationTime = Instant.now();
+    }
+
+    public void incrementRequestCount() {
+        ++this.requestCount;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("ChannelDiagnostics")
+                       .add("channel", channel)
+                       .add("channelAge", Duration.between(channelCreationTime, Instant.now()))
+                       .add("requestCount", requestCount)
+                       .build();
+    }
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelPipelineInitializer.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.CHANNEL_DIAGNOSTICS;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.HTTP2_CONNECTION;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.HTTP2_INITIAL_WINDOW_SIZE;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.PROTOCOL_FUTURE;
@@ -88,6 +89,7 @@ public final class ChannelPipelineInitializer extends AbstractChannelPoolHandler
 
     @Override
     public void channelCreated(Channel ch) {
+        ch.attr(CHANNEL_DIAGNOSTICS).set(new ChannelDiagnostics(ch));
         ch.attr(PROTOCOL_FUTURE).set(new CompletableFuture<>());
         ChannelPipeline pipeline = ch.pipeline();
         if (sslCtx != null) {

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import static software.amazon.awssdk.http.HttpMetric.CONCURRENCY_ACQUIRE_DURATION;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.CHANNEL_DIAGNOSTICS;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTE_FUTURE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTION_ID_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.IN_USE;
@@ -23,8 +24,9 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.LAST_HTTP_CONTENT_RECEIVED_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_CONTENT_LENGTH;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_DATA_READ;
 import static software.amazon.awssdk.http.nio.netty.internal.NettyRequestMetrics.measureTimeTaken;
-import static software.amazon.awssdk.http.nio.netty.internal.utils.NettyUtils.CLOSED_CHANNEL_MESSAGE;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -38,9 +40,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutHandler;
-import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -48,12 +48,10 @@ import io.netty.util.concurrent.Promise;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
@@ -176,9 +174,13 @@ public final class NettyRequestExecutor {
         if (channelFuture.isSuccess()) {
             channel = channelFuture.getNow();
             NettyUtils.doInEventLoop(channel.eventLoop(), () -> {
-                configureChannel();
-                if (tryConfigurePipeline()) {
+                try {
+                    configureChannel();
+                    configurePipeline();
                     makeRequest();
+                } catch (Throwable t) {
+                    closeAndRelease(channel);
+                    handleFailure(channel, () -> "Failed to initiate request to " + endpoint(), t);
                 }
             });
         } else {
@@ -192,10 +194,13 @@ public final class NettyRequestExecutor {
         channel.attr(REQUEST_CONTEXT_KEY).set(context);
         channel.attr(RESPONSE_COMPLETE_KEY).set(false);
         channel.attr(LAST_HTTP_CONTENT_RECEIVED_KEY).set(false);
+        channel.attr(RESPONSE_CONTENT_LENGTH).set(null);
+        channel.attr(RESPONSE_DATA_READ).set(null);
+        channel.attr(CHANNEL_DIAGNOSTICS).get().incrementRequestCount();
         channel.config().setOption(ChannelOption.AUTO_READ, false);
     }
 
-    private boolean tryConfigurePipeline() {
+    private void configurePipeline() throws IOException {
         Protocol protocol = ChannelAttributeKey.getProtocolNow(channel);
         ChannelPipeline pipeline = channel.pipeline();
 
@@ -210,10 +215,7 @@ public final class NettyRequestExecutor {
                 requestAdapter = REQUEST_ADAPTER_HTTP1_1;
                 break;
             default:
-                String errorMsg = "Unknown protocol: " + protocol;
-                closeAndRelease(channel);
-                handleFailure(channel, () -> errorMsg, new RuntimeException(errorMsg));
-                return false;
+                throw new IOException("Unknown protocol: " + protocol);
         }
 
         pipeline.addLast(LastHttpContentHandler.create());
@@ -227,13 +229,8 @@ public final class NettyRequestExecutor {
         // handler (which will monitor for it going inactive from now on).
         // Make sure it's active here, or the request will never complete: https://github.com/aws/aws-sdk-java-v2/issues/1207
         if (!channel.isActive()) {
-            String errorMessage = "Channel was closed before it could be written to.";
-            closeAndRelease(channel);
-            handleFailure(channel, () -> errorMessage, new IOException(errorMessage));
-            return false;
+            throw new IOException(NettyUtils.closedChannelMessage(channel));
         }
-
-        return true;
     }
 
     private void makeRequest() {
@@ -308,78 +305,9 @@ public final class NettyRequestExecutor {
 
     private void handleFailure(Channel channel, Supplier<String> msgSupplier, Throwable cause) {
         log.debug(channel, msgSupplier, cause);
-        cause = decorateException(cause);
+        cause = NettyUtils.decorateException(channel, cause);
         context.handler().onError(cause);
         executeFuture.completeExceptionally(cause);
-    }
-
-    private Throwable decorateException(Throwable originalCause) {
-        if (isAcquireTimeoutException(originalCause)) {
-            return new Throwable(getMessageForAcquireTimeoutException(), originalCause);
-        } else if (isTooManyPendingAcquiresException(originalCause)) {
-            return new Throwable(getMessageForTooManyAcquireOperationsError(), originalCause);
-        } else if (originalCause instanceof ReadTimeoutException) {
-            return new IOException("Read timed out", originalCause);
-        } else if (originalCause instanceof WriteTimeoutException) {
-            return new IOException("Write timed out", originalCause);
-        } else if (originalCause instanceof ClosedChannelException) {
-            return new IOException(CLOSED_CHANNEL_MESSAGE, originalCause);
-        }
-
-        return originalCause;
-    }
-
-    private boolean isAcquireTimeoutException(Throwable originalCause) {
-        String message = originalCause.getMessage();
-        return originalCause instanceof TimeoutException &&
-                message != null &&
-                message.contains("Acquire operation took longer");
-    }
-
-    private boolean isTooManyPendingAcquiresException(Throwable originalCause) {
-        String message = originalCause.getMessage();
-        return originalCause instanceof IllegalStateException &&
-               message != null &&
-               originalCause.getMessage().contains("Too many outstanding acquire operations");
-    }
-
-    private String getMessageForAcquireTimeoutException() {
-        return "Acquire operation took longer than the configured maximum time. This indicates that a request cannot get a "
-                + "connection from the pool within the specified maximum time. This can be due to high request rate.\n"
-
-                + "Consider taking any of the following actions to mitigate the issue: increase max connections, "
-                + "increase acquire timeout, or slowing the request rate.\n"
-
-                + "Increasing the max connections can increase client throughput (unless the network interface is already "
-                + "fully utilized), but can eventually start to hit operation system limitations on the number of file "
-                + "descriptors used by the process. If you already are fully utilizing your network interface or cannot "
-                + "further increase your connection count, increasing the acquire timeout gives extra time for requests to "
-                + "acquire a connection before timing out. If the connections doesn't free up, the subsequent requests "
-                + "will still timeout.\n"
-
-                + "If the above mechanisms are not able to fix the issue, try smoothing out your requests so that large "
-                + "traffic bursts cannot overload the client, being more efficient with the number of times you need to "
-                + "call AWS, or by increasing the number of hosts sending requests.";
-    }
-
-    private String getMessageForTooManyAcquireOperationsError() {
-        return "Maximum pending connection acquisitions exceeded. The request rate is too high for the client to keep up.\n"
-
-                + "Consider taking any of the following actions to mitigate the issue: increase max connections, "
-                + "increase max pending acquire count, decrease pool lease timeout, or slowing the request rate.\n"
-
-                + "Increasing the max connections can increase client throughput (unless the network interface is already "
-                + "fully utilized), but can eventually start to hit operation system limitations on the number of file "
-                + "descriptors used by the process. If you already are fully utilizing your network interface or cannot "
-                + "further increase your connection count, increasing the pending acquire count allows extra requests to be "
-                + "buffered by the client, but can cause additional request latency and higher memory usage. If your request"
-                + " latency or memory usage is already too high, decreasing the lease timeout will allow requests to fail "
-                + "more quickly, reducing the number of pending connection acquisitions, but likely won't decrease the total "
-                + "number of failed requests.\n"
-
-                + "If the above mechanisms are not able to fix the issue, try smoothing out your requests so that large "
-                + "traffic bursts cannot overload the client, being more efficient with the number of times you need to call "
-                + "AWS, or by increasing the number of hosts sending requests.";
     }
 
     /**

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -22,9 +22,10 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.LAST_HTTP_CONTENT_RECEIVED_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_CONTENT_LENGTH;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_DATA_READ;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatch;
 import static software.amazon.awssdk.http.nio.netty.internal.utils.ExceptionHandlingUtils.tryCatchFinally;
-import static software.amazon.awssdk.http.nio.netty.internal.utils.NettyUtils.CLOSED_CHANNEL_MESSAGE;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -33,12 +34,11 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
-import io.netty.handler.timeout.ReadTimeoutException;
-import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -62,6 +62,7 @@ import software.amazon.awssdk.http.nio.netty.internal.http2.Http2ResetSendingSub
 import software.amazon.awssdk.http.nio.netty.internal.nrs.HttpStreamsClientHandler;
 import software.amazon.awssdk.http.nio.netty.internal.nrs.StreamedHttpResponse;
 import software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger;
+import software.amazon.awssdk.http.nio.netty.internal.utils.NettyUtils;
 import software.amazon.awssdk.utils.FunctionalUtils.UnsafeRunnable;
 import software.amazon.awssdk.utils.async.DelegatingSubscription;
 
@@ -87,6 +88,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                                                              .statusCode(response.status().code())
                                                              .statusText(response.status().reasonPhrase())
                                                              .build();
+            channelContext.channel().attr(RESPONSE_CONTENT_LENGTH).set(responseContentLength(response));
             channelContext.channel().attr(KEEP_ALIVE).set(shouldKeepAlive(response));
             requestContext.handler().onHeaders(sdkResponse);
         }
@@ -94,7 +96,9 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         CompletableFuture<Void> ef = executeFuture(channelContext);
         if (msg instanceof StreamedHttpResponse) {
             requestContext.handler().onStream(
-                    new PublisherAdapter((StreamedHttpResponse) msg, channelContext, requestContext, ef));
+                    new DataCountingPublisher(channelContext,
+                                              new PublisherAdapter((StreamedHttpResponse) msg, channelContext,
+                                                                   requestContext, ef)));
         } else if (msg instanceof FullHttpResponse) {
             ByteBuf fullContent = null;
             try {
@@ -106,13 +110,51 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
 
                 fullContent = ((FullHttpResponse) msg).content();
                 ByteBuffer bb = copyToByteBuffer(fullContent);
-                requestContext.handler().onStream(new FullResponseContentPublisher(channelContext, bb, ef));
-                finalizeResponse(requestContext, channelContext);
+                requestContext.handler().onStream(new DataCountingPublisher(channelContext,
+                                                                            new FullResponseContentPublisher(channelContext,
+                                                                                                             bb, ef)));
+
+                try {
+                    validateResponseContentLength(channelContext);
+                    finalizeResponse(requestContext, channelContext);
+                } catch (IOException e) {
+                    exceptionCaught(channelContext, e);
+                }
             } finally {
                 Optional.ofNullable(fullContent).ifPresent(ByteBuf::release);
             }
         }
     }
+
+    private Long responseContentLength(HttpResponse response) {
+        String length = response.headers().get(HttpHeaderNames.CONTENT_LENGTH);
+        if (length == null) {
+            return null;
+        }
+
+        return Long.parseLong(length);
+    }
+
+    private static void validateResponseContentLength(ChannelHandlerContext ctx) throws IOException {
+        Long contentLengthHeader = ctx.channel().attr(RESPONSE_CONTENT_LENGTH).get();
+        Long actualContentLength = ctx.channel().attr(RESPONSE_DATA_READ).get();
+
+        if (contentLengthHeader == null) {
+            return;
+        }
+
+        if (actualContentLength == null) {
+            actualContentLength = 0L;
+        }
+
+        if (actualContentLength.equals(contentLengthHeader)) {
+            return;
+        }
+
+        throw new IOException("Response had content-length of " + contentLengthHeader + " bytes, but only received "
+                              + actualContentLength + " bytes before the connection was closed.");
+    }
+
 
     /**
      * Finalize the response by completing the execute future and release the channel pool being used.
@@ -122,6 +164,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
      */
     private static void finalizeResponse(RequestContext requestContext, ChannelHandlerContext channelContext) {
         channelContext.channel().attr(RESPONSE_COMPLETE_KEY).set(true);
+
         executeFuture(channelContext).complete(null);
         if (!channelContext.channel().attr(KEEP_ALIVE).get()) {
             closeAndRelease(channelContext);
@@ -141,7 +184,7 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         RequestContext requestContext = ctx.channel().attr(REQUEST_CONTEXT_KEY).get();
         log.debug(ctx.channel(), () -> "Exception processing request: " + requestContext.executeRequest().request(), cause);
-        Throwable throwable = wrapException(cause);
+        Throwable throwable = NettyUtils.decorateException(ctx.channel(), cause);
         executeFuture(ctx).completeExceptionally(throwable);
         runAndLogError(ctx.channel(), "Fail to execute SdkAsyncHttpResponseHandler#onError",
                        () -> requestContext.handler().onError(throwable));
@@ -295,11 +338,19 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                     if (!isDone.compareAndSet(false, true)) {
                         return;
                     }
+
                     try {
-                        runAndLogError(channelContext.channel(), String.format("Subscriber %s threw an exception in onComplete.",
-                                                                               subscriber.toString()), subscriber::onComplete);
-                    } finally {
-                        finalizeResponse(requestContext, channelContext);
+                        validateResponseContentLength(channelContext);
+                        try {
+                            runAndLogError(channelContext.channel(),
+                                           String.format("Subscriber %s threw an exception in onComplete.",
+                                                         subscriber.toString()),
+                                           subscriber::onComplete);
+                        } finally {
+                            finalizeResponse(requestContext, channelContext);
+                        }
+                    } catch (IOException e) {
+                        notifyError(e);
                     }
                 }
 
@@ -366,7 +417,9 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                         if (l <= 0) {
                             subscriber.onError(new IllegalArgumentException("Demand must be positive!"));
                         } else {
-                            subscriber.onNext(fullContent);
+                            if (fullContent.hasRemaining()) {
+                                subscriber.onNext(fullContent);
+                            }
                             subscriber.onComplete();
                             executeFuture.complete(null);
                         }
@@ -382,16 +435,6 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         }
     }
 
-    private Throwable wrapException(Throwable originalCause) {
-        if (originalCause instanceof ReadTimeoutException) {
-            return new IOException("Read timed out", originalCause);
-        } else if (originalCause instanceof WriteTimeoutException) {
-            return new IOException("Write timed out", originalCause);
-        }
-
-        return originalCause;
-    }
-
     private void notifyIfResponseNotCompleted(ChannelHandlerContext handlerCtx) {
         RequestContext requestCtx = handlerCtx.channel().attr(REQUEST_CONTEXT_KEY).get();
         Boolean responseCompleted = handlerCtx.channel().attr(RESPONSE_COMPLETE_KEY).get();
@@ -399,11 +442,52 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
         handlerCtx.channel().attr(KEEP_ALIVE).set(false);
 
         if (!Boolean.TRUE.equals(responseCompleted) && !Boolean.TRUE.equals(lastHttpContentReceived)) {
-            IOException err = new IOException("Server failed to send complete response. " + CLOSED_CHANNEL_MESSAGE);
+            IOException err = new IOException(NettyUtils.closedChannelMessage(handlerCtx.channel()));
             runAndLogError(handlerCtx.channel(), "Fail to execute SdkAsyncHttpResponseHandler#onError",
                            () -> requestCtx.handler().onError(err));
             executeFuture(handlerCtx).completeExceptionally(err);
             runAndLogError(handlerCtx.channel(), "Could not release channel", () -> closeAndRelease(handlerCtx));
+        }
+    }
+
+    private static final class DataCountingPublisher implements Publisher<ByteBuffer> {
+        private final ChannelHandlerContext ctx;
+        private final Publisher<ByteBuffer> delegate;
+
+        private DataCountingPublisher(ChannelHandlerContext ctx, Publisher<ByteBuffer> delegate) {
+            this.ctx = ctx;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+            delegate.subscribe(new Subscriber<ByteBuffer>() {
+                @Override
+                public void onSubscribe(Subscription subscription) {
+                    subscriber.onSubscribe(subscription);
+                }
+
+                @Override
+                public void onNext(ByteBuffer byteBuffer) {
+                    Long responseDataSoFar = ctx.channel().attr(RESPONSE_DATA_READ).get();
+                    if (responseDataSoFar == null) {
+                        responseDataSoFar = 0L;
+                    }
+
+                    ctx.channel().attr(RESPONSE_DATA_READ).set(responseDataSoFar + byteBuffer.remaining());
+                    subscriber.onNext(byteBuffer);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    subscriber.onError(throwable);
+                }
+
+                @Override
+                public void onComplete() {
+                    subscriber.onComplete();
+                }
+            });
         }
     }
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/MultiplexedChannelRecord.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/http2/MultiplexedChannelRecord.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey;
+import software.amazon.awssdk.http.nio.netty.internal.ChannelDiagnostics;
 import software.amazon.awssdk.http.nio.netty.internal.UnusedChannelExceptionHandler;
 import software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger;
 
@@ -111,6 +112,7 @@ public class MultiplexedChannelRecord {
                 Http2StreamChannel channel = future.getNow();
                 channel.pipeline().addLast(UnusedChannelExceptionHandler.getInstance());
                 channel.attr(ChannelAttributeKey.HTTP2_FRAME_STREAM).set(channel.stream());
+                channel.attr(ChannelAttributeKey.CHANNEL_DIAGNOSTICS).set(new ChannelDiagnostics(channel));
                 childChannels.put(channel.id(), channel);
                 promise.setSuccess(channel);
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/NettyUtils.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/NettyUtils.java
@@ -15,25 +15,34 @@
 
 package software.amazon.awssdk.http.nio.netty.internal.utils;
 
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.CHANNEL_DIAGNOSTICS;
+
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.SucceededFuture;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.http.nio.netty.internal.ChannelDiagnostics;
 import software.amazon.awssdk.utils.FunctionalUtils;
 import software.amazon.awssdk.utils.Logger;
 
@@ -44,17 +53,104 @@ public final class NettyUtils {
      */
     public static final SucceededFuture<?> SUCCEEDED_FUTURE = new SucceededFuture<>(null, null);
 
-    // TODO: add a link to the guide on how to diagnose this error here once it's available
-    public static final String CLOSED_CHANNEL_MESSAGE = "The channel was closed. This may have been done by the client (e.g. "
-                                                        + "because the request was aborted), " +
-                                                        "by the service (e.g. because there was a handshake error, the request "
-                                                        + "took too long, or the client tried to write on a read-only socket), " +
-                                                        "or by an intermediary party (e.g. because the channel was idle for too"
-                                                        + " long).";
-
     private static final Logger log = Logger.loggerFor(NettyUtils.class);
 
     private NettyUtils() {
+    }
+
+    public static Throwable decorateException(Channel channel, Throwable originalCause) {
+        if (isAcquireTimeoutException(originalCause)) {
+            return new Throwable(getMessageForAcquireTimeoutException(), originalCause);
+        } else if (isTooManyPendingAcquiresException(originalCause)) {
+            return new Throwable(getMessageForTooManyAcquireOperationsError(), originalCause);
+        } else if (originalCause instanceof ReadTimeoutException) {
+            return new IOException("Read timed out", originalCause);
+        } else if (originalCause instanceof WriteTimeoutException) {
+            return new IOException("Write timed out", originalCause);
+        } else if (originalCause instanceof ClosedChannelException || isConnectionResetException(originalCause)) {
+            return new IOException(NettyUtils.closedChannelMessage(channel), originalCause);
+        }
+
+        return originalCause;
+    }
+
+    private static boolean isConnectionResetException(Throwable originalCause) {
+        return originalCause instanceof IOException && originalCause.getMessage().contains("Connection reset by peer");
+    }
+
+    private static boolean isAcquireTimeoutException(Throwable originalCause) {
+        String message = originalCause.getMessage();
+        return originalCause instanceof TimeoutException &&
+               message != null &&
+               message.contains("Acquire operation took longer");
+    }
+
+    private static boolean isTooManyPendingAcquiresException(Throwable originalCause) {
+        String message = originalCause.getMessage();
+        return originalCause instanceof IllegalStateException &&
+               message != null &&
+               originalCause.getMessage().contains("Too many outstanding acquire operations");
+    }
+
+    private static String getMessageForAcquireTimeoutException() {
+        return "Acquire operation took longer than the configured maximum time. This indicates that a request cannot get a "
+               + "connection from the pool within the specified maximum time. This can be due to high request rate.\n"
+
+               + "Consider taking any of the following actions to mitigate the issue: increase max connections, "
+               + "increase acquire timeout, or slowing the request rate.\n"
+
+               + "Increasing the max connections can increase client throughput (unless the network interface is already "
+               + "fully utilized), but can eventually start to hit operation system limitations on the number of file "
+               + "descriptors used by the process. If you already are fully utilizing your network interface or cannot "
+               + "further increase your connection count, increasing the acquire timeout gives extra time for requests to "
+               + "acquire a connection before timing out. If the connections doesn't free up, the subsequent requests "
+               + "will still timeout.\n"
+
+               + "If the above mechanisms are not able to fix the issue, try smoothing out your requests so that large "
+               + "traffic bursts cannot overload the client, being more efficient with the number of times you need to "
+               + "call AWS, or by increasing the number of hosts sending requests.";
+    }
+
+    private static String getMessageForTooManyAcquireOperationsError() {
+        return "Maximum pending connection acquisitions exceeded. The request rate is too high for the client to keep up.\n"
+
+               + "Consider taking any of the following actions to mitigate the issue: increase max connections, "
+               + "increase max pending acquire count, decrease pool lease timeout, or slowing the request rate.\n"
+
+               + "Increasing the max connections can increase client throughput (unless the network interface is already "
+               + "fully utilized), but can eventually start to hit operation system limitations on the number of file "
+               + "descriptors used by the process. If you already are fully utilizing your network interface or cannot "
+               + "further increase your connection count, increasing the pending acquire count allows extra requests to be "
+               + "buffered by the client, but can cause additional request latency and higher memory usage. If your request"
+               + " latency or memory usage is already too high, decreasing the lease timeout will allow requests to fail "
+               + "more quickly, reducing the number of pending connection acquisitions, but likely won't decrease the total "
+               + "number of failed requests.\n"
+
+               + "If the above mechanisms are not able to fix the issue, try smoothing out your requests so that large "
+               + "traffic bursts cannot overload the client, being more efficient with the number of times you need to call "
+               + "AWS, or by increasing the number of hosts sending requests.";
+    }
+
+    public static String closedChannelMessage(Channel channel) {
+        ChannelDiagnostics channelDiagnostics = channel.attr(CHANNEL_DIAGNOSTICS).get();
+        ChannelDiagnostics parentChannelDiagnostics = channel.parent() != null ? channel.parent().attr(CHANNEL_DIAGNOSTICS).get()
+                                                                               : null;
+
+        StringBuilder error = new StringBuilder();
+        error.append("The connection was closed during the request. The request will usually succeed on a retry, but if it does"
+                     + " not: consider disabling any proxies you have configured, enabling debug logging, or performing a TCP"
+                     + " dump to identify the root cause. If this is a streaming operation, validate that data is being read or"
+                     + " written in a timely manner.");
+
+        if (channelDiagnostics != null) {
+            error.append(" Channel Information: ").append(channelDiagnostics);
+
+            if (parentChannelDiagnostics != null) {
+                error.append(" Parent Channel Information: ").append(parentChannelDiagnostics);
+            }
+        }
+
+        return error.toString();
     }
 
     /**
@@ -200,7 +296,7 @@ public final class NettyUtils {
     /**
      * @return a new {@link SslHandler} with ssl engine configured
      */
-    public static SslHandler newSslHandler(SslContext sslContext, ByteBufAllocator alloc,  String peerHost, int peerPort,
+    public static SslHandler newSslHandler(SslContext sslContext, ByteBufAllocator alloc, String peerHost, int peerPort,
                                            Duration handshakeTimeout) {
         // Need to provide host and port to enable SNI
         // https://github.com/netty/netty/issues/3801#issuecomment-104274440

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyClientTlsAuthTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/NettyClientTlsAuthTest.java
@@ -173,7 +173,7 @@ public class NettyClientTlsAuthTest extends ClientTlsAuthTestBase {
     @Test
     public void nonProxy_noKeyManagerGiven_shouldThrowException() {
         thrown.expectCause(instanceOf(IOException.class));
-        thrown.expectMessage("The channel was closed");
+        thrown.expectMessage("The connection was closed");
 
         netty = NettyNioAsyncHttpClient.builder()
                                        .buildWithDefaults(DEFAULTS);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/DelegatingSslEngine.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/DelegatingSslEngine.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.fault;
+
+import java.nio.ByteBuffer;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+
+public class DelegatingSslEngine extends SSLEngine {
+    private final SSLEngine delegate;
+
+    public DelegatingSslEngine(SSLEngine delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public SSLEngineResult wrap(ByteBuffer[] srcs, int offset, int length, ByteBuffer dst) throws SSLException {
+        return delegate.wrap(srcs, offset, length, dst);
+    }
+
+    @Override
+    public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) throws SSLException {
+        return delegate.unwrap(src, dsts, offset, length);
+    }
+
+    @Override
+    public Runnable getDelegatedTask() {
+        return delegate.getDelegatedTask();
+    }
+
+    @Override
+    public void closeInbound() throws SSLException {
+        delegate.closeInbound();
+    }
+
+    @Override
+    public boolean isInboundDone() {
+        return delegate.isInboundDone();
+    }
+
+    @Override
+    public void closeOutbound() {
+        delegate.closeOutbound();
+    }
+
+    @Override
+    public boolean isOutboundDone() {
+        return delegate.isOutboundDone();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public String[] getEnabledCipherSuites() {
+        return delegate.getEnabledCipherSuites();
+    }
+
+    @Override
+    public void setEnabledCipherSuites(String[] suites) {
+        delegate.setEnabledCipherSuites(suites);
+    }
+
+    @Override
+    public String[] getSupportedProtocols() {
+        return delegate.getSupportedProtocols();
+    }
+
+    @Override
+    public String[] getEnabledProtocols() {
+        return delegate.getEnabledProtocols();
+    }
+
+    @Override
+    public void setEnabledProtocols(String[] protocols) {
+        delegate.setEnabledProtocols(protocols);
+    }
+
+    @Override
+    public SSLSession getSession() {
+        return delegate.getSession();
+    }
+
+    @Override
+    public void beginHandshake() throws SSLException {
+        delegate.beginHandshake();
+    }
+
+    @Override
+    public SSLEngineResult.HandshakeStatus getHandshakeStatus() {
+        return delegate.getHandshakeStatus();
+    }
+
+    @Override
+    public void setUseClientMode(boolean mode) {
+        delegate.setUseClientMode(mode);
+    }
+
+    @Override
+    public boolean getUseClientMode() {
+        return delegate.getUseClientMode();
+    }
+
+    @Override
+    public void setNeedClientAuth(boolean need) {
+        delegate.setNeedClientAuth(need);
+    }
+
+    @Override
+    public boolean getNeedClientAuth() {
+        return delegate.getNeedClientAuth();
+    }
+
+    @Override
+    public void setWantClientAuth(boolean want) {
+        delegate.setWantClientAuth(want);
+    }
+
+    @Override
+    public boolean getWantClientAuth() {
+        return delegate.getWantClientAuth();
+    }
+
+    @Override
+    public void setEnableSessionCreation(boolean flag) {
+        delegate.setEnableSessionCreation(flag);
+    }
+
+    @Override
+    public boolean getEnableSessionCreation() {
+        return delegate.getEnableSessionCreation();
+    }
+}

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/ServerConnectivityErrorMessageTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/ServerConnectivityErrorMessageTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.fault;
+
+import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_TASK;
+import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_UNWRAP;
+import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NEED_WRAP;
+import static javax.net.ssl.SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.reactivestreams.Publisher;
+import software.amazon.awssdk.http.EmptyPublisher;
+import software.amazon.awssdk.http.Protocol;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
+import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.Logger;
+
+public class ServerConnectivityErrorMessageTest {
+    private static final Logger LOGGER = Logger.loggerFor(ServerConnectivityErrorMessageTest.class);
+    private SdkAsyncHttpClient netty;
+    private Server server;
+
+    public static Collection<TestCase> testCases() {
+        return Arrays.asList(new TestCase(CloseTime.DURING_INIT, "The connection was closed during the request."),
+                             new TestCase(CloseTime.BEFORE_SSL_HANDSHAKE, "The connection was closed during the request."),
+                             new TestCase(CloseTime.DURING_SSL_HANDSHAKE, "The connection was closed during the request."),
+                             new TestCase(CloseTime.BEFORE_REQUEST_PAYLOAD, "The connection was closed during the request."),
+                             new TestCase(CloseTime.DURING_REQUEST_PAYLOAD, "The connection was closed during the request."),
+                             new TestCase(CloseTime.BEFORE_RESPONSE_HEADERS, "The connection was closed during the request."),
+                             new TestCase(CloseTime.BEFORE_RESPONSE_PAYLOAD, "Response had content-length"),
+                             new TestCase(CloseTime.DURING_RESPONSE_PAYLOAD, "Response had content-length"));
+    }
+
+    @AfterEach
+    public void teardown() throws InterruptedException {
+        if (server != null) {
+            server.shutdown();
+        }
+        server = null;
+
+        if (netty != null) {
+            netty.close();
+        }
+        netty = null;
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    public void closeTimeHasCorrectMessage(TestCase testCase) throws Exception {
+        setupTestCase(testCase);
+        server.closeTime = testCase.closeTime;
+        assertThat(captureException()).hasMessageContaining(testCase.errorMessageSubstring);
+    }
+
+    public void setupTestCase(TestCase testCase) throws Exception {
+        server = new Server();
+        server.init(testCase.closeTime);
+
+        netty = NettyNioAsyncHttpClient.builder()
+                                       .readTimeout(Duration.ofMillis(500))
+                                       .eventLoopGroup(SdkEventLoopGroup.builder().numberOfThreads(3).build())
+                                       .protocol(Protocol.HTTP1_1)
+                                       .buildWithDefaults(AttributeMap.builder().put(TRUST_ALL_CERTIFICATES, true).build());
+    }
+
+    private Throwable captureException() {
+        try {
+            sendGetRequest().get(10, TimeUnit.SECONDS);
+        } catch (InterruptedException | TimeoutException e) {
+            throw new Error(e);
+        } catch (ExecutionException e) {
+            return e.getCause();
+        }
+
+        throw new AssertionError("Call did not fail as expected.");
+    }
+
+    private CompletableFuture<Void> sendGetRequest() {
+        AsyncExecuteRequest req = AsyncExecuteRequest.builder()
+                                                     .responseHandler(new SdkAsyncHttpResponseHandler() {
+                                                         private SdkHttpResponse headers;
+
+                                                         @Override
+                                                         public void onHeaders(SdkHttpResponse headers) {
+                                                             this.headers = headers;
+                                                         }
+
+                                                         @Override
+                                                         public void onStream(Publisher<ByteBuffer> stream) {
+                                                             Flowable.fromPublisher(stream).forEach(b -> {
+                                                             });
+                                                         }
+
+                                                         @Override
+                                                         public void onError(Throwable error) {
+                                                         }
+                                                     })
+                                                     .request(SdkHttpFullRequest.builder()
+                                                                                .method(SdkHttpMethod.GET)
+                                                                                .protocol("https")
+                                                                                .host("localhost")
+                                                                                .port(server.port())
+                                                                                .build())
+                                                     .requestContentPublisher(new EmptyPublisher())
+                                                     .build();
+
+        return netty.execute(req);
+    }
+
+    private static class TestCase {
+        private CloseTime closeTime;
+        private String errorMessageSubstring;
+
+        private TestCase(CloseTime closeTime, String errorMessageSubstring) {
+            this.closeTime = closeTime;
+            this.errorMessageSubstring = errorMessageSubstring;
+        }
+
+        @Override
+        public String toString() {
+            return "Closure " + closeTime;
+        }
+    }
+
+    private enum CloseTime {
+        DURING_INIT,
+
+        BEFORE_SSL_HANDSHAKE,
+        DURING_SSL_HANDSHAKE,
+
+        BEFORE_REQUEST_PAYLOAD,
+        DURING_REQUEST_PAYLOAD,
+
+        BEFORE_RESPONSE_HEADERS,
+        BEFORE_RESPONSE_PAYLOAD,
+        DURING_RESPONSE_PAYLOAD
+    }
+
+    private static class Server extends ChannelInitializer<Channel> {
+        private final NioEventLoopGroup group = new NioEventLoopGroup();
+        private CloseTime closeTime;
+        private ServerBootstrap bootstrap;
+        private ServerSocketChannel serverSock;
+        private SslContext sslCtx;
+
+        private void init(CloseTime closeTime) throws Exception {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+
+            bootstrap = new ServerBootstrap()
+                .channel(NioServerSocketChannel.class)
+                .group(group)
+                .childHandler(this);
+
+            serverSock = (ServerSocketChannel) bootstrap.bind(0).sync().channel();
+            this.closeTime = closeTime;
+        }
+
+        public int port() {
+            return serverSock.localAddress().getPort();
+        }
+
+        public void shutdown() throws InterruptedException {
+            group.shutdownGracefully().await();
+            serverSock.close();
+        }
+
+        @Override
+        protected void initChannel(Channel ch) {
+            LOGGER.info(() -> "Initializing channel " + ch);
+
+            if (closeTime == CloseTime.DURING_INIT) {
+                LOGGER.info(() -> "Closing channel during initialization " + ch);
+                ch.close();
+                return;
+            }
+
+            ChannelPipeline pipeline = ch.pipeline();
+            pipeline.addLast(new SslHandler(new FaultInjectionSslEngine(sslCtx.newEngine(ch.alloc()), ch), false));
+            pipeline.addLast(new HttpServerCodec());
+            pipeline.addLast(new FaultInjectionHttpHandler());
+
+            LOGGER.info(() -> "Channel initialized " + ch);
+        }
+
+        private class FaultInjectionSslEngine extends DelegatingSslEngine {
+            private final Channel channel;
+            private volatile boolean closed = false;
+
+            public FaultInjectionSslEngine(SSLEngine delegate, Channel channel) {
+                super(delegate);
+                this.channel = channel;
+            }
+
+            @Override
+            public SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts, int offset, int length) throws SSLException {
+                handleBeforeFailures();
+                return super.unwrap(src, dsts, offset, length);
+            }
+
+            @Override
+            public SSLEngineResult wrap(ByteBuffer[] srcs, int offset, int length, ByteBuffer dst) throws SSLException {
+                handleBeforeFailures();
+                return super.wrap(srcs, offset, length, dst);
+            }
+
+            private void handleBeforeFailures() {
+                if (getHandshakeStatus() == NOT_HANDSHAKING && closeTime == CloseTime.BEFORE_SSL_HANDSHAKE) {
+                    closeChannel("Closing channel before handshake " + channel);
+                }
+
+                if ((getHandshakeStatus() == NEED_WRAP || getHandshakeStatus() == NEED_TASK || getHandshakeStatus() == NEED_UNWRAP)
+                    && closeTime == CloseTime.DURING_SSL_HANDSHAKE) {
+                    closeChannel("Closing channel during handshake " + channel);
+                }
+            }
+
+            private void closeChannel(String message) {
+                if (!closed) {
+                    LOGGER.info(() -> message);
+                    closed = true;
+                    channel.close();
+                }
+            }
+        }
+
+        private class FaultInjectionHttpHandler extends SimpleChannelInboundHandler<Object> {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                LOGGER.info(() -> "Reading " + msg);
+
+                if (msg instanceof HttpRequest) {
+                    if (closeTime == CloseTime.BEFORE_REQUEST_PAYLOAD) {
+                        LOGGER.info(() -> "Closing channel before request payload " + ctx.channel());
+                        ctx.channel().disconnect();
+                        return;
+                    }
+                }
+
+                if (msg instanceof HttpContent) {
+                    if (closeTime == CloseTime.DURING_REQUEST_PAYLOAD) {
+                        LOGGER.info(() -> "Closing channel during request payload handling " + ctx.channel());
+                        ctx.close();
+                        return;
+                    }
+
+                    if (msg instanceof LastHttpContent) {
+                        if (closeTime == CloseTime.BEFORE_RESPONSE_HEADERS) {
+                            LOGGER.info(() -> "Closing channel before response headers " + ctx.channel());
+                            ctx.close();
+                            return;
+                        }
+
+                        writeResponse(ctx);
+                    }
+                }
+            }
+
+            private void writeResponse(ChannelHandlerContext ctx) {
+                int responseLength = 10 * 1024 * 1024; // 10 MB
+                HttpHeaders headers = new DefaultHttpHeaders().add("Content-Length", responseLength);
+                ctx.writeAndFlush(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, headers)).addListener(x -> {
+                    if (closeTime == CloseTime.BEFORE_RESPONSE_PAYLOAD) {
+                        LOGGER.info(() -> "Closing channel before response payload " + ctx.channel());
+                        ctx.close();
+                        return;
+                    }
+
+                    ByteBuf firstPartOfResponsePayload = ctx.alloc().buffer(1);
+                    firstPartOfResponsePayload.writeByte(0);
+                    ctx.writeAndFlush(new DefaultHttpContent(firstPartOfResponsePayload)).addListener(x2 -> {
+                        if (closeTime == CloseTime.DURING_RESPONSE_PAYLOAD) {
+                            LOGGER.info(() -> "Closing channel during response payload handling " + ctx.channel());
+                            ctx.close();
+                            return;
+                        }
+
+                        ByteBuf lastPartOfResponsePayload = ctx.alloc().buffer(responseLength - 1);
+                        lastPartOfResponsePayload.writeBytes(new byte[responseLength - 1]);
+                        ctx.writeAndFlush(new DefaultLastHttpContent(lastPartOfResponsePayload))
+                           .addListener(ChannelFutureListener.CLOSE);
+                    });
+                });
+            }
+        }
+    }
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -420,6 +420,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
             <scope>test</scope>

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkAsyncHttpClientH1TestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkAsyncHttpClientH1TestSuite.java
@@ -17,15 +17,12 @@ package software.amazon.awssdk.http;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
-import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -45,7 +42,6 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -133,7 +129,6 @@ public abstract class SdkAsyncHttpClientH1TestSuite {
     }
 
     private static class Server extends ChannelInitializer<Channel> {
-        private static final byte[] CONTENT = "helloworld".getBytes(StandardCharsets.UTF_8);
         private ServerBootstrap bootstrap;
         private ServerSocketChannel serverSock;
         private List<Channel> channels = new ArrayList<>();
@@ -185,12 +180,8 @@ public abstract class SdkAsyncHttpClientH1TestSuite {
                         status = OK;
                     }
 
-                    FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status,
-                                                                            Unpooled.wrappedBuffer(CONTENT));
-
-                    response.headers()
-                            .set(CONTENT_TYPE, TEXT_PLAIN)
-                            .setInt(CONTENT_LENGTH, response.content().readableBytes());
+                    FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status);
+                    response.headers().set(CONTENT_LENGTH, 0);
 
                     if (closeConnection) {
                         response.headers().set(CONNECTION, CLOSE);


### PR DESCRIPTION
…vice actually returns.

Also update error messaging in the event of service-side connection closes, and add testing to protect these error messages against regression.