### PR TITLE
Fix NPE in netty client

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-b5e47f7.json
+++ b/.changes/next-release/bugfix-NettyNIOAsyncHTTPClient-b5e47f7.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO Async HTTP Client", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed an issue in Netty async http client where NPE was thrown when the execution got cancelled before executionId was attached to the channel."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandler.java
@@ -51,8 +51,8 @@ public final class FutureCancelHandler extends ChannelInboundHandlerAdapter {
 
         if (channelExecutionId == null) {
             RequestContext requestContext = ctx.channel().attr(REQUEST_CONTEXT_KEY).get();
-            LOG.debug(ctx.channel(), () -> String.format("Received a cancellation exception on a channel that doesn't have an "
-                                                         + "execution Id attached yet. Exception's execution ID is %d. "
+            LOG.warn(ctx.channel(), () -> String.format("Received a cancellation exception on a channel that doesn't have an "
+                                                         + "execution Id attached. Exception's execution ID is %d. "
                                                          + "Exception is being ignored. Closing the channel",
                                                          executionId(ctx)));
             ctx.close();

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -42,6 +42,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.util.Attribute;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
@@ -130,8 +131,9 @@ public final class NettyRequestExecutor {
                 Channel ch = channelPromise.getNow();
                 try {
                     ch.eventLoop().submit(() -> {
-                        if (ch.attr(IN_USE).get()) {
-                            ch.pipeline().fireExceptionCaught(new FutureCancelledException(executionId, t));
+                        Attribute<Long> executionIdKey = ch.attr(EXECUTION_ID_KEY);
+                        if (ch.attr(IN_USE) != null && ch.attr(IN_USE).get() && executionIdKey != null) {
+                            ch.pipeline().fireExceptionCaught(new FutureCancelledException(this.executionId, t));
                         } else {
                             ch.close().addListener(closeFuture -> context.channelPool().release(ch));
                         }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
@@ -25,6 +25,7 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelId;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.DefaultAttributeMap;
 import java.io.IOException;
@@ -77,6 +78,7 @@ public class FutureCancelHandlerTest {
         when(ctx.channel()).thenReturn(channel);
         when(channel.attr(EXECUTION_ID_KEY)).thenReturn(attrMap.attr(EXECUTION_ID_KEY));
         when(channel.attr(REQUEST_CONTEXT_KEY)).thenReturn(attrMap.attr(REQUEST_CONTEXT_KEY));
+        when(channel.id()).thenReturn(DefaultChannelId.newInstance());
     }
 
     @Test

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/FutureCancelHandlerTest.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.EXECUTION_ID_KEY;
@@ -97,5 +99,16 @@ public class FutureCancelHandlerTest {
 
         verify(ctx).fireExceptionCaught(exceptionCaptor.capture());
         assertThat(exceptionCaptor.getValue()).isEqualTo(err);
+    }
+
+    @Test
+    public void cancelledException_executionIdNull_shouldIgnoreExceptionAndCloseChannel() {
+        when(channel.attr(EXECUTION_ID_KEY)).thenReturn(null);
+
+        FutureCancelledException cancelledException = new FutureCancelledException(1L, new CancellationException());
+        handler.exceptionCaught(ctx, cancelledException);
+
+        verify(ctx, never()).fireExceptionCaught(any(Throwable.class));
+        verify(ctx).close();
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix NPE in netty client where a future got cancelled before the execution id was attached to the channel

## Modifications
Add null check in `FutureCancelHandler` to handle the edge case

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
