### PR TITLE
[DRAFT]Provide JSON helper methods to input and output data to DynamoDB in Json Format

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/TableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/TableSchema.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.internal.JsonItemTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.ImmutableTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticImmutableTableSchema;
@@ -26,6 +27,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPreserveEmptyObject;
+import software.amazon.awssdk.enhanced.dynamodb.model.JsonItem;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -79,6 +81,16 @@ public interface TableSchema<T> {
      */
     static <T> BeanTableSchema<T> fromBean(Class<T> beanClass) {
         return BeanTableSchema.create(beanClass);
+    }
+
+    /**
+     * Returns implementation of {@link JsonItemTableSchema} which supports DDB operation with Json string inputs and Outputs
+     * @param tableMetadata Implementation {@link TableMetadata} which specifies the partition key value and sort key of the
+     *                      table.
+     * @return An initialized {@link JsonItemTableSchema}.
+     */
+    static TableSchema<JsonItem> withDocumentSchema(TableMetadata tableMetadata) {
+        return JsonItemTableSchema.builder().tableMetadata(tableMetadata).build();
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/JsonItemTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/JsonItemTableSchema.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.JsonItem;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Implementation of {@link TableSchema} that builds a schema that is used to while using enhanced ddb client with Json input and
+ * outputs {@link TableSchema}.
+ * <p>
+ */
+@SdkInternalApi
+public final class JsonItemTableSchema implements TableSchema<JsonItem> {
+
+    private final TableMetadata tableMetadata;
+
+    public JsonItemTableSchema(Builder builder) {
+        Validate.paramNotNull(builder.tableMetadata, "tableMetadata");
+        this.tableMetadata = builder.tableMetadata;
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public TableMetadata tableMetadata() {
+        return tableMetadata;
+    }
+
+    @Override
+    public EnhancedType<JsonItem> itemType() {
+        return EnhancedType.of(JsonItem.class);
+    }
+
+    @Override
+    public List<String> attributeNames() {
+        throw new UnsupportedOperationException("attributeNames is not supported for JsonImmutableTableSchema");
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return false;
+    }
+
+    @Override
+    public JsonItem mapToItem(Map<String, AttributeValue> attributeMap) {
+        if (attributeMap == null) {
+            return null;
+        }
+        return JsonItem.fromAttributeValueMap(attributeMap);
+    }
+
+    @Override
+    public Map<String, AttributeValue> itemToMap(JsonItem item, boolean ignoreNulls) {
+        if (item == null) {
+            return Collections.emptyMap();
+        }
+        return item.itemToMap();
+    }
+
+    @Override
+    public Map<String, AttributeValue> itemToMap(JsonItem item, Collection<String> attributes) {
+
+        Map<String, AttributeValue> attributeValueMap = item.itemToMap();
+        Map<String, AttributeValue> newMap = new LinkedHashMap<>();
+        attributes.forEach(key -> Optional.ofNullable(attributeValueMap.get(key))
+                                          .ifPresent(value -> newMap.put(key, value)));
+        return newMap;
+    }
+
+    @Override
+    public AttributeValue attributeValue(JsonItem item, String attributeName) {
+        if (item != null) {
+            return item.itemToMap().get(attributeName);
+        }
+        return null;
+    }
+
+    public static class Builder {
+        private TableMetadata tableMetadata;
+
+        public Builder tableMetadata(TableMetadata tableMetadata) {
+            this.tableMetadata = tableMetadata;
+            return this;
+        }
+
+        public JsonItemTableSchema build() {
+            return new JsonItemTableSchema(this);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/JsonItemAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/JsonItemAttributeConverter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.model.JsonItem;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.ArrayJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.BooleanJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.NumberJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.ObjectJsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.StringJsonNode;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * An Internal converter between {@link JsonItem} and {@link AttributeValue}.
+ *
+ * <p>
+ * This converts the Attribute Value read from the DDB to JsonNode.
+ */
+@SdkInternalApi
+@ThreadSafe
+@Immutable
+public final class JsonItemAttributeConverter implements AttributeConverter<JsonNode> {
+    private static final Visitor VISITOR = new Visitor();
+
+    private JsonItemAttributeConverter() {
+    }
+
+    public static JsonItemAttributeConverter create() {
+        return new JsonItemAttributeConverter();
+    }
+
+    @Override
+    public EnhancedType<JsonNode> type() {
+        return EnhancedType.of(JsonNode.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.M;
+    }
+
+    @Override
+    public AttributeValue transformFrom(JsonNode input) {
+        JsonNodeToAttributeValueMapConvertor jsonNodeToAttributeValueMapConvertor = new JsonNodeToAttributeValueMapConvertor();
+        return input.visit(jsonNodeToAttributeValueMapConvertor);
+    }
+
+    @Override
+    public JsonNode transformTo(AttributeValue input) {
+        return EnhancedAttributeValue.fromAttributeValue(input).convert(VISITOR);
+    }
+
+    private static final class Visitor extends TypeConvertingVisitor<JsonNode> {
+        private Visitor() {
+            super(JsonNode.class, JsonItemAttributeConverter.class);
+        }
+
+        @Override
+        public JsonNode convertMap(Map<String, AttributeValue> value) {
+            Map<String, JsonNode> jsonNodeMap = new LinkedHashMap<>();
+            value.entrySet().forEach(
+                k -> jsonNodeMap.put(k.getKey(), this.convert(EnhancedAttributeValue.fromAttributeValue(k.getValue()))));
+            return new ObjectJsonNode(jsonNodeMap);
+        }
+
+        @Override
+        public JsonNode convertString(String value) {
+            return new StringJsonNode(value);
+        }
+
+        @Override
+        public JsonNode convertNumber(String value) {
+            return new NumberJsonNode(value);
+        }
+
+        @Override
+        public JsonNode convertBytes(SdkBytes value) {
+            throw new IllegalStateException("Not supported operation");
+        }
+
+        @Override
+        public JsonNode convertBoolean(Boolean value) {
+            return new BooleanJsonNode(value);
+        }
+
+        @Override
+        public JsonNode convertSetOfStrings(List<String> value) {
+            return new ArrayJsonNode(value.stream().map(s -> new StringJsonNode(s)).collect(Collectors.toList()));
+        }
+
+        @Override
+        public JsonNode convertSetOfNumbers(List<String> value) {
+            return new ArrayJsonNode(value.stream().map(s -> new NumberJsonNode(s)).collect(Collectors.toList()));
+        }
+
+        @Override
+        public JsonNode convertSetOfBytes(List<SdkBytes> value) {
+            throw new IllegalStateException("Not supported operation");
+        }
+
+        @Override
+        public JsonNode convertListOfAttributeValues(List<AttributeValue> value) {
+            return new ArrayJsonNode(value.stream().map(
+                attributeValue -> EnhancedAttributeValue.fromAttributeValue(
+                    attributeValue).convert(VISITOR)).collect(Collectors.toList()));
+
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/JsonNodeToAttributeValueMapConvertor.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/JsonNodeToAttributeValueMapConvertor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.JsonNodeVisitor;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+@SdkInternalApi
+public class JsonNodeToAttributeValueMapConvertor implements JsonNodeVisitor<AttributeValue> {
+    @Override
+    public AttributeValue visitNull() {
+        return AttributeValue.builder().build();
+    }
+
+    @Override
+    public AttributeValue visitBoolean(boolean bool) {
+        return AttributeValue.builder().bool(bool).build();
+    }
+
+    @Override
+    public AttributeValue visitNumber(String number) {
+        return AttributeValue.builder().n(number).build();
+    }
+
+    @Override
+    public AttributeValue visitString(String string) {
+        return AttributeValue.builder().s(string).build();
+    }
+
+    @Override
+    public AttributeValue visitArray(List<JsonNode> array) {
+        return AttributeValue.builder().l(array.stream()
+                                        .map(node -> node.visit(this))
+                                        .collect(Collectors.toList())).build();
+    }
+
+    @Override
+    public AttributeValue visitObject(Map<String, JsonNode> object) {
+        return AttributeValue.builder().m(object.entrySet()
+                                      .stream().collect(Collectors.toMap(entry -> entry.getKey(),
+                                                                         entry -> entry.getValue().visit(this),
+                                                                         (left, right) -> left,
+                                                                         LinkedHashMap::new))).build();
+    }
+
+    @Override
+    public AttributeValue visitEmbeddedObject(Object embeddedObject) {
+        throw new UnsupportedOperationException("Embedded objects are not supported within Document types.");
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/JsonItem.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/model/JsonItem.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.model;
+
+
+import static java.util.Collections.unmodifiableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.JsonItemAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.JsonNodeToAttributeValueMapConvertor;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.internal.ObjectJsonNode;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.StringUtils;
+
+
+@SdkPublicApi
+public class JsonItem {
+    private final JsonNode delegateJsonNode;
+
+    public JsonItem(String jsonString) {
+        this.delegateJsonNode = JsonNode.parser().parse(jsonString);
+    }
+
+    private JsonItem(JsonNode objectJsonNode) {
+        this.delegateJsonNode = objectJsonNode;
+
+    }
+
+    public static JsonItem fromJson(String jsonString) {
+        StringUtils.isNotBlank(jsonString);
+        return new JsonItem(jsonString);
+    }
+
+    public static JsonItem fromAttributeValueMap(Map<String, AttributeValue> attributeMap) {
+        JsonItemAttributeConverter jsonItemAttributeConverter = JsonItemAttributeConverter.create();
+        Map<String, JsonNode> jsonNodeMap = new HashMap<>();
+        attributeMap.entrySet().forEach(entrt -> jsonNodeMap.put(entrt.getKey(),
+                                                                 jsonItemAttributeConverter.transformTo(entrt.getValue())));
+
+        return new JsonItem(new ObjectJsonNode(jsonNodeMap));
+    }
+
+    @Override
+    public String toString() {
+        return delegateJsonNode.toString();
+
+    }
+
+    public boolean contains(String key) {
+        return delegateJsonNode.field(key).isPresent();
+    }
+
+    public Optional<JsonItem> get(String key) {
+        return delegateJsonNode.isObject() ? Optional.of(new JsonItem(delegateJsonNode.field(key).get()))
+                                           : Optional.empty();
+    }
+
+
+    public String toJson() {
+        return delegateJsonNode != null ? delegateJsonNode.toString() : null;
+    }
+
+    public Map<String, AttributeValue> itemToMap() {
+        Map<String, AttributeValue> attributeValueMap = new HashMap<>();
+
+        if (!this.delegateJsonNode.isObject()) {
+            throw new IllegalStateException("Cannot convert item " + this.delegateJsonNode + " to map.");
+
+        }
+        JsonNodeToAttributeValueMapConvertor jsonNodeToAttributeValueMapConvertor = new JsonNodeToAttributeValueMapConvertor();
+        this.delegateJsonNode.asObject().forEach(
+            (key, value) -> attributeValueMap.put(key, value.visit(jsonNodeToAttributeValueMapConvertor)));
+        return unmodifiableMap(attributeValueMap);
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/JsonItemTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/JsonItemTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.enhanced.dynamodb.model.JsonItem;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class JsonItemTest {
+
+    String COMPLEX_JSON_STRING = "{\"binary\":\"AQIDBA==\",\"binarySet\":[\"BQY=\",\"Bwg=\"],\"booleanTrue\":true,"
+                                 + "\"booleanFalse\":false,\"intAttr\":1234,\"listAtr\":[\"abc\",\"123\"],"
+                                 + "\"mapAttr\":{\"key1\":\"value1\",\"key2\":999},\"nullAttr\":null,\"numberAttr\":999.1234,"
+                                 + "\"stringAttr\":\"bla\",\"stringSetAttr\":[\"da\",\"di\",\"foo\",\"bar\",\"bazz\"]}";
+
+    static String SIMPLE_STRING_JSON = "{\"key\":\"AQIDBA==\"}";
+    static String SIMPLE_NUMBER_JSON = "{\"key\":99}";
+    static String SIMPLE_BOOLEAN_JSON = "{\"key\":true}";
+    static String SIMPLE_ARRAY_JSON = "{\"key\":[\"BQY=\",\"Bwg=\"]}";
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void jsonItem_from_JsonString() throws JsonProcessingException {
+        JsonItem jsonItem = JsonItem.fromJson(COMPLEX_JSON_STRING);
+        assertEquals(mapper.readTree(COMPLEX_JSON_STRING), mapper.readTree(jsonItem.toJson()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideJsonToItemMapValues")
+    public void jsonItem_To_MapConversion(String jsonString , Map<String, AttributeValue> attributeValue){
+        JsonItem jsonItem = JsonItem.fromJson(jsonString);
+        assertThat(jsonItem.itemToMap()).isEqualTo(attributeValue);
+    }
+
+    private static Stream<Arguments> provideJsonToItemMapValues() {
+        Map<String, AttributeValue> stringMap = new HashMap<String, AttributeValue>();
+        stringMap.put("key", AttributeValue.builder().s("AQIDBA==").build());
+
+        Map<String, AttributeValue> numberMap = new HashMap<String, AttributeValue>();
+        numberMap.put("key", AttributeValue.builder().n("99").build());
+
+        Map<String, AttributeValue> boolMap = new HashMap<String, AttributeValue>();
+        boolMap.put("key", AttributeValue.builder().bool(true).build());
+
+
+        Map<String, AttributeValue> stringListMap = new HashMap<String, AttributeValue>();
+        stringListMap.put("key", AttributeValue.builder().l(AttributeValue.builder().s("BQY=").build(),
+                                                                             AttributeValue.builder().s("Bwg=").build()).build());
+        return Stream.of(
+            Arguments.of(SIMPLE_STRING_JSON, stringMap),
+            Arguments.of(SIMPLE_NUMBER_JSON,numberMap),
+            Arguments.of(SIMPLE_BOOLEAN_JSON,boolMap),
+            Arguments.of(SIMPLE_ARRAY_JSON, stringListMap)
+        );
+    }
+
+
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/JsonSchemaBasedTableTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/JsonSchemaBasedTableTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static software.amazon.awssdk.enhanced.dynamodb.internal.AttributeValues.numberValue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.model.JsonItem;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+
+
+public class JsonSchemaBasedTableTest extends LocalDynamoDbSyncTestBase {
+
+
+    ObjectMapper mapper = new ObjectMapper();
+    private DynamoDbEnhancedClient enhancedClient;
+    private DynamoDbTable<JsonItem> mappedTable1;
+
+    @Before
+    public void createTable() {
+
+        enhancedClient = DynamoDbEnhancedClient.builder()
+                                               .dynamoDbClient(getDynamoDbClient())
+                                               .build();
+
+        mappedTable1 = enhancedClient.table(getConcreteTableName("table-name-1"),
+                                            TableSchema.withDocumentSchema(
+                                                StaticTableMetadata.builder().addIndexPartitionKey(
+                                                    TableMetadata.primaryIndexName(), "hash-key", AttributeValueType.S).build()));
+
+        mappedTable1.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+    }
+
+    @Test
+    public void putObject_And_getSameObjectAsJson() throws JsonProcessingException {
+
+        String INPUT_JSON_STRING = "{\"hash-key\":\"1234\",\"binarySet\":[\"BQY=\",\"Bwg=\"],"
+                                   + "\"booleanTrue\":true,\"booleanFalse\":false,\"intAttr\":1234}";
+        mappedTable1.putItem(JsonItem.fromJson(INPUT_JSON_STRING));
+
+        JsonItem item = mappedTable1.getItem(Key.builder().partitionValue("1234").build());
+        assertEquals(mapper.readTree(INPUT_JSON_STRING), mapper.readTree(item.toJson()));
+    }
+
+    @Test
+    public void updateItem_that_AlreadyExist() throws JsonProcessingException, InterruptedException {
+
+        String INPUT_JSON_STRING = "{\"hash-key\":\"1234\",\"updateDone\":false}";
+        mappedTable1.putItem(JsonItem.fromJson(INPUT_JSON_STRING));
+
+        String UPDATE_INPUT_JSON_STRING = "{\"hash-key\":\"1234\",\"updateDone\":true}";
+        JsonItem jsonItem = mappedTable1.updateItem(item -> item.item(JsonItem.fromJson(UPDATE_INPUT_JSON_STRING)));
+        assertEquals(mapper.readTree(UPDATE_INPUT_JSON_STRING), mapper.readTree(jsonItem.toJson()));
+
+        JsonItem item = mappedTable1.getItem(Key.builder().partitionValue("1234").build());
+        assertEquals(mapper.readTree(UPDATE_INPUT_JSON_STRING), mapper.readTree(item.toJson()));
+    }
+
+    @Test
+    public void deleteItem() throws JsonProcessingException, InterruptedException {
+
+        String INPUT_JSON_STRING = "{\"hash-key\":\"1234\",\"updateDone\":false}";
+        mappedTable1.putItem(JsonItem.fromJson(INPUT_JSON_STRING));
+
+        JsonItem item = mappedTable1.getItem(Key.builder().partitionValue("1234").build());
+        assertEquals(mapper.readTree(INPUT_JSON_STRING), mapper.readTree(item.toJson()));
+
+        JsonItem deletedItem = mappedTable1.deleteItem(Key.builder().partitionValue("1234").build());
+        assertEquals(mapper.readTree(INPUT_JSON_STRING), mapper.readTree(deletedItem.toJson()));
+
+        JsonItem getDeletedItem = mappedTable1.getItem(Key.builder().partitionValue("1234").build());
+        assertNull(getDeletedItem);
+    }
+
+    @Test
+    public void keyFromJsonItem() throws JsonProcessingException, InterruptedException {
+
+        String INPUT_JSON_STRING = "{\"hash-key\":\"1234\",\"updateDone\":false}";
+        mappedTable1.putItem(JsonItem.fromJson(INPUT_JSON_STRING));
+        Key key = mappedTable1.keyFrom(JsonItem.fromJson(INPUT_JSON_STRING));
+        assertEquals(key.partitionKeyValue(), AttributeValue.builder().s("1234").build());
+    }
+
+
+    @Test
+    public void scanRequest() throws JsonProcessingException {
+
+        Map<String, AttributeValue> expressionValues = new HashMap<>();
+        expressionValues.put(":min_value", numberValue(3));
+        expressionValues.put(":max_value", numberValue(5));
+        Expression expression = Expression.builder()
+                                          .expression("#value >= :min_value AND #value <= :max_value")
+                                          .expressionValues(expressionValues)
+                                          .expressionNames(Collections.singletonMap("#value", "value"))
+                                          .build();
+
+        String INPUT_ONE_JSON_STRING = "{\"hash-key\":\"0001\",\"name\":\"one\",\"value\":4}";
+        String INPUT_TWO_JSON_STRING = "{\"hash-key\":\"0002\",\"name\":\"two\",\"value\":5}";
+        String INPUT_ONE_DUPE_JSON_STRING = "{\"hash-key\":\"0003\",\"name\":\"three\",\"value\":9}";
+        mappedTable1.putItem(JsonItem.fromJson(INPUT_ONE_JSON_STRING));
+        mappedTable1.putItem(r -> r.item(JsonItem.fromJson(INPUT_TWO_JSON_STRING)));
+        mappedTable1.putItem(PutItemEnhancedRequest.builder(JsonItem.class).item(JsonItem.fromJson(INPUT_ONE_DUPE_JSON_STRING)).build());
+
+        PageIterable<JsonItem> iterable =
+            mappedTable1.scan(s -> s.filterExpression(expression));
+        assertEquals(iterable.items().stream().count(), 2);
+
+        List<JsonItem> jsonItemList = iterable.items().stream().collect(Collectors.toList());
+        System.out.println(jsonItemList);
+        assertEquals(mapper.readTree(jsonItemList.get(0).toJson()), mapper.readTree(INPUT_TWO_JSON_STRING));
+        assertEquals(mapper.readTree(jsonItemList.get(1).toJson()), mapper.readTree(INPUT_ONE_JSON_STRING));
+;
+    }
+
+    @After
+    public void deleteTable() {
+        getDynamoDbClient().deleteTable(DeleteTableRequest.builder()
+                                                          .tableName(getConcreteTableName("table-name-1"))
+                                                          .build());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

- PR created to review the design approach, will update the java docs and detailed test cases in future revision of this PR

- [Issue-1862](https://github.com/aws/aws-sdk-java-v2/issues/1862)  Preserve JSON helper methods in the DynamoDB Document API #1862 
- Currently V2 did not have a way to input/output in json format.


## Modifications
<!--- Describe your changes in detail -->
- Added a Public class called JsonItem
```java

 public static JsonItem fromJson(String jsonString) {}
 public static JsonItem fromAttributeValueMap(Map<String, AttributeValue> attributeMap) {}

 public String toJson(){};

 public boolean contains(String key)

 public String toString()

```

- Rest of the classes are Internal.


- Added convertors to convert from AttributeValue to Json and vice-versa.


In order to create DDB Enhanced client table which Supports Json , we need to create the Table with Json Schema as below

```java 
 TableSchema.withDocumentSchema(
              StaticTableMetadata.builder().addIndexPartitionKey(
                        TableMetadata.primaryIndexName(), "hash-key", AttributeValueType.S).build()));
```
Note  : The StaticTableMetadata needs to be built by the user since we need to specify the Table meta data like primary key and sort key etc , this is one time operation.

```java

        DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
                                               .dynamoDbClient(getDynamoDbClient())
                                               .build();

        DynamoDbTable<JsonItem> mappedTable1 = enhancedClient.table(getConcreteTableName("table-name-1"),
                                            TableSchema.withDocumentSchema(
                                                StaticTableMetadata.builder().addIndexPartitionKey(
                                                    TableMetadata.primaryIndexName(), "hash-key", AttributeValueType.S).build()));

        mappedTable1.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));


        mappedTable1.putItem(JsonItem.fromJson("{\"hash-key\":\"1234\",\"updateDone\":false}"));


```


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  Junits for put,get,scan, query and delete items.


## Todo

- Will update the Java docs
- Will add more test cases to check how to deal with Bytes 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
