### PR TITLE
Adding @Deprecated annotation when API is marked as deprecated

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java
@@ -155,6 +155,7 @@ final class AddOperations {
 
             operationModel.setOperationName(operationName);
             operationModel.setDeprecated(op.isDeprecated());
+            operationModel.setDeprecatedMessage(op.getDeprecatedMessage());
             operationModel.setDocumentation(op.getDocumentation());
             operationModel.setIsAuthenticated(isAuthenticated(op));
             operationModel.setAuthType(op.getAuthtype());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/OperationModel.java
@@ -32,6 +32,8 @@ public class OperationModel extends DocumentationModel {
 
     private boolean deprecated;
 
+    private String deprecatedMessage;
+
     private VariableModel input;
 
     private ReturnTypeModel returnType;
@@ -82,6 +84,14 @@ public class OperationModel extends DocumentationModel {
 
     public void setDeprecated(boolean deprecated) {
         this.deprecated = deprecated;
+    }
+
+    public String getDeprecatedMessage() {
+        return deprecatedMessage;
+    }
+
+    public void setDeprecatedMessage(String deprecatedMessage) {
+        this.deprecatedMessage = deprecatedMessage;
     }
 
     public String getDocs(IntermediateModel model,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Operation.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/Operation.java
@@ -24,6 +24,8 @@ public class Operation {
 
     private boolean deprecated;
 
+    private String deprecatedMessage;
+
     private Http http;
 
     private Input input;
@@ -65,6 +67,14 @@ public class Operation {
 
     public void setDeprecated(boolean deprecated) {
         this.deprecated = deprecated;
+    }
+
+    public String getDeprecatedMessage() {
+        return deprecatedMessage;
+    }
+
+    public void setDeprecatedMessage(String deprecatedMessage) {
+        this.deprecatedMessage = deprecatedMessage;
     }
 
     public Http getHttp() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
+import software.amazon.awssdk.codegen.poet.model.DeprecationUtils;
 import software.amazon.awssdk.codegen.utils.PaginatorUtils;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -179,7 +180,9 @@ public class AsyncClientInterface implements ClassSpec {
         methods.addAll(traditionalMethods(operationModel));
         methods.addAll(overloadMethods(operationModel));
         methods.addAll(paginatedMethods(operationModel));
-        return methods.stream();
+        return methods.stream()
+                      // Add Deprecated annotation if needed to all overloads
+                      .map(m -> DeprecationUtils.checkDeprecated(operationModel, m));
     }
 
     private List<MethodSpec> paginatedMethods(OperationModel opModel) {
@@ -406,7 +409,7 @@ public class AsyncClientInterface implements ClassSpec {
      */
     private MethodSpec.Builder interfaceMethodSignature(OperationModel opModel) {
         return methodSignatureWithReturnType(opModel)
-                .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT);
+            .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT);
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -64,6 +64,7 @@ final class ClientClassUtils {
         MethodSpec.Builder result = MethodSpec.methodBuilder(spec.name)
                                               .returns(spec.returnType)
                                               .addExceptions(spec.exceptions)
+                                              .addAnnotations(spec.annotations)
                                               .addJavadoc(javadoc)
                                               .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                                               .addTypeVariables(spec.typeVariables)

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientInterface.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtensions;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.codegen.poet.model.DeprecationUtils;
 import software.amazon.awssdk.codegen.utils.PaginatorUtils;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -176,7 +177,10 @@ public final class SyncClientInterface implements ClassSpec {
         methods.addAll(streamingSimpleMethods(opModel));
         methods.addAll(paginatedMethods(opModel));
 
-        return methods;
+        return methods.stream()
+                      // Add Deprecated annotation if needed to all overloads
+                      .map(m -> DeprecationUtils.checkDeprecated(opModel, m))
+                      .collect(toList());
     }
 
     private MethodSpec simpleMethod(OperationModel opModel) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/DeprecationUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/DeprecationUtils.java
@@ -22,6 +22,7 @@ import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.MethodSpec;
 import java.util.List;
 import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.utils.StringUtils;
 
 public final class DeprecationUtils {
@@ -44,6 +45,24 @@ public final class DeprecationUtils {
             builder.addJavadoc(LF + "@deprecated");
             if (StringUtils.isNotBlank(member.getDeprecatedMessage())) {
                 builder.addJavadoc(" $L", member.getDeprecatedMessage());
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * If a given operation is modeled as deprecated, add the {@link Deprecated} annotation to the method and, if the method
+     * already has existing Javadoc, append a section with the {@code @deprecated} tag.
+     */
+    public static MethodSpec checkDeprecated(OperationModel operation, MethodSpec method) {
+        if (!operation.isDeprecated() || method.annotations.contains(DEPRECATED)) {
+            return method;
+        }
+        MethodSpec.Builder builder = method.toBuilder().addAnnotation(DEPRECATED);
+        if (!method.javadoc.isEmpty()) {
+            builder.addJavadoc(LF + "@deprecated");
+            if (StringUtils.isNotBlank(operation.getDeprecatedMessage())) {
+                builder.addJavadoc(" $L", operation.getDeprecatedMessage());
             }
         }
         return builder.build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/service-2.json
@@ -39,6 +39,8 @@
           "shape": "InvalidInputException"
         }
       ],
+      "deprecated": true,
+      "deprecatedMessage": "This API is deprecated, use something else",
       "documentation": "<p>Performs a post operation to the query service and has no output</p>"
     },
     "GetWithoutRequiredMembers": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -95,7 +95,10 @@ public interface JsonAsyncClient extends SdkClient {
      * @sample JsonAsyncClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
+     *
+     * @deprecated This API is deprecated, use something else
      */
+    @Deprecated
     default CompletableFuture<APostOperationResponse> aPostOperation(APostOperationRequest aPostOperationRequest) {
         throw new UnsupportedOperationException();
     }
@@ -128,7 +131,10 @@ public interface JsonAsyncClient extends SdkClient {
      * @sample JsonAsyncClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
+     *
+     * @deprecated This API is deprecated, use something else
      */
+    @Deprecated
     default CompletableFuture<APostOperationResponse> aPostOperation(Consumer<APostOperationRequest.Builder> aPostOperationRequest) {
         return aPostOperation(APostOperationRequest.builder().applyMutation(aPostOperationRequest).build());
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-interface.java
@@ -88,7 +88,10 @@ public interface JsonClient extends SdkClient {
      * @sample JsonClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
+     *
+     * @deprecated This API is deprecated, use something else
      */
+    @Deprecated
     default APostOperationResponse aPostOperation(APostOperationRequest aPostOperationRequest) throws InvalidInputException,
                                                                                                       AwsServiceException, SdkClientException, JsonException {
         throw new UnsupportedOperationException();
@@ -119,7 +122,10 @@ public interface JsonClient extends SdkClient {
      * @sample JsonClient.APostOperation
      * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/APostOperation" target="_top">AWS
      *      API Documentation</a>
+     *
+     * @deprecated This API is deprecated, use something else
      */
+    @Deprecated
     default APostOperationResponse aPostOperation(Consumer<APostOperationRequest.Builder> aPostOperationRequest)
         throws InvalidInputException, AwsServiceException, SdkClientException, JsonException {
         return aPostOperation(APostOperationRequest.builder().applyMutation(aPostOperationRequest).build());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change generates the @Deprecated annotation for all APIs marked as deprecated in the C2J model.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This adds clear guidance for deprecated APIs in the IDE.

<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Modifications
<!--- Describe your changes in detail -->
Modifies the code generator to add the @Deprecated annotation to client/interface methods that correspond to a deprecated API.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added deprecated trait to one of the existing poet test models and modified expected generation files.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x ] Local run of `mvn install` succeeds
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x ] I have added tests to cover my changes
- [x ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x ] I confirm that this pull request can be released under the Apache 2 license
