### PR TITLE
…Create nonexistent parent directories in AsyncResponseTransformer#toF

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-5fdaf2b.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-5fdaf2b.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "`AsyncResponseTransformer#toFile` and `ResponseTransformer#toFile` will now create all nonexistent parent directories if they don't exist instead of throwing NoSuchFileException`"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncResponseTransformer.java
@@ -111,7 +111,7 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
     /**
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file. In the event of an error,
      * the SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an
-     * exception will be thrown.
+     * exception will be thrown. All nonexistent parent directories will be created.
      *
      * @param path        Path to file to write to.
      * @param <ResponseT> Pojo Response type.
@@ -124,7 +124,7 @@ public interface AsyncResponseTransformer<ResponseT, ResultT> {
     /**
      * Creates an {@link AsyncResponseTransformer} that writes all the content to the given file. In the event of an error,
      * the SDK will attempt to delete the file (whatever has been written to it so far). If the file already exists, an
-     * exception will be thrown.
+     * exception will be thrown. All nonexistent parent directories will be created.
      *
      * @param file        File to write to.
      * @param <ResponseT> Pojo Response type.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/sync/ResponseTransformer.java
@@ -93,7 +93,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
 
     /**
      * Creates a response transformer that writes all response content to the specified file. If the file already exists
-     * then a {@link java.nio.file.FileAlreadyExistsException} will be thrown.
+     * then a {@link java.nio.file.FileAlreadyExistsException} will be thrown. All nonexistent parent directories will be created.
      *
      * @param path        Path to file to write to.
      * @param <ResponseT> Type of unmarshalled response POJO.
@@ -103,6 +103,11 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
         return (resp, in) -> {
             try {
                 InterruptMonitor.checkInterrupted();
+                Path parentDirectory = path.getParent();
+                if (parentDirectory != null) {
+                    Files.createDirectories(parentDirectory);
+                }
+
                 Files.copy(in, path);
                 return resp;
             } catch (IOException copyException) {
@@ -135,7 +140,7 @@ public interface ResponseTransformer<ResponseT, ReturnT> {
 
     /**
      * Creates a response transformer that writes all response content to the specified file. If the file already exists
-     * then a {@link java.nio.file.FileAlreadyExistsException} will be thrown.
+     * then a {@link java.nio.file.FileAlreadyExistsException} will be thrown. All nonexistent parent directories will be created.
      *
      * @param file        File to write to.
      * @param <ResponseT> Type of unmarshalled response POJO.

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -77,6 +77,19 @@ public class FileAsyncResponseTransformerTest {
     }
 
     @Test
+    public void parentDirectoryNotExists_shouldCreate() {
+        Path testPath = testFs.getPath("test/test_file.txt");
+        FileAsyncResponseTransformer xformer = new FileAsyncResponseTransformer(testPath);
+
+        CompletableFuture prepareFuture = xformer.prepare();
+
+        xformer.onResponse(new Object());
+        xformer.onStream(new TestPublisher());
+
+        assertThat(prepareFuture.isCompletedExceptionally()).isFalse();
+    }
+
+    @Test
     public void synchronousPublisher_shouldNotHang() throws Exception {
         List<CompletableFuture> futures = new ArrayList<>();
 

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -136,5 +136,10 @@
             <artifactId>eventstream</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/GetObjectIntegrationTest.java
@@ -19,11 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
+import com.google.common.jimfs.Jimfs;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.UUID;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,7 +42,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.testutils.RandomTempFile;
 
 public class GetObjectIntegrationTest extends S3IntegrationTestBase {
-
+    private static FileSystem testFs;
     private static final String BUCKET = temporaryBucketName(GetObjectIntegrationTest.class);
 
     private static final String KEY = "some-key";
@@ -55,6 +58,7 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     @BeforeClass
     public static void setupFixture() throws IOException {
         createBucket(BUCKET);
+        testFs = Jimfs.newFileSystem();
         file = new RandomTempFile(10_000);
         s3.putObject(PutObjectRequest.builder()
                                      .bucket(BUCKET)
@@ -63,9 +67,10 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @AfterClass
-    public static void tearDownFixture() {
+    public static void tearDownFixture() throws IOException {
         deleteBucketAndAllContents(BUCKET);
         file.delete();
+        testFs.close();
     }
 
     @Test
@@ -96,6 +101,13 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
             assertEquals(Long.valueOf(path.toFile().length()), response.contentLength());
             path.toFile().delete();
         }
+    }
+
+    @Test
+    public void toFile_parentDirectoriesDoNotExist_shouldSucceed() throws Exception {
+        Path path = testFs.getPath(UUID.randomUUID().toString(), "test1", "test2", "test.txt");
+        s3.getObject(getObjectRequest, path);
+        assertThat(path).hasSameBinaryContentAs(file.toPath());
     }
 
     @Test


### PR DESCRIPTION
…ile and ResponseTransformer#toFile.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Currently, if the parent directory does not exist, `NoSuchFileException` is thrown, which is not a good customer experience.

## Modifications
Create nonexistent parent directories in `AsyncResponseTransformer#toFile`
and `ResponseTransformer#ToFile`

## Testing
Add unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
