### PR TITLE
Adding SDK Policy Builder and extensions to IAM

### DIFF
--- a/services/iam/pom.xml
+++ b/services/iam/pom.xml
@@ -56,5 +56,13 @@
             <artifactId>protocol-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/services/iam/src/it/java/software/amazon/awssdk/services/iam/ServiceIntegrationTest.java
+++ b/services/iam/src/it/java/software/amazon/awssdk/services/iam/ServiceIntegrationTest.java
@@ -21,6 +21,13 @@ import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPolicy;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPrincipal;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamStatement;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamStatement.Effect;
+import software.amazon.awssdk.services.iam.model.CreatePolicyRequest;
+import software.amazon.awssdk.services.iam.model.CreatePolicyResponse;
+import software.amazon.awssdk.services.iam.model.Policy;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 
 public class ServiceIntegrationTest extends AwsTestBase {
@@ -39,4 +46,20 @@ public class ServiceIntegrationTest extends AwsTestBase {
     public void smokeTest() {
         assertThat(iam.listUsers().users()).isNotNull();
     }
+
+
+    @Test
+    public void createPolicyUsingPojo() {
+        String policyName = "test-policy";
+        SdkIamPolicy policy = SdkIamPolicy.builder()
+                                          .id("policy-id")
+                                          .statements(new SdkIamStatement(Effect.Allow).withPrincipals(SdkIamPrincipal.ALL_USERS))
+                                          .build();
+        CreatePolicyResponse createPolicyResponse = iam.createPolicy(policy, CreatePolicyRequest.builder()
+                                                                                                .policyName(policyName)
+                                                                                                .build());
+        Policy createdPolicy = createPolicyResponse.policy();
+        assertThat(createdPolicy.policyName()).isEqualTo(policyName);
+    }
+
 }

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamAction.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy;
+
+/**
+ * An access control policy action identifies a specific action in a service
+ * that can be performed on a resource. For example, sending a message to a
+ * queue.
+ * <p>
+ * Actions allow you to limit what your access control policy statement affects.
+ * For example, you could create a policy statement that enables a certain group
+ * of users to send messages to your queue, but not allow them to perform any
+ * other actions on your queue.
+ * <p>
+ * The action is B in the statement
+ * "A has permission to do B to C where D applies."
+ * <p>
+ * Free form access control policy actions may include a wildcard (*) to match
+ * multiple actions.
+ */
+public class SdkIamAction {
+
+    private final String name;
+
+    public SdkIamAction(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of this action. For example, 'sqs:SendMessage' is the
+     * name corresponding to the SQS action that enables users to send a message
+     * to an SQS queue.
+     *
+     * @return The name of this action.
+     */
+    public String getActionName() {
+        return name;
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamCondition.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamCondition.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy;
+
+import java.util.Arrays;
+import java.util.List;
+import software.amazon.awssdk.services.iam.auth.policy.conditions.ConditionFactory;
+
+/**
+ * AWS access control policy conditions are contained in {@link SdkIamStatement}
+ * objects, and affect when a statement is applied. For example, a statement
+ * that allows access to an Amazon SQS queue could use a condition to only apply
+ * the effect of that statement for requests that are made before a certain
+ * date, or that originate from a range of IP addresses.
+ * <p>
+ * Multiple conditions can be included in a single statement, and all conditions
+ * must evaluate to true in order for the statement to take effect.
+ * <p>
+ * The set of conditions is D in the statement
+ * "A has permission to do B to C where D applies."
+ * <p>
+ * A condition is composed of three parts:
+ * <ul>
+ * <li><b>Condition Key</b> - The condition key declares which value of a
+ * request to pull in and compare against when a policy is evaluated by AWS. For
+ * example, using {@link ConditionFactory#SOURCE_IP_CONDITION_KEY} will cause
+ * AWS to pull in the current request's source IP as the first value to compare
+ * against every time your policy is evaluated.
+ * <li><b>Comparison Type</b> - Most condition types allow several ways to
+ * compare the value obtained from the condition key and the comparison value.
+ * <li><b>Comparison Value</b> - This is a static value used as the second value
+ * in the comparison when your policy is evaluated. Depending on the comparison
+ * type, this value can optionally use wildcards. See the documentation for
+ * individual comparison types for more information.
+ * </ul>
+ * <p>
+ * There are many expressive conditions available in the
+ * <code>software.amazon.awssdk.core.auth.policy.conditions</code> package to use in access
+ * control policy statements.
+ * <p>
+ * This class is not intended to be directly subclassed by users, instead users
+ * should use the many available conditions and condition factories in the
+ * software.amazon.awssdk.core.auth.policy.conditions package.
+ */
+//TODO Remove or clean this up along with its subclasses.
+public class SdkIamCondition {
+    protected String type;
+    protected String conditionKey;
+    protected List<String> values;
+
+    /**
+     * Returns the type of this condition.
+     *
+     * @return The type of this condition.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the type of this condition.
+     *
+     * @param type
+     *            The type of this condition.
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Returns the name of the condition key involved in this condition.
+     * Condition keys are predefined values supported by AWS that provide input
+     * to a condition's evaluation, such as the current time, or the IP address
+     * of the incoming request.
+     * <p>
+     * Your policy is evaluated for each incoming request, and condition keys
+     * specify what information to pull out of those incoming requests and plug
+     * into the conditions in your policy.
+     *
+     * @return The name of the condition key involved in this condition.
+     */
+    public String getConditionKey() {
+        return conditionKey;
+    }
+
+    /**
+     * Sets the name of the condition key involved in this condition.
+     * Condition keys are predefined values supported by AWS that provide
+     * input to a condition's evaluation, such as the current time, or the IP
+     * address of the incoming request.
+     * <p>
+     * Your policy is evaluated for each incoming request, and condition keys
+     * specify what information to pull out of those incoming requests and plug
+     * into the conditions in your policy.
+     *
+     * @param conditionKey
+     *            The name of the condition key involved in this condition.
+     */
+    public void setConditionKey(String conditionKey) {
+        this.conditionKey = conditionKey;
+    }
+
+    /**
+     * Returns the values specified for this access control policy condition.
+     * For example, in a condition that compares the incoming IP address of a
+     * request to a specified range of IP addresses, the range of IP addresses
+     * is the single value in the condition.
+     * <p>
+     * Most conditions accept only one value, but multiple values are possible.
+     *
+     * @return The values specified for this access control policy condition.
+     */
+    public List<String> getValues() {
+        return values;
+    }
+
+    /**
+     * Sets the values specified for this access control policy condition. For
+     * example, in a condition that compares the incoming IP address of a
+     * request to a specified range of IP addresses, the range of IP addresses
+     * is the single value in the condition.
+     * <p>
+     * Most conditions accept only one value, but multiple values are possible.
+     *
+     * @param values
+     *            The values specified for this access control policy condition.
+     */
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    /**
+     * Fluent version of {@link SdkIamCondition#setType(String)}
+     * @return this
+     */
+    public SdkIamCondition withType(String type) {
+        setType(type);
+        return this;
+    }
+
+    /**
+     * Fluent version of {@link SdkIamCondition#setConditionKey(String)}
+     * @return this
+     */
+    public SdkIamCondition withConditionKey(String key) {
+        setConditionKey(key);
+        return this;
+    }
+
+    /**
+     * Fluent version of {@link SdkIamCondition#setValues(List)}
+     * @return this
+     */
+    public SdkIamCondition withValues(String... values) {
+        setValues(Arrays.asList(values));
+        return this;
+    }
+
+
+    /**
+     * Fluent version of {@link SdkIamCondition#setValues(List)}
+     * @return this
+     */
+    public SdkIamCondition withValues(List<String> values) {
+        setValues(values);
+        return this;
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamPolicy.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamPolicy.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import software.amazon.awssdk.services.iam.auth.policy.internal.JsonPolicyReader;
+import software.amazon.awssdk.services.iam.auth.policy.internal.JsonPolicyWriter;
+
+
+/**
+ * An AWS access control policy is a object that acts as a container for one or
+ * more statements, which specify fine grained rules for allowing or denying
+ * various types of actions from being performed on your AWS resources.
+ * <p>
+ * By default, all requests to use your resource coming from anyone but you are
+ * denied. Access control polices can override that by allowing different types
+ * of access to your resources, or by explicitly denying different types of
+ * access.
+ * <p>
+ * Each statement in an AWS access control policy takes the form:
+ * "A has permission to do B to C where D applies".
+ * <ul>
+ *   <li>A is the <b>principal</b> - the AWS account that is making a request to
+ *       access or modify one of your AWS resources.
+ *   <li>B is the <b>action</b> - the way in which your AWS resource is being accessed or modified, such
+ *       as sending a message to an Amazon SQS queue, or storing an object in an Amazon S3 bucket.
+ *   <li>C is the <b>resource</b> - your AWS entity that the principal wants to access, such
+ *       as an Amazon SQS queue, or an object stored in Amazon S3.
+ *   <li>D is the set of <b>conditions</b> - optional constraints that specify when to allow or deny
+ *       access for the principal to access your resource.  Many expressive conditions are available,
+ *       some specific to each service.  For example you can use date conditions to allow access to
+ *       your resources only after or before a specific time.
+ * </ul>
+ * <p>
+ * Note that an AWS access control policy should not be confused with the
+ * similarly named "POST form policy" concept used in Amazon S3.
+ */
+public class SdkIamPolicy {
+
+    /** The default policy version. */
+    private static final String DEFAULT_POLICY_VERSION = "2012-10-17";
+
+    private String id;
+    private String version = DEFAULT_POLICY_VERSION;
+    private Collection<SdkIamStatement> statements = new ArrayList<>();
+
+    /**
+     * Constructs an empty AWS access control policy ready to be populated with
+     * statements.
+     */
+    public SdkIamPolicy() {
+    }
+
+    private SdkIamPolicy(BuilderImpl builder) {
+        this.id = builder.id;
+        this.version = builder.version != null ? builder.version : DEFAULT_POLICY_VERSION;
+        this.statements = Collections.unmodifiableCollection(builder.statements);
+    }
+
+    /**
+     * Constructs a new AWS access control policy with the specified policy ID.
+     * The policy ID is a user specified string that serves to help developers
+     * keep track of multiple polices. Policy IDs are often used as a human
+     * readable name for a policy.
+     *
+     * @param id
+     *            The policy ID for the new policy object. Policy IDs serve to
+     *            help developers keep track of multiple policies, and are often
+     *            used to give the policy a meaningful, human readable name.
+     */
+    public SdkIamPolicy(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Constructs a new AWS access control policy with the specified policy ID
+     * and collection of statements. The policy ID is a user specified string
+     * that serves to help developers keep track of multiple polices. Policy IDs
+     * are often used as a human readable name for a policy.
+     * <p>
+     * Any statements that don't have a statement ID yet will automatically be
+     * assigned a unique ID within this policy.
+     *
+     * @param id
+     *            The policy ID for the new policy object. Policy IDs serve to
+     *            help developers keep track of multiple policies, and are often
+     *            used to give the policy a meaningful, human readable name.
+     * @param statements
+     *            The statements to include in the new policy.
+     */
+    public SdkIamPolicy(String id, Collection<SdkIamStatement> statements) {
+        this(id);
+        setStatements(statements);
+    }
+
+    /**
+     * Returns an AWS access control policy object generated from JSON string.
+     *
+     * @param jsonString
+     *            The JSON string representation of this AWS access control policy.
+     *
+     * @return An AWS access control policy object.
+     *
+     * @throws IllegalArgumentException
+     *      If the specified JSON string is null or invalid and cannot be
+     *      converted to an AWS policy object.
+     */
+    public static SdkIamPolicy fromJson(String jsonString) {
+        return new JsonPolicyReader().createPolicyFromJsonString(jsonString);
+    }
+
+    /**
+     * Returns the policy ID for this policy. Policy IDs serve to help
+     * developers keep track of multiple policies, and are often used as human
+     * readable name for a policy.
+     *
+     * @return The policy ID for this policy.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the policy ID for this policy. Policy IDs serve to help developers
+     * keep track of multiple policies, and are often used as human readable
+     * name for a policy.
+     *
+     * @param id
+     *            The policy ID for this policy.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Sets the policy ID for this policy and returns the updated policy so that
+     * multiple calls can be chained together.
+     * <p>
+     * Policy IDs serve to help developers keep track of multiple policies, and
+     * are often used as human readable name for a policy.
+     *
+     * @param id
+     *            The policy ID for this policy.
+     *
+     * @return The updated Policy object so that additional calls can be chained
+     *         together.
+     */
+    public SdkIamPolicy withId(String id) {
+        setId(id);
+        return this;
+    }
+
+    /**
+     * Returns the version of this AWS policy.
+     *
+     * @return The version of this AWS policy.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Returns the collection of statements contained by this policy. Individual
+     * statements in a policy are what specify the rules that enable or disable
+     * access to your AWS resources.
+     *
+     * @return The collection of statements contained by this policy.
+     */
+    public Collection<SdkIamStatement> getStatements() {
+        return statements;
+    }
+
+    /**
+     * Sets the collection of statements contained by this policy. Individual
+     * statements in a policy are what specify the rules that enable or disable
+     * access to your AWS resources.
+     * <p>
+     * Any statements that don't have a statement ID yet will automatically be
+     * assigned a unique ID within this policy.
+     *
+     * @param statements
+     *            The collection of statements included in this policy.
+     */
+    public void setStatements(Collection<SdkIamStatement> statements) {
+        this.statements = new ArrayList<>(statements);
+        assignUniqueStatementIds();
+    }
+
+    /**
+     * Sets the collection of statements contained by this policy and returns
+     * this policy object so that additional method calls can be chained
+     * together.
+     * <p>
+     * Individual statements in a policy are what specify the rules that enable
+     * or disable access to your AWS resources.
+     * <p>
+     * Any statements that don't have a statement ID yet will automatically be
+     * assigned a unique ID within this policy.
+     *
+     * @param statements
+     *            The collection of statements included in this policy.
+     *
+     * @return The updated policy object, so that additional method calls can be
+     *         chained together.
+     */
+    public SdkIamPolicy withStatements(SdkIamStatement... statements) {
+        setStatements(Arrays.asList(statements));
+        return this;
+    }
+
+    /**
+     * Returns a JSON string representation of this AWS access control policy,
+     * suitable to be sent to an AWS service as part of a request to set an
+     * access control policy.
+     *
+     * @return A JSON string representation of this AWS access control policy.
+     */
+    public String toJsonDocument() {
+        return new JsonPolicyWriter().writePolicyToString(this);
+    }
+
+    private void assignUniqueStatementIds() {
+        Set<String> usedStatementIds = new HashSet<>();
+        for (SdkIamStatement statement : statements) {
+            if (statement.getId() != null) {
+                usedStatementIds.add(statement.getId());
+            }
+        }
+
+        int counter = 0;
+        for (SdkIamStatement statement : statements) {
+            if (statement.getId() != null) {
+                continue;
+            }
+
+            while (usedStatementIds.contains(Integer.toString(++counter))) {
+                ;
+            }
+            statement.setId(Integer.toString(counter));
+        }
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder {
+        String id();
+        Builder id(String id);
+
+        String version();
+        Builder version(String version);
+
+        Collection<SdkIamStatement> statements();
+        Builder statements(Collection<SdkIamStatement> statements);
+        Builder statements(SdkIamStatement... statements);
+
+        SdkIamPolicy build();
+    }
+
+    private static final class BuilderImpl implements Builder {
+        private String id;
+        private String version;
+        private Collection<SdkIamStatement> statements = new ArrayList<>();
+
+        private BuilderImpl() {}
+
+
+        @Override
+        public String id() {
+            return id;
+        }
+
+        @Override
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        @Override
+        public String version() {
+            return version;
+        }
+
+        @Override
+        public Builder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        @Override
+        public Collection<SdkIamStatement> statements() {
+            return statements;
+        }
+
+        @Override
+        public Builder statements(Collection<SdkIamStatement> statements) {
+            this.statements = statements;
+            return this;
+        }
+
+        @Override
+        public Builder statements(SdkIamStatement... statements) {
+            this.statements = Arrays.asList(statements);
+            return this;
+        }
+
+        @Override
+        public SdkIamPolicy build() {
+            return new SdkIamPolicy(this);
+        }
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamPrincipal.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamPrincipal.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy;
+
+/**
+ * A principal is an AWS account or AWS web service, which is being allowed or denied access to a
+ * resource through an access control policy. The principal is a property of the
+ * {@link SdkIamStatement} object, not directly the {@link SdkIamPolicy} object.
+ * <p>
+ * The principal is A in the statement
+ * "A has permission to do B to C where D applies."
+ * <p>
+ * In an access control policy statement, you can set the principal to all
+ * authenticated AWS users through the {@link SdkIamPrincipal#ALL_USERS} member. This
+ * is useful when you don't want to restrict access based on the identity of the
+ * requester, but instead on other identifying characteristics such as the
+ * requester's IP address.
+ */
+public class SdkIamPrincipal {
+
+    /**
+     * Principal instance that includes all users, including anonymous users.
+     * <p>
+     * This is useful when you don't want to restrict access based on the
+     * identity of the requester, but instead on other identifying
+     * characteristics such as the requester's IP address.
+     */
+    public static final SdkIamPrincipal ALL_USERS = new SdkIamPrincipal("AWS", "*");
+
+    /**
+     * Principal instance that includes all AWS web services.
+     */
+    public static final SdkIamPrincipal ALL_SERVICES = new SdkIamPrincipal("Service", "*");
+
+    /**
+     * Principal instance that includes all the web identity providers.
+     */
+    public static final SdkIamPrincipal ALL_WEB_PROVIDERS = new SdkIamPrincipal("Federated", "*");
+
+    /**
+     * Principal instance that includes all the AWS accounts, AWS web services and web identity providers.
+     */
+    public static final SdkIamPrincipal ALL = new SdkIamPrincipal("*", "*");
+
+    private final String id;
+    private final String provider;
+
+    /**
+     * Constructs a new principal with the specified AWS web service which
+     * is being allowed or denied access to a resource through an access control
+     * policy.
+     *
+     * @param service
+     *            An AWS service.
+     */
+    public SdkIamPrincipal(Service service) {
+        if (service == null) {
+            throw new IllegalArgumentException("Null AWS service name specified");
+        }
+        id = service.getServiceId();
+        provider = "Service";
+    }
+
+
+    /**
+     * Constructs a new principal with the specified AWS account ID. This method
+     * automatically strips hyphen characters found in the account Id.
+     *
+     * @param accountId
+     *            An AWS account ID.
+     */
+    public SdkIamPrincipal(String accountId) {
+        this("AWS", accountId);
+
+        if (accountId == null) {
+            throw new IllegalArgumentException("Null AWS account ID specified");
+        }
+    }
+
+    /**
+     * Constructs a new principal with the specified id and provider. This
+     * method automatically strips hyphen characters found in the account ID if
+     * the provider is "AWS".
+     */
+    public SdkIamPrincipal(String provider, String id) {
+        this(provider, id, provider.equals("AWS"));
+    }
+
+    /**
+     * Constructs a new principal with the specified id and provider. This
+     * method optionally strips hyphen characters found in the account Id.
+     */
+    public SdkIamPrincipal(String provider, String id, boolean stripHyphen) {
+        this.provider = provider;
+        this.id = stripHyphen ?
+                  id.replace("-", "") : id;
+    }
+
+    /**
+     * Constructs a new principal with the specified web identity provider.
+     *
+     * @param webIdentityProvider
+     *            An web identity provider.
+     */
+    public SdkIamPrincipal(WebIdentityProvider webIdentityProvider) {
+        if (webIdentityProvider == null) {
+            throw new IllegalArgumentException("Null web identity provider specified");
+        }
+        this.id = webIdentityProvider.getWebIdentityProvider();
+        provider = "Federated";
+    }
+
+    /**
+     * Returns the provider for this principal, which indicates in what group of
+     * users this principal resides.
+     *
+     * @return The provider for this principal.
+     */
+    public String getProvider() {
+        return provider;
+    }
+
+    /**
+     * Returns the unique ID for this principal.
+     *
+     * @return The unique ID for this principal.
+     */
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public int hashCode() {
+        int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode + provider.hashCode();
+        hashCode = prime * hashCode + id.hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object principal) {
+        if (this == principal) {
+            return true;
+        }
+
+        if (principal == null) {
+            return false;
+        }
+
+        if (principal instanceof SdkIamPrincipal == false) {
+            return false;
+        }
+
+        SdkIamPrincipal other = (SdkIamPrincipal) principal;
+
+        if (this.getProvider().equals(other.getProvider())
+            && this.getId().equals(other.getId())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * The services who have the right to do the assume the role
+     * action. The AssumeRole action returns a set of temporary security
+     * credentials that you can use to access resources that are defined in the
+     * role's policy. The returned credentials consist of an Access Key ID, a
+     * Secret Access Key, and a security token.
+     */
+    public enum Service {
+
+        AWSDataPipeline("datapipeline.amazonaws.com"),
+        AmazonElasticTranscoder("elastictranscoder.amazonaws.com"),
+        AmazonEC2("ec2.amazonaws.com"),
+        AWSOpsWorks("opsworks.amazonaws.com"),
+        AWSCloudHSM("cloudhsm.amazonaws.com"),
+        AllServices("*");
+        private String serviceId;
+
+        /**
+         * The service which has the right to assume the role.
+         */
+        Service(String serviceId) {
+            this.serviceId = serviceId;
+        }
+
+        /**
+         * Construct the Services object from a string representing the service id.
+         */
+        public static Service fromString(String serviceId) {
+            if (serviceId != null) {
+                for (Service s : Service.values()) {
+                    if (s.getServiceId().equalsIgnoreCase(serviceId)) {
+                        return s;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public String getServiceId() {
+            return serviceId;
+        }
+
+
+    }
+
+    /**
+     * Web identity providers, such as Login with Amazon, Facebook, or Google.
+     */
+    public enum WebIdentityProvider {
+
+        Facebook("graph.facebook.com"),
+        Google("accounts.google.com"),
+        Amazon("www.amazon.com"),
+        AllProviders("*");
+
+        private String webIdentityProvider;
+
+        /**
+         * The web identity provider which has the right to assume the role.
+         */
+        WebIdentityProvider(String webIdentityProvider) {
+            this.webIdentityProvider = webIdentityProvider;
+        }
+
+        /**
+         * Construct the Services object from a string representing web identity provider.
+         */
+        public static WebIdentityProvider fromString(String webIdentityProvider) {
+            if (webIdentityProvider != null) {
+                for (WebIdentityProvider provider : WebIdentityProvider.values()) {
+                    if (provider.getWebIdentityProvider().equalsIgnoreCase(webIdentityProvider)) {
+                        return provider;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public String getWebIdentityProvider() {
+            return webIdentityProvider;
+        }
+
+
+    }
+
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamResource.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy;
+
+/**
+ * Represents a resource involved in an AWS access control policy statement.
+ * Resources are the service specific AWS entities owned by your account. Amazon
+ * SQS queues, Amazon S3 buckets and objects, and Amazon SNS topics are all
+ * examples of AWS resources.
+ * <p>
+ * The standard way of specifying an AWS resource is with an Amazon Resource
+ * Name (ARN).
+ * <p>
+ * The resource is C in the statement
+ * "A has permission to do B to C where D applies."
+ */
+public class SdkIamResource {
+    private final String resource;
+
+    /**
+     * Constructs a new AWS access control policy resource. Resources are
+     * typically specified as Amazon Resource Names (ARNs).
+     * <p>
+     * You specify the resource using the following Amazon Resource Name (ARN)
+     * format:
+     * <b>{@code arn:aws:<vendor>:<region>:<namespace>:<relative-id>}</b>
+     * <p>
+     * <ul>
+     * <li>vendor identifies the AWS product (e.g., sns)</li>
+     * <li>region is the AWS Region the resource resides in (e.g., us-east-1),
+     * if any
+     * <li>namespace is the AWS account ID with no hyphens (e.g., 123456789012)
+     * <li>relative-id is the service specific portion that identifies the
+     * specific resource
+     * </ul>
+     * <p>
+     * For example, an Amazon SQS queue might be addressed with the following
+     * ARN: <b>arn:aws:sqs:us-east-1:987654321000:MyQueue</b>
+     * <p>
+     * Some resources may not use every field in an ARN. For example, resources
+     * in Amazon S3 are global, so they omit the region field:
+     * <b>arn:aws:s3:::bucket/*</b>
+     *
+     * @param resource
+     *            The Amazon Resource Name (ARN) uniquely identifying the
+     *            desired AWS resource.
+     */
+    public SdkIamResource(String resource) {
+        this.resource = resource;
+    }
+
+    /**
+     * Returns the resource ID, typically an Amazon Resource Name (ARN),
+     * identifying this resource.
+     *
+     * @return The resource ID, typically an Amazon Resource Name (ARN),
+     *         identifying this resource.
+     */
+    public String getId() {
+        return resource;
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamStatement.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/SdkIamStatement.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy;
+
+import static java.util.Collections.unmodifiableCollection;
+import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import software.amazon.awssdk.utils.CollectionUtils;
+
+/**
+ * A statement is the formal description of a single permission, and is always
+ * contained within a policy object.
+ * <p>
+ * A statement describes a rule for allowing or denying access to a specific AWS
+ * resource based on how the resource is being accessed, and who is attempting
+ * to access the resource. Statements can also optionally contain a list of
+ * conditions that specify when a statement is to be honored.
+ * <p>
+ * For example, consider a statement that:
+ * <ul>
+ * <li>allows access (the effect)
+ * <li>for a list of specific AWS account IDs (the principals)
+ * <li>when accessing an SQS queue (the resource)
+ * <li>using the SendMessage operation (the action)
+ * <li>and the request occurs before a specific date (a condition)
+ * </ul>
+ *
+ * <p>
+ * Statements takes the form:  "A has permission to do B to C where D applies".
+ * <ul>
+ *   <li>A is the <b>principal</b> - the AWS account that is making a request to
+ *       access or modify one of your AWS resources.
+ *   <li>B is the <b>action</b> - the way in which your AWS resource is being accessed or modified, such
+ *       as sending a message to an Amazon SQS queue, or storing an object in an Amazon S3 bucket.
+ *   <li>C is the <b>resource</b> - your AWS entity that the principal wants to access, such
+ *       as an Amazon SQS queue, or an object stored in Amazon S3.
+ *   <li>D is the set of <b>conditions</b> - optional constraints that specify when to allow or deny
+ *       access for the principal to access your resource.  Many expressive conditions are available,
+ *       some specific to each service.  For example you can use date conditions to allow access to
+ *       your resources only after or before a specific time.
+ * </ul>
+ *
+ * <p>
+ * There are many resources and conditions available for use in statements, and
+ * you can combine them to form fine grained custom access control polices.
+ */
+public class SdkIamStatement {
+
+    private String id;
+    private Effect effect;
+    private Collection<SdkIamPrincipal> principals = new ArrayList<>();
+    private Collection<SdkIamAction> actions = new ArrayList<>();
+    private Collection<SdkIamResource> resources = new ArrayList<>();
+    private Collection<SdkIamCondition> conditions = new ArrayList<>();
+
+    private SdkIamStatement(BuilderImpl builder) {
+        this.effect = builder.effect;
+        this.id = builder.id;
+        this.principals = isNullOrEmpty(builder.principals) ? new ArrayList<>() : unmodifiableCollection(builder.principals);
+        this.actions = isNullOrEmpty(builder.actions) ? new ArrayList<>() : unmodifiableCollection(builder.actions);
+        this.resources = isNullOrEmpty(builder.resources) ? new ArrayList<>() : unmodifiableCollection(builder.resources);
+        this.conditions = isNullOrEmpty(builder.conditions) ? new ArrayList<>() : unmodifiableCollection(builder.conditions);
+    }
+
+    /**
+     * Constructs a new access control policy statement with the specified
+     * effect.
+     * <p>
+     * Before a statement is valid and can be sent to AWS, callers must set the
+     * principals, resources, and actions (as well as any optional conditions)
+     * involved in the statement.
+     *
+     * @param effect
+     *            The effect this statement has (allowing access or denying
+     *            access) when all conditions, resources, principals, and
+     *            actions are matched.
+     */
+    public SdkIamStatement(Effect effect) {
+        this.effect = effect;
+        this.id = null;
+    }
+
+    /**
+     * Returns the ID for this statement. Statement IDs serve to help keep track
+     * of multiple statements, and are often used to give the statement a
+     * meaningful, human readable name.
+     * <p>
+     * Statement IDs must be unique within a policy, but are not required to be
+     * globally unique.
+     * <p>
+     * If you do not explicitly assign an ID to a statement, a unique ID will be
+     * automatically assigned when the statement is added to a policy.
+     * <p>
+     * Developers should be careful to not use the same statement ID for
+     * multiple statements in the same policy. Reusing the same statement ID in
+     * different policies is not a problem.
+     *
+     * @return The statement ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the ID for this statement. Statement IDs serve to help keep track of
+     * multiple statements, and are often used to give the statement a
+     * meaningful, human readable name.
+     * <p>
+     * Statement IDs must be unique within a policy, but are not required to be
+     * globally unique.
+     * <p>
+     * If you do not explicitly assign an ID to a statement, a unique ID will be
+     * automatically assigned when the statement is added to a policy.
+     * <p>
+     * Developers should be careful to not use the same statement ID for
+     * multiple statements in the same policy. Reusing the same statement ID in
+     * different policies is not a problem.
+     *
+     * @param id
+     *            The new statement ID for this statement.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Sets the ID for this statement and returns the updated statement so
+     * multiple calls can be chained together.
+     * <p>
+     * Statement IDs serve to help keep track of multiple statements, and are
+     * often used to give the statement a meaningful, human readable name.
+     * <p>
+     * If you do not explicitly assign an ID to a statement, a unique ID will be
+     * automatically assigned when the statement is added to a policy.
+     * <p>
+     * Developers should be careful to not use the same statement ID for
+     * multiple statements in the same policy. Reusing the same statement ID in
+     * different policies is not a problem.
+     *
+     * @param id
+     *            The new statement ID for this statement.
+     */
+    public SdkIamStatement withId(String id) {
+        setId(id);
+        return this;
+    }
+
+    /**
+     * Returns the result effect of this policy statement when it is evaluated.
+     * A policy statement can either allow access or explicitly
+     *
+     * @return The result effect of this policy statement.
+     */
+    public Effect getEffect() {
+        return effect;
+    }
+
+    /**
+     * Sets the result effect of this policy statement when it is evaluated. A
+     * policy statement can either allow access or explicitly
+     *
+     * @param effect
+     *            The result effect of this policy statement.
+     */
+    public void setEffect(Effect effect) {
+        this.effect = effect;
+    }
+
+    /**
+     * Returns the list of actions to which this policy statement applies.
+     * Actions limit a policy statement to specific service operations that are
+     * being allowed or denied by the policy statement. For example, you might
+     * want to allow any AWS user to post messages to your SQS queue using the
+     * SendMessage action, but you don't want to allow those users other actions
+     * such as ReceiveMessage or DeleteQueue.
+     *
+     * @return The list of actions to which this policy statement applies.
+     */
+    public Collection<SdkIamAction> getActions() {
+        return actions;
+    }
+
+    /**
+     * Sets the list of actions to which this policy statement applies. Actions
+     * limit a policy statement to specific service operations that are being
+     * allowed or denied by the policy statement. For example, you might want to
+     * allow any AWS user to post messages to your SQS queue using the
+     * SendMessage action, but you don't want to allow those users other actions
+     * such as ReceiveMessage or DeleteQueue.
+     *
+     * @param actions
+     *            The list of actions to which this policy statement applies.
+     */
+    public void setActions(Collection<SdkIamAction> actions) {
+        this.actions = new ArrayList<>(actions);
+    }
+
+    /**
+     * Sets the list of actions to which this policy statement applies and
+     * returns this updated Statement object so that additional method calls can
+     * be chained together.
+     * <p>
+     * Actions limit a policy statement to specific service operations that are
+     * being allowed or denied by the policy statement. For example, you might
+     * want to allow any AWS user to post messages to your SQS queue using the
+     * SendMessage action, but you don't want to allow those users other actions
+     * such as ReceiveMessage or DeleteQueue.
+     *
+     * @param actions
+     *            The list of actions to which this statement applies.
+     *
+     * @return The updated Statement object so that additional method calls can
+     *         be chained together.
+     */
+    public SdkIamStatement withActions(SdkIamAction... actions) {
+        setActions(Arrays.asList(actions));
+        return this;
+    }
+
+    /**
+     * Returns the resources associated with this policy statement. Resources
+     * are what a policy statement is allowing or denying access to, such as an
+     * Amazon SQS queue or an Amazon SNS topic.
+     * <p>
+     * Note that some services allow only one resource to be specified per
+     * policy statement.
+     *
+     * @return The resources associated with this policy statement.
+     */
+    public Collection<SdkIamResource> getResources() {
+        return resources;
+    }
+
+    /**
+     * Sets the resources associated with this policy statement. Resources are
+     * what a policy statement is allowing or denying access to, such as an
+     * Amazon SQS queue or an Amazon SNS topic.
+     * <p>
+     * Note that some services allow only one resource to be specified per
+     * policy statement.
+     *
+     * @param resources
+     *            The resources associated with this policy statement.
+     */
+    public void setResources(Collection<SdkIamResource> resources) {
+        this.resources = new ArrayList<>(resources);
+    }
+
+    /**
+     * Sets the resources associated with this policy statement and returns this
+     * updated Statement object so that additional method calls can be chained
+     * together.
+     * <p>
+     * Resources are what a policy statement is allowing or denying access to,
+     * such as an Amazon SQS queue or an Amazon SNS topic.
+     * <p>
+     * Note that some services allow only one resource to be specified per
+     * policy statement.
+     *
+     * @param resources
+     *            The resources associated with this policy statement.
+     *
+     * @return The updated Statement object so that additional method calls can
+     *         be chained together.
+     */
+    public SdkIamStatement withResources(SdkIamResource... resources) {
+        setResources(Arrays.asList(resources));
+        return this;
+    }
+
+    /**
+     * Returns the conditions associated with this policy statement. Conditions
+     * allow policy statements to be conditionally evaluated based on the many
+     * available condition types.
+     * <p>
+     * For example, a statement that allows access to an Amazon SQS queue could
+     * use a condition to only apply the effect of that statement for requests
+     * that are made before a certain date, or that originate from a range of IP
+     * addresses.
+     * <p>
+     * When multiple conditions are included in a single statement, all
+     * conditions must evaluate to true in order for the statement to take
+     * effect.
+     *
+     * @return The conditions associated with this policy statement.
+     */
+    public Collection<SdkIamCondition> getConditions() {
+        return conditions;
+    }
+
+    /**
+     * Sets the conditions associated with this policy statement. Conditions
+     * allow policy statements to be conditionally evaluated based on the many
+     * available condition types.
+     * <p>
+     * For example, a statement that allows access to an Amazon SQS queue could
+     * use a condition to only apply the effect of that statement for requests
+     * that are made before a certain date, or that originate from a range of IP
+     * addresses.
+     * <p>
+     * Multiple conditions can be included in a single statement, and all
+     * conditions must evaluate to true in order for the statement to take
+     * effect.
+     *
+     * @param conditions
+     *            The conditions associated with this policy statement.
+     */
+    public void setConditions(List<SdkIamCondition> conditions) {
+        this.conditions = conditions;
+    }
+
+    /**
+     * Sets the conditions associated with this policy statement, and returns
+     * this updated Statement object so that additional method calls can be
+     * chained together.
+     * <p>
+     * Conditions allow policy statements to be conditionally evaluated based on
+     * the many available condition types.
+     * <p>
+     * For example, a statement that allows access to an Amazon SQS queue could
+     * use a condition to only apply the effect of that statement for requests
+     * that are made before a certain date, or that originate from a range of IP
+     * addresses.
+     * <p>
+     * Multiple conditions can be included in a single statement, and all
+     * conditions must evaluate to true in order for the statement to take
+     * effect.
+     *
+     * @param conditions
+     *            The conditions associated with this policy statement.
+     *
+     * @return The updated Statement object so that additional method calls can
+     *         be chained together.
+     */
+    public SdkIamStatement withConditions(SdkIamCondition... conditions) {
+        setConditions(Arrays.asList(conditions));
+        return this;
+    }
+
+    /**
+     * Returns the principals associated with this policy statement, indicating
+     * which AWS accounts are affected by this policy statement.
+     *
+     * @return The list of principals associated with this policy statement.
+     */
+    public Collection<SdkIamPrincipal> getPrincipals() {
+        return principals;
+    }
+
+    /**
+     * Sets the principals associated with this policy statement, indicating
+     * which AWS accounts are affected by this policy statement.
+     * <p>
+     * If you don't want to restrict your policy to specific users, you can use
+     * {@link SdkIamPrincipal#ALL_USERS} to apply the policy to any user trying to
+     * access your resource.
+     *
+     * @param principals
+     *            The list of principals associated with this policy statement.
+     */
+    public void setPrincipals(Collection<SdkIamPrincipal> principals) {
+        this.principals = new ArrayList<>(principals);
+    }
+
+    /**
+     * Sets the principals associated with this policy statement, indicating
+     * which AWS accounts are affected by this policy statement.
+     * <p>
+     * If you don't want to restrict your policy to specific users, you can use
+     * {@link SdkIamPrincipal#ALL_USERS} to apply the policy to any user trying to
+     * access your resource.
+     *
+     * @param principals
+     *            The list of principals associated with this policy statement.
+     */
+    public void setPrincipals(SdkIamPrincipal... principals) {
+        setPrincipals(new ArrayList<>(Arrays.asList(principals)));
+    }
+
+    /**
+     * Sets the principals associated with this policy statement, and returns
+     * this updated Statement object. Principals control which AWS accounts are
+     * affected by this policy statement.
+     * <p>
+     * If you don't want to restrict your policy to specific users, you can use
+     * {@link SdkIamPrincipal#ALL_USERS} to apply the policy to any user trying to
+     * access your resource.
+     *
+     * @param principals
+     *            The list of principals associated with this policy statement.
+     *
+     * @return The updated Statement object so that additional method calls can
+     *         be chained together.
+     */
+    public SdkIamStatement withPrincipals(SdkIamPrincipal... principals) {
+        setPrincipals(principals);
+        return this;
+    }
+
+    /**
+     * The effect is the result that you want a policy statement to return at
+     * evaluation time. A policy statement can either allow access or explicitly
+     * deny access.
+     */
+    public enum Effect {
+        Allow(), Deny();
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder {
+        Builder id(String id);
+        Builder effect(Effect effect);
+        Builder principals(Collection<SdkIamPrincipal> principals);
+        Builder actions(Collection<SdkIamAction> actions);
+        Builder resources(Collection<SdkIamResource> resources);
+        Builder conditions(Collection<SdkIamCondition> conditions);
+
+        SdkIamStatement build();
+    }
+
+
+    private static final class BuilderImpl implements Builder {
+        private String id;
+        private Effect effect;
+        private Collection<SdkIamPrincipal> principals = new ArrayList<>();
+        private Collection<SdkIamAction> actions = new ArrayList<>();
+        private Collection<SdkIamResource> resources = new ArrayList<>();
+        private Collection<SdkIamCondition> conditions = new ArrayList<>();
+
+        private String id() {
+            return id;
+        }
+
+        @Override
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        @Override
+        public Builder effect(Effect effect) {
+            this.effect = effect;
+            return this;
+        }
+
+        @Override
+        public Builder principals(Collection<SdkIamPrincipal> principals) {
+            this.principals = principals;
+            return this;
+        }
+
+        @Override
+        public Builder actions(Collection<SdkIamAction> actions) {
+            this.actions = actions;
+            return this;
+        }
+
+        @Override
+        public Builder resources(Collection<SdkIamResource> resources) {
+            this.resources = resources;
+            return this;
+        }
+
+        @Override
+        public Builder conditions(Collection<SdkIamCondition> conditions) {
+            this.conditions = conditions;
+            return this;
+        }
+
+
+        @Override
+        public SdkIamStatement build() {
+            return new SdkIamStatement(this);
+        }
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/ArnCondition.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/ArnCondition.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.conditions;
+
+import java.util.Arrays;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+
+/**
+ * AWS access control policy condition that allows an access control statement
+ * to be conditionally applied based on the comparison of an Amazon Resource
+ * Name (ARN).
+ * <p>
+ * An Amazon Resource Name (ARN) takes the following format:
+ * <b>{@code arn:aws:<vendor>:<region>:<namespace>:<relative-id>}</b>
+ * <p>
+ * <ul>
+ * <li>vendor identifies the AWS product (e.g., sns)</li>
+ * <li>region is the AWS Region the resource resides in (e.g., us-east-1), if
+ * any
+ * <li>namespace is the AWS account ID with no hyphens (e.g., 123456789012)
+ * <li>relative-id is the service specific portion that identifies the specific
+ * resource
+ * </ul>
+ * <p>
+ * For example, an Amazon SQS queue might be addressed with the following ARN:
+ * <b>arn:aws:sqs:us-east-1:987654321000:MyQueue</b>
+ * <p>
+ * <p>
+ * Currently the only valid condition key to use in an ARN condition is
+ * {@link ConditionFactory#SOURCE_ARN_CONDITION_KEY}, which indicates the
+ * source resource that is modifying another resource, for example, an SNS topic
+ * is the source ARN when publishing messages from the topic to an SQS queue.
+ */
+public class ArnCondition extends SdkIamCondition {
+
+    /**
+     * Constructs a new access control policy condition that compares ARNs
+     * (Amazon Resource Names).
+     *
+     * @param type
+     *            The type of comparison to perform.
+     * @param key
+     *            The access policy condition key specifying where to get the
+     *            first ARN for the comparison (ex:
+     *            {@link ConditionFactory#SOURCE_ARN_CONDITION_KEY}).
+     * @param value
+     *            The second ARN to compare against. When using
+     *            {@link ArnComparisonType#ArnLike} or
+     *            {@link ArnComparisonType#ArnNotLike} this may contain the
+     *            multi-character wildcard (*) or the single-character wildcard
+     *            (?).
+     */
+    public ArnCondition(ArnComparisonType type, String key, String value) {
+        super.type = type.toString();
+        super.conditionKey = key;
+        super.values = Arrays.asList(value);
+    }
+
+    ;
+
+    /**
+     * Enumeration of the supported ways an ARN comparison can be evaluated.
+     */
+    public enum ArnComparisonType {
+        /**
+         * Exact matching.
+         */
+        ArnEquals,
+
+        /**
+         * Loose case-insensitive matching of the ARN. Each of the six
+         * colon-delimited components of the ARN is checked separately and each
+         * can include a multi-character match wildcard (*) or a
+         * single-character match wildcard (?).
+         */
+        ArnLike,
+
+        /**
+         * Negated form of {@link #ArnEquals}
+         */
+        ArnNotEquals,
+
+        /**
+         * Negated form of {@link #ArnLike}
+         */
+        ArnNotLike
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/ConditionFactory.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/ConditionFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.conditions;
+
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+
+/**
+ * Factory for creating common AWS access control policy conditions. These
+ * conditions are common for AWS services and can be expected to work across any
+ * service that supports AWS access control policies.
+ */
+public final class ConditionFactory {
+
+    /**
+     * Condition key for the current time.
+     * <p>
+     * This condition key should only be used with {@link DateCondition}
+     * objects.
+     */
+    public static final String CURRENT_TIME_CONDITION_KEY = "aws:CurrentTime";
+
+    /**
+     * Condition key for the source IP from which a request originates.
+     * <p>
+     * This condition key should only be used with {@link IpAddressCondition}
+     * objects.
+     */
+    public static final String SOURCE_IP_CONDITION_KEY = "aws:SourceIp";
+
+    /**
+     * Condition key for the Amazon Resource Name (ARN) of the source specified
+     * in a request. The source ARN indicates which resource is affecting the
+     * resource listed in your policy. For example, an SNS topic is the source
+     * ARN when publishing messages from the topic to an SQS queue.
+     * <p>
+     * This condition key should only be used with {@link ArnCondition} objects.
+     */
+    public static final String SOURCE_ARN_CONDITION_KEY = "aws:SourceArn";
+
+    private ConditionFactory() {
+    }
+
+    /**
+     * Constructs a new access policy condition that compares the Amazon
+     * Resource Name (ARN) of the source of an AWS resource that is modifying
+     * another AWS resource with the specified pattern.
+     * <p>
+     * For example, the source ARN could be an Amazon SNS topic ARN that is
+     * sending messages to an Amazon SQS queue. In that case, the SNS topic ARN
+     * would be compared the ARN pattern specified here.
+     * <p>
+     * The endpoint pattern may optionally contain the multi-character wildcard
+     * (*) or the single-character wildcard (?). Each of the six colon-delimited
+     * components of the ARN is checked separately and each can include a
+     * wildcard.
+     *
+     * <pre class="brush: java">
+     * Policy policy = new Policy(&quot;MyQueuePolicy&quot;);
+     * policy.withStatements(new Statement(&quot;AllowSNSMessages&quot;, Effect.Allow)
+     *         .withPrincipals(new Principal(&quot;*&quot;)).withActions(SQSActions.SendMessage)
+     *         .withResources(new Resource(myQueueArn))
+     *         .withConditions(ConditionFactory.newSourceArnCondition(myTopicArn)));
+     * </pre>
+     *
+     * @param arnPattern
+     *            The ARN pattern against which the source ARN will be compared.
+     *            Each of the six colon-delimited components of the ARN is
+     *            checked separately and each can include a wildcard.
+     *
+     * @return A new access control policy condition that compares the ARN of
+     *         the source specified in an incoming request with the ARN pattern
+     *         specified here.
+     */
+    public static SdkIamCondition newSourceArnCondition(String arnPattern) {
+        return new ArnCondition(ArnCondition.ArnComparisonType.ArnLike, SOURCE_ARN_CONDITION_KEY, arnPattern);
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/DateCondition.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/DateCondition.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.conditions;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+import java.util.Collections;
+import java.util.Date;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+
+
+/**
+ * AWS access control policy condition that allows an access control statement
+ * to be conditionally applied based on the comparison of the current time at
+ * which a request is received, and a specific date.
+ */
+public class DateCondition extends SdkIamCondition {
+
+    /**
+     * Constructs a new access policy condition that compares the current time
+     * (on the AWS servers) to the specified date.
+     *
+     * @param type
+     *            The type of comparison to perform. For example,
+     *            {@link DateComparisonType#DateLessThan} will cause this policy
+     *            condition to evaluate to true if the current date is less than
+     *            the date specified in the second argument.
+     * @param date
+     *            The date to compare against.
+     */
+    public DateCondition(DateComparisonType type, Date date) {
+        super.type = type.toString();
+        super.conditionKey = ConditionFactory.CURRENT_TIME_CONDITION_KEY;
+        super.values = Collections.singletonList(ISO_INSTANT.format(date.toInstant()));
+    }
+
+    ;
+
+    /**
+     * Enumeration of the supported ways a date comparison can be evaluated.
+     */
+    public enum DateComparisonType {
+        DateEquals,
+        DateGreaterThan,
+        DateGreaterThanEquals,
+        DateLessThan,
+        DateLessThanEquals,
+        DateNotEquals;
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/IpAddressCondition.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/IpAddressCondition.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.conditions;
+
+import java.util.Arrays;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+
+/**
+ * AWS access control policy condition that allows an access control statement
+ * to be conditionally applied based on the comparison of the the incoming
+ * source IP address at the time of a request against a CIDR IP range.
+ * <p>
+ * For more information about CIDR IP ranges, see <a
+ * href="http://en.wikipedia.org/wiki/CIDR_notation">
+ * http://en.wikipedia.org/wiki/CIDR_notation</a>
+ */
+public class IpAddressCondition extends SdkIamCondition {
+
+    /**
+     * Constructs a new access policy condition that compares the source IP
+     * address of the incoming request to an AWS service against the specified
+     * CIDR range. The condition evaluates to true (meaning the policy statement
+     * containing it will be applied) if the incoming source IP address is
+     * within that range.
+     * <p>
+     * To achieve the opposite effect (i.e. cause the condition to evaluate to
+     * true when the incoming source IP is <b>not</b> in the specified CIDR
+     * range) use the alternate constructor form and specify
+     * {@link IpAddressComparisonType#NotIpAddress}
+     * <p>
+     * For more information about CIDR IP ranges, see <a
+     * href="http://en.wikipedia.org/wiki/CIDR_notation">
+     * http://en.wikipedia.org/wiki/CIDR_notation</a>
+     *
+     * @param ipAddressRange
+     *            The CIDR IP range involved in the policy condition.
+     */
+    public IpAddressCondition(String ipAddressRange) {
+        this(IpAddressComparisonType.IpAddress, ipAddressRange);
+    }
+
+    /**
+     * Constructs a new access policy condition that compares the source IP
+     * address of the incoming request to an AWS service against the specified
+     * CIDR range. When the condition evaluates to true (i.e. when the incoming
+     * source IP address is within the CIDR range or not) depends on the
+     * specified {@link IpAddressComparisonType}.
+     * <p>
+     * For more information about CIDR IP ranges, see <a
+     * href="http://en.wikipedia.org/wiki/CIDR_notation">
+     * http://en.wikipedia.org/wiki/CIDR_notation</a>
+     *
+     * @param type
+     *            The type of comparison to to perform.
+     * @param ipAddressRange
+     *            The CIDR IP range involved in the policy condition.
+     */
+    public IpAddressCondition(IpAddressComparisonType type, String ipAddressRange) {
+        super.type = type.toString();
+        super.conditionKey = ConditionFactory.SOURCE_IP_CONDITION_KEY;
+        super.values = Arrays.asList(ipAddressRange);
+    }
+
+    /**
+     * Enumeration of the supported ways an IP address comparison can be evaluated.
+     */
+    public enum IpAddressComparisonType {
+        /**
+         * Matches an IP address against a CIDR IP range, evaluating to true if
+         * the IP address being tested is in the condition's specified CIDR IP
+         * range.
+         * <p>
+         * For more information about CIDR IP ranges, see <a
+         * href="http://en.wikipedia.org/wiki/CIDR_notation">
+         * http://en.wikipedia.org/wiki/CIDR_notation</a>
+         */
+        IpAddress,
+
+        /**
+         * Negated form of {@link #IpAddress}
+         */
+        NotIpAddress,
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/StringCondition.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/conditions/StringCondition.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.conditions;
+
+import java.util.Arrays;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+
+/**
+ * String conditions let you constrain AWS access control policy statements
+ * using string matching rules.
+ */
+public class StringCondition extends SdkIamCondition {
+
+    /**
+     * Constructs a new access control policy condition that compares two
+     * strings.
+     *
+     * @param type
+     *            The type of comparison to perform.
+     * @param key
+     *            The access policy condition key specifying where to get the
+     *            first string for the comparison (ex: aws:UserAgent). See
+     *            {@link ConditionFactory} for a list of the condition keys
+     *            available for all services.
+     * @param value
+     *            The second string to compare against. When using
+     *            {@link StringComparisonType#StringLike} or
+     *            {@link StringComparisonType#StringNotLike} this may contain
+     *            the multi-character wildcard (*) or the single-character
+     *            wildcard (?).
+     */
+    public StringCondition(StringComparisonType type, String key, String value) {
+        super.type = type.toString();
+        super.conditionKey = key;
+        super.values = Arrays.asList(value);
+    }
+
+    /**
+     * Enumeration of the supported ways a string comparison can be evaluated.
+     */
+    public enum StringComparisonType {
+        /** Case-sensitive exact string matching. */
+        StringEquals,
+
+        /** Case-insensitive string matching. */
+        StringEqualsIgnoreCase,
+
+        /**
+         * Loose case-insensitive matching. The values can include a
+         * multi-character match wildcard (*) or a single-character match
+         * wildcard (?) anywhere in the string.
+         */
+        StringLike,
+
+        /**
+         * Negated form of {@link #StringEquals}
+         */
+        StringNotEquals,
+
+        /**
+         * Negated form of {@link #StringEqualsIgnoreCase}
+         */
+        StringNotEqualsIgnoreCase,
+
+        /**
+         * Negated form of {@link #StringLike}
+         */
+        StringNotLike;
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JacksonUtils.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JacksonUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.internal;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.Writer;
+
+public final class JacksonUtils {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        OBJECT_MAPPER.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private JacksonUtils() {
+    }
+
+    /**
+     * Returns the deserialized object from the given json string and target
+     * class; or null if the given json string is null.
+     */
+    public static <T> T fromJsonString(String json, Class<T> clazz) {
+        if (json == null) {
+            return null;
+        }
+
+        return invokeSafely(() -> OBJECT_MAPPER.readValue(json, clazz));
+    }
+
+    public static JsonNode jsonNodeOf(String json) {
+        return fromJsonString(json, JsonNode.class);
+    }
+
+    public static JsonGenerator jsonGeneratorOf(Writer writer) throws IOException {
+        return new JsonFactory().createGenerator(writer);
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JsonDocumentField.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JsonDocumentField.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.internal;
+
+public final class JsonDocumentField {
+
+    public static final String VERSION = "Version";
+    public static final String POLICY_ID = "Id";
+    public static final String STATEMENT = "Statement";
+    public static final String STATEMENT_EFFECT = "Effect";
+    public static final String EFFECT_VALUE_ALLOW = "Allow";
+    public static final String STATEMENT_ID = "Sid";
+    public static final String PRINCIPAL = "Principal";
+    public static final String ACTION = "Action";
+    public static final String RESOURCE = "Resource";
+    public static final String CONDITION = "Condition";
+
+    private JsonDocumentField() {
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JsonPolicyReader.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JsonPolicyReader.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamAction;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPolicy;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPrincipal;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamResource;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamStatement;
+
+/**
+ * Generate an AWS policy object by parsing the given JSON string.
+ */
+public class JsonPolicyReader {
+
+    private static final String PRINCIPAL_SCHEMA_USER = "AWS";
+
+    private static final String PRINCIPAL_SCHEMA_SERVICE = "Service";
+
+    private static final String PRINCIPAL_SCHEMA_FEDERATED = "Federated";
+
+    /**
+     * Converts the specified JSON string to an AWS policy object.
+     *
+     * For more information see, @see
+     * http://docs.aws.amazon.com/AWSSdkDocsJava/latest
+     * /DeveloperGuide/java-dg-access-control.html
+     *
+     * @param jsonString
+     *            the specified JSON string representation of this AWS access
+     *            control policy.
+     *
+     * @return An AWS policy object.
+     *
+     * @throws IllegalArgumentException
+     *             If the specified JSON string is null or invalid and cannot be
+     *             converted to an AWS policy object.
+     */
+    public SdkIamPolicy createPolicyFromJsonString(String jsonString) {
+
+        if (jsonString == null) {
+            throw new IllegalArgumentException("JSON string cannot be null");
+        }
+
+        JsonNode policyNode;
+        JsonNode idNode;
+        JsonNode statementNodes;
+        SdkIamPolicy policy = new SdkIamPolicy();
+        List<SdkIamStatement> statements = new LinkedList<>();
+
+        try {
+            policyNode = JacksonUtils.jsonNodeOf(jsonString);
+
+            idNode = policyNode.get(JsonDocumentField.POLICY_ID);
+            if (isNotNull(idNode)) {
+                policy.setId(idNode.asText());
+            }
+
+            statementNodes = policyNode.get(JsonDocumentField.STATEMENT);
+            if (isNotNull(statementNodes)) {
+                for (JsonNode node : statementNodes) {
+                    statements.add(statementOf(node));
+                }
+            }
+
+        } catch (Exception e) {
+            String message = "Unable to generate policy object fron JSON string "
+                             + e.getMessage();
+            throw new IllegalArgumentException(message, e);
+        }
+        policy.setStatements(statements);
+        return policy;
+    }
+
+    /**
+     * Creates a <code>Statement</code> instance from the statement node.
+     *
+     * A statement consists of an Effect, id (optional), principal, action, resource,
+     * and conditions.
+     * <p>
+     * principal is the AWS account that is making a request to access or modify one of your AWS resources.
+     * <p>
+     * action is the way in which your AWS resource is being accessed or modified, such as sending a message to an Amazon
+     * SQS queue, or storing an object in an Amazon S3 bucket.
+     * <p>
+     * resource is the AWS entity that the principal wants to access, such as an Amazon SQS queue, or an object stored in
+     * Amazon S3.
+     * <p>
+     * conditions are the optional constraints that specify when to allow or deny access for the principal to access your
+     * resource. Many expressive conditions are available, some specific to each service. For example, you can use date
+     * conditions to allow access to your resources only after or before a specific time.
+     *
+     * @param jStatement
+     *            JsonNode representing the statement.
+     * @return a reference to the statement instance created.
+     */
+    private SdkIamStatement statementOf(JsonNode jStatement) {
+
+        JsonNode effectNode = jStatement.get(JsonDocumentField.STATEMENT_EFFECT);
+
+        SdkIamStatement.Effect effect = isNotNull(effectNode)
+                                        ? SdkIamStatement.Effect.valueOf(effectNode.asText())
+                                        : SdkIamStatement.Effect.Deny;
+
+        SdkIamStatement statement = new SdkIamStatement(effect);
+
+        JsonNode id = jStatement.get(JsonDocumentField.STATEMENT_ID);
+        if (isNotNull(id)) {
+            statement.setId(id.asText());
+        }
+
+        JsonNode actionNodes = jStatement.get(JsonDocumentField.ACTION);
+        if (isNotNull(actionNodes)) {
+            statement.setActions(actionsOf(actionNodes));
+        }
+
+        JsonNode resourceNodes = jStatement.get(JsonDocumentField.RESOURCE);
+        if (isNotNull(resourceNodes)) {
+            statement.setResources(resourcesOf(resourceNodes));
+        }
+
+        JsonNode conditionNodes = jStatement.get(JsonDocumentField.CONDITION);
+        if (isNotNull(conditionNodes)) {
+            statement.setConditions(conditionsOf(conditionNodes));
+        }
+
+        JsonNode principalNodes = jStatement.get(JsonDocumentField.PRINCIPAL);
+        if (isNotNull(principalNodes)) {
+            statement.setPrincipals(principalOf(principalNodes));
+        }
+
+        return statement;
+    }
+
+    /**
+     * Generates a list of actions from the Action Json Node.
+     *
+     * @param actionNodes
+     *            the action Json node to be parsed.
+     * @return the list of actions.
+     */
+    private Collection<SdkIamAction> actionsOf(JsonNode actionNodes) {
+        List<SdkIamAction> actions = new LinkedList<>();
+
+        if (actionNodes.isArray()) {
+            for (JsonNode action : actionNodes) {
+                actions.add(new SdkIamAction(action.asText()));
+            }
+        } else {
+            actions.add(new SdkIamAction(actionNodes.asText()));
+        }
+        return actions;
+    }
+
+    /**
+     * Generates a list of resources from the Resource Json Node.
+     *
+     * @param resourceNodes
+     *            the resource Json node to be parsed.
+     * @return the list of resources.
+     */
+    private Collection<SdkIamResource> resourcesOf(JsonNode resourceNodes) {
+        List<SdkIamResource> resources = new LinkedList<>();
+
+        if (resourceNodes.isArray()) {
+            for (JsonNode resource : resourceNodes) {
+                resources.add(new SdkIamResource(resource.asText()));
+            }
+        } else {
+            resources.add(new SdkIamResource(resourceNodes.asText()));
+        }
+
+        return resources;
+    }
+
+    /**
+     * Generates a list of principals from the Principal Json Node
+     *
+     * @param principalNodes
+     *            the principal Json to be parsed
+     * @return a list of principals
+     */
+    private Collection<SdkIamPrincipal> principalOf(JsonNode principalNodes) {
+        List<SdkIamPrincipal> principals = new LinkedList<>();
+
+        if (principalNodes.asText().equals("*")) {
+            principals.add(SdkIamPrincipal.ALL);
+            return principals;
+        }
+
+        Iterator<Entry<String, JsonNode>> mapOfPrincipals = principalNodes
+                .fields();
+        String schema;
+        JsonNode principalNode;
+        Entry<String, JsonNode> principal;
+        Iterator<JsonNode> elements;
+        while (mapOfPrincipals.hasNext()) {
+            principal = mapOfPrincipals.next();
+            schema = principal.getKey();
+            principalNode = principal.getValue();
+
+            if (principalNode.isArray()) {
+                elements = principalNode.elements();
+                while (elements.hasNext()) {
+                    principals.add(createPrincipal(schema, elements.next()));
+                }
+            } else {
+                principals.add(createPrincipal(schema, principalNode));
+            }
+        }
+
+        return principals;
+    }
+
+    /**
+     * Creates a new principal instance for the given schema and the Json node.
+     *
+     * @param schema
+     *            the schema for the principal instance being created.
+     * @param principalNode
+     *            the node indicating the AWS account that is making the
+     *            request.
+     * @return a principal instance.
+     */
+    private SdkIamPrincipal createPrincipal(String schema, JsonNode principalNode) {
+        if (schema.equalsIgnoreCase(PRINCIPAL_SCHEMA_USER)) {
+            return new SdkIamPrincipal(principalNode.asText());
+        } else if (schema.equalsIgnoreCase(PRINCIPAL_SCHEMA_SERVICE)) {
+            return new SdkIamPrincipal(schema, principalNode.asText());
+        } else if (schema.equalsIgnoreCase(PRINCIPAL_SCHEMA_FEDERATED)) {
+            if (SdkIamPrincipal.WebIdentityProvider.fromString(principalNode.asText()) != null) {
+                return new SdkIamPrincipal(
+                    SdkIamPrincipal.WebIdentityProvider.fromString(principalNode.asText()));
+            } else {
+                return new SdkIamPrincipal(PRINCIPAL_SCHEMA_FEDERATED, principalNode.asText());
+            }
+        }
+        throw new IllegalArgumentException("Schema " + schema + " is not a valid value for the principal.");
+    }
+
+    /**
+     * Generates a list of condition from the Json node.
+     *
+     * @param conditionNodes
+     *            the condition Json node to be parsed.
+     * @return the list of conditions.
+     */
+    private List<SdkIamCondition> conditionsOf(JsonNode conditionNodes) {
+
+        List<SdkIamCondition> conditionList = new LinkedList<>();
+        Iterator<Entry<String, JsonNode>> mapOfConditions = conditionNodes
+                .fields();
+
+        Entry<String, JsonNode> condition;
+        while (mapOfConditions.hasNext()) {
+            condition = mapOfConditions.next();
+            convertConditionRecord(conditionList, condition.getKey(),
+                                   condition.getValue());
+        }
+
+        return conditionList;
+    }
+
+    /**
+     * Generates a condition instance for each condition type under the
+     * Condition Json node.
+     *
+     * @param conditions
+     *            the complete list of conditions
+     * @param conditionType
+     *            the condition type for the condition being created.
+     * @param conditionNode
+     *            each condition node to be parsed.
+     */
+    private void convertConditionRecord(List<SdkIamCondition> conditions,
+                                        String conditionType, JsonNode conditionNode) {
+
+        Iterator<Entry<String, JsonNode>> mapOfFields = conditionNode
+                .fields();
+        List<String> values;
+        Entry<String, JsonNode> field;
+        JsonNode fieldValue;
+        Iterator<JsonNode> elements;
+
+        while (mapOfFields.hasNext()) {
+            values = new LinkedList<>();
+            field = mapOfFields.next();
+            fieldValue = field.getValue();
+
+            if (fieldValue.isArray()) {
+                elements = fieldValue.elements();
+                while (elements.hasNext()) {
+                    values.add(elements.next().asText());
+                }
+            } else {
+                values.add(fieldValue.asText());
+            }
+            conditions.add(new SdkIamCondition().withType(conditionType)
+                                                .withConditionKey(field.getKey()).withValues(values));
+        }
+    }
+
+    /**
+     * Checks if the given object is not null.
+     *
+     * @param object
+     *            the object compared to null.
+     * @return true if the object is not null else false
+     */
+    private boolean isNotNull(Object object) {
+        return null != object;
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JsonPolicyWriter.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/auth/policy/internal/JsonPolicyWriter.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.auth.policy.internal;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamAction;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamCondition;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPolicy;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPrincipal;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamResource;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamStatement;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Serializes an AWS policy object to a JSON string, suitable for sending to an
+ * AWS service.
+ */
+public class JsonPolicyWriter {
+    private static final Logger log = LoggerFactory.getLogger(JsonPolicyWriter.class);
+
+    /** The JSON Generator to generator a JSON string.*/
+    private JsonGenerator generator = null;
+    /** The output writer to which the JSON String is written.*/
+    private Writer writer;
+
+    /**
+     * Constructs a new instance of JSONPolicyWriter.
+     */
+    public JsonPolicyWriter() {
+        writer = new StringWriter();
+        generator = invokeSafely(() -> JacksonUtils.jsonGeneratorOf(writer));
+    }
+
+    /**
+     * Converts the specified AWS policy object to a JSON string, suitable for
+     * passing to an AWS service.
+     *
+     * @param policy
+     *            The AWS policy object to convert to a JSON string.
+     *
+     * @return The JSON string representation of the specified policy object.
+     *
+     * @throws IllegalArgumentException
+     *             If the specified policy is null or invalid and cannot be
+     *             serialized to a JSON string.
+     */
+    public String writePolicyToString(SdkIamPolicy policy) {
+
+        if (!isNotNull(policy)) {
+            throw new IllegalArgumentException("Policy cannot be null");
+        }
+
+        try {
+            return jsonStringOf(policy);
+        } catch (Exception e) {
+            String message = "Unable to serialize policy to JSON string: "
+                             + e.getMessage();
+            throw new IllegalArgumentException(message, e);
+        } finally {
+            IoUtils.closeQuietly(writer, log);
+        }
+    }
+
+    /**
+     * Converts the given <code>Policy</code> into a JSON String.
+     *
+     * @param policy
+     *            the policy to be converted.
+     * @return a JSON String of the specified policy object.
+     */
+    private String jsonStringOf(SdkIamPolicy policy) throws IOException {
+        generator.writeStartObject();
+
+        writeJsonKeyValue(JsonDocumentField.VERSION, policy.getVersion());
+
+        if (isNotNull(policy.getId())) {
+            writeJsonKeyValue(JsonDocumentField.POLICY_ID, policy.getId());
+        }
+
+        writeJsonArrayStart(JsonDocumentField.STATEMENT);
+
+        for (SdkIamStatement statement : policy.getStatements()) {
+            generator.writeStartObject();
+
+            if (isNotNull(statement.getId())) {
+                writeJsonKeyValue(JsonDocumentField.STATEMENT_ID, statement.getId());
+            }
+            writeJsonKeyValue(JsonDocumentField.STATEMENT_EFFECT, statement
+                    .getEffect().toString());
+
+            Collection<SdkIamPrincipal> principals = statement.getPrincipals();
+            if (isNotNull(principals) && !principals.isEmpty()) {
+                writePrincipals(principals);
+            }
+
+            Collection<SdkIamAction> actions = statement.getActions();
+            if (isNotNull(actions) && !actions.isEmpty()) {
+                writeActions(actions);
+            }
+
+            Collection<SdkIamResource> resources = statement.getResources();
+            if (isNotNull(resources) && !resources.isEmpty()) {
+                writeResources(resources);
+            }
+
+            Collection<SdkIamCondition> conditions = statement.getConditions();
+            if (isNotNull(conditions) && !conditions.isEmpty()) {
+                writeConditions(conditions);
+            }
+
+            generator.writeEndObject();
+        }
+
+        writeJsonArrayEnd();
+
+        generator.writeEndObject();
+
+        generator.flush();
+
+        return writer.toString();
+
+    }
+
+    /**
+     * Writes the list of conditions to the JSONGenerator.
+     *
+     * @param conditions
+     *            the conditions to be written.
+     */
+    private void writeConditions(Collection<SdkIamCondition> conditions) throws IOException {
+        Map<String, ConditionsByKey> conditionsByType = groupConditionsByTypeAndKey(conditions);
+
+        writeJsonObjectStart(JsonDocumentField.CONDITION);
+
+        ConditionsByKey conditionsByKey;
+        for (Map.Entry<String, ConditionsByKey> entry : conditionsByType
+                .entrySet()) {
+            conditionsByKey = conditionsByType.get(entry.getKey());
+
+            writeJsonObjectStart(entry.getKey());
+            for (String key : conditionsByKey.keySet()) {
+                writeJsonArray(key, conditionsByKey.getConditionsByKey(key));
+            }
+            writeJsonObjectEnd();
+        }
+        writeJsonObjectEnd();
+    }
+
+    /**
+     * Writes the list of <code>Resource</code>s to the JSONGenerator.
+     *
+     * @param resources
+     *            the list of resources to be written.
+     */
+    private void writeResources(Collection<SdkIamResource> resources) throws IOException {
+
+        List<String> resourceStrings = new ArrayList<>();
+
+        for (SdkIamResource resource : resources) {
+            resourceStrings.add(resource.getId());
+        }
+        writeJsonArray(JsonDocumentField.RESOURCE, resourceStrings);
+    }
+
+    /**
+     * Writes the list of <code>Action</code>s to the JSONGenerator.
+     *
+     * @param actions
+     *            the list of the actions to be written.
+     */
+    private void writeActions(Collection<SdkIamAction> actions) throws IOException {
+        List<String> actionStrings = new ArrayList<>();
+
+        for (SdkIamAction action : actions) {
+            actionStrings.add(action.getActionName());
+        }
+        writeJsonArray(JsonDocumentField.ACTION, actionStrings);
+    }
+
+    /**
+     * Writes the list of <code>Principal</code>s to the JSONGenerator.
+     *
+     * @param principals
+     *            the list of principals to be written.
+     */
+    private void writePrincipals(Collection<SdkIamPrincipal> principals) throws IOException {
+        if (hasOneAllPrincipals(principals)) {
+            writeJsonKeyValue(JsonDocumentField.PRINCIPAL, SdkIamPrincipal.ALL.getId());
+        } else {
+            writeJsonObjectStart(JsonDocumentField.PRINCIPAL);
+
+            Map<String, List<String>> principalsByScheme = groupPrincipalByScheme(principals);
+
+            List<String> principalValues;
+            for (Map.Entry<String, List<String>> entry : principalsByScheme.entrySet()) {
+                principalValues = principalsByScheme.get(entry.getKey());
+
+                if (principalValues.size() == 1) {
+                    writeJsonKeyValue(entry.getKey(), principalValues.get(0));
+                } else {
+                    writeJsonArray(entry.getKey(), principalValues);
+                }
+
+            }
+            writeJsonObjectEnd();
+        }
+    }
+
+    private static boolean hasOneAllPrincipals(Collection<SdkIamPrincipal> principals) {
+        return principals.size() == 1 && principals.stream().anyMatch(p -> p.equals(SdkIamPrincipal.ALL));
+    }
+
+    /**
+     * Groups the list of <code>Principal</code>s by the Scheme.
+     *
+     * @param principals
+     *            the list of <code>Principal</code>s
+     * @return a map grouped by scheme of the principal.
+     */
+    private Map<String, List<String>> groupPrincipalByScheme(Collection<SdkIamPrincipal> principals) {
+        Map<String, List<String>> principalsByScheme = new LinkedHashMap<>();
+
+        String provider;
+        List<String> principalValues;
+        for (SdkIamPrincipal principal : principals) {
+            provider = principal.getProvider();
+            if (!principalsByScheme.containsKey(provider)) {
+                principalsByScheme.put(provider, new ArrayList<>());
+            }
+            principalValues = principalsByScheme.get(provider);
+            principalValues.add(principal.getId());
+        }
+
+        return principalsByScheme;
+    }
+
+    /**
+     * Groups the list of <code>Condition</code>s by the condition type and
+     * condition key.
+     *
+     * @param conditions
+     *            the list of conditions to be grouped
+     * @return a map of conditions grouped by type and then key.
+     */
+    private Map<String, ConditionsByKey> groupConditionsByTypeAndKey(Collection<SdkIamCondition> conditions) {
+        Map<String, ConditionsByKey> conditionsByType = new LinkedHashMap<>();
+
+        String type;
+        String key;
+        ConditionsByKey conditionsByKey;
+        for (SdkIamCondition condition : conditions) {
+            type = condition.getType();
+            key = condition.getConditionKey();
+
+            if (!(conditionsByType.containsKey(type))) {
+                conditionsByType.put(type, new ConditionsByKey());
+            }
+
+            conditionsByKey = conditionsByType.get(type);
+            conditionsByKey.addValuesToKey(key, condition.getValues());
+        }
+        return conditionsByType;
+    }
+
+    /**
+     * Writes an array along with its values to the JSONGenerator.
+     *
+     * @param arrayName
+     *            name of the JSON array.
+     * @param values
+     *            values of the JSON array.
+     */
+    private void writeJsonArray(String arrayName, List<String> values) throws IOException {
+        writeJsonArrayStart(arrayName);
+        for (String value : values) {
+            generator.writeString(value);
+        }
+        writeJsonArrayEnd();
+    }
+
+    /**
+     * Writes the Start of Object String to the JSONGenerator along with Object
+     * Name.
+     *
+     * @param fieldName
+     *            name of the JSON Object.
+     */
+    private void writeJsonObjectStart(String fieldName) throws IOException {
+        generator.writeObjectFieldStart(fieldName);
+    }
+
+    /**
+     * Writes the End of Object String to the JSONGenerator.
+     */
+    private void writeJsonObjectEnd() throws IOException {
+        generator.writeEndObject();
+    }
+
+    /**
+     * Writes the Start of Array String to the JSONGenerator along with Array
+     * Name.
+     *
+     * @param fieldName
+     *            name of the JSON array
+     */
+    private void writeJsonArrayStart(String fieldName) throws IOException {
+        generator.writeArrayFieldStart(fieldName);
+    }
+
+    /**
+     * Writes the End of Array String to the JSONGenerator.
+     */
+    private void writeJsonArrayEnd() throws IOException {
+        generator.writeEndArray();
+    }
+
+    /**
+     * Writes the given field and the value to the JsonGenerator
+     *
+     * @param fieldName
+     *            the JSON field name
+     * @param value
+     *            value for the field
+     */
+    private void writeJsonKeyValue(String fieldName, String value) throws IOException {
+        generator.writeStringField(fieldName, value);
+    }
+
+    /**
+     * Checks if the given object is not null.
+     *
+     * @param object
+     *            the object compared to null.
+     * @return true if the object is not null else false
+     */
+    private boolean isNotNull(Object object) {
+        return null != object;
+    }
+
+    /**
+     * Inner class to hold condition values for each key under a condition type.
+     */
+    static class ConditionsByKey {
+        private Map<String, List<String>> conditionsByKey;
+
+        ConditionsByKey() {
+            conditionsByKey = new LinkedHashMap<>();
+        }
+
+        public Map<String, List<String>> getConditionsByKey() {
+            return conditionsByKey;
+        }
+
+        public void setConditionsByKey(Map<String, List<String>> conditionsByKey) {
+            this.conditionsByKey = conditionsByKey;
+        }
+
+        public boolean containsKey(String key) {
+            return conditionsByKey.containsKey(key);
+        }
+
+        public List<String> getConditionsByKey(String key) {
+            return conditionsByKey.get(key);
+        }
+
+        public Set<String> keySet() {
+            return conditionsByKey.keySet();
+        }
+
+        public void addValuesToKey(String key, List<String> values) {
+
+            List<String> conditionValues = getConditionsByKey(key);
+            if (conditionValues == null) {
+                conditionsByKey.put(key, new ArrayList<>(values));
+            } else {
+                conditionValues.addAll(values);
+            }
+        }
+    }
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/extensions/IamClientSdkExtension.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/extensions/IamClientSdkExtension.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.extensions;
+
+import software.amazon.awssdk.annotations.SdkExtensionMethod;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPolicy;
+import software.amazon.awssdk.services.iam.internal.extensions.DefaultIamClientSdkExtension;
+import software.amazon.awssdk.services.iam.model.CreatePolicyRequest;
+import software.amazon.awssdk.services.iam.model.CreatePolicyResponse;
+
+/**
+ * Extension methods for the {@link IamClient} interface.
+ */
+@SdkPublicApi
+public interface IamClientSdkExtension {
+
+    /**
+     * Create an IAM Policy.
+     */
+    @SdkExtensionMethod
+    default CreatePolicyResponse createPolicy(SdkIamPolicy policy, CreatePolicyRequest request) {
+        return new DefaultIamClientSdkExtension((IamClient) this).createPolicy(policy, request);
+    }
+
+}

--- a/services/iam/src/main/java/software/amazon/awssdk/services/iam/internal/extensions/DefaultIamClientSdkExtension.java
+++ b/services/iam/src/main/java/software/amazon/awssdk/services/iam/internal/extensions/DefaultIamClientSdkExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.iam.internal.extensions;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.auth.policy.SdkIamPolicy;
+import software.amazon.awssdk.services.iam.extensions.IamClientSdkExtension;
+import software.amazon.awssdk.services.iam.model.CreatePolicyRequest;
+import software.amazon.awssdk.services.iam.model.CreatePolicyResponse;
+import software.amazon.awssdk.utils.Validate;
+
+@SdkInternalApi
+public class DefaultIamClientSdkExtension implements IamClientSdkExtension {
+
+    private final IamClient iam;
+
+    public DefaultIamClientSdkExtension(IamClient iam) {
+        this.iam = Validate.notNull(iam, "iam");
+    }
+
+    @Override
+    public CreatePolicyResponse createPolicy(SdkIamPolicy policy, CreatePolicyRequest request) {
+        Validate.notNull(policy, "policy");
+        CreatePolicyRequest.Builder changedRequest = request.toBuilder().policyDocument(policy.toJsonDocument());
+        return iam.createPolicy(changedRequest.build());
+    }
+}

--- a/services/iam/src/main/resources/codegen-resources/customization.config
+++ b/services/iam/src/main/resources/codegen-resources/customization.config
@@ -29,5 +29,8 @@
   "blacklistedSimpleMethods": [
     "updateAccountPasswordPolicy"
   ],
-  "excludeClientCreateMethod": true
+  "excludeClientCreateMethod": true,
+  "clientExtensions": {
+    "sync": true
+  }
 }


### PR DESCRIPTION
- Adds the AWS SDK for Java v1 Policy POJOs to V2 and modifies some of them
- Adds an extension to IAM where you can supply a POJO representing a policy to `createPolicy` instead of a JSON representation

ToDo
- Clean up the POJO classes (added builders to two of them but more refactoring is needed)

Open questions
- How to correctly include Jackson dependencies?
- What is the best API for the extension that is maintainable but yet intuitive?
- How do the Sdk policy classes compare to the codegen model classes?
- What development has happened in IAM since the V1 library was updated?