### PR TITLE
Add Transfer Manager integ tests for local dirs with Unicode characters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,9 +234,9 @@
                             <exclude>**/*StabilityTest.java</exclude>
                             <exclude>**/*StabilityTests.java</exclude>
                             <exclude>**/*CucumberTest.java</exclude>
-<!--                            <exclude>**/*IntegrationTest.java</exclude>-->
-<!--                            <exclude>**/*IntegrationTests.java</exclude>-->
-<!--                            <exclude>**/*IntegTest.java</exclude>-->
+                            <exclude>**/*IntegrationTest.java</exclude>
+                            <exclude>**/*IntegrationTests.java</exclude>
+                            <exclude>**/*IntegTest.java</exclude>
                             <exclude>**/*IntegrationTestCase.java</exclude>
                         </excludes>
                         <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -234,9 +234,9 @@
                             <exclude>**/*StabilityTest.java</exclude>
                             <exclude>**/*StabilityTests.java</exclude>
                             <exclude>**/*CucumberTest.java</exclude>
-                            <exclude>**/*IntegrationTest.java</exclude>
-                            <exclude>**/*IntegrationTests.java</exclude>
-                            <exclude>**/*IntegTest.java</exclude>
+<!--                            <exclude>**/*IntegrationTest.java</exclude>-->
+<!--                            <exclude>**/*IntegrationTests.java</exclude>-->
+<!--                            <exclude>**/*IntegTest.java</exclude>-->
                             <exclude>**/*IntegrationTestCase.java</exclude>
                         </excludes>
                         <includes>

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -173,6 +173,12 @@
             <artifactId>equalsverifier</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.verion}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/CrtExceptionTransformationIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/CrtExceptionTransformationIntegrationTest.java
