### PR TITLE
Add support for producing EnhancedType with tableSchema from Sets

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -262,6 +263,12 @@ public final class BeanTableSchema<T> extends WrappedTableSchema<T, StaticTableS
                 EnhancedType<?> enhancedType = convertTypeToEnhancedType(parameterizedType.getActualTypeArguments()[0],
                                                                          metaTableSchemaCache, attributeConfiguration);
                 return EnhancedType.listOf(enhancedType);
+            }
+
+            if (Set.class.equals(rawType)) {
+                EnhancedType<?> enhancedType = convertTypeToEnhancedType(parameterizedType.getActualTypeArguments()[0],
+                                                                         metaTableSchemaCache, attributeConfiguration);
+                return EnhancedType.setOf(enhancedType);
             }
 
             if (Map.class.equals(rawType)) {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchemaTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchemaTest.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -288,6 +289,33 @@ public class BeanTableSchemaTest {
         assertThat(itemMap, hasEntry("id", stringValue("id-value")));
         assertThat(itemMap, hasEntry("attribute1", stringValue("one")));
         assertThat(itemMap, hasEntry("abstractBeanList", expectedList));
+    }
+
+    @Test
+    public void documentBean_set_correctlyMapsBeanAttributes() {
+        BeanTableSchema<DocumentBean> beanTableSchema = BeanTableSchema.create(DocumentBean.class);
+        AbstractBean abstractBean1 = new AbstractBean();
+        abstractBean1.setAttribute2("two");
+        AbstractBean abstractBean2 = new AbstractBean();
+        abstractBean2.setAttribute2("three");
+        DocumentBean documentBean = new DocumentBean();
+        documentBean.setId("id-value");
+        documentBean.setAttribute1("one");
+        documentBean.setAbstractBeanSet(new HashSet(Arrays.asList(abstractBean1, abstractBean2)));
+
+        AttributeValue expectedDocument1 = AttributeValue.builder()
+                                                        .m(singletonMap("attribute2", stringValue("two")))
+                                                        .build();
+        AttributeValue expectedDocument2 = AttributeValue.builder()
+                                                         .m(singletonMap("attribute2", stringValue("three")))
+                                                         .build();
+        AttributeValue expectedSet = AttributeValue.builder().l(expectedDocument1, expectedDocument2).build();
+
+        Map<String, AttributeValue> itemMap = beanTableSchema.itemToMap(documentBean, true);
+        assertThat(itemMap.size(), is(3));
+        assertThat(itemMap, hasEntry("id", stringValue("id-value")));
+        assertThat(itemMap, hasEntry("attribute1", stringValue("one")));
+        assertThat(itemMap, hasEntry("abstractBeanSet", expectedSet));
     }
 
     @Test

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/DocumentBean.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/mapper/testbeans/DocumentBean.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.enhanced.dynamodb.mapper.testbeans;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
@@ -30,6 +31,8 @@ public class DocumentBean {
     private List<AbstractImmutable> abstractImmutableList;
     private Map<String, AbstractBean> abstractBeanMap;
     private Map<String, AbstractImmutable> abstractImmutableMap;
+    private Set<AbstractBean> abstractBeanSet;
+    private Set<AbstractImmutable> abstractImmutableSet;
 
     @DynamoDbPartitionKey
     public String getId() {
@@ -60,6 +63,13 @@ public class DocumentBean {
         this.abstractBeanList = abstractBeanList;
     }
 
+    public Set<AbstractBean> getAbstractBeanSet() {
+        return abstractBeanSet;
+    }
+    public void setAbstractBeanSet(Set<AbstractBean> abstractBeanSet) {
+        this.abstractBeanSet = abstractBeanSet;
+    }
+
     public Map<String, AbstractBean> getAbstractBeanMap() {
         return abstractBeanMap;
     }
@@ -79,6 +89,13 @@ public class DocumentBean {
     }
     public void setAbstractImmutableList(List<AbstractImmutable> abstractImmutableList) {
         this.abstractImmutableList = abstractImmutableList;
+    }
+
+    public Set<AbstractImmutable> getAbstractImmutableSet() {
+        return abstractImmutableSet;
+    }
+    public void setAbstractImmutableSet(Set<AbstractImmutable> abstractImmutableSet) {
+        this.abstractImmutableSet = abstractImmutableSet;
     }
 
     public Map<String, AbstractImmutable> getAbstractImmutableMap() {


### PR DESCRIPTION
## Motivation and Context
There's support for Sets in `DefaultAttributeConverterProvider`, but it was missing from `BeanTableSchema`. As a result, Sets always require a customer converter, but Lists do not. This adds support for `Set` in `BeanTableSchema`.

## Modifications
I added a stanza in `BeanTableSchema::convertTypeToEnhancedType` that checks if the type is a `Set`, and handles it analogously to how lists and maps are being handled. I also added a test modelled on the existing tests for list and map.

## Testing
I couldn't get the project building locally, so I haven't tested it.

## Screenshots (if appropriate)

## Types of changes
I don't know which of these it is. It seems like a bug, since there is support for `Set` half implemented, but it's not documented anywhere.
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [X] I confirm that this pull request can be released under the Apache 2 license
