### PR TITLE
Change action names and add copyable builders

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverter.java
@@ -23,10 +23,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
-import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.AddAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -95,7 +95,7 @@ public final class UpdateExpressionConverter {
      * the combined collection of paths and ExpressionName values. Because attribute names can be composed from nested
      * attribute references and list references, the leftmost part will be returned if composition is detected.
      * <p>
-     * Examples: The expression contains a {@link DeleteUpdateAction} with a path value of 'MyAttribute[1]'; the list returned
+     * Examples: The expression contains a {@link DeleteAction} with a path value of 'MyAttribute[1]'; the list returned
      * will have 'MyAttribute' as an element.}
      *
      * @return A list of top level attribute names that have update actions associated.
@@ -119,7 +119,7 @@ public final class UpdateExpressionConverter {
         }
         if (!expression.removeActions().isEmpty()) {
             groupExpressions.add(REMOVE + expression.removeActions().stream()
-                                                    .map(RemoveUpdateAction::path)
+                                                    .map(RemoveAction::path)
                                                     .collect(Collectors.joining(ACTION_SEPARATOR)));
         }
         if (!expression.deleteActions().isEmpty()) {
@@ -136,12 +136,12 @@ public final class UpdateExpressionConverter {
     }
 
     private static Stream<Map<String, String>> streamOfExpressionNames(UpdateExpression expression) {
-        return Stream.concat(expression.setActions().stream().map(SetUpdateAction::expressionNames),
-                             Stream.concat(expression.removeActions().stream().map(RemoveUpdateAction::expressionNames),
+        return Stream.concat(expression.setActions().stream().map(SetAction::expressionNames),
+                             Stream.concat(expression.removeActions().stream().map(RemoveAction::expressionNames),
                                            Stream.concat(expression.deleteActions().stream()
-                                                                   .map(DeleteUpdateAction::expressionNames),
+                                                                   .map(DeleteAction::expressionNames),
                                                          expression.addActions().stream()
-                                                                   .map(AddUpdateAction::expressionNames))));
+                                                                   .map(AddAction::expressionNames))));
     }
 
     private static Map<String, AttributeValue> mergeExpressionValues(UpdateExpression expression) {
@@ -151,9 +151,9 @@ public final class UpdateExpressionConverter {
     }
 
     private static Stream<Map<String, AttributeValue>> streamOfExpressionValues(UpdateExpression expression) {
-        return Stream.concat(expression.setActions().stream().map(SetUpdateAction::expressionValues),
-                             Stream.concat(expression.deleteActions().stream().map(DeleteUpdateAction::expressionValues),
-                                           expression.addActions().stream().map(AddUpdateAction::expressionValues)));
+        return Stream.concat(expression.setActions().stream().map(SetAction::expressionValues),
+                             Stream.concat(expression.deleteActions().stream().map(DeleteAction::expressionValues),
+                                           expression.addActions().stream().map(AddAction::expressionValues)));
     }
 
     private static Map<String, String> mergeExpressionNames(UpdateExpression expression) {
@@ -163,10 +163,10 @@ public final class UpdateExpressionConverter {
     }
 
     private static List<String> listPathsWithoutTokens(UpdateExpression expression) {
-        return Stream.concat(expression.setActions().stream().map(SetUpdateAction::path),
-                             Stream.concat(expression.removeActions().stream().map(RemoveUpdateAction::path),
-                                           Stream.concat(expression.deleteActions().stream().map(DeleteUpdateAction::path),
-                                                         expression.addActions().stream().map(AddUpdateAction::path))))
+        return Stream.concat(expression.setActions().stream().map(SetAction::path),
+                             Stream.concat(expression.removeActions().stream().map(RemoveAction::path),
+                                           Stream.concat(expression.deleteActions().stream().map(DeleteAction::path),
+                                                         expression.addActions().stream().map(AddAction::path))))
                      .map(UpdateExpressionConverter::removeNestingAndListReference)
                      .filter(attributeName -> !attributeName.contains("#"))
                      .collect(Collectors.toList());

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionUtils.java
@@ -29,8 +29,8 @@ import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
 import software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils;
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.UpdateBehaviorTag;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.UpdateBehavior;
-import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
@@ -86,7 +86,7 @@ public final class UpdateExpressionUtils {
     /**
      * Creates a list of SET actions for all attributes supplied in the map.
      */
-    private static List<SetUpdateAction> setActionsFor(Map<String, AttributeValue> attributesToSet, TableMetadata tableMetadata) {
+    private static List<SetAction> setActionsFor(Map<String, AttributeValue> attributesToSet, TableMetadata tableMetadata) {
         return attributesToSet.entrySet()
                               .stream()
                               .map(entry -> setValue(entry.getKey(),
@@ -98,7 +98,7 @@ public final class UpdateExpressionUtils {
     /**
      * Creates a list of REMOVE actions for all attributes supplied in the map.
      */
-    private static List<RemoveUpdateAction> removeActionsFor(Map<String, AttributeValue> attributesToSet) {
+    private static List<RemoveAction> removeActionsFor(Map<String, AttributeValue> attributesToSet) {
         return attributesToSet.entrySet()
                               .stream()
                               .map(entry -> remove(entry.getKey()))
@@ -108,11 +108,11 @@ public final class UpdateExpressionUtils {
     /**
      * Creates a REMOVE action for an attribute, using a token as a placeholder for the attribute name.
      */
-    private static RemoveUpdateAction remove(String attributeName) {
-        return RemoveUpdateAction.builder()
-                                 .path(keyRef(attributeName))
-                                 .expressionNames(Collections.singletonMap(keyRef(attributeName), attributeName))
-                                 .build();
+    private static RemoveAction remove(String attributeName) {
+        return RemoveAction.builder()
+                           .path(keyRef(attributeName))
+                           .expressionNames(Collections.singletonMap(keyRef(attributeName), attributeName))
+                           .build();
     }
 
     /**
@@ -120,13 +120,13 @@ public final class UpdateExpressionUtils {
      *
      * @see UpdateBehavior for information about the values available.
      */
-    private static SetUpdateAction setValue(String attributeName, AttributeValue value, UpdateBehavior updateBehavior) {
-        return SetUpdateAction.builder()
-                              .path(keyRef(attributeName))
-                              .value(behaviorBasedValue(updateBehavior).apply(attributeName))
-                              .expressionNames(expressionNamesFor(attributeName))
-                              .expressionValues(Collections.singletonMap(valueRef(attributeName), value))
-                              .build();
+    private static SetAction setValue(String attributeName, AttributeValue value, UpdateBehavior updateBehavior) {
+        return SetAction.builder()
+                        .path(keyRef(attributeName))
+                        .value(behaviorBasedValue(updateBehavior).apply(attributeName))
+                        .expressionNames(expressionNamesFor(attributeName))
+                        .expressionValues(Collections.singletonMap(valueRef(attributeName), value))
+                        .build();
     }
 
     /**

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/AddAction.java
@@ -21,15 +21,14 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * A representation of a single {@link UpdateExpression} SET action.
+ * A representation of a single {@link UpdateExpression} ADD action.
  * <p>
  * At a minimum, this action must contain a path string referencing the attribute that should be acted upon and a value string
- * referencing the value to set or change.
- * <p>
- * The value string may contain just an operand, or operands combined with '+' or '-'. Furthermore, an operand can be a
- * reference to a specific value or a function. All references to values should be substituted with tokens using the
+ * referencing the value to be added to the attribute. The value should be substituted with tokens using the
  * ':value_token' syntax and values associated with the token must be explicitly added to the expressionValues map.
  * Consult the DynamoDB UpdateExpression documentation for details on this action.
  * <p>
@@ -40,34 +39,24 @@ import software.amazon.awssdk.utils.Validate;
  * Example:-
  * <pre>
  * {@code
- * //Simply setting the value of 'attributeA' to 'myAttributeValue'
- * SetUpdateAction setAction1 = SetUpdateAction.builder()
- *                                             .path("#a")
- *                                             .value(":b")
- *                                             .putExpressionName("#a", "attributeA")
- *                                             .putExpressionValue(":b", myAttributeValue)
- *                                             .build();
- *
- * //Increasing the value of 'attributeA' with 'delta' if it already exists, otherwise sets it to 'startValue'
- * SetUpdateAction setAction2 = SetUpdateAction.builder()
- *                                             .path("#a")
- *                                             .value("if_not_exists(#a, :startValue) + :delta")
- *                                             .putExpressionName("#a", "attributeA")
- *                                             .putExpressionValue(":delta", myNumericAttributeValue1)
- *                                             .putExpressionValue(":startValue", myNumericAttributeValue2)
- *                                             .build();
+ * AddUpdateAction addAction = AddUpdateAction.builder()
+ *                                            .path("#a")
+ *                                            .value(":b")
+ *                                            .putExpressionName("#a", "attributeA")
+ *                                            .putExpressionValue(":b", myAttributeValue)
+ *                                            .build();
  * }
  * </pre>
  */
 @SdkPublicApi
-public final class SetUpdateAction implements UpdateAction {
+public final class AddAction implements UpdateAction, ToCopyableBuilder<AddAction.Builder, AddAction> {
 
     private final String path;
     private final String value;
     private final Map<String, String> expressionNames;
     private final Map<String, AttributeValue> expressionValues;
 
-    private SetUpdateAction(Builder builder) {
+    private AddAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
         this.expressionValues = wrapSecure(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
@@ -79,12 +68,20 @@ public final class SetUpdateAction implements UpdateAction {
     }
 
     /**
-     * Constructs a new builder for {@link SetUpdateAction}.
+     * Constructs a new builder for {@link AddAction}.
      *
      * @return a new builder.
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().path(path)
+                        .value(value)
+                        .expressionNames(expressionNames)
+                        .expressionValues(expressionValues);
     }
 
     public String path() {
@@ -112,7 +109,7 @@ public final class SetUpdateAction implements UpdateAction {
             return false;
         }
 
-        SetUpdateAction that = (SetUpdateAction) o;
+        AddAction that = (AddAction) o;
 
         if (path != null ? ! path.equals(that.path) : that.path != null) {
             return false;
@@ -137,9 +134,9 @@ public final class SetUpdateAction implements UpdateAction {
     }
 
     /**
-     * A builder for {@link DeleteUpdateAction}
+     * A builder for {@link AddAction}
      */
-    public static final class Builder {
+    public static final class Builder implements CopyableBuilder<Builder, AddAction> {
 
         private String path;
         private String value;
@@ -164,8 +161,8 @@ public final class SetUpdateAction implements UpdateAction {
         }
 
         /**
-         * Sets the 'expression values' token map that maps from value references (expression attribute values) to
-         * DynamoDB AttributeValues, overriding any existing values.
+         * Sets the 'expression values' token map that maps from value references (expression attribute values) to 
+         * DynamoDB AttributeValues, overriding any existing values. 
          * The value reference should always start with ':' (colon).
          *
          * @see #putExpressionValue(String, AttributeValue)
@@ -190,11 +187,11 @@ public final class SetUpdateAction implements UpdateAction {
         }
 
         /**
-         * Sets the optional 'expression names' token map, overriding any existing values. Use if the attribute
-         * references in the path expression are token ('expression attribute names') prepended with the
+         * Sets the optional 'expression names' token map, overriding any existing values. Use if the attribute 
+         * references in the path expression are token ('expression attribute names') prepended with the 
          * '#' (pound) sign. It should map from token name to real attribute name.
-         *
-         * @see #putExpressionName(String, String)
+         * 
+         * @see #putExpressionName(String, String) 
          */
         public Builder expressionNames(Map<String, String> expressionNames) {
             this.expressionNames = expressionNames == null ? null : new HashMap<>(expressionNames);
@@ -204,7 +201,7 @@ public final class SetUpdateAction implements UpdateAction {
         /**
          * Adds a single element to the optional 'expression names' token map.
          *
-         * @see #expressionNames(Map)
+         * @see #expressionNames(Map) 
          */
         public Builder putExpressionName(String key, String value) {
             if (this.expressionNames == null) {
@@ -215,10 +212,10 @@ public final class SetUpdateAction implements UpdateAction {
         }
 
         /**
-         * Builds an {@link SetUpdateAction} based on the values stored in this builder.
+         * Builds an {@link AddAction} based on the values stored in this builder.
          */
-        public SetUpdateAction build() {
-            return new SetUpdateAction(this);
+        public AddAction build() {
+            return new AddAction(this);
         }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteAction.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * A representation of a single {@link UpdateExpression} DELETE action.
@@ -47,14 +49,14 @@ import software.amazon.awssdk.utils.Validate;
  * </pre>
  */
 @SdkPublicApi
-public final class DeleteUpdateAction implements UpdateAction {
+public final class DeleteAction implements UpdateAction, ToCopyableBuilder<DeleteAction.Builder, DeleteAction> {
 
     private final String path;
     private final String value;
     private final Map<String, String> expressionNames;
     private final Map<String, AttributeValue> expressionValues;
 
-    private DeleteUpdateAction(Builder builder) {
+    private DeleteAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.value = Validate.paramNotNull(builder.value, "value");
         this.expressionValues = wrapSecure(Validate.paramNotNull(builder.expressionValues, "expressionValues"));
@@ -66,12 +68,20 @@ public final class DeleteUpdateAction implements UpdateAction {
     }
 
     /**
-     * Constructs a new builder for {@link DeleteUpdateAction}.
+     * Constructs a new builder for {@link DeleteAction}.
      *
      * @return a new builder.
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().path(path)
+                        .value(value)
+                        .expressionNames(expressionNames)
+                        .expressionValues(expressionValues);
     }
 
     public String path() {
@@ -99,7 +109,7 @@ public final class DeleteUpdateAction implements UpdateAction {
             return false;
         }
 
-        DeleteUpdateAction that = (DeleteUpdateAction) o;
+        DeleteAction that = (DeleteAction) o;
 
         if (path != null ? ! path.equals(that.path) : that.path != null) {
             return false;
@@ -124,9 +134,9 @@ public final class DeleteUpdateAction implements UpdateAction {
     }
 
     /**
-     * A builder for {@link DeleteUpdateAction}
+     * A builder for {@link DeleteAction}
      */
-    public static final class Builder {
+    public static final class Builder implements CopyableBuilder<Builder, DeleteAction> {
 
         private String path;
         private String value;
@@ -202,10 +212,10 @@ public final class DeleteUpdateAction implements UpdateAction {
         }
 
         /**
-         * Builds an {@link DeleteUpdateAction} based on the values stored in this builder.
+         * Builds an {@link DeleteAction} based on the values stored in this builder.
          */
-        public DeleteUpdateAction build() {
-            return new DeleteUpdateAction(this);
+        public DeleteAction build() {
+            return new DeleteAction(this);
         }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveAction.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveAction.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * A representation of a single {@link UpdateExpression} REMOVE action.
@@ -42,12 +44,12 @@ import software.amazon.awssdk.utils.Validate;
  * </pre>
  */
 @SdkPublicApi
-public final class RemoveUpdateAction implements UpdateAction {
+public final class RemoveAction implements UpdateAction, ToCopyableBuilder<RemoveAction.Builder, RemoveAction> {
 
     private final String path;
     private final Map<String, String> expressionNames;
 
-    private RemoveUpdateAction(Builder builder) {
+    private RemoveAction(Builder builder) {
         this.path = Validate.paramNotNull(builder.path, "path");
         this.expressionNames = wrapSecure(builder.expressionNames != null ? builder.expressionNames : new HashMap<>());
     }
@@ -57,12 +59,18 @@ public final class RemoveUpdateAction implements UpdateAction {
     }
 
     /**
-     * Constructs a new builder for {@link RemoveUpdateAction}.
+     * Constructs a new builder for {@link RemoveAction}.
      *
      * @return a new builder.
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().path(path)
+                        .expressionNames(expressionNames);
     }
 
     public String path() {
@@ -82,7 +90,7 @@ public final class RemoveUpdateAction implements UpdateAction {
             return false;
         }
 
-        RemoveUpdateAction that = (RemoveUpdateAction) o;
+        RemoveAction that = (RemoveAction) o;
 
         if (path != null ? ! path.equals(that.path) : that.path != null) {
             return false;
@@ -98,9 +106,9 @@ public final class RemoveUpdateAction implements UpdateAction {
     }
 
     /**
-     * A builder for {@link RemoveUpdateAction}
+     * A builder for {@link RemoveAction}
      */
-    public static final class Builder {
+    public static final class Builder implements CopyableBuilder<Builder, RemoveAction> {
 
         private String path;
         private Map<String, String> expressionNames;
@@ -139,10 +147,10 @@ public final class RemoveUpdateAction implements UpdateAction {
         }
 
         /**
-         * Builds an {@link RemoveUpdateAction} based on the values stored in this builder.
+         * Builds an {@link RemoveAction} based on the values stored in this builder.
          */
-        public RemoveUpdateAction build() {
-            return new RemoveUpdateAction(this);
+        public RemoveAction build() {
+            return new RemoveAction(this);
         }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpression.java
@@ -44,15 +44,15 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  * }
  * </pre>
  *
- * See respective subtype of {@link UpdateAction}, for example {@link SetUpdateAction}, for details on creating that action.
+ * See respective subtype of {@link UpdateAction}, for example {@link SetAction}, for details on creating that action.
  */
 @SdkPublicApi
 public final class UpdateExpression {
 
-    private final List<RemoveUpdateAction> removeActions;
-    private final List<SetUpdateAction> setActions;
-    private final List<DeleteUpdateAction> deleteActions;
-    private final List<AddUpdateAction> addActions;
+    private final List<RemoveAction> removeActions;
+    private final List<SetAction> setActions;
+    private final List<DeleteAction> deleteActions;
+    private final List<AddAction> addActions;
 
     private UpdateExpression(Builder builder) {
         this.removeActions = builder.removeActions;
@@ -70,19 +70,19 @@ public final class UpdateExpression {
         return new Builder();
     }
 
-    public List<RemoveUpdateAction> removeActions() {
+    public List<RemoveAction> removeActions() {
         return Collections.unmodifiableList(new ArrayList<>(removeActions));
     }
 
-    public List<SetUpdateAction> setActions() {
+    public List<SetAction> setActions() {
         return Collections.unmodifiableList(new ArrayList<>(setActions));
     }
 
-    public List<DeleteUpdateAction> deleteActions() {
+    public List<DeleteAction> deleteActions() {
         return Collections.unmodifiableList(new ArrayList<>(deleteActions));
     }
 
-    public List<AddUpdateAction> addActions() {
+    public List<AddAction> addActions() {
         return Collections.unmodifiableList(new ArrayList<>(addActions));
     }
 
@@ -145,42 +145,42 @@ public final class UpdateExpression {
      */
     public static final class Builder {
 
-        private List<RemoveUpdateAction> removeActions = new ArrayList<>();
-        private List<SetUpdateAction> setActions = new ArrayList<>();
-        private List<DeleteUpdateAction> deleteActions = new ArrayList<>();
-        private List<AddUpdateAction> addActions = new ArrayList<>();
+        private List<RemoveAction> removeActions = new ArrayList<>();
+        private List<SetAction> setActions = new ArrayList<>();
+        private List<DeleteAction> deleteActions = new ArrayList<>();
+        private List<AddAction> addActions = new ArrayList<>();
 
         private Builder() {
         }
 
         /**
-         * Add an action of type {@link RemoveUpdateAction}
+         * Add an action of type {@link RemoveAction}
          */
-        public Builder addAction(RemoveUpdateAction action) {
+        public Builder addAction(RemoveAction action) {
             removeActions.add(action);
             return this;
         }
 
         /**
-         * Add an action of type {@link SetUpdateAction}
+         * Add an action of type {@link SetAction}
          */
-        public Builder addAction(SetUpdateAction action) {
+        public Builder addAction(SetAction action) {
             setActions.add(action);
             return this;
         }
 
         /**
-         * Add an action of type {@link DeleteUpdateAction}
+         * Add an action of type {@link DeleteAction}
          */
-        public Builder addAction(DeleteUpdateAction action) {
+        public Builder addAction(DeleteAction action) {
             deleteActions.add(action);
             return this;
         }
 
         /**
-         * Add an action of type {@link AddUpdateAction}
+         * Add an action of type {@link AddAction}
          */
-        public Builder addAction(AddUpdateAction action) {
+        public Builder addAction(AddAction action) {
             addActions.add(action);
             return this;
         }
@@ -219,14 +219,14 @@ public final class UpdateExpression {
         }
 
         private void assignAction(UpdateAction action) {
-            if (action instanceof RemoveUpdateAction) {
-                addAction((RemoveUpdateAction) action);
-            } else if (action instanceof SetUpdateAction) {
-                addAction((SetUpdateAction) action);
-            } else if (action instanceof DeleteUpdateAction) {
-                addAction((DeleteUpdateAction) action);
-            } else if (action instanceof AddUpdateAction) {
-                addAction((AddUpdateAction) action);
+            if (action instanceof RemoveAction) {
+                addAction((RemoveAction) action);
+            } else if (action instanceof SetAction) {
+                addAction((SetAction) action);
+            } else if (action instanceof DeleteAction) {
+                addAction((DeleteAction) action);
+            } else if (action instanceof AddAction) {
+                addAction((AddAction) action);
             } else {
                 throw new IllegalArgumentException(
                     String.format("Do not recognize UpdateAction: %s", action.getClass()));

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/extensions/ChainExtensionTest.java
@@ -46,10 +46,8 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.ChainExtensi
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.DefaultDynamoDbExtensionContext;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.DefaultOperationContext;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationName;
-import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -304,20 +302,20 @@ public class ChainExtensionTest {
         return context.build();
     }
 
-    private static RemoveUpdateAction removeAction(String attributeName) {
-        return RemoveUpdateAction.builder()
-                                 .path(keyRef(attributeName))
-                                 .putExpressionName(keyRef(attributeName), attributeName)
-                                 .build();
+    private static RemoveAction removeAction(String attributeName) {
+        return RemoveAction.builder()
+                           .path(keyRef(attributeName))
+                           .putExpressionName(keyRef(attributeName), attributeName)
+                           .build();
     }
 
-    private static SetUpdateAction setAction(String attributeName, AttributeValue value) {
-        return SetUpdateAction.builder()
-                              .value(valueRef(attributeName))
-                              .putExpressionValue(valueRef(attributeName), value)
-                              .path(keyRef(attributeName))
-                              .putExpressionName(keyRef(attributeName), attributeName)
-                              .build();
+    private static SetAction setAction(String attributeName, AttributeValue value) {
+        return SetAction.builder()
+                        .value(valueRef(attributeName))
+                        .putExpressionValue(valueRef(attributeName), value)
+                        .path(keyRef(attributeName))
+                        .putExpressionName(keyRef(attributeName), attributeName)
+                        .build();
     }
 
     private UpdateExpression updateExpression(UpdateAction... actions) {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/UpdateExpressionTest.java
@@ -19,8 +19,10 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.RecordForUpdateExpressions;
 import software.amazon.awssdk.enhanced.dynamodb.internal.operations.OperationName;
-import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.internal.operations.UpdateItemOperation;
+import software.amazon.awssdk.enhanced.dynamodb.internal.update.UpdateExpressionConverter;
+import software.amazon.awssdk.enhanced.dynamodb.update.AddAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
@@ -28,19 +30,16 @@ import software.amazon.awssdk.utils.CollectionUtils;
 
 public class UpdateExpressionTest extends LocalDynamoDbSyncTestBase {
 
-    private static final Long ATTRIBUTE1_INCREMENT = 5L;
-    private static final Set<String> ATTRIBUTE2_INIT_VALUE = Stream.of("YELLOW", "BLUE", "RED", "GREEN")
-                                                                   .collect(Collectors.toSet());
-    private static final Set<String> ATTRIBUTE2_DELETE = Stream.of("YELLOW", "RED").collect(Collectors.toSet());
+    private static final Set<String> SET_ATTRIBUTE_INIT_VALUE = Stream.of("YELLOW", "BLUE", "RED", "GREEN")
+                                                                      .collect(Collectors.toSet());
+    private static final Set<String> SET_ATTRIBUTE_DELETE = Stream.of("YELLOW", "RED").collect(Collectors.toSet());
 
-    private static final String ATTRIBUTE1 = "extensionAttribute1";
-    private static final String ATTRIBUTE2 = "extensionAttribute2";
+    private static final String NUMBER_ATTRIBUTE_REF = "extensionNumberAttribute";
+    private static final long NUMBER_ATTRIBUTE_VALUE = 5L;
+    private static final String NUMBER_ATTRIBUTE_VALUE_REF = ":increment_value_ref";
+    private static final String SET_ATTRIBUTE_REF = "extensionSetAttribute";
 
-
-    private static final TableSchema<RecordForUpdateExpressions> TABLE_SCHEMA =
-            TableSchema.fromClass(RecordForUpdateExpressions.class);
-
-
+    private static final TableSchema<RecordForUpdateExpressions> TABLE_SCHEMA = TableSchema.fromClass(RecordForUpdateExpressions.class);
     private DynamoDbTable<RecordForUpdateExpressions> mappedTable;
 
     private void initClientWithExtensions(DynamoDbEnhancedClientExtension... extensions) {
@@ -59,181 +58,244 @@ public class UpdateExpressionTest extends LocalDynamoDbSyncTestBase {
     }
 
     @Test
-    public void attribute1NotInPojo_notFilteredInExtension_RequestIgnoresNull() {
-        initClientWithExtensions(new NonFilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
+    public void attribute_notInPojo_notFilteredInExtension_ignoresNulls_updatesNormally() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
 
         mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
 
         RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
-        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
-        assertThat(persistedRecord.getExtensionAttribute1()).isEqualTo(5L);
+        assertThat(persistedRecord.getStringAttribute()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionNumberAttribute()).isEqualTo(5L);
     }
 
+    /**
+     * This test case represents the most likely extension UpdateExpression use case;
+     * an attribute is set in the extensions and isn't present in the request POJO item, and there is no change in
+     * the request to set ignoreNull to true.
+     * <p>
+     * By default, ignorNull is false, so attributes that aren't set on the request are deleted from the DDB table through
+     * the updateItemOperation generating REMOVE actions for those attributes. This is prevented by
+     * {@link UpdateItemOperation} using {@link UpdateExpressionConverter#findAttributeNames(UpdateExpression)}
+     * to not create REMOVE actions attributes it finds referenced in an extension UpdateExpression.
+     * Therefore, this use case updates normally.
+     */
     @Test
-    public void attribute1NotInPojo_notFilteredInExtension_IgnoreNullDefaultFalse_HandledByFilter() {
-        initClientWithExtensions(new NonFilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
+    public void attribute_notInPojo_notFilteredInExtension_defaultSetsNull_updatesNormally() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
 
         mappedTable.updateItem(r -> r.item(record));
 
         RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
-        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
-        assertThat(persistedRecord.getExtensionAttribute1()).isEqualTo(5L);
+        assertThat(persistedRecord.getStringAttribute()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionNumberAttribute()).isEqualTo(5L);
     }
 
     @Test
-    public void attribute1InPojo_notFilteredInExtension_RequestIgnoresNull_duplicateError() {
-        initClientWithExtensions(new NonFilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
-        record.setExtensionAttribute1(100L);
-
-        assertThatThrownBy(() ->mappedTable.updateItem(r -> r.item(record).ignoreNulls(true)))
-            .isInstanceOf(DynamoDbException.class)
-            .hasMessageContaining("Two document paths")
-            .hasMessageContaining(ATTRIBUTE1);
-    }
-
-    @Test
-    public void attribute1InPojo_notFilteredInExtension_IgnoreNullDefaultFalse_duplicateError() {
-        initClientWithExtensions(new NonFilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
-        record.setExtensionAttribute1(100L);
-
-        assertThatThrownBy(() ->mappedTable.updateItem(r -> r.item(record).ignoreNulls(true)))
-            .isInstanceOf(DynamoDbException.class)
-            .hasMessageContaining("Two document paths")
-            .hasMessageContaining(ATTRIBUTE1);
-    }
-
-    @Test
-    public void attribute2NotInPojo_filteredInExtension_RequestIgnoresNull() {
-        initClientWithExtensions(new FilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
-        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+    public void attribute_notInPojo_filteredInExtension_ignoresNulls_updatesNormally() {
+        initClientWithExtensions(new ItemFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+        record.setExtensionSetAttribute(SET_ATTRIBUTE_INIT_VALUE);
         mappedTable.putItem(record);
 
-        record.setStringAttribute1("init");
+        record.setStringAttribute("init");
         mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
 
-        verifyAttribute2(record);
+        verifySetAttribute(record);
     }
 
     @Test
-    public void attribute2NotInPojo_filteredInExtension_IgnoreNullDefaultFalse() {
-        initClientWithExtensions(new FilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
-        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+    public void attribute_notInPojo_filteredInExtension_defaultSetsNull_updatesNormally() {
+        initClientWithExtensions(new ItemFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+        record.setExtensionSetAttribute(SET_ATTRIBUTE_INIT_VALUE);
         mappedTable.putItem(record);
 
-        record.setStringAttribute1("init");
+        record.setStringAttribute("init");
         mappedTable.updateItem(r -> r.item(record));
 
-        verifyAttribute2(record);
+        verifySetAttribute(record);
+    }
+
+    /**
+     * The extension adds an UpdateExpression with the number attribute, and the request
+     * results in an UpdateExpression with the number attribute. This causes DDB to reject the request.
+     */
+    @Test
+    public void attribute_inPojo_notFilteredInExtension_ignoresNulls_ddbError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+        record.setExtensionNumberAttribute(100L);
+
+        verifyDDBError(record, true);
     }
 
     @Test
-    public void attribute2InPojo_filteredInExtension_RequestIgnoresNull_duplicateError() {
-        initClientWithExtensions(new FilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
-        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+    public void attribute_inPojo_notFilteredInExtension_defaultSetsNull_ddbError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+        record.setExtensionNumberAttribute(100L);
+
+        verifyDDBError(record, false);
+    }
+
+    /**
+     * When the extension filters the transact item representing the request POJO attributes and removes the attribute
+     * from the POJO if it's there, only the extension UpdateExpression will reference the attribute and no DDB
+     * conflict results.
+     */
+    @Test
+    public void attribute_inPojo_filteredInExtension_ignoresNulls_updatesNormally() {
+        initClientWithExtensions(new ItemFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+        record.setExtensionSetAttribute(SET_ATTRIBUTE_INIT_VALUE);
         mappedTable.putItem(record);
 
-        record.setStringAttribute1("init");
-        record.setExtensionAttribute2(Stream.of("PURPLE").collect(Collectors.toSet()));
+        record.setStringAttribute("init");
+        record.setExtensionSetAttribute(Stream.of("PURPLE").collect(Collectors.toSet()));
         mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
 
-        verifyAttribute2(record);
+        verifySetAttribute(record);
     }
 
     @Test
-    public void attribute2InPojo_filteredInExtension_IgnoreNullDefaultFalse_duplicateError() {
-        initClientWithExtensions(new FilteringUpdateExtension());
-        RecordForUpdateExpressions record = createRecord();
-        record.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+    public void attribute_inPojo_filteredInExtension_defaultSetsNull_updatesNormally() {
+        initClientWithExtensions(new ItemFilteringUpdateExtension());
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+        record.setExtensionSetAttribute(SET_ATTRIBUTE_INIT_VALUE);
         mappedTable.putItem(record);
 
-        record.setStringAttribute1("init");
-        record.setExtensionAttribute2(Stream.of("PURPLE").collect(Collectors.toSet()));
+        record.setStringAttribute("init");
+        record.setExtensionSetAttribute(Stream.of("PURPLE").collect(Collectors.toSet()));
         mappedTable.updateItem(r -> r.item(record));
 
-        verifyAttribute2(record);
+        verifySetAttribute(record);
     }
 
     @Test
-    public void multipleExtensions_RequestIgnoresNull() {
-        initClientWithExtensions(new NonFilteringUpdateExtension(), new FilteringUpdateExtension());
-        RecordForUpdateExpressions putRecord = createRecord();
-        putRecord.setExtensionAttribute1(11L);
-        putRecord.setExtensionAttribute2(ATTRIBUTE2_INIT_VALUE);
+    public void chainedExtensions_noDuplicates_ignoresNulls_updatesNormally() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension(), new ItemFilteringUpdateExtension());
+        RecordForUpdateExpressions putRecord = createRecordWithoutExtensionAttributes();
+        putRecord.setExtensionNumberAttribute(11L);
+        putRecord.setExtensionSetAttribute(SET_ATTRIBUTE_INIT_VALUE);
         mappedTable.putItem(putRecord);
 
-        RecordForUpdateExpressions record = createRecord();
-        record.setStringAttribute1("init");
-        mappedTable.updateItem(r -> r.item(record).ignoreNulls(true));
+        RecordForUpdateExpressions updateRecord = createRecordWithoutExtensionAttributes();
+        updateRecord.setStringAttribute("updated");
+        mappedTable.updateItem(r -> r.item(updateRecord).ignoreNulls(true));
 
-        Set<String> expectedExtensionAttribute2 = Stream.of("BLUE", "GREEN").collect(Collectors.toSet());
-        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
-        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
-        assertThat(persistedRecord.getExtensionAttribute1()).isEqualTo(16L);
-        assertThat(persistedRecord.getExtensionAttribute2()).isEqualTo(expectedExtensionAttribute2);
+        Set<String> expectedSetExtensionAttribute = Stream.of("BLUE", "GREEN").collect(Collectors.toSet());
+        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(mappedTable.keyFrom(putRecord));
+        assertThat(persistedRecord.getExtensionNumberAttribute()).isEqualTo(16L);
+        assertThat(persistedRecord.getExtensionSetAttribute()).isEqualTo(expectedSetExtensionAttribute);
     }
 
-    private void verifyAttribute2(RecordForUpdateExpressions record) {
-        Set<String> expectedExtensionAttribute2 = Stream.of("BLUE", "GREEN").collect(Collectors.toSet());
-        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
-        assertThat(persistedRecord.getStringAttribute1()).isEqualTo("init");
-        assertThat(persistedRecord.getExtensionAttribute1()).isNull();
-        assertThat(persistedRecord.getExtensionAttribute2()).isEqualTo(expectedExtensionAttribute2);
+    @Test
+    public void chainedExtensions_duplicateAttributes_sameValue_sameValueRef_ddbError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension(), new ItemPreservingUpdateExtension());
+        verifyDDBError(createRecordWithoutExtensionAttributes(), false);
     }
 
-    private RecordForUpdateExpressions createRecord() {
+    @Test
+    public void chainedExtensions_duplicateAttributes_sameValue_differentValueRef_ddbError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension(), new ItemPreservingUpdateExtension(NUMBER_ATTRIBUTE_VALUE, ":ref"));
+        verifyDDBError(createRecordWithoutExtensionAttributes(), false);
+    }
+
+    @Test
+    public void chainedExtensions_duplicateAttributes_differentValue_differentValueRef_ddbError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension(), new ItemPreservingUpdateExtension(13L, ":ref"));
+        verifyDDBError(createRecordWithoutExtensionAttributes(), false);
+    }
+
+    @Test
+    public void chainedExtensions_duplicateAttributes_differentValue_sameValueRef_operationMergeError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension(), new ItemPreservingUpdateExtension(10L, NUMBER_ATTRIBUTE_VALUE_REF));
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+
+        assertThatThrownBy(() ->mappedTable.updateItem(r -> r.item(record)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
+            .hasMessageContaining(NUMBER_ATTRIBUTE_VALUE_REF);
+    }
+
+    @Test
+    public void chainedExtensions_duplicateAttributes_invalidValueRef_operationMergeError() {
+        initClientWithExtensions(new ItemPreservingUpdateExtension(), new ItemPreservingUpdateExtension(10L, "illegal"));
+        RecordForUpdateExpressions record = createRecordWithoutExtensionAttributes();
+
+        assertThatThrownBy(() ->mappedTable.updateItem(r -> r.item(record)))
+            .isInstanceOf(DynamoDbException.class)
+            .hasMessageContaining("ExpressionAttributeValues contains invalid key")
+            .hasMessageContaining("illegal");
+    }
+
+    private void verifyDDBError(RecordForUpdateExpressions record, boolean ignoreNulls) {
+        assertThatThrownBy(() -> mappedTable.updateItem(r -> r.item(record).ignoreNulls(ignoreNulls)))
+            .isInstanceOf(DynamoDbException.class)
+            .hasMessageContaining("Two document paths")
+            .hasMessageContaining(NUMBER_ATTRIBUTE_REF);
+    }
+
+    private void verifySetAttribute(RecordForUpdateExpressions record) {
+        Set<String> expectedAttribute = Stream.of("BLUE", "GREEN").collect(Collectors.toSet());
+        RecordForUpdateExpressions persistedRecord = mappedTable.getItem(record);
+        assertThat(persistedRecord.getStringAttribute()).isEqualTo("init");
+        assertThat(persistedRecord.getExtensionNumberAttribute()).isNull();
+        assertThat(persistedRecord.getExtensionSetAttribute()).isEqualTo(expectedAttribute);
+    }
+
+    private RecordForUpdateExpressions createRecordWithoutExtensionAttributes() {
         RecordForUpdateExpressions record = new RecordForUpdateExpressions();
         record.setId("1");
-        record.setStringAttribute1("init");
+        record.setStringAttribute("init");
         return record;
     }
 
-    private static final class NonFilteringUpdateExtension implements DynamoDbEnhancedClientExtension {
+    private static final class ItemPreservingUpdateExtension implements DynamoDbEnhancedClientExtension {
+        private long incrementValue;
+        private String valueRef;
+
+        private ItemPreservingUpdateExtension() {
+            this(NUMBER_ATTRIBUTE_VALUE, NUMBER_ATTRIBUTE_VALUE_REF);
+        }
+
+        private ItemPreservingUpdateExtension(long incrementValue, String valueRef) {
+            this.incrementValue = incrementValue;
+            this.valueRef = valueRef;
+        }
 
         @Override
         public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
             UpdateExpression updateExpression =
-                UpdateExpression.builder()
-                                .addAction(addToNumericAttribute(ATTRIBUTE1))
-                                .build();
+                UpdateExpression.builder().addAction(addToNumericAttribute(NUMBER_ATTRIBUTE_REF)).build();
 
-            return WriteModification.builder()
-                                    .updateExpression(updateExpression)
-                                    .build();
+            return WriteModification.builder().updateExpression(updateExpression).build();
         }
 
-        private AddUpdateAction addToNumericAttribute(String attributeName) {
-            AttributeValue actualValue = AttributeValue.builder().n(Long.toString(ATTRIBUTE1_INCREMENT)).build();
-            String valueName = ":increment";
-            return AddUpdateAction.builder()
-                                  .path(attributeName)
-                                  .value(valueName)
-                                  .putExpressionValue(valueName, actualValue)
-                                  .build();
+        private AddAction addToNumericAttribute(String attributeName) {
+            AttributeValue actualValue = AttributeValue.builder().n(Long.toString(incrementValue)).build();
+            return AddAction.builder()
+                            .path(attributeName)
+                            .value(valueRef)
+                            .putExpressionValue(valueRef, actualValue)
+                            .build();
         }
-
     }
 
-    private static final class FilteringUpdateExtension implements DynamoDbEnhancedClientExtension {
+    private static final class ItemFilteringUpdateExtension implements DynamoDbEnhancedClientExtension {
 
         @Override
         public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
             Map<String, AttributeValue> transformedItemMap = context.items();
 
             if ( context.operationName() == OperationName.UPDATE_ITEM) {
-                List<String> attributesToFilter = Arrays.asList(ATTRIBUTE2);
+                List<String> attributesToFilter = Arrays.asList(SET_ATTRIBUTE_REF);
                 transformedItemMap = CollectionUtils.filterMap(transformedItemMap, e -> !attributesToFilter.contains(e.getKey()));
             }
             UpdateExpression updateExpression =
-                UpdateExpression.builder()
-                                .addAction(deleteFromList(ATTRIBUTE2))
-                                .build();
+                UpdateExpression.builder().addAction(deleteFromList(SET_ATTRIBUTE_REF)).build();
 
             return WriteModification.builder()
                                     .updateExpression(updateExpression)
@@ -241,14 +303,14 @@ public class UpdateExpressionTest extends LocalDynamoDbSyncTestBase {
                                     .build();
         }
 
-        private DeleteUpdateAction deleteFromList(String attributeName) {
-            AttributeValue actualValue = AttributeValue.builder().ss(ATTRIBUTE2_DELETE).build();
+        private DeleteAction deleteFromList(String attributeName) {
+            AttributeValue actualValue = AttributeValue.builder().ss(SET_ATTRIBUTE_DELETE).build();
             String valueName = ":toDelete";
-            return DeleteUpdateAction.builder()
-                                     .path(attributeName)
-                                     .value(valueName)
-                                     .putExpressionValue(valueName, actualValue)
-                                     .build();
+            return DeleteAction.builder()
+                               .path(attributeName)
+                               .value(valueName)
+                               .putExpressionValue(valueName, actualValue)
+                               .build();
         }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/RecordForUpdateExpressions.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/RecordForUpdateExpressions.java
@@ -39,27 +39,27 @@ public class RecordForUpdateExpressions {
     }
 
     @DynamoDbUpdateBehavior(WRITE_IF_NOT_EXISTS)
-    public String getStringAttribute1() {
+    public String getStringAttribute() {
         return stringAttribute1;
     }
 
-    public void setStringAttribute1(String stringAttribute1) {
+    public void setStringAttribute(String stringAttribute1) {
         this.stringAttribute1 = stringAttribute1;
     }
 
-    public Long getExtensionAttribute1() {
+    public Long getExtensionNumberAttribute() {
         return extensionAttribute1;
     }
 
-    public void setExtensionAttribute1(Long extensionAttribute1) {
+    public void setExtensionNumberAttribute(Long extensionAttribute1) {
         this.extensionAttribute1 = extensionAttribute1;
     }
 
-    public Set<String> getExtensionAttribute2() {
+    public Set<String> getExtensionSetAttribute() {
         return extensionAttribute2;
     }
 
-    public void setExtensionAttribute2(Set<String> extensionAttribute2) {
+    public void setExtensionSetAttribute(Set<String> extensionAttribute2) {
         this.extensionAttribute2 = extensionAttribute2;
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperationTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/operations/UpdateItemOperationTest.java
@@ -54,7 +54,7 @@ import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItem;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.FakeItemWithSort;
 import software.amazon.awssdk.enhanced.dynamodb.internal.extensions.DefaultDynamoDbExtensionContext;
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -345,11 +345,11 @@ public class UpdateItemOperationTest {
     @Test
     public void generateRequest_withExtensions_singleUpdateExpression() {
         Map<String, AttributeValue> deleteActionMap = singletonMap(":val", AttributeValue.builder().s("s").build());
-        DeleteUpdateAction deleteUpdateAction = DeleteUpdateAction.builder().path("attr1")
-                                                                  .value(":val")
-                                                                  .expressionValues(deleteActionMap)
-                                                                  .build();
-        UpdateExpression updateExpression = UpdateExpression.builder().addAction(deleteUpdateAction).build();
+        DeleteAction deleteAction = DeleteAction.builder().path("attr1")
+                                                .value(":val")
+                                                .expressionValues(deleteActionMap)
+                                                .build();
+        UpdateExpression updateExpression = UpdateExpression.builder().addAction(deleteAction).build();
 
         FakeItem item = createUniqueFakeItem();
         when(mockDynamoDbEnhancedClientExtension.beforeWrite(any(DynamoDbExtensionContext.BeforeWrite.class)))
@@ -373,11 +373,11 @@ public class UpdateItemOperationTest {
         Expression condition = Expression.builder().expression("condition").expressionValues(fakeMap).build();
 
         Map<String, AttributeValue> deleteActionMap = singletonMap(":val", AttributeValue.builder().s("s").build());
-        DeleteUpdateAction deleteUpdateAction = DeleteUpdateAction.builder().path("attr1")
-                                                                  .value(":val")
-                                                                  .expressionValues(deleteActionMap)
-                                                                  .build();
-        UpdateExpression updateExpression = UpdateExpression.builder().addAction(deleteUpdateAction).build();
+        DeleteAction deleteAction = DeleteAction.builder().path("attr1")
+                                                .value(":val")
+                                                .expressionValues(deleteActionMap)
+                                                .build();
+        UpdateExpression updateExpression = UpdateExpression.builder().addAction(deleteAction).build();
 
         when(mockDynamoDbEnhancedClientExtension.beforeWrite(any(DynamoDbExtensionContext.BeforeWrite.class)))
             .thenReturn(WriteModification.builder()

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/update/UpdateExpressionConverterTest.java
@@ -18,20 +18,29 @@ package software.amazon.awssdk.enhanced.dynamodb.internal.update;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.amazonaws.util.StringUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 
-import software.amazon.awssdk.enhanced.dynamodb.update.AddUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.DeleteUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.RemoveUpdateAction;
-import software.amazon.awssdk.enhanced.dynamodb.update.SetUpdateAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.AddAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.DeleteAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.RemoveAction;
+import software.amazon.awssdk.enhanced.dynamodb.update.SetAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateAction;
 import software.amazon.awssdk.enhanced.dynamodb.update.UpdateExpression;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+/**
+ * When converting, SetAction, DeleteAction and AddAction work similarly. Advanced test cases thus only need to test
+ * using one of these types of action. RemoveAction, lacking expression values, work slightly differently.
+ *
+ */
+@TestMethodOrder(MethodOrderer.MethodName.class)
 class UpdateExpressionConverterTest {
 
     private static final String KEY_TOKEN = "#PRE_";
@@ -41,35 +50,37 @@ class UpdateExpressionConverterTest {
     void convert_emptyExpression() {
         UpdateExpression updateExpression = UpdateExpression.builder().build();
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
         assertThat(expression.expression()).isEmpty();
         assertThat(expression.expressionNames()).isEmpty();
         assertThat(expression.expressionValues()).isEmpty();
     }
 
     @Test
-    void convert_single_removeAction() {
-        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", false));
+    void convert_removeAction_single() {
+        UpdateExpression updateExpression = createUpdateExpression(removeAction("attribute1", null));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
         assertThat(expression.expression()).isEqualTo("REMOVE attribute1");
         assertThat(expression.expressionNames()).isEmpty();
         assertThat(expression.expressionValues()).isEmpty();
     }
 
     @Test
-    void convert_multiple_removeAction() {
-        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", false),
-                                                             removeAction("attribute2", false));
-
+    void convert_removeActions() {
+        UpdateExpression updateExpression = createUpdateExpression(removeAction("attribute1", null),
+                                                                   removeAction("attribute2", null));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
         assertThat(expression.expression()).isEqualTo("REMOVE attribute1, attribute2");
         assertThat(expression.expressionNames()).isEmpty();
         assertThat(expression.expressionValues()).isEmpty();
     }
 
     @Test
-    void convert_multiple_removeAction_useNameTokens() {
-        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", true),
-                                                             removeAction("attribute2", true));
+    void convert_removeActions_uniqueNameTokens() {
+        UpdateExpression updateExpression = createUpdateExpression(removeAction("attribute1", KEY_TOKEN),
+                                                                   removeAction("attribute2", KEY_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, String> expectedExpressionNames = new HashMap<>();
@@ -81,9 +92,72 @@ class UpdateExpressionConverterTest {
         assertThat(expression.expressionValues()).isEmpty();
     }
 
+    /**
+     * Attributes with the same name are simply added to the list. There is no check to compare the contents
+     * of two remove action paths.
+     *
+     * This would fail when calling DDB; note that UpdateItemOperation always prefixes attribute names and the probability of
+     * this use case is low.
+     */
     @Test
-    void convert_single_setAction() {
-        UpdateExpression updateExpression = updateExpression(setAction("attribute1", string("val1"),false));
+    void convert_removeActions_duplicateAttributes_createsDdbFailExpression() {
+        UpdateExpression updateExpression = createUpdateExpression(removeAction("attribute1", null),
+                                                                   removeAction("attribute1", null));
+
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("REMOVE attribute1, attribute1");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    /**
+     * The joining logic in {@link Expression#joinNames(Map, Map)} will be merge the two entries, since here the
+     * same key will point at the same value.
+     *
+     * This would fail when calling DDB; note that UpdateItemOperation always prefixes attribute names and the probability of
+     * this use case is low.
+     */
+    @Test
+    void convert_removeActions_duplicateAttributes_uniqueNameTokens_createsDdbFailExpression() {
+        UpdateExpression updateExpression = createUpdateExpression(removeAction("attribute1", KEY_TOKEN),
+                                                                   removeAction("attribute1", KEY_TOKEN));
+
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("REMOVE #PRE_attribute1, #PRE_attribute1");
+        assertThat(expression.expressionNames()).hasSize(1);
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    /**
+     * This is the same case as using a name prefix with the same attribute name, i.e. `duplicateAttributes_uniqueNameTokens`
+     */
+    @Test
+    void convert_removeActions_duplicateAttributes_duplicateNameTokens_createsDdbFailExpression() {
+        UpdateExpression updateExpression = createUpdateExpression(
+            RemoveAction.builder().path("attribute_ref").putExpressionName("attribute_ref", "attribute1").build(),
+            RemoveAction.builder().path("attribute_ref").putExpressionName("attribute_ref", "attribute1").build());
+
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("REMOVE attribute_ref, attribute_ref");
+        assertThat(expression.expressionNames()).hasSize(1);
+        assertThat(expression.expressionValues()).isEmpty();
+    }
+
+    @Test
+    void convert_removeActions_uniqueAttributes_duplicateNameTokens_error() {
+        UpdateExpression updateExpression = createUpdateExpression(
+            RemoveAction.builder().path("attribute_ref").putExpressionName("attribute_ref", "attribute1").build(),
+            RemoveAction.builder().path("attribute_ref").putExpressionName("attribute_ref", "attribute2").build());
+
+        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression names")
+            .hasMessageContaining("attribute_ref");
+    }
+
+    @Test
+    void convert_setAction_single() {
+        UpdateExpression updateExpression = createUpdateExpression(setAction("attribute1", string("val1"), null, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
         assertThat(expression.expression()).isEqualTo("SET attribute1 = :PRE_attribute1");
         assertThat(expression.expressionNames()).isEmpty();
@@ -91,9 +165,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_setAction() {
-        UpdateExpression updateExpression = updateExpression(setAction("attribute1", string("val1"), false),
-                                                             setAction("attribute2", string("val2"), false));
+    void convert_setActions() {
+        UpdateExpression updateExpression = createUpdateExpression(setAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   setAction("attribute2", string("val2"), null, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
@@ -106,9 +180,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_setAction_useNameTokens() {
-        UpdateExpression updateExpression = updateExpression(setAction("attribute1", string("val1"), true),
-                                                             setAction("attribute2", string("val2"), true));
+    void convert_setActions_uniqueNameTokens() {
+        UpdateExpression updateExpression = createUpdateExpression(setAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   setAction("attribute2", string("val2"), KEY_TOKEN, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, String> expectedExpressionNames = new HashMap<>();
@@ -125,8 +199,8 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_single_deleteAction() {
-        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"),false));
+    void convert_deleteAction_single() {
+        UpdateExpression updateExpression = createUpdateExpression(deleteAction("attribute1", string("val1"), null, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
         assertThat(expression.expression()).isEqualTo("DELETE attribute1 :PRE_attribute1");
         assertThat(expression.expressionNames()).isEmpty();
@@ -134,9 +208,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_deleteAction() {
-        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), false),
-                                                             deleteAction("attribute2", string("val2"), false));
+    void convert_deleteActions() {
+        UpdateExpression updateExpression = createUpdateExpression(deleteAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute2", string("val2"), null, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
@@ -149,9 +223,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_deleteAction_useNameTokens() {
-        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), true),
-                                                             deleteAction("attribute2", string("val2"), true));
+    void convert_deleteActions_uniqueNameTokens() {
+        UpdateExpression updateExpression = createUpdateExpression(deleteAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   deleteAction("attribute2", string("val2"), KEY_TOKEN, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, String> expectedExpressionNames = new HashMap<>();
@@ -167,9 +241,70 @@ class UpdateExpressionConverterTest {
         assertThat(expression.expressionValues()).containsExactlyEntriesOf(expectedExpressionValues);
     }
 
+    /**
+     * The joining logic in {@link Expression#joinValues(Map, Map)} will be throw an error, because the same key
+     * is pointing to different values. Actions that use expression value maps (Add, Delete, Set) exhibit the same behavior.
+     */
     @Test
-    void convert_single_addAction() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"),false));
+    void convert_deleteActions_duplicateAttributes_error() {
+        UpdateExpression updateExpression = createUpdateExpression(deleteAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute1", string("val2"), null, VALUE_TOKEN));
+
+        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
+            .hasMessageContaining(":PRE_attribute1");
+    }
+
+    /**
+     * The joining logic in {@link Expression#joinValues(Map, Map)} will be throw an error, because the same key
+     * is pointing to different values. Actions that use expression value maps (Add, Delete, Set) exhibit the same behavior.
+     */
+    @Test
+    void convert_deleteActions_duplicateAttributes_uniqueNameTokens_error() {
+        UpdateExpression updateExpression = createUpdateExpression(deleteAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   deleteAction("attribute1", string("val2"), KEY_TOKEN, VALUE_TOKEN));
+
+        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
+            .hasMessageContaining(":PRE_attribute1");
+    }
+
+    /**
+     * The joining logic in {@link Expression#joinValues(Map, Map)} will be merge the two entries, since here the
+     * same key will point at the same value.
+     *
+     * This would fail when calling DDB; note that UpdateItemOperation always prefixes attribute names and the probability of
+     * this use case is low.
+     */
+    @Test
+    void convert_deleteActions_duplicateAttributes_duplicateValueTokens_createsDdbFailExpression() {
+        UpdateExpression updateExpression = createUpdateExpression(
+            DeleteAction.builder().path("attribute1").value("attribute_ref").putExpressionValue("attribute_ref", string("val1")).build(),
+            DeleteAction.builder().path("attribute1").value("attribute_ref").putExpressionValue("attribute_ref", string("val1")).build());
+
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+        assertThat(expression.expression()).isEqualTo("DELETE attribute1 attribute_ref, attribute1 attribute_ref");
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).containsEntry("attribute_ref", string("val1"));
+    }
+
+    @Test
+    void convert_deleteActions_uniqueAttributes_duplicateValueTokens_error() {
+        UpdateExpression updateExpression = createUpdateExpression(
+            DeleteAction.builder().path("attribute1").value("attribute_ref").putExpressionValue("attribute_ref", string("val1")).build(),
+            DeleteAction.builder().path("attribute2").value("attribute_ref").putExpressionValue("attribute_ref", string("val2")).build());
+
+        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
+            .hasMessageContaining("attribute_ref");
+    }
+
+    @Test
+    void convert_addAction_single() {
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), null, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
         assertThat(expression.expression()).isEqualTo("ADD attribute1 :PRE_attribute1");
         assertThat(expression.expressionNames()).isEmpty();
@@ -177,9 +312,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_addAction() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), false),
-                                                             addAction("attribute2", string("val2"), false));
+    void convert_addActions() {
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   addAction("attribute2", string("val2"), null, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, AttributeValue> expectedExpressionValues = new HashMap<>();
@@ -192,9 +327,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_addAction_useNameTokens() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), true),
-                                                             addAction("attribute2", string("val2"), true));
+    void convert_addActions_uniqueNameTokens() {
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   addAction("attribute2", string("val2"), KEY_TOKEN, VALUE_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         Map<String, String> expectedExpressionNames = new HashMap<>();
@@ -211,16 +346,39 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_mixedAction_useNameTokens() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), true),
-                                                             deleteAction("attribute2", string("val2"), true),
-                                                             removeAction("attribute3", true),
-                                                             setAction("attribute4", string("val4"), true),
-                                                             deleteAction("attribute5", string("val5"), true),
-                                                             setAction("attribute6", string("val6"), true),
-                                                             removeAction("attribute7", true),
-                                                             addAction("attribute8", string("val8"), true),
-                                                             removeAction("attribute9", true));
+    void convert_mixedActions() {
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute2", string("val2"), null, VALUE_TOKEN),
+                                                                   removeAction("attribute3", null),
+                                                                   setAction("attribute4", string("val4"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute5", string("val5"), null, VALUE_TOKEN),
+                                                                   setAction("attribute6", string("val6"), null, VALUE_TOKEN),
+                                                                   removeAction("attribute7", null),
+                                                                   addAction("attribute8", string("val8"), null, VALUE_TOKEN),
+                                                                   removeAction("attribute9", null));
+        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
+
+        assertThat(expression.expression()).isEqualTo(
+            "SET attribute4 = :PRE_attribute4, attribute6 = :PRE_attribute6 " +
+            "REMOVE attribute3, attribute7, attribute9 " +
+            "DELETE attribute2 :PRE_attribute2, attribute5 :PRE_attribute5 " +
+            "ADD attribute1 :PRE_attribute1, attribute8 :PRE_attribute8"
+        );
+        assertThat(expression.expressionNames()).isEmpty();
+        assertThat(expression.expressionValues()).hasSize(6);
+    }
+
+    @Test
+    void convert_mixedActions_uniqueNameTokens() {
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   deleteAction("attribute2", string("val2"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   removeAction("attribute3", KEY_TOKEN),
+                                                                   setAction("attribute4", string("val4"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   deleteAction("attribute5", string("val5"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   setAction("attribute6", string("val6"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   removeAction("attribute7", KEY_TOKEN),
+                                                                   addAction("attribute8", string("val8"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   removeAction("attribute9", KEY_TOKEN));
         Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
 
         assertThat(expression.expression()).isEqualTo(
@@ -234,31 +392,9 @@ class UpdateExpressionConverterTest {
     }
 
     @Test
-    void convert_multiple_actions_with_duplicates() {
-        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), true),
-                                                             deleteAction("attribute1", string("val2"), true));
-
-        assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
-            .hasMessageContaining(":PRE_attribute1");
-    }
-
-    @Test
-    void convert_multiple_actions_with_duplicates_removes() {
-        UpdateExpression updateExpression = updateExpression(removeAction("attribute1", true),
-                                                             removeAction("attribute1", true));
-
-        Expression expression = UpdateExpressionConverter.toExpression(updateExpression);
-        assertThat(expression.expression()).isEqualTo("REMOVE #PRE_attribute1, #PRE_attribute1");
-        assertThat(expression.expressionNames()).hasSize(1);
-        assertThat(expression.expressionValues()).isEmpty();
-    }
-
-    @Test
-    void convert_multiple_actions_with_duplicates_diffact() {
-        UpdateExpression updateExpression = updateExpression(deleteAction("attribute1", string("val1"), true),
-                                                             addAction("attribute1", string("val2"), true));
+    void convert_mixedActions_duplicateAttributes_error() {
+        UpdateExpression updateExpression = createUpdateExpression(deleteAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   addAction("attribute1", string("val2"), KEY_TOKEN, VALUE_TOKEN));
         assertThatThrownBy(() -> UpdateExpressionConverter.toExpression(updateExpression))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Attempt to coalesce two expressions with conflicting expression values")
@@ -274,107 +410,107 @@ class UpdateExpressionConverterTest {
 
     @Test
     void findAttributeNames_noComposedNames_noTokens() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), false),
-                                                             deleteAction("attribute2", string("val2"), false),
-                                                             removeAction("attribute3", false),
-                                                             setAction("attribute4", string("val4"), false));
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute2", string("val2"), null, VALUE_TOKEN),
+                                                                   removeAction("attribute3", null),
+                                                                   setAction("attribute4", string("val4"), null, VALUE_TOKEN));
         List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
         assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
     }
 
     @Test
     void findAttributeNames_noComposedNames_tokens() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), true),
-                                                             deleteAction("attribute2", string("val2"), true),
-                                                             removeAction("attribute3", true),
-                                                             setAction("attribute4", string("val4"), true));
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   deleteAction("attribute2", string("val2"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   removeAction("attribute3", KEY_TOKEN),
+                                                                   setAction("attribute4", string("val4"), KEY_TOKEN, VALUE_TOKEN));
         List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
         assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
     }
 
     @Test
     void findAttributeNames_noComposedNames_duplicates() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1", string("val1"), false),
-                                                             deleteAction("attribute1", string("val2"), true));
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute1", string("val2"), KEY_TOKEN, VALUE_TOKEN));
         List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
         assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute1");
     }
 
     @Test
     void findAttributeNames_composedNames_noTokens() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1.#nested", string("val1"), false),
-                                                             deleteAction("attribute2.nested", string("val2"), false),
-                                                             removeAction("attribute3[1]", false),
-                                                             setAction("attribute4[1].nested", string("val4"), false));
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1.#nested", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute2.nested", string("val2"), null, VALUE_TOKEN),
+                                                                   removeAction("attribute3[1]", null),
+                                                                   setAction("attribute4[1].nested", string("val4"), null, VALUE_TOKEN));
         List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
         assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
     }
 
     @Test
     void findAttributeNames_composedNames_tokens() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1.nested[1]", string("val1"), true),
-                                                             deleteAction("attribute2.nested", string("val2"), true),
-                                                             removeAction("attribute3[1]", true),
-                                                             setAction("attribute4[1].nested", string("val4"), true));
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1.nested[1]", string("val1"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   deleteAction("attribute2.nested", string("val2"), KEY_TOKEN, VALUE_TOKEN),
+                                                                   removeAction("attribute3[1]", KEY_TOKEN),
+                                                                   setAction("attribute4[1].nested", string("val4"), KEY_TOKEN, VALUE_TOKEN));
         List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
         assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute2", "attribute3", "attribute4");
     }
 
     @Test
     void findAttributeNames_composedNames_duplicates() {
-        UpdateExpression updateExpression = updateExpression(addAction("attribute1[1]", string("val1"), false),
-                                                             deleteAction("attribute1.nested", string("val2"), true));
+        UpdateExpression updateExpression = createUpdateExpression(addAction("attribute1[1]", string("val1"), null, VALUE_TOKEN),
+                                                                   deleteAction("attribute1.nested", string("val2"), KEY_TOKEN, VALUE_TOKEN));
         List<String> attributes = UpdateExpressionConverter.findAttributeNames(updateExpression);
         assertThat(attributes).containsExactlyInAnyOrder("attribute1", "attribute1");
     }
 
-    private static RemoveUpdateAction removeAction(String attributeName, boolean useToken) {
-        RemoveUpdateAction.Builder builder = RemoveUpdateAction.builder()
-                                                               .path(attributeName);
-        if (useToken) {
-            builder.path(keyRef(attributeName));
-            builder.putExpressionName(keyRef(attributeName), attributeName);
+    private static RemoveAction removeAction(String attributeName, String keyToken) {
+        RemoveAction.Builder builder = RemoveAction.builder()
+                                                   .path(attributeName);
+        if (!StringUtils.isNullOrEmpty(keyToken)) {
+            builder.path(keyRef(attributeName, keyToken));
+            builder.putExpressionName(keyRef(attributeName, keyToken), attributeName);
         }
         return builder.build();
     }
 
-    private static SetUpdateAction setAction(String attributeName, AttributeValue value, boolean useToken) {
-        SetUpdateAction.Builder builder = SetUpdateAction.builder()
-                                                         .path(attributeName)
-                                                         .value(valueRef(attributeName))
-                                                         .putExpressionValue(valueRef(attributeName), value);
-        if (useToken) {
-            builder.path(keyRef(attributeName));
-            builder.putExpressionName(keyRef(attributeName), attributeName);
+    private static SetAction setAction(String attributeName, AttributeValue value, String keyToken, String valueToken) {
+        SetAction.Builder builder = SetAction.builder()
+                                             .path(attributeName)
+                                             .value(valueRef(attributeName, valueToken))
+                                             .putExpressionValue(valueRef(attributeName, valueToken), value);
+        if (!StringUtils.isNullOrEmpty(keyToken)) {
+            builder.path(keyRef(attributeName, keyToken));
+            builder.putExpressionName(keyRef(attributeName, keyToken), attributeName);
         }
         return builder.build();
     }
 
-    private static DeleteUpdateAction deleteAction(String attributeName, AttributeValue value, boolean useToken) {
-        DeleteUpdateAction.Builder builder = DeleteUpdateAction.builder()
-                                                         .path(attributeName)
-                                                         .value(valueRef(attributeName))
-                                                         .putExpressionValue(valueRef(attributeName), value);
-        if (useToken) {
-            builder.path(keyRef(attributeName));
-            builder.putExpressionName(keyRef(attributeName), attributeName);
+    private static DeleteAction deleteAction(String attributeName, AttributeValue value, String keyToken, String valueToken) {
+        DeleteAction.Builder builder = DeleteAction.builder()
+                                                   .path(attributeName)
+                                                   .value(valueRef(attributeName, valueToken))
+                                                   .putExpressionValue(valueRef(attributeName, valueToken), value);
+        if (!StringUtils.isNullOrEmpty(keyToken)) {
+            builder.path(keyRef(attributeName, keyToken));
+            builder.putExpressionName(keyRef(attributeName, keyToken), attributeName);
         }
         return builder.build();
     }
 
-    private static AddUpdateAction addAction(String attributeName, AttributeValue value, boolean useToken) {
-        AddUpdateAction.Builder builder = AddUpdateAction.builder()
-                                                               .path(attributeName)
-                                                               .value(valueRef(attributeName))
-                                                               .putExpressionValue(valueRef(attributeName), value);
-        if (useToken) {
-            builder.path(keyRef(attributeName));
-            builder.putExpressionName(keyRef(attributeName), attributeName);
+    private static AddAction addAction(String attributeName, AttributeValue value, String keyToken, String valueToken) {
+        AddAction.Builder builder = AddAction.builder()
+                                             .path(attributeName)
+                                             .value(valueRef(attributeName, valueToken))
+                                             .putExpressionValue(valueRef(attributeName, valueToken), value);
+        if (!StringUtils.isNullOrEmpty(keyToken)) {
+            builder.path(keyRef(attributeName, keyToken));
+            builder.putExpressionName(keyRef(attributeName, keyToken), attributeName);
         }
         return builder.build();
     }
 
-    private UpdateExpression updateExpression(UpdateAction... actions) {
+    private UpdateExpression createUpdateExpression(UpdateAction... actions) {
         return UpdateExpression.builder().actions(actions).build();
     }
 
@@ -382,11 +518,11 @@ class UpdateExpressionConverterTest {
         return AttributeValue.builder().s(s).build();
     }
 
-    private static String keyRef(String key) {
-        return KEY_TOKEN + key;
+    private static String keyRef(String key, String token) {
+        return token + key;
     }
 
-    private static String valueRef(String value) {
-        return VALUE_TOKEN + value;
+    private static String valueRef(String value, String valueToken) {
+        return valueToken + value;
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/AddActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/AddActionTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-class AddUpdateActionTest {
+class AddActionTest {
 
     private static final String PATH = "path string";
     private static final String VALUE = "value string";
@@ -33,7 +33,7 @@ class AddUpdateActionTest {
 
     @Test
     void equalsHashcode() {
-        EqualsVerifier.forClass(AddUpdateAction.class)
+        EqualsVerifier.forClass(AddAction.class)
                       .usingGetClass()
                       .withPrefabValues(AttributeValue.class,
                                         AttributeValue.builder().s("1").build(),
@@ -43,11 +43,11 @@ class AddUpdateActionTest {
 
     @Test
     void build_minimal() {
-        AddUpdateAction action = AddUpdateAction.builder()
-                                                .path(PATH)
-                                                .value(VALUE)
-                                                .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
-                                                .build();
+        AddAction action = AddAction.builder()
+                                    .path(PATH)
+                                    .value(VALUE)
+                                    .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
+                                    .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.value()).isEqualTo(VALUE);
         assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
@@ -56,15 +56,27 @@ class AddUpdateActionTest {
 
     @Test
     void build_maximal() {
-        AddUpdateAction action = AddUpdateAction.builder()
-                                                .path(PATH)
-                                                .value(VALUE)
-                                                .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
-                                                .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
-                                                .build();
+        AddAction action = AddAction.builder()
+                                    .path(PATH)
+                                    .value(VALUE)
+                                    .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                    .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                    .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.value()).isEqualTo(VALUE);
         assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
         assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+
+    @Test
+    void copy() {
+        AddAction action = AddAction.builder()
+                                    .path(PATH)
+                                    .value(VALUE)
+                                    .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                    .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                    .build();
+        AddAction copy = action.toBuilder().build();
+        assertThat(action).isEqualTo(copy);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/DeleteActionTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-class SetUpdateActionTest {
+class DeleteActionTest {
 
     private static final String PATH = "path string";
     private static final String VALUE = "value string";
@@ -33,7 +33,7 @@ class SetUpdateActionTest {
 
     @Test
     void equalsHashcode() {
-        EqualsVerifier.forClass(SetUpdateAction.class)
+        EqualsVerifier.forClass(DeleteAction.class)
                       .usingGetClass()
                       .withPrefabValues(AttributeValue.class,
                                         AttributeValue.builder().s("1").build(),
@@ -43,11 +43,11 @@ class SetUpdateActionTest {
 
     @Test
     void build_minimal() {
-        SetUpdateAction action = SetUpdateAction.builder()
-                                                .path(PATH)
-                                                .value(VALUE)
-                                                .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
-                                                .build();
+        DeleteAction action = DeleteAction.builder()
+                                          .path(PATH)
+                                          .value(VALUE)
+                                          .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
+                                          .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.value()).isEqualTo(VALUE);
         assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
@@ -56,15 +56,27 @@ class SetUpdateActionTest {
 
     @Test
     void build_maximal() {
-        SetUpdateAction action = SetUpdateAction.builder()
-                                                .path(PATH)
-                                                .value(VALUE)
-                                                .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
-                                                .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
-                                                .build();
+        DeleteAction action = DeleteAction.builder()
+                                          .path(PATH)
+                                          .value(VALUE)
+                                          .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                          .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                          .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.value()).isEqualTo(VALUE);
         assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
         assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+
+    @Test
+    void copy() {
+        DeleteAction action = DeleteAction.builder()
+                                          .path(PATH)
+                                          .value(VALUE)
+                                          .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                          .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                          .build();
+        DeleteAction copy = action.toBuilder().build();
+        assertThat(action).isEqualTo(copy);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/RemoveActionTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-class RemoveUpdateActionTest {
+class RemoveActionTest {
 
     private static final String PATH = "path string";
     private static final String ATTRIBUTE_TOKEN = "#attributeToken";
@@ -29,27 +29,37 @@ class RemoveUpdateActionTest {
 
     @Test
     void equalsHashcode() {
-        EqualsVerifier.forClass(RemoveUpdateAction.class)
+        EqualsVerifier.forClass(RemoveAction.class)
                       .usingGetClass()
                       .verify();
     }
 
     @Test
     void build_minimal() {
-        RemoveUpdateAction action = RemoveUpdateAction.builder()
-                                                      .path(PATH)
-                                                      .build();
+        RemoveAction action = RemoveAction.builder()
+                                          .path(PATH)
+                                          .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.expressionNames()).isEmpty();
     }
 
     @Test
     void build_maximal() {
-        RemoveUpdateAction action = RemoveUpdateAction.builder()
-                                                      .path(PATH)
-                                                      .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
-                                                      .build();
+        RemoveAction action = RemoveAction.builder()
+                                          .path(PATH)
+                                          .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                          .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+
+    @Test
+    void copy() {
+        RemoveAction action = RemoveAction.builder()
+                                          .path(PATH)
+                                          .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                          .build();
+        RemoveAction copy = action.toBuilder().build();
+        assertThat(action).isEqualTo(copy);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/SetActionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/SetActionTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-class DeleteUpdateActionTest {
+class SetActionTest {
 
     private static final String PATH = "path string";
     private static final String VALUE = "value string";
@@ -33,7 +33,7 @@ class DeleteUpdateActionTest {
 
     @Test
     void equalsHashcode() {
-        EqualsVerifier.forClass(DeleteUpdateAction.class)
+        EqualsVerifier.forClass(SetAction.class)
                       .usingGetClass()
                       .withPrefabValues(AttributeValue.class,
                                         AttributeValue.builder().s("1").build(),
@@ -43,11 +43,11 @@ class DeleteUpdateActionTest {
 
     @Test
     void build_minimal() {
-        DeleteUpdateAction action = DeleteUpdateAction.builder()
-                                                      .path(PATH)
-                                                      .value(VALUE)
-                                                      .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
-                                                      .build();
+        SetAction action = SetAction.builder()
+                                    .path(PATH)
+                                    .value(VALUE)
+                                    .putExpressionValue(VALUE_TOKEN, NUMERIC_VALUE)
+                                    .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.value()).isEqualTo(VALUE);
         assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
@@ -56,15 +56,27 @@ class DeleteUpdateActionTest {
 
     @Test
     void build_maximal() {
-        DeleteUpdateAction action = DeleteUpdateAction.builder()
-                                                      .path(PATH)
-                                                      .value(VALUE)
-                                                      .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
-                                                      .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
-                                                      .build();
+        SetAction action = SetAction.builder()
+                                    .path(PATH)
+                                    .value(VALUE)
+                                    .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                    .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                    .build();
         assertThat(action.path()).isEqualTo(PATH);
         assertThat(action.value()).isEqualTo(VALUE);
         assertThat(action.expressionValues()).containsEntry(VALUE_TOKEN, NUMERIC_VALUE);
         assertThat(action.expressionNames()).containsEntry(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME);
+    }
+
+    @Test
+    void copy() {
+        SetAction action = SetAction.builder()
+                                    .path(PATH)
+                                    .value(VALUE)
+                                    .expressionValues(Collections.singletonMap(VALUE_TOKEN, NUMERIC_VALUE))
+                                    .expressionNames(Collections.singletonMap(ATTRIBUTE_TOKEN, ATTRIBUTE_NAME))
+                                    .build();
+        SetAction copy = action.toBuilder().build();
+        assertThat(action).isEqualTo(copy);
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/update/UpdateExpressionTest.java
@@ -28,22 +28,22 @@ class UpdateExpressionTest {
 
     private static final AttributeValue VAL = AttributeValue.builder().n("5").build();
 
-    private static final RemoveUpdateAction removeAction = RemoveUpdateAction.builder().path("").build();
-    private static final SetUpdateAction setAction = SetUpdateAction.builder()
-                                                                    .path("")
-                                                                    .value("")
-                                                                    .putExpressionValue("", VAL)
-                                                                    .build();
-    private static final DeleteUpdateAction deleteAction = DeleteUpdateAction.builder()
-                                                                             .path("")
-                                                                             .value("")
-                                                                             .putExpressionValue("", VAL)
-                                                                             .build();
-    private static final AddUpdateAction addAction = AddUpdateAction.builder()
-                                                                    .path("")
-                                                                    .value("")
-                                                                    .putExpressionValue("", VAL)
-                                                                    .build();
+    private static final RemoveAction removeAction = RemoveAction.builder().path("").build();
+    private static final SetAction setAction = SetAction.builder()
+                                                        .path("")
+                                                        .value("")
+                                                        .putExpressionValue("", VAL)
+                                                        .build();
+    private static final DeleteAction deleteAction = DeleteAction.builder()
+                                                                 .path("")
+                                                                 .value("")
+                                                                 .putExpressionValue("", VAL)
+                                                                 .build();
+    private static final AddAction addAction = AddAction.builder()
+                                                        .path("")
+                                                        .value("")
+                                                        .putExpressionValue("", VAL)
+                                                        .build();
 
     @Test
     void equalsHashcode() {
@@ -91,7 +91,7 @@ class UpdateExpressionTest {
 
     @Test
     void build_plural_is_not_additive() {
-        List<RemoveUpdateAction> removeActions = Arrays.asList(removeAction, removeAction);
+        List<RemoveAction> removeActions = Arrays.asList(removeAction, removeAction);
         UpdateExpression updateExpression = UpdateExpression.builder()
                                                             .actions(removeActions)
                                                             .actions(setAction, deleteAction, addAction)
@@ -140,7 +140,7 @@ class UpdateExpressionTest {
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
 
-        RemoveUpdateAction extraRemoveAction = RemoveUpdateAction.builder().path("a").build();
+        RemoveAction extraRemoveAction = RemoveAction.builder().path("a").build();
         UpdateExpression additionalExpression = UpdateExpression.builder()
                                                                 .addAction(extraRemoveAction)
                                                                 .build();
@@ -157,10 +157,10 @@ class UpdateExpressionTest {
                                                             .actions(removeAction, setAction, deleteAction, addAction)
                                                             .build();
 
-        RemoveUpdateAction extraRemoveAction = RemoveUpdateAction.builder().path("a").build();
-        SetUpdateAction extraSetAction = SetUpdateAction.builder().path("").value("").putExpressionValue("", VAL).build();
-        DeleteUpdateAction extraDeleteAction = DeleteUpdateAction.builder().path("").value("").putExpressionValue("", VAL).build();
-        AddUpdateAction extraAddAction = AddUpdateAction.builder().path("").value("").putExpressionValue("", VAL).build();
+        RemoveAction extraRemoveAction = RemoveAction.builder().path("a").build();
+        SetAction extraSetAction = SetAction.builder().path("").value("").putExpressionValue("", VAL).build();
+        DeleteAction extraDeleteAction = DeleteAction.builder().path("").value("").putExpressionValue("", VAL).build();
+        AddAction extraAddAction = AddAction.builder().path("").value("").putExpressionValue("", VAL).build();
         UpdateExpression additionalExpression = UpdateExpression.builder()
                                                                 .actions(extraRemoveAction, extraSetAction, extraDeleteAction, extraAddAction)
                                                                 .build();


### PR DESCRIPTION
## Motivation and Context
Adding copyable builders helps users write fluent code. Renaming action names and removing the `Update` will also hopefully feel more natural and less ambiguous, ie. going from `AddUpdateAction` to `AddAction`. 

## Modifications
- Added copyable builder
- Renamed UpdateAction classes
- Updated the functional tests

## Testing
Reran all functional tests, refactored and added more test cases.
