### PR TITLE
A couple of minor refactoring on the S3TransferManager

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-2f34394.json
+++ b/.changes/next-release/bugfix-S3TransferManager-2f34394.json
@@ -1,0 +1,6 @@
+{
+    "category": "S3 Transfer Manager", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "A couple of minor refactoring on the S3TransferManager. 1. `CompletedDirectoryUpload#failedTransfers` now returns `List<FailedFileUpload>` instead of `Collection<FailedFileUpload>`. 2. `UploadDirectoryOverrideConfiguration#uploadFileRequestTransformer` now returns `Consumer<UploadFileRequest.Builder>` instead of `Optional<Consumer<UploadFileRequest.Builder>>` it will be no-op if no uploadFileRequestTransformer is provided"
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/CompletedDirectoryDownload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/CompletedDirectoryDownload.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.transfer.s3;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -38,15 +39,15 @@ public final class CompletedDirectoryDownload implements CompletedDirectoryTrans
                                                          ToCopyableBuilder<CompletedDirectoryDownload.Builder,
                                                              CompletedDirectoryDownload> {
 
-    private final Collection<FailedFileDownload> failedTransfers;
+    private final List<FailedFileDownload> failedTransfers;
 
     private CompletedDirectoryDownload(DefaultBuilder builder) {
-        this.failedTransfers = Collections.unmodifiableCollection(
+        this.failedTransfers = Collections.unmodifiableList(
             new ArrayList<>(Validate.paramNotNull(builder.failedTransfers, "failedTransfers")));
     }
 
     @Override
-    public Collection<FailedFileDownload> failedTransfers() {
+    public List<FailedFileDownload> failedTransfers() {
         return failedTransfers;
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/CompletedDirectoryTransfer.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/CompletedDirectoryTransfer.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3;
 
-import java.util.Collection;
+import java.util.List;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
@@ -34,5 +34,5 @@ public interface CompletedDirectoryTransfer extends CompletedTransfer {
      *
      * @return an immutable list of failed transfers
      */
-    Collection<? extends FailedObjectTransfer> failedTransfers();
+    List<? extends FailedObjectTransfer> failedTransfers();
 }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/CompletedDirectoryUpload.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/CompletedDirectoryUpload.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.transfer.s3;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -38,15 +39,15 @@ public final class CompletedDirectoryUpload implements CompletedDirectoryTransfe
                                                        ToCopyableBuilder<CompletedDirectoryUpload.Builder,
                                                            CompletedDirectoryUpload> {
     
-    private final Collection<FailedFileUpload> failedTransfers;
+    private final List<FailedFileUpload> failedTransfers;
 
     private CompletedDirectoryUpload(DefaultBuilder builder) {
-        this.failedTransfers = Collections.unmodifiableCollection(
+        this.failedTransfers = Collections.unmodifiableList(
             new ArrayList<>(Validate.paramNotNull(builder.failedTransfers, "failedTransfers")));
     }
     
     @Override
-    public Collection<FailedFileUpload> failedTransfers() {
+    public List<FailedFileUpload> failedTransfers() {
         return failedTransfers;
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/DownloadDirectoryOverrideConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/DownloadDirectoryOverrideConfiguration.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.transfer.s3;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
@@ -45,11 +44,11 @@ public final class DownloadDirectoryOverrideConfiguration implements ToCopyableB
     }
 
     /**
-     * @return the optional download request transformer
+     * @return the download request transformer if not null, otherwise no-op
      * @see DownloadDirectoryOverrideConfiguration.Builder#downloadFileRequestTransformer(Consumer)
      */
-    public Optional<Consumer<DownloadFileRequest.Builder>> downloadFileRequestTransformer() {
-        return Optional.ofNullable(downloadFileRequestTransformer);
+    public Consumer<DownloadFileRequest.Builder> downloadFileRequestTransformer() {
+        return downloadFileRequestTransformer == null ? ignore -> { } : downloadFileRequestTransformer;
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/UploadDirectoryOverrideConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/UploadDirectoryOverrideConfiguration.java
@@ -75,11 +75,11 @@ public final class UploadDirectoryOverrideConfiguration implements ToCopyableBui
     }
 
     /**
-     * @return the optional upload request transformer
+     * @return the upload request transformer if not null, otherwise no-op
      * @see UploadDirectoryOverrideConfiguration.Builder#uploadFileRequestTransformer(Consumer)
      */
-    public Optional<Consumer<UploadFileRequest.Builder>> uploadFileRequestTransformer() {
-        return Optional.ofNullable(uploadFileRequestTransformer);
+    public Consumer<UploadFileRequest.Builder> uploadFileRequestTransformer() {
+        return uploadFileRequestTransformer == null ? ignore -> { } : uploadFileRequestTransformer;
     }
 
     @Override

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelper.java
@@ -237,7 +237,7 @@ public class UploadDirectoryHelper {
                                                                     .putObjectRequest(putObjectRequest);
 
         uploadDirectoryRequest.overrideConfiguration()
-                              .flatMap(UploadDirectoryOverrideConfiguration::uploadFileRequestTransformer)
+                              .map(UploadDirectoryOverrideConfiguration::uploadFileRequestTransformer)
                               .ifPresent(c -> c.accept(requestBuilder));
 
         return requestBuilder.build();

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/DownloadDirectoryOverrideConfigurationTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/DownloadDirectoryOverrideConfigurationTest.java
@@ -15,31 +15,10 @@
 
 package software.amazon.awssdk.transfer.s3;
 
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.nio.file.Paths;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 class DownloadDirectoryOverrideConfigurationTest {
-
-    @Test
-    void defaultBuilder() {
-        DownloadDirectoryOverrideConfiguration configuration =
-            DownloadDirectoryOverrideConfiguration.builder()
-                                                  .build();
-        assertThat(configuration.downloadFileRequestTransformer()).isEmpty();
-    }
-
-    @Test
-    void defaultBuilderWithPropertySet() {
-        DownloadDirectoryOverrideConfiguration configuration =
-            DownloadDirectoryOverrideConfiguration.builder()
-                .downloadFileRequestTransformer((request -> request.destination(Paths.get("."))))
-                                                  .build();
-        assertThat(configuration.downloadFileRequestTransformer()).isNotEmpty();
-    }
 
     @Test
     void equalsHashCode() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
1. `CompletedDirectoryUpload#failedTransfers` now returns `List<FailedFileUpload>` instead of `Collection<FailedFileUpload>`. 

2. `UploadDirectoryOverrideConfiguration#uploadFileRequestTransformer` now returns `Consumer<UploadFileRequest.Builder>` instead of `Optional<Consumer<UploadFileRequest.Builder>>` it will be no-op if no uploadFileRequestTransformer is provided

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
