### PR TITLE
Expose S3TransferManager property S3ClientConfiguration.endpointOverride

### DIFF
--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3ClientConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3ClientConfiguration.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3;
 
+import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 import software.amazon.awssdk.annotations.SdkPreviewApi;
@@ -39,6 +40,7 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
     private final Long minimumPartSizeInBytes;
     private final Double targetThroughputInGbps;
     private final Integer maxConcurrency;
+    private final URI endpointOverride;
 
     private S3ClientConfiguration(DefaultBuilder builder) {
         this.credentialsProvider = builder.credentialsProvider;
@@ -47,6 +49,7 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
         this.targetThroughputInGbps = Validate.isPositiveOrNull(builder.targetThroughputInGbps, "targetThroughputInGbps");
         this.maxConcurrency = Validate.isPositiveOrNull(builder.maxConcurrency,
                                                         "maxConcurrency");
+        this.endpointOverride = builder.endpointOverride;
     }
 
     /**
@@ -84,6 +87,13 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
         return Optional.ofNullable(maxConcurrency);
     }
 
+    /**
+     * @return the optional endpoint override with which the SDK should communicate.
+     */
+    public Optional<URI> endpointOverride() {
+        return Optional.ofNullable(endpointOverride);
+    }
+
     @Override
     public Builder toBuilder() {
         return new DefaultBuilder(this);
@@ -112,7 +122,10 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
         if (!Objects.equals(targetThroughputInGbps, that.targetThroughputInGbps)) {
             return false;
         }
-        return Objects.equals(maxConcurrency, that.maxConcurrency);
+        if (!Objects.equals(maxConcurrency, that.maxConcurrency)) {
+            return false;
+        }
+        return Objects.equals(endpointOverride, that.endpointOverride);
     }
 
     @Override
@@ -122,6 +135,7 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
         result = 31 * result + (minimumPartSizeInBytes != null ? minimumPartSizeInBytes.hashCode() : 0);
         result = 31 * result + (targetThroughputInGbps != null ? targetThroughputInGbps.hashCode() : 0);
         result = 31 * result + (maxConcurrency != null ? maxConcurrency.hashCode() : 0);
+        result = 31 * result + (endpointOverride != null ? endpointOverride.hashCode() : 0);
         return result;
     }
 
@@ -216,6 +230,14 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
          * @see #targetThroughputInGbps(Double)
          */
         Builder maxConcurrency(Integer maxConcurrency);
+
+        /**
+         * Configure the endpoint override with which the SDK should communicate.
+         *
+         * @param endpointOverride the endpoint override to be used
+         * @return this builder for method chaining.
+         */
+        Builder endpointOverride(URI endpointOverride);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -224,6 +246,7 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
         private Long minimumPartSizeInBytes;
         private Double targetThroughputInGbps;
         private Integer maxConcurrency;
+        private URI endpointOverride;
 
         private DefaultBuilder() {
         }
@@ -234,6 +257,7 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
             this.minimumPartSizeInBytes = configuration.minimumPartSizeInBytes;
             this.targetThroughputInGbps = configuration.targetThroughputInGbps;
             this.maxConcurrency = configuration.maxConcurrency;
+            this.endpointOverride = configuration.endpointOverride;
         }
 
         @Override
@@ -263,6 +287,12 @@ public final class S3ClientConfiguration implements ToCopyableBuilder<S3ClientCo
         @Override
         public Builder maxConcurrency(Integer maxConcurrency) {
             this.maxConcurrency = maxConcurrency;
+            return this;
+        }
+
+        @Override
+        public Builder endpointOverride(URI endpointOverride) {
+            this.endpointOverride = endpointOverride;
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3CrtAsyncClient.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3CrtAsyncClient.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.transfer.s3.internal;
 import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.SDK_HTTP_EXECUTION_ATTRIBUTES;
 import static software.amazon.awssdk.transfer.s3.internal.S3InternalSdkHttpExecutionAttribute.OPERATION_NAME;
 
+import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
@@ -58,6 +59,7 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
                                                         .minimumPartSizeInBytes(builder.minimumPartSizeInBytes())
                                                         .maxConcurrency(builder.maxConcurrency)
                                                         .region(builder.region)
+                                                        .endpointOverride(builder.endpointOverride)
                                                         .credentialsProvider(builder.credentialsProvider)
                                                         .build();
 
@@ -79,6 +81,7 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
                                                                  .checksumValidationEnabled(false)
                                                                  .build())
                             .region(builder.region)
