### PR TITLE
Adding an explicit isPresent check in SyncHttpChecksumInTrailerInterc…

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/SyncHttpChecksumInTrailerInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/SyncHttpChecksumInTrailerInterceptor.java
@@ -58,14 +58,7 @@ public final class SyncHttpChecksumInTrailerInterceptor implements ExecutionInte
         ChecksumSpecs checksumSpecs =
             HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes).orElse(null);
 
-        if (checksumSpecs == null
-            || ! context.requestBody().isPresent()
-            || !HttpChecksumUtils
-            .isTrailerBasedChecksumForClientType(
-                executionAttributes, context.httpRequest(),
-                ClientType.SYNC, checksumSpecs,
-                context.requestBody().isPresent(),
-                context.requestBody().map(requestBody -> requestBody.contentStreamProvider() != null).orElse(false))) {
+        if (!shouldAddTrailerBasedChecksumInRequest(context, executionAttributes, checksumSpecs)) {
             return context.requestBody();
         }
 
@@ -85,19 +78,26 @@ public final class SyncHttpChecksumInTrailerInterceptor implements ExecutionInte
                 requestBody.contentType()));
     }
 
+    private static boolean shouldAddTrailerBasedChecksumInRequest(Context.ModifyHttpRequest context,
+                                                                  ExecutionAttributes executionAttributes,
+                                                                  ChecksumSpecs checksumSpecs) {
+        return checksumSpecs != null
+               && context.requestBody().isPresent()
+               && HttpChecksumUtils.isTrailerBasedChecksumForClientType(
+                   executionAttributes,
+                   context.httpRequest(),
+                   ClientType.SYNC, checksumSpecs,
+                   context.requestBody().isPresent(),
+                   context.requestBody().map(requestBody -> requestBody.contentStreamProvider() != null).orElse(false));
+    }
+
     @Override
     public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
 
         ChecksumSpecs checksumSpecs =
             HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes).orElse(null);
-        if (checksumSpecs == null ||
-            !HttpChecksumUtils
-                .isTrailerBasedChecksumForClientType(
-                    executionAttributes,
-                    context.httpRequest(),
-                    ClientType.SYNC, checksumSpecs,
-                    context.requestBody().isPresent(),
-                    context.requestBody().map(requestBody -> requestBody.contentStreamProvider() != null).orElse(false))) {
+
+        if (!shouldAddTrailerBasedChecksumInRequest(context, executionAttributes, checksumSpecs)) {
             return context.httpRequest();
         }
 


### PR DESCRIPTION
…eptor to improve readibilty also to address sonarcloud bug

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Sonarcloud complaining not doing isPresent() before .get.
- This is just additional check since in HttpChecksumUtils.isTrailerBasedChecksumForClientType() we already to a isPresent check and donot do any checksum related operation if requestBody is not present.

## Modifications
<!--- Describe your changes in detail -->
- Added explicit isPresent check before doing a .get()

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
