### PR TITLE
Set tableSchema to chained extensions read context

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-820a3eb.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-820a3eb.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "alvinsee", 
+    "type": "bugfix", 
+    "description": "sets tableSchema field when provisioning the extension context in ChainExtension#afterRead"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/extensions/ChainExtension.java
@@ -152,6 +152,7 @@ public final class ChainExtension implements DynamoDbEnhancedClientExtension {
                 DefaultDynamoDbExtensionContext.builder().items(itemToTransform)
                                                .operationContext(context.operationContext())
                                                .tableMetadata(context.tableMetadata())
+                                               .tableSchema(context.tableSchema())
                                                .build();
 
             ReadModification readModification = iterator.next().afterRead(afterRead);

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
@@ -276,6 +276,7 @@ public class ChainExtensionTest {
         DefaultDynamoDbExtensionContext.Builder context =
             DefaultDynamoDbExtensionContext.builder()
                                            .tableMetadata(FakeItem.getTableMetadata())
+                                           .tableSchema(FakeItem.getTableSchema())
                                            .operationContext(PRIMARY_CONTEXT)
                                            .items(fakeItems.get(i));
         if (operationName != null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
DynamoDB Enhanced Client allows custom extensions to be installed. However, the behavior of the meta extension ChainExtension differs when providing a `DefaultDynamoDbExtensionContext` to each extension's invocation of `afterRead`. The [default behavior](https://github.com/aws/aws-sdk-java-v2/blob/620c4c5690d5109a26940262d988ddb35cf7ecc1/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java#L78) for a single extension (by ways of `VersionRecordExtension`) passes in the table schema to the builder. However, when two or more extensions are specified, `ChainExtension` omits the table schema entirely when it does the delegation. This breaks any custom extension that might require inferring the table schema in a read operation.

## Description
- sets `tableSchema` field when provisioning the extension context in `ChainExtension#afterRead`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
