### PR TITLE
Fixed the issue where the SDK did not offload future completion

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -174,11 +174,10 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         long callStart = System.nanoTime();
         CompletableFuture<Void> httpClientFuture = sdkAsyncHttpClient.execute(executeRequest);
 
-        // Offload the metrics reporting from this stage onto the future completion executor
-        CompletableFuture<Void> result = httpClientFuture.whenCompleteAsync((r, t) -> {
+        CompletableFuture<Void> result = httpClientFuture.whenComplete((r, t) -> {
             long duration = System.nanoTime() - callStart;
             metricCollector.reportMetric(CoreMetric.SERVICE_CALL_DURATION, Duration.ofNanos(duration));
-        }, futureCompletionExecutor);
+        });
 
         // Make sure failures on the result future are forwarded to the http client future.
         CompletableFutureUtils.forwardExceptionTo(result, httpClientFuture);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.Response;
@@ -48,7 +47,6 @@ import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
@@ -119,59 +117,12 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         return toReturn;
     }
 
-    private static final class WrappedErrorForwardingResponseHandler<T>
-            implements TransformingAsyncResponseHandler<T> {
-
-        private final TransformingAsyncResponseHandler<T> wrappedHandler;
-        private final CompletableFuture<T> responseFuture;
-
-        private WrappedErrorForwardingResponseHandler(TransformingAsyncResponseHandler<T> wrappedHandler,
-                                                      CompletableFuture<T> responseFuture) {
-            this.wrappedHandler = wrappedHandler;
-            this.responseFuture = responseFuture;
-
-        }
-
-        private static <T> WrappedErrorForwardingResponseHandler<T> of(
-                TransformingAsyncResponseHandler<T> wrappedHandler,
-                CompletableFuture<T> responseFuture) {
-
-            return new WrappedErrorForwardingResponseHandler<>(wrappedHandler, responseFuture);
-        }
-
-        @Override
-        public CompletableFuture<T> prepare() {
-            return wrappedHandler.prepare();
-        }
-
-        @Override
-        public void onHeaders(SdkHttpResponse headers) {
-            wrappedHandler.onHeaders(headers);
-        }
-
-        @Override
-        public void onStream(Publisher<ByteBuffer> stream) {
-            wrappedHandler.onStream(stream);
-        }
-
-        @Override
-        public void onError(Throwable error) {
-            responseFuture.completeExceptionally(error);
-            wrappedHandler.onError(error);
-        }
-    }
-
     private CompletableFuture<Response<OutputT>> executeHttpRequest(SdkHttpFullRequest request,
                                                                     RequestExecutionContext context) {
 
         CompletableFuture<Response<OutputT>> responseFuture = new CompletableFuture<>();
 
-        // Wrap the response handler in a layer that will notify the newly created responseFuture when the onError event
-        // is triggered
-        TransformingAsyncResponseHandler<Response<OutputT>> wrappedResponseHandler =
-            WrappedErrorForwardingResponseHandler.of(responseHandler, responseFuture);
-
-        CompletableFuture<Response<OutputT>> responseHandlerFuture = wrappedResponseHandler.prepare();
+        CompletableFuture<Response<OutputT>> responseHandlerFuture = responseHandler.prepare();
 
         SdkHttpContentPublisher requestProvider = context.requestProvider() == null
                                                   ? new SimpleHttpContentPublisher(request)
@@ -184,7 +135,7 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         AsyncExecuteRequest.Builder executeRequestBuilder = AsyncExecuteRequest.builder()
                                                                 .request(requestWithContentLength)
                                                                 .requestContentPublisher(requestProvider)
-                                                                .responseHandler(wrappedResponseHandler)
+                                                                .responseHandler(responseHandler)
                                                                 .fullDuplex(isFullDuplex(context.executionAttributes()))
                                                                 .metricCollector(httpMetricCollector);
         if (context.executionAttributes().getAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES) != null) {
@@ -224,10 +175,10 @@ public final class MakeAsyncHttpRequestStage<OutputT>
         CompletableFuture<Void> httpClientFuture = sdkAsyncHttpClient.execute(executeRequest);
 
         // Offload the metrics reporting from this stage onto the future completion executor
-        CompletableFuture<Void> result = httpClientFuture.whenComplete((r, t) -> {
+        CompletableFuture<Void> result = httpClientFuture.whenCompleteAsync((r, t) -> {
             long duration = System.nanoTime() - callStart;
             metricCollector.reportMetric(CoreMetric.SERVICE_CALL_DURATION, Duration.ofNanos(duration));
-        });
+        }, futureCompletionExecutor);
 
         // Make sure failures on the result future are forwarded to the http client future.
         CompletableFutureUtils.forwardExceptionTo(result, httpClientFuture);

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
@@ -20,9 +20,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/AsyncResponseThreadingTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 
@@ -69,8 +68,7 @@ public class AsyncResponseThreadingTest {
                 client.streamingOutputOperation(StreamingOutputOperationRequest.builder().build(),
                                                 AsyncResponseTransformer.toBytes()).join();
 
-        // #1 reporting metrics, #2 completing response
-        verify(mockExecutor, times(2)).execute(any());
+        verify(mockExecutor).execute(any());
 
         byte[] arrayCopy = response.asByteArray();
         assertThat(arrayCopy).containsExactly('t', 'e', 's', 't');
@@ -96,8 +94,7 @@ public class AsyncResponseThreadingTest {
                                             AsyncResponseTransformer.toBytes()).join())
             .hasCauseInstanceOf(SdkClientException.class);
 
-        // #1 reporting metrics, #2 completing response
-        verify(mockExecutor, times(2)).execute(any());
+        verify(mockExecutor).execute(any());
     }
 
     @Test