@@ -21,9 +21,9 @@ import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBu
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -42,7 +42,7 @@ public class CrtExceptionTransformationIntegrationTest extends S3IntegrationTest
     private static S3TransferManager transferManager;
     private static S3CrtAsyncClient s3Crt;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupFixture() throws IOException {
         createBucket(BUCKET);
         testFile = new RandomTempFile(BUCKET, OBJ_SIZE);
@@ -57,7 +57,7 @@ public class CrtExceptionTransformationIntegrationTest extends S3IntegrationTest
                              .build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownFixture() {
         deleteBucketAndAllContents(BUCKET);
         s3Crt.close();

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3CrtClientPutObjectIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3CrtClientPutObjectIntegrationTest.java
@@ -27,9 +27,9 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -48,7 +48,7 @@ public class S3CrtClientPutObjectIntegrationTest extends S3IntegrationTestBase {
     private static RandomTempFile testFile;
     private static S3CrtAsyncClient s3Crt;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         S3IntegrationTestBase.setUp();
         S3IntegrationTestBase.createBucket(TEST_BUCKET);
@@ -61,7 +61,7 @@ public class S3CrtClientPutObjectIntegrationTest extends S3IntegrationTestBase {
                                 .build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() throws IOException {
         S3IntegrationTestBase.deleteBucketAndAllContents(TEST_BUCKET);
         Files.delete(testFile.toPath());
@@ -70,7 +70,7 @@ public class S3CrtClientPutObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void putObject_fileRequestBody_objectSentCorrectly() throws Exception {
+    void putObject_fileRequestBody_objectSentCorrectly() throws Exception {
         AsyncRequestBody body = AsyncRequestBody.fromFile(testFile.toPath());
         s3Crt.putObject(r -> r.bucket(TEST_BUCKET).key(TEST_KEY), body).join();
 
@@ -83,7 +83,7 @@ public class S3CrtClientPutObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void putObject_byteBufferBody_objectSentCorrectly() {
+    void putObject_byteBufferBody_objectSentCorrectly() {
         byte[] data = new byte[16384];
         new Random().nextBytes(data);
         ByteBuffer byteBuffer = ByteBuffer.wrap(data);
@@ -101,7 +101,7 @@ public class S3CrtClientPutObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void putObject_customRequestBody_objectSentCorrectly() throws IOException {
+    void putObject_customRequestBody_objectSentCorrectly() throws IOException {
         Random rng = new Random();
         int bufferSize = 16384;
         int nBuffers = 15;

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3CrtGetObjectIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3CrtGetObjectIntegrationTest.java
@@ -26,9 +26,9 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.http.async.SimpleSubscriber;
@@ -46,7 +46,7 @@ public class S3CrtGetObjectIntegrationTest extends S3IntegrationTestBase {
     private static File file;
     private static ExecutorService executorService;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         S3IntegrationTestBase.createBucket(BUCKET);
         crtClient = S3CrtAsyncClient.builder()
@@ -61,7 +61,7 @@ public class S3CrtGetObjectIntegrationTest extends S3IntegrationTestBase {
         executorService = Executors.newFixedThreadPool(2);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         crtClient.close();
         S3IntegrationTestBase.deleteBucketAndAllContents(BUCKET);
@@ -70,7 +70,7 @@ public class S3CrtGetObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void getObject_toFiles() throws IOException {
+    void getObject_toFiles() throws IOException {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
 
         GetObjectResponse response =
@@ -80,14 +80,14 @@ public class S3CrtGetObjectIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void getObject_toBytes() throws IOException {
+    void getObject_toBytes() throws IOException {
         byte[] bytes =
             crtClient.getObject(b -> b.bucket(BUCKET).key(KEY), AsyncResponseTransformer.toBytes()).join().asByteArray();
         assertThat(bytes).isEqualTo(Files.readAllBytes(file.toPath()));
     }
 
     @Test
-    public void getObject_customResponseTransformer() {
+    void getObject_customResponseTransformer() {
         crtClient.getObject(b -> b.bucket(BUCKET).key(KEY),
                             new TestResponseTransformer()).join();
 

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3IntegrationTestBase.java
@@ -15,8 +15,8 @@
 
 package software.amazon.awssdk.transfer.s3;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
 import software.amazon.awssdk.regions.Region;
@@ -56,7 +56,7 @@ public class S3IntegrationTestBase extends AwsTestBase {
      * Loads the AWS account info for the integration tests and creates an S3
      * client for tests to use.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         Log.initLoggingToStdout(Log.LogLevel.Warn);
         System.setProperty("aws.crt.debugnative", "true");
@@ -64,7 +64,7 @@ public class S3IntegrationTestBase extends AwsTestBase {
         s3Async = s3AsyncClientBuilder().build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanUp() {
         CrtResource.waitForNoResources();
     }

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerCopyIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerCopyIntegrationTest.java
@@ -21,9 +21,9 @@ import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
 import static software.amazon.awssdk.transfer.s3.util.ChecksumUtils.computeCheckSum;
 
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
@@ -38,7 +38,7 @@ public class S3TransferManagerCopyIntegrationTest extends S3IntegrationTestBase 
 
     private static S3TransferManager tm;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         S3IntegrationTestBase.setUp();
         createBucket(BUCKET);
@@ -50,7 +50,7 @@ public class S3TransferManagerCopyIntegrationTest extends S3IntegrationTestBase 
                               .build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() throws Exception {
         tm.close();
         deleteBucketAndAllContents(BUCKET);
@@ -58,7 +58,7 @@ public class S3TransferManagerCopyIntegrationTest extends S3IntegrationTestBase 
     }
 
     @Test
-    public void copy_copiedObject_hasSameContent() {
+    void copy_copiedObject_hasSameContent() {
         byte[] originalContent = randomBytes(OBJ_SIZE);
         createOriginalObject(originalContent);
         copyObject();

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadDirectoryIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadDirectoryIntegrationTest.java
@@ -29,18 +29,18 @@ import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.ComparisonFailure;
-import org.junit.Test;
 import software.amazon.awssdk.testutils.FileUtils;
 import software.amazon.awssdk.utils.Logger;
 
 public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3IntegrationTestBase {
     private static final Logger log = Logger.loggerFor(S3TransferManagerDownloadDirectoryIntegrationTest.class);
-    private static final String TEST_BUCKET = temporaryBucketName(S3TransferManagerUploadIntegrationTest.class);
+    private static final String TEST_BUCKET = temporaryBucketName(S3TransferManagerDownloadDirectoryIntegrationTest.class);
     private static final String TEST_BUCKET_CUSTOM_DELIMITER = temporaryBucketName("S3TransferManagerUploadIntegrationTest"
                                                                                    + "-delimiter");
     private static final String CUSTOM_DELIMITER = "-";
@@ -49,7 +49,7 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
     private static Path sourceDirectory;
     private Path destinationDirectory;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         S3IntegrationTestBase.setUp();
         createBucket(TEST_BUCKET);
@@ -70,17 +70,17 @@ public class S3TransferManagerDownloadDirectoryIntegrationTest extends S3Integra
           .completionFuture().join();
     }
 
-    @Before
+    @BeforeEach
     public void setUpPerTest() throws IOException {
         destinationDirectory = Files.createTempDirectory("destination");
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         FileUtils.cleanUpTestDirectory(destinationDirectory);
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() {
         try {
             FileUtils.cleanUpTestDirectory(sourceDirectory);

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadIntegrationTest.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.ResponsePublisher;
@@ -42,7 +42,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     private static S3TransferManager tm;
     private static File file;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws IOException {
         createBucket(BUCKET);
         file = new RandomTempFile(OBJ_SIZE);
@@ -56,7 +56,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
                               .build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         deleteBucketAndAllContents(BUCKET);
         tm.close();
@@ -64,7 +64,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     }
 
     @Test
-    public void download_toFile() throws IOException {
+    void download_toFile() throws IOException {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
         FileDownload download =
             tm.downloadFile(DownloadFileRequest.builder()
@@ -78,7 +78,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     }
 
     @Test
-    public void download_toBytes() throws Exception {
+    void download_toBytes() throws Exception {
         Download<ResponseBytes<GetObjectResponse>> download =
             tm.download(DownloadRequest.builder()
                                        .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))
@@ -92,7 +92,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     }
 
     @Test
-    public void download_toPublisher() throws Exception {
+    void download_toPublisher() throws Exception {
         Download<ResponsePublisher<GetObjectResponse>> download =
             tm.download(DownloadRequest.builder()
                                        .getObjectRequest(b -> b.bucket(BUCKET).key(KEY))

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryIntegrationTest.java
@@ -28,9 +28,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -39,14 +39,14 @@ import software.amazon.awssdk.utils.Logger;
 
 public class S3TransferManagerUploadDirectoryIntegrationTest extends S3IntegrationTestBase {
     private static final Logger log = Logger.loggerFor(S3TransferManagerUploadDirectoryIntegrationTest.class);
-    private static final String TEST_BUCKET = temporaryBucketName(S3TransferManagerUploadIntegrationTest.class);
+    private static final String TEST_BUCKET = temporaryBucketName(S3TransferManagerUploadDirectoryIntegrationTest.class);
 
     private static S3TransferManager tm;
     private static Path directory;
     private static S3Client s3Client;
     private static String randomString;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         S3IntegrationTestBase.setUp();
         createBucket(TEST_BUCKET);
@@ -64,7 +64,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
                            .build();
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() {
         try {
             FileUtils.cleanUpTestDirectory(directory);
@@ -84,7 +84,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
     }
 
     @Test
-    public void uploadDirectory_filesSentCorrectly() {
+    void uploadDirectory_filesSentCorrectly() {
         String prefix = "yolo";
         DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.sourceDirectory(directory)
                                                                           .bucket(TEST_BUCKET)
@@ -103,7 +103,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
     }
 
     @Test
-    public void uploadDirectory_withDelimiter_filesSentCorrectly() {
+    void uploadDirectory_withDelimiter_filesSentCorrectly() {
         String prefix = "hello";
         String delimiter = "0";
         DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.sourceDirectory(directory)
@@ -126,7 +126,7 @@ public class S3TransferManagerUploadDirectoryIntegrationTest extends S3Integrati
     }
 
     @Test
-    public void uploadDirectory_withRequestTransformer_usesRequestTransformer() throws Exception {
+    void uploadDirectory_withRequestTransformer_usesRequestTransformer() throws Exception {
         String prefix = "requestTransformerTest";
         Path newSourceForEachUpload = Paths.get(directory.toString(), "bar.txt");
 

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryUnicodeIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadDirectoryUnicodeIntegrationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
+import static software.amazon.awssdk.utils.IoUtils.closeQuietly;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.testutils.FileUtils;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * Tests the behavior of traversing local directories with special Unicode characters in their path name. These characters have
+ * known to be problematic when using Java's old File API or with Windows (which uses UTF-16 for file-name encoding).
+ */
+@RunWith(Parameterized.class)
+public class S3TransferManagerUploadDirectoryUnicodeIntegrationTest extends S3IntegrationTestBase {
+    private static final Logger log = Logger.loggerFor(S3TransferManagerUploadDirectoryUnicodeIntegrationTest.class);
+    private static final String TEST_BUCKET = temporaryBucketName(S3TransferManagerUploadDirectoryUnicodeIntegrationTest.class);
+
+    private static S3TransferManager tm;
+    private static S3Client s3Client;
+
+    private final String directoryPrefix;
+    private Path testDirectory;
+
+    @Parameterized.Parameters(name = "Directory Prefix: {0}")
+    public static Collection<Object> data() {
+        return Arrays.asList(
+            /* ASCII, 1-byte UTF-8 */
+            "E",
+            /* ASCII, 2-byte UTF-8 */
+            "É",
+            /* Non-ASCII, 2-byte UTF-8 */
+            "Ũ",
+            /* Non-ASCII, 3-byte UTF-8 */
+            "स",
+            /* Non-ASCII, 4-byte UTF-8 */
+            "\uD808\uDC8C"
+        );
+    }
+
+    public S3TransferManagerUploadDirectoryUnicodeIntegrationTest(String directoryPrefix) {
+        this.directoryPrefix = directoryPrefix;
+        log.info(() -> "Testing directory prefix: " + directoryPrefix);
+        log.info(() -> "UTF-8 bytes: " + Hex.encodeHexString(directoryPrefix.getBytes(StandardCharsets.UTF_8)));
+        log.info(() -> "UTF-16 bytes: " + Hex.encodeHexString(directoryPrefix.getBytes(StandardCharsets.UTF_16)));
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        S3IntegrationTestBase.setUp();
+        tm = S3TransferManager.builder()
+                              .s3ClientConfiguration(b -> b.credentialsProvider(CREDENTIALS_PROVIDER_CHAIN)
+                                                           .region(DEFAULT_REGION)
+                                                           .maxConcurrency(100))
+                              .build();
+        s3Client = S3Client.builder()
+                           .credentialsProvider(CREDENTIALS_PROVIDER_CHAIN).region(DEFAULT_REGION)
+                           .build();
+    }
+
+    @Before
+    public void testSetup() throws Exception {
+        createBucket(TEST_BUCKET);
+        testDirectory = createLocalTestDirectory();
+    }
+
+    @After
+    public void testTeardown() {
+        try {
+            FileUtils.cleanUpTestDirectory(testDirectory);
+        } catch (Exception exception) {
+            log.warn(() -> "Failed to clean up test directory " + testDirectory, exception);
+        }
+        try {
+            deleteBucketAndAllContents(TEST_BUCKET);
+        } catch (Exception exception) {
+            log.warn(() -> "Failed to delete s3 bucket " + TEST_BUCKET, exception);
+        }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        closeQuietly(tm, log.logger());
+        closeQuietly(s3Client, log.logger());
+        S3IntegrationTestBase.cleanUp();
+    }
+
+    @Test
+    public void uploadDirectory_traversedCorrectly() {
+        DirectoryUpload uploadDirectory = tm.uploadDirectory(u -> u.sourceDirectory(testDirectory)
+                                                                   .bucket(TEST_BUCKET)
+                                                                   .overrideConfiguration(o -> o.recursive(true)));
+        CompletedDirectoryUpload completedDirectoryUpload = uploadDirectory.completionFuture().join();
+        assertThat(completedDirectoryUpload.failedTransfers()).isEmpty();
+
+        List<String> keys = s3Client.listObjectsV2Paginator(b -> b.bucket(TEST_BUCKET))
+                                    .contents()
+                                    .stream()
+                                    .map(S3Object::key)
+                                    .collect(Collectors.toList());
+
+        assertThat(keys).containsOnly("bar.txt", "foo/1.txt", "foo/2.txt");
+
+        keys.forEach(this::verifyContent);
+    }
+
+
+    private Path createLocalTestDirectory() throws IOException {
+        Path dir = Files.createTempDirectory(directoryPrefix);
+        Files.createDirectory(Paths.get(dir + "/foo"));
+        Files.write(dir.resolve("bar.txt"), randomBytes(1024));
+        Files.write(dir.resolve("foo/1.txt"), randomBytes(1024));
+        Files.write(dir.resolve("foo/2.txt"), randomBytes(1024));
+        return dir;
+    }
+
+    private void verifyContent(String key) {
+        try {
+            byte[] expectedContent = Files.readAllBytes(testDirectory.resolve(key));
+            byte[] actualContent = s3.getObject(r -> r.bucket(TEST_BUCKET).key(key), ResponseTransformer.toBytes()).asByteArray();
+            assertThat(actualContent).isEqualTo(expectedContent);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static byte[] randomBytes(long size) {
+        byte[] bytes = new byte[Math.toIntExact(size)];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+}

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadIntegrationTest.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.UUID;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
@@ -41,7 +41,7 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
     private static RandomTempFile testFile;
     private static S3TransferManager tm;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         S3IntegrationTestBase.setUp();
         createBucket(TEST_BUCKET);
@@ -56,7 +56,7 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
 
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() throws IOException {
         tm.close();
         Files.delete(testFile.toPath());
@@ -65,7 +65,7 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
     }
 
     @Test
-    public void upload_file_SentCorrectly() throws IOException {
+    void upload_file_SentCorrectly() throws IOException {
         FileUpload fileUpload =
             tm.uploadFile(u -> u.putObjectRequest(p -> p.bucket(TEST_BUCKET).key(TEST_KEY))
                                 .source(testFile.toPath())
@@ -85,7 +85,7 @@ public class S3TransferManagerUploadIntegrationTest extends S3IntegrationTestBas
     }
 
     @Test
-    public void upload_asyncRequestBody_SentCorrectly() throws IOException {
+    void upload_asyncRequestBody_SentCorrectly() throws IOException {
         String content = UUID.randomUUID().toString();
 
         Upload upload =

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperParameterizedTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperParameterizedTest.java
@@ -191,7 +191,7 @@ public class UploadDirectoryHelperParameterizedTest {
 
         List<String> keys =
             actualRequests.stream().map(u -> u.putObjectRequest().key())
-                                 .collect(Collectors.toList());
+                          .collect(Collectors.toList());
 
         assertThat(keys.size()).isEqualTo(5);
         assertThat(keys).containsOnly("bar.txt", "foo/1.txt", "foo/2.txt", "symlink/2.txt", "symlink2");
@@ -292,9 +292,9 @@ public class UploadDirectoryHelperParameterizedTest {
 
         when(singleUploadFunction.apply(requestArgumentCaptor.capture())).thenReturn(completedUpload());
         DirectoryUpload uploadDirectory = uploadDirectoryHelper.uploadDirectory(UploadDirectoryRequest.builder()
-                                                                                                             .overrideConfiguration(o -> o.followSymbolicLinks(true))
-                                                                                                             .sourceDirectory(Paths.get(directory.toString(), "symlink"))
-                                                                                                             .bucket("bucket").build());
+                                                                                                      .overrideConfiguration(o -> o.followSymbolicLinks(true))
+                                                                                                      .sourceDirectory(Paths.get(directory.toString(), "symlink"))
+                                                                                                      .bucket("bucket").build());
 
         uploadDirectory.completionFuture().join();
 
@@ -312,9 +312,9 @@ public class UploadDirectoryHelperParameterizedTest {
 
     private DefaultFileUpload completedUpload() {
         return new DefaultFileUpload(CompletableFuture.completedFuture(CompletedFileUpload.builder()
-                                                                                      .response(PutObjectResponse.builder().build())
-                                                                                      .build()),
-                                 new DefaultTransferProgress(DefaultTransferProgressSnapshot.builder().build()));
+                                                                                          .response(PutObjectResponse.builder().build())
+                                                                                          .build()),
+                                     new DefaultTransferProgress(DefaultTransferProgressSnapshot.builder().build()));
     }
 
     private Path createTestDirectory() throws IOException {

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java
@@ -155,7 +155,8 @@ public class UploadDirectoryHelperTest {
 
         assertThat(completedDirectoryUpload.failedTransfers()).hasSize(1);
         assertThat(completedDirectoryUpload.failedTransfers().iterator().next().exception()).isEqualTo(exception);
-        assertThat(completedDirectoryUpload.failedTransfers().iterator().next().request().source().toString()).isEqualTo("test/2");
+        assertThat(completedDirectoryUpload.failedTransfers().iterator().next().request().source().toString())
+            .isEqualTo("test" + directory.getFileSystem().getSeparator() + "2");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->



## Modifications
- Add Transfer Manager integ tests for local dirs with Unicode characters added through #3105 
- Fix failed unit test
- Fix bucket name
- Migrate some JUnit5 eligible tests to JUnit5

## Testing
Verified the tests passed on Windows and Linux  