+                            .endpointOverride(builder.endpointOverride)
                             .credentialsProvider(builder.credentialsProvider)
                             .overrideConfiguration(o -> o.putAdvancedOption(SdkAdvancedClientOption.SIGNER,
                                                                             new NoOpSigner())
@@ -144,6 +147,7 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
         private Long minimalPartSizeInBytes;
         private Double targetThroughputInGbps;
         private Integer maxConcurrency;
+        private URI endpointOverride;
 
         public AwsCredentialsProvider credentialsProvider() {
             return credentialsProvider;
@@ -164,6 +168,11 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
         public Integer maxConcurrency() {
             return maxConcurrency;
         }
+
+        public URI endpointOverride() {
+            return endpointOverride;
+        }
+
 
         @Override
         public S3CrtAsyncClientBuilder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
@@ -192,6 +201,12 @@ public final class DefaultS3CrtAsyncClient implements S3CrtAsyncClient {
         @Override
         public S3CrtAsyncClientBuilder maxConcurrency(Integer maxConcurrency) {
             this.maxConcurrency = maxConcurrency;
+            return this;
+        }
+
+        @Override
+        public S3CrtAsyncClientBuilder endpointOverride(URI endpointOverride) {
+            this.endpointOverride = endpointOverride;
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
@@ -96,6 +96,7 @@ public final class DefaultS3TransferManager implements S3TransferManager {
         tmBuilder.s3ClientConfiguration.minimumPartSizeInBytes().ifPresent(clientBuilder::minimumPartSizeInBytes);
         tmBuilder.s3ClientConfiguration.region().ifPresent(clientBuilder::region);
         tmBuilder.s3ClientConfiguration.targetThroughputInGbps().ifPresent(clientBuilder::targetThroughputInGbps);
+        tmBuilder.s3ClientConfiguration.endpointOverride().ifPresent(clientBuilder::endpointOverride);
 
         return clientBuilder.build();
     }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3CrtAsyncClient.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3CrtAsyncClient.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.transfer.s3.internal;
 
+import java.net.URI;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -38,6 +39,8 @@ public interface S3CrtAsyncClient extends S3AsyncClient {
         S3CrtAsyncClientBuilder targetThroughputInGbps(Double targetThroughputInGbps);
 
         S3CrtAsyncClientBuilder maxConcurrency(Integer maxConcurrency);
+
+        S3CrtAsyncClientBuilder endpointOverride(URI endpointOverride);
 
         @Override
         S3CrtAsyncClient build();

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3NativeClientConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3NativeClientConfiguration.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.transfer.s3.internal;
 
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -50,6 +51,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final long partSizeInBytes;
     private final double targetThroughputInGbps;
     private final int maxConcurrency;
+    private final URI endpointOverride;
     private final Executor futureCompletionExecutor;
 
     public S3NativeClientConfiguration(Builder builder) {
@@ -71,6 +73,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         // Using 0 so that CRT will calculate it based on targetThroughputGbps
         this.maxConcurrency = builder.maxConcurrency == null ? 0 : builder.maxConcurrency;
+
+        this.endpointOverride = builder.endpointOverride;
 
         this.futureCompletionExecutor = resolveAsyncFutureCompletionExecutor(builder.asynConfiguration);
     }
@@ -101,6 +105,10 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
     public int maxConcurrency() {
         return maxConcurrency;
+    }
+
+    public URI endpointOverride() {
+        return endpointOverride;
     }
 
     public Executor futureCompletionExecutor() {
@@ -155,6 +163,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private Long partSizeInBytes;
         private Double targetThroughputInGbps;
         private Integer maxConcurrency;
+        private URI endpointOverride;
         private ClientAsyncConfiguration asynConfiguration;
 
         private Builder() {
@@ -182,6 +191,11 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         public Builder maxConcurrency(Integer maxConcurrency) {
             this.maxConcurrency = maxConcurrency;
+            return this;
+        }
+
+        public Builder endpointOverride(URI endpointOverride) {
+            this.endpointOverride = endpointOverride;
             return this;
         }
 

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/S3ClientConfigurationTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/S3ClientConfigurationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
 
+import java.net.URI;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -73,12 +74,15 @@ public class S3ClientConfigurationTest {
                                                                    .maxConcurrency(100)
                                                                    .targetThroughputInGbps(10.0)
                                                                    .region(Region.US_WEST_2)
+                                                                   .endpointOverride(URI.create(
+                                                                       "http://s3.us-west-1.amazonaws.com:80"))
                                                                    .minimumPartSizeInBytes(5 * MB)
                                                                    .build();
 
         assertThat(configuration.credentialsProvider()).contains(credentials);
         assertThat(configuration.maxConcurrency()).contains(100);
         assertThat(configuration.region()).contains(Region.US_WEST_2);
+        assertThat(configuration.endpointOverride().toString()).contains("http://s3.us-west-1.amazonaws.com:80");
         assertThat(configuration.targetThroughputInGbps()).contains(10.0);
         assertThat(configuration.minimumPartSizeInBytes()).contains(5 * MB);
     }
@@ -91,6 +95,7 @@ public class S3ClientConfigurationTest {
         assertThat(configuration.credentialsProvider()).isEmpty();
         assertThat(configuration.maxConcurrency()).isEmpty();
         assertThat(configuration.region()).isEmpty();
+        assertThat(configuration.endpointOverride()).isEmpty();
         assertThat(configuration.targetThroughputInGbps()).isEmpty();
         assertThat(configuration.minimumPartSizeInBytes()).isEmpty();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow setting endpointOverride for the S3TransferManager

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/aws-sdk-java-v2/issues/2740
https://github.com/aws/aws-sdk-java-v2/issues/2945

The S3AsyncClient offers the ability to set the endpointOverride as follows:
```
S3AsyncClient.builder().endpointOverride(URI("http://minio-s3:9000"))
```
This change adds the endpointOverride feature to the S3TransferManager.

## Modifications
<!--- Describe your changes in detail -->
Enhance the `S3TransferManager` `S3ClientConfiguration` with the ability to set the `endpointOverride(URI)`. This feature requires the following enhancement provided in aws-crt-java v0.15.20: https://github.com/awslabs/aws-crt-java/commit/f5a7955989d3b2701d923631886666e6d41bcd23.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I executed all s3-transfer-manager unit and integration tests with these changes applied using "isolated" S3 test buckets. I also executed the s3-transfer-manager integration tests against a local Minio server. This required modifying the integration tests to specify endpointOverride(URI.create("http://localhost:9000") and to comment the use of ListObjectVersionsRequest in method `S3IntegrationTestBase.deleteBucketAndAllContents` which proved problematic for Minio.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
