### PR TITLE
Improve documentation & add warnings for FUTURE_COMPLETION_EXECUTOR

### DIFF
--- a/.changes/next-release/documentation-AWSSDKforJavav2-af5702d.json
+++ b/.changes/next-release/documentation-AWSSDKforJavav2-af5702d.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "documentation", 
+    "description": "Improve documentation & add warnings for FUTURE_COMPLETION_EXECUTOR"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
@@ -46,7 +46,7 @@ public final class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
      *     or sharing a single pool between multiple clients.
      *     <li>You want to add instrumentation (i.e., metrics) around how the {@link Executor} is used.
      *     <li>You know, for certain, that all of your {@link CompletableFuture} usage is strictly non-blocking, and you wish to
-     *     remove the minor overhead incurred by using a separate {@link Executor}. In this case, you can use
+     *     remove the minor overhead incurred by using a separate thread. In this case, you can use
      *     {@code Runnable::run} to execute the future-completion directly from within the I/O thread.
      * </ol>
      */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkAdvancedAsyncClientOption.java
@@ -36,18 +36,18 @@ public final class SdkAdvancedAsyncClientOption<T> extends ClientOption<T> {
      * Configure the {@link Executor} that should be used to complete the {@link CompletableFuture} that is returned by the async
      * service client. By default, this is a dedicated, per-client {@link ThreadPoolExecutor} that is managed by the SDK.
      * <p>
-     * The configured {@link Executor} will be invoked by the async HTTP client's I/O threads (i.e., EventLoops), which must be
+     * The configured {@link Executor} will be invoked by the async HTTP client's I/O threads (e.g., EventLoops), which must be
      * reserved for non-blocking behavior. Blocking an I/O thread can cause severe performance degradation, including across
-     * multiple clients, as clients are configured, by default, to share a single I/O thread pool (i.e., EventLoopGroup).
+     * multiple clients, as clients are configured, by default, to share a single I/O thread pool (e.g., EventLoopGroup).
      * <p>
      * You should typically only want to customize the future-completion {@link Executor} for a few possible reasons:
      * <ol>
-     *     <li>You know, for certain, that all of your {@link CompletableFuture} usage is strictly non-blocking, and you wish to
-     *     remove the minor overhead incurred by using a separate {@link Executor}. In this case, you can use
-     *     {@code Runnable::run} to execute the future-completion directly from within the I/O thread.
      *     <li>You want more fine-grained control over the {@link ThreadPoolExecutor} used, such as configuring the pool size
      *     or sharing a single pool between multiple clients.
      *     <li>You want to add instrumentation (i.e., metrics) around how the {@link Executor} is used.
+     *     <li>You know, for certain, that all of your {@link CompletableFuture} usage is strictly non-blocking, and you wish to
+     *     remove the minor overhead incurred by using a separate {@link Executor}. In this case, you can use
+     *     {@code Runnable::run} to execute the future-completion directly from within the I/O thread.
      * </ol>
      */
     public static final SdkAdvancedAsyncClientOption<Executor> FUTURE_COMPLETION_EXECUTOR =


### PR DESCRIPTION
This enhances the documentation around `SdkAdvancedAsyncClientOption#FUTURE_COMPLETION_EXECUTOR` to more clearly explain its usage and to warn of potential negative side effects if it is misconfigured or misused.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license