### PR TITLE
Set response handler for eventstream request

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7564897.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7564897.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix an issue where the error response handler is not set for eventstream operations on XML services, for example `SelectObjectContent` for Amazon S3."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
@@ -195,7 +195,8 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                .add(".withMarshaller($L)\n", asyncMarshaller(intermediateModel, opModel, marshaller, "protocolFactory"));
 
         if (opModel.hasEventStreamOutput()) {
-            builder.add(".withResponseHandler(responseHandler)");
+            builder.add(".withResponseHandler(responseHandler)")
+                   .add(".withErrorResponseHandler(errorResponseHandler)");
         } else {
             builder.add(".withCombinedResponseHandler(responseHandler)");
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -263,8 +263,9 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
                 new ClientExecutionParams<EventStreamOperationRequest, EventStreamOperationResponse>()
                     .withOperationName("EventStreamOperation")
                     .withMarshaller(new EventStreamOperationRequestMarshaller(protocolFactory))
-                    .withResponseHandler(responseHandler).withMetricCollector(apiCallMetricCollector)
-                    .withInput(eventStreamOperationRequest), restAsyncResponseTransformer);
+                    .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                    .withMetricCollector(apiCallMetricCollector).withInput(eventStreamOperationRequest),
+                restAsyncResponseTransformer);
             CompletableFuture<Void> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
                 if (e != null) {


### PR DESCRIPTION
## Motivation and Context
Bug fix.

## Description
Fix an issue where the code generator does not set the error response handler
when generating code for handling an eventstream response for XML protocol
services.

## Testing
- New integration and protocol tests
- Verified diff of generated source

Checked the diffs of the 3 `REST-XML` services, S3, CloudFront, Route53, before and after the fix. Only `DefaultAmazonS3AsyncClient.java` had any diffs, which is expected.

```
diff -qr pre-fix post-fix

Files pre-fix/sdk/software/amazon/awssdk/services/s3/DefaultS3AsyncClient.java and post-fix/sdk/software/amazon/awssdk/services/s3/DefaultS3AsyncClient.java differ
```

```
diff pre-fix/sdk/software/amazon/awssdk/services/s3/DefaultS3AsyncClient.java post-fix/sdk/software/amazon/awssdk/services/s3/DefaultS3AsyncClient.java
```

```diff

11222,11223c11222,11224
<                             .withResponseHandler(responseHandler).withMetricCollector(apiCallMetricCollector)
<                             .withInput(selectObjectContentRequest), restAsyncResponseTransformer);
---
>                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
>                             .withMetricCollector(apiCallMetricCollector).withInput(selectObjectContentRequest),
>                     restAsyncResponseTransformer);
```


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