@@ -118,8 +115,7 @@ public class AsyncResponseThreadingTest {
         assertThatThrownBy(() ->
             client.streamingOutputOperation(StreamingOutputOperationRequest.builder().build(),
                                             AsyncResponseTransformer.toBytes()).join()).hasCauseInstanceOf(ProtocolRestJsonException.class);
-        // #1 reporting metrics, #2 completing response
-        verify(mockExecutor, times(2)).execute(any());
+        verify(mockExecutor).execute(any());
     }
 
     private static class SpyableExecutor implements Executor {

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AsyncAwsJsonRetryTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/retry/AsyncAwsJsonRetryTest.java
@@ -51,7 +51,7 @@ public class AsyncAwsJsonRetryTest {
     public void setupClient() {
         client = ProtocolJsonRpcAsyncClient.builder()
                                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create
-                                               ("akid", "skid")))
+                                                                                                                        ("akid", "skid")))
                                            .region(Region.US_EAST_1)
                                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                            .build();

--- a/test/protocol-tests/src/test/resources/jetty-logging.properties
+++ b/test/protocol-tests/src/test/resources/jetty-logging.properties
@@ -15,4 +15,4 @@
 
 # Set up logging implementation
 org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
-org.eclipse.jetty.LEVEL=INFO
+org.eclipse.jetty.LEVEL=OFF


### PR DESCRIPTION
## Motivation and Context
Fixed the issue where the SDK did not offload future completion to the future completion executor

### RCA
**Happy case workflow** (Always complete on futureCompletionExecutor)

- `responseFuture` gets completed by `futureCompletionExecutor` after the future in the `AsyncResponseHandler#prepare` gets completed

https://github.com/aws/aws-sdk-java-v2/blob/e4c4612fe3c6250ed6995de2f71a11cfbc79b2bb/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java#L210-L216


- `toReturn` future gets completed after  `responseFuture` gets completed. This will happen in the `futureCompletionExecutor`.

https://github.com/aws/aws-sdk-java-v2/blob/e4c4612fe3c6250ed6995de2f71a11cfbc79b2bb/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java#L103-L108

**Error case workflow** (Most of the time complete on futureCompletionExecutor)
- `responseFuture` gets completed exceptionally  before `responseHandlerFuture` gets completed.

https://github.com/aws/aws-sdk-java-v2/blob/e4c4612fe3c6250ed6995de2f71a11cfbc79b2bb/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java#L158-L160

- toReturn future gets completed after `responseFuture` gets completed. This will happen in the event loop thread due to the use of `whenComplete`.

https://github.com/aws/aws-sdk-java-v2/blob/e4c4612fe3c6250ed6995de2f71a11cfbc79b2bb/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/MakeAsyncHttpRequestStage.java#L103-L108

## Modifications
- Removed `WrappedErrorForwardingResponseHandler`. I'm not sure why it's needed since we are relying on `responseHandlerFuture` to complete the `responseFuture` anyway.
~~- Updated to offload the metrics reporting to futureCompletionExecutor~~

## Testing
Added unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
