### PR TITLE
Only include non-null Extended Request IDs in exception messages

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d9ba0a4.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d9ba0a4.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Only include non-null Extended Request IDs in exception messages"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.awscore.exception;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.StringJoiner;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.awscore.internal.AwsErrorCode;
 import software.amazon.awssdk.awscore.internal.AwsStatusCode;
@@ -62,11 +63,14 @@ public class AwsServiceException extends SdkServiceException {
     @Override
     public String getMessage() {
         if (awsErrorDetails != null) {
-            return awsErrorDetails().errorMessage() +
-                    " (Service: " + awsErrorDetails().serviceName() +
-                    ", Status Code: " + statusCode() +
-                    ", Request ID: " + requestId() +
-                    ", Extended Request ID: " + extendedRequestId() + ")";
+            StringJoiner details = new StringJoiner(", ", "(", ")");
+            details.add("Service: " + awsErrorDetails().serviceName());
+            details.add("Status Code: " + statusCode());
+            details.add("Request ID: " + requestId());
+            if (extendedRequestId() != null) {
+                details.add("Extended Request ID: " + extendedRequestId());
+            }
+            return awsErrorDetails().errorMessage() + " " + details;
         }
 
         return super.getMessage();

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
@@ -52,6 +52,36 @@ public class AwsServiceExceptionTest {
         assertSkewed(SKEWED_SECONDS, "", 403, unskewedDate);
     }
 
+    @Test
+    public void exceptionMessage_withExtendedRequestId() {
+        AwsServiceException e = AwsServiceException.builder()
+                                                   .awsErrorDetails(AwsErrorDetails.builder()
+                                                                                   .errorMessage("errorMessage")
+                                                                                   .serviceName("serviceName")
+                                                                                   .errorCode("errorCode")
+                                                                                   .build())
+                                                   .statusCode(500)
+                                                   .requestId("requestId")
+                                                   .extendedRequestId("extendedRequestId")
+                                                   .build();
+        assertThat(e.getMessage()).isEqualTo("errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId, " 
+                                             + "Extended Request ID: extendedRequestId)");
+    }
+
+    @Test
+    public void exceptionMessage_withoutExtendedRequestId() {
+        AwsServiceException e = AwsServiceException.builder()
+                                                   .awsErrorDetails(AwsErrorDetails.builder()
+                                                                                   .errorMessage("errorMessage")
+                                                                                   .serviceName("serviceName")
+                                                                                   .errorCode("errorCode")
+                                                                                   .build())
+                                                   .statusCode(500)
+                                                   .requestId("requestId")
+                                                   .build();
+        assertThat(e.getMessage()).isEqualTo("errorMessage (Service: serviceName, Status Code: 500, Request ID: requestId)");
+    }
+
     public void assertSkewed(int clientSideTimeOffset,
                              String errorCode,
                              int statusCode,


### PR DESCRIPTION
Currently, every `AwsServiceException` message contains a field for the `"Extended Request ID"`, even though only a minority of services actually utilize two request IDs. Explicitly mentioning `"Extended Request ID: null"` may cause it to appear like the extended request ID is missing, even if it was not expected in the response. Beyond being potentially misleading, it also contributes to making the core exception wording more verbose than it needs to be.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
