### PR TITLE
Remove unnecessary dependencies on JDK modules not in java.base.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-d2d8d5d.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d2d8d5d.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Remove unnecessary dependencies on JDK modules not in java.base. This didn't remove all of the dependencies on such modules, just the unnecessary ones."
+}

--- a/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/NonJavaBaseModuleCheck.java
+++ b/build-tools/src/main/java/software/amazon/awssdk/buildtools/checkstyle/NonJavaBaseModuleCheck.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.buildtools.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Verify that we're not using classes in rt.jar that aren't exported via the java.base module.
+ *
+ * If anything fails this check, it increases our module dependencies. If you absolutely must use one of these
+ * (e.g. java.beans) because it's fundamental to your functionality, you can suppress this checkstyle rule via
+ * {@link #setLegalPackages(String...)}, but know that it is not free - you're essentially adding a dependency
+ * for customers that use the module path.
+ */
+public class NonJavaBaseModuleCheck extends AbstractCheck {
+    private static final List<String> ILLEGAL_PACKAGES = Arrays.asList(
+        "java",
+        "javax",
+        "sun",
+        "apple",
+        "com.apple",
+        "com.oracle");
+
+    private static final Set<String> LEGAL_PACKAGES = new HashSet<>(Arrays.asList(
+        "java.io",
+        "java.lang",
+        "java.lang.annotation",
+        "java.lang.invoke",
+        "java.lang.module",
+        "java.lang.ref",
+        "java.lang.reflect",
+        "java.math",
+        "java.net",
+        "java.net.spi",
+        "java.nio",
+        "java.nio.channels",
+        "java.nio.channels.spi",
+        "java.nio.charset",
+        "java.nio.charset.spi",
+        "java.nio.file",
+        "java.nio.file.attribute",
+        "java.nio.file.spi",
+        "java.security",
+        "java.security.acl",
+        "java.security.cert",
+        "java.security.interfaces",
+        "java.security.spec",
+        "java.text",
+        "java.text.spi",
+        "java.time",
+        "java.time.chrono",
+        "java.time.format",
+        "java.time.temporal",
+        "java.time.zone",
+        "java.util",
+        "java.util.concurrent",
+        "java.util.concurrent.atomic",
+        "java.util.concurrent.locks",
+        "java.util.function",
+        "java.util.jar",
+        "java.util.regex",
+        "java.util.spi",
+        "java.util.stream",
+        "java.util.jar",
+        "java.util.zip",
+        "javax.crypto",
+        "javax.crypto.interfaces",
+        "javax.crypto.spec",
+        "javax.net",
+        "javax.net.ssl",
+        "javax.security.auth",
+        "javax.security.auth.callback",
+        "javax.security.auth.login",
+        "javax.security.auth.spi",
+        "javax.security.auth.x500",
+        "javax.security.cert"));
+
+    private static final Pattern CLASSNAME_START_PATTERN = Pattern.compile("[A-Z]");
+
+    private String currentSdkPackage;
+
+    private HashMap<String, Set<String>> additionalLegalPackagesBySdkPackage = new HashMap<>();
+
+    /**
+     * Additional legal packages are formatted as "sdk.package.name:jdk.package.name,sdk.package.name2:jdk.package.name2".
+     * Multiple SDK packages can be repeated.
+     */
+    public void setLegalPackages(String... legalPackages) {
+        for (String additionalLegalPackage : legalPackages) {
+            String[] splitPackage = additionalLegalPackage.split(":", 2);
+            if (splitPackage.length != 2) {
+                throw new IllegalArgumentException("Invalid legal package definition '" + additionalLegalPackage + "'. Expected"
+                                                   + " format is sdk.package.name:jdk.package.name");
+            }
+
+            this.additionalLegalPackagesBySdkPackage.computeIfAbsent(splitPackage[0], k -> new HashSet<>())
+                                                    .add(splitPackage[1]);
+        }
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] { TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT, TokenTypes.PACKAGE_DEF };
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        if (ast.getType() == TokenTypes.PACKAGE_DEF) {
+            handlePackageDefToken(ast);
+            return;
+        }
+
+        handleImportToken(ast);
+    }
+
+    private void handlePackageDefToken(DetailAST ast) {
+        this.currentSdkPackage = FullIdent.createFullIdent(ast.getLastChild().getPreviousSibling()).getText();
+    }
+
+    private void handleImportToken(DetailAST ast) {
+        FullIdent importIdentifier;
+        if (ast.getType() == TokenTypes.IMPORT) {
+            importIdentifier = FullIdent.createFullIdentBelow(ast);
+        } else {
+            importIdentifier = FullIdent.createFullIdent(ast.getFirstChild().getNextSibling());
+        }
+
+        String importText = importIdentifier.getText();
+        if (isIllegalImport(importText) && !isLegalImport(importText)) {
+            log(ast, "Import '" + importText + "' uses a JDK class that is not in java.base. This essentially adds an "
+                     + "additional module dependency. Don't suppress this rule unless it's absolutely required, and only "
+                     + "suppress the specific package you need via checkstyle.xml instead of suppressing the entire rule.");
+        }
+    }
+
+    private boolean isIllegalImport(String importText) {
+        for (String illegalPackage : ILLEGAL_PACKAGES) {
+            if (importText.startsWith(illegalPackage + ".")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isLegalImport(String importText) {
+        String importPackageWithTrailingDot = CLASSNAME_START_PATTERN.split(importText, 2)[0];
+        String importPackage = importText.substring(0, importPackageWithTrailingDot.length() - 1);
+
+        if (LEGAL_PACKAGES.contains(importPackage)) {
+            return true;
+        }
+
+        if (additionalLegalPackagesBySdkPackage.entrySet()
+                                               .stream()
+                                               .anyMatch(e -> currentSdkPackage.startsWith(e.getKey()) &&
+                                                              e.getValue().contains(importPackage))) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle-suppressions.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle-suppressions.xml
@@ -50,4 +50,7 @@
     <!-- Ignore usage of sslContext.newHandler for NettyUtils.!-->
     <suppress checks="Regexp"
               files=".*NettyUtils\.java$"/>
+
+    <!-- Allow non-java.base usage in tests -->
+    <suppress checks="software.amazon.awssdk.buildtools.checkstyle.NonJavaBaseModuleCheck" files=".*testutils.*"/>
 </suppressions>

--- a/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
+++ b/build-tools/src/main/resources/software/amazon/awssdk/checkstyle.xml
@@ -431,6 +431,18 @@
             <property name="packageToCheck" value="software.amazon.awssdk.http.nio.netty" />
             <property name="illegalPkgs" value="software.amazon.awssdk.utils.Logger,org.slf4j.Logger"/>
         </module>
+        
+        <module name="software.amazon.awssdk.buildtools.checkstyle.NonJavaBaseModuleCheck">
+            <!--
+            codegen: Allowed to use classes from java.compiler, because poet requires them.
+            aws-query-protocol: Allowed to use classes from java.xml for XML parsing.
+            protocol-tests-core: Allows to use classes from java.xml for XML assertions.
+            dynamodb-enhanced: Allowed to use classes from java.beans for bean processing.
+            release-scripts: Allowed to use classes from java.xml for XML writing.
+            sdk-benchmarks: Allowed to use classes from javax.servlet.http for benchmark servlets.
+            -->
+            <property name="legalPackages" value="software.amazon.awssdk.codegen:javax.lang.model, software.amazon.awssdk.codegen:javax.lang.model.element, software.amazon.awssdk.codegen:javax.lang.model.type, software.amazon.awssdk.protocols.query:javax.xml.stream, software.amazon.awssdk.protocols.query:javax.xml.stream.events, software.amazon.awssdk.protocol.asserts.marshalling:javax.xml, software.amazon.awssdk.protocol.asserts.marshalling:javax.xml.parsers, software.amazon.awssdk.protocol.asserts.marshalling:javax.xml.transform, software.amazon.awssdk.protocol.asserts.marshalling:javax.xml.transform.dom, software.amazon.awssdk.protocol.asserts.marshalling:javax.xml.transform.stream, software.amazon.awssdk.enhanced.dynamodb.mapper:java.beans, software.amazon.awssdk.release:javax.xml, software.amazon.awssdk.release:javax.xml.parsers, software.amazon.awssdk.release:javax.xml.transform, software.amazon.awssdk.release:javax.xml.xpath, software.amazon.awssdk.release:javax.xml.transform.dom, software.amazon.awssdk.release:javax.xml.transform.stream, software.amazon.awssdk.benchmark:javax.servlet.http"/>
+        </module>
     </module>
 
         <!-- Enforce maximum line lengths. -->

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AbstractMemberSetters.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/AbstractMemberSetters.java
@@ -15,14 +15,19 @@
 
 package software.amazon.awssdk.codegen.poet.model;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 import static software.amazon.awssdk.codegen.poet.model.TypeProvider.ShapeTransformation.USE_BUILDER_IMPL;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
+// CHECKSTYLE:OFF java.beans is required for services that use names starting with 'set' to fix bean-based marshalling.
 import java.beans.Transient;
+// CHECKSTYLE:ON
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
@@ -85,9 +90,17 @@ abstract class AbstractMemberSetters implements MemberSetters {
         return MethodSpec.methodBuilder(methodName)
                          .addParameter(setterParam)
                          .addAnnotation(Override.class)
-                         .addAnnotation(Transient.class)
+                         .addAnnotations(maybeTransient(methodName))
                          .returns(returnType)
                          .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+    }
+
+    private Iterable<AnnotationSpec> maybeTransient(String methodName) {
+        if (methodName.startsWith("set")) {
+            return singleton(AnnotationSpec.builder(Transient.class).build());
+        }
+
+        return emptyList();
     }
 
     protected MethodSpec.Builder beanStyleSetterBuilder() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesrequest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Arrays;
@@ -2328,7 +2327,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             this.stringMember = stringMember;
             return this;
@@ -2343,7 +2341,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder integerMember(Integer integerMember) {
             this.integerMember = integerMember;
             return this;
@@ -2358,7 +2355,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder booleanMember(Boolean booleanMember) {
             this.booleanMember = booleanMember;
             return this;
@@ -2373,7 +2369,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder floatMember(Float floatMember) {
             this.floatMember = floatMember;
             return this;
@@ -2388,7 +2383,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder doubleMember(Double doubleMember) {
             this.doubleMember = doubleMember;
             return this;
@@ -2403,7 +2397,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder longMember(Long longMember) {
             this.longMember = longMember;
             return this;
@@ -2418,7 +2411,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder shortMember(Short shortMember) {
             this.shortMember = shortMember;
             return this;
@@ -2436,14 +2428,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder simpleList(Collection<String> simpleList) {
             this.simpleList = ListOfStringsCopier.copy(simpleList);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder simpleList(String... simpleList) {
             simpleList(Arrays.asList(simpleList));
@@ -2462,14 +2452,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfEnumsWithStrings(Collection<String> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfEnumsWithStrings(String... listOfEnums) {
             listOfEnumsWithStrings(Arrays.asList(listOfEnums));
@@ -2477,14 +2465,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfEnums(Collection<EnumType> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copyEnumToString(listOfEnums);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfEnums(EnumType... listOfEnums) {
             listOfEnums(Arrays.asList(listOfEnums));
@@ -2503,14 +2489,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfMaps(Collection<? extends Map<String, String>> listOfMaps) {
             this.listOfMaps = ListOfMapStringToStringCopier.copy(listOfMaps);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMaps(Map<String, String>... listOfMaps) {
             listOfMaps(Arrays.asList(listOfMaps));
@@ -2530,14 +2514,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfStructs(Collection<SimpleStruct> listOfStructs) {
             this.listOfStructs = ListOfSimpleStructsCopier.copy(listOfStructs);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfStructs(SimpleStruct... listOfStructs) {
             listOfStructs(Arrays.asList(listOfStructs));
@@ -2545,7 +2527,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
@@ -2565,14 +2546,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMapOfEnumToStringWithStrings(Map<String, String>... listOfMapOfEnumToString) {
             listOfMapOfEnumToStringWithStrings(Arrays.asList(listOfMapOfEnumToString));
@@ -2594,14 +2573,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfMapOfStringToStruct(Collection<? extends Map<String, SimpleStruct>> listOfMapOfStringToStruct) {
             this.listOfMapOfStringToStruct = ListOfMapOfStringToStructCopier.copy(listOfMapOfStringToStruct);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMapOfStringToStruct(Map<String, SimpleStruct>... listOfMapOfStringToStruct) {
             listOfMapOfStringToStruct(Arrays.asList(listOfMapOfStringToStruct));
@@ -2620,7 +2597,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToIntegerList(Map<String, ? extends Collection<Integer>> mapOfStringToIntegerList) {
             this.mapOfStringToIntegerList = MapOfStringToIntegerListCopier.copy(mapOfStringToIntegerList);
             return this;
@@ -2638,7 +2614,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToString(Map<String, String> mapOfStringToString) {
             this.mapOfStringToString = MapOfStringToStringCopier.copy(mapOfStringToString);
             return this;
@@ -2658,7 +2633,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct) {
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToSimpleStruct);
             return this;
@@ -2676,14 +2650,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToEnum(Map<EnumType, EnumType> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copyEnumToString(mapOfEnumToEnum);
             return this;
@@ -2701,14 +2673,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToString(Map<EnumType, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copyEnumToString(mapOfEnumToString);
             return this;
@@ -2726,14 +2696,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToEnum(Map<String, EnumType> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copyEnumToString(mapOfStringToEnum);
             return this;
@@ -2752,14 +2720,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copy(mapOfEnumToSimpleStruct);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToSimpleStruct(Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyEnumToString(mapOfEnumToSimpleStruct);
             return this;
@@ -2777,14 +2743,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToListOfEnums(Map<EnumType, ? extends Collection<EnumType>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copyEnumToString(mapOfEnumToListOfEnums);
             return this;
@@ -2802,7 +2766,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToMapOfStringToEnumWithStrings(
             Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
@@ -2810,7 +2773,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToMapOfStringToEnum(
             Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copyEnumToString(mapOfEnumToMapOfStringToEnum);
@@ -2826,7 +2788,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder timestampMember(Instant timestampMember) {
             this.timestampMember = timestampMember;
             return this;
@@ -2842,7 +2803,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder structWithNestedTimestampMember(StructWithTimestamp structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember;
             return this;
@@ -2857,7 +2817,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder blobArg(SdkBytes blobArg) {
             this.blobArg = blobArg;
             return this;
@@ -2872,7 +2831,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder structWithNestedBlob(StructWithNestedBlobType structWithNestedBlob) {
             this.structWithNestedBlob = structWithNestedBlob;
             return this;
@@ -2892,7 +2850,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
             return this;
@@ -2911,14 +2868,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
@@ -2934,7 +2889,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder recursiveStruct(RecursiveStructType recursiveStruct) {
             this.recursiveStruct = recursiveStruct;
             return this;
@@ -2949,7 +2903,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder polymorphicTypeWithSubTypes(BaseType polymorphicTypeWithSubTypes) {
             this.polymorphicTypeWithSubTypes = polymorphicTypeWithSubTypes;
             return this;
@@ -2965,7 +2918,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder polymorphicTypeWithoutSubTypes(SubTypeOne polymorphicTypeWithoutSubTypes) {
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes;
             return this;
@@ -2980,14 +2932,12 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder enumType(String enumType) {
             this.enumType = enumType;
             return this;
         }
 
         @Override
-        @Transient
         public final Builder enumType(EnumType enumType) {
             this.enumType(enumType == null ? null : enumType.toString());
             return this;
@@ -3002,7 +2952,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder underscore_Name_Type(Underscore_Name_Type underscore_Name_Type) {
             this.underscore_Name_Type = underscore_Name_Type;
             return this;
@@ -3017,7 +2966,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder myDocument(Document myDocument) {
             this.myDocument = myDocument;
             return this;
@@ -3032,7 +2980,6 @@ public final class AllTypesRequest extends JsonProtocolTestsRequest implements
         }
 
         @Override
-        @Transient
         public final Builder allTypesUnionStructure(AllTypesUnionStructure allTypesUnionStructure) {
             this.allTypesUnionStructure = allTypesUnionStructure;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Arrays;
@@ -2321,7 +2320,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             this.stringMember = stringMember;
             return this;
@@ -2336,7 +2334,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder integerMember(Integer integerMember) {
             this.integerMember = integerMember;
             return this;
@@ -2351,7 +2348,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder booleanMember(Boolean booleanMember) {
             this.booleanMember = booleanMember;
             return this;
@@ -2366,7 +2362,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder floatMember(Float floatMember) {
             this.floatMember = floatMember;
             return this;
@@ -2381,7 +2376,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder doubleMember(Double doubleMember) {
             this.doubleMember = doubleMember;
             return this;
@@ -2396,7 +2390,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder longMember(Long longMember) {
             this.longMember = longMember;
             return this;
@@ -2411,7 +2404,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder shortMember(Short shortMember) {
             this.shortMember = shortMember;
             return this;
@@ -2429,14 +2421,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder simpleList(Collection<String> simpleList) {
             this.simpleList = ListOfStringsCopier.copy(simpleList);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder simpleList(String... simpleList) {
             simpleList(Arrays.asList(simpleList));
@@ -2455,14 +2445,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfEnumsWithStrings(Collection<String> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfEnumsWithStrings(String... listOfEnums) {
             listOfEnumsWithStrings(Arrays.asList(listOfEnums));
@@ -2470,14 +2458,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfEnums(Collection<EnumType> listOfEnums) {
             this.listOfEnums = ListOfEnumsCopier.copyEnumToString(listOfEnums);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfEnums(EnumType... listOfEnums) {
             listOfEnums(Arrays.asList(listOfEnums));
@@ -2496,14 +2482,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfMaps(Collection<? extends Map<String, String>> listOfMaps) {
             this.listOfMaps = ListOfMapStringToStringCopier.copy(listOfMaps);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMaps(Map<String, String>... listOfMaps) {
             listOfMaps(Arrays.asList(listOfMaps));
@@ -2523,14 +2507,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfStructs(Collection<SimpleStruct> listOfStructs) {
             this.listOfStructs = ListOfSimpleStructsCopier.copy(listOfStructs);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfStructs(SimpleStruct... listOfStructs) {
             listOfStructs(Arrays.asList(listOfStructs));
@@ -2538,7 +2520,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
@@ -2558,14 +2539,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMapOfEnumToStringWithStrings(Map<String, String>... listOfMapOfEnumToString) {
             listOfMapOfEnumToStringWithStrings(Arrays.asList(listOfMapOfEnumToString));
@@ -2587,14 +2566,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfMapOfStringToStruct(Collection<? extends Map<String, SimpleStruct>> listOfMapOfStringToStruct) {
             this.listOfMapOfStringToStruct = ListOfMapOfStringToStructCopier.copy(listOfMapOfStringToStruct);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMapOfStringToStruct(Map<String, SimpleStruct>... listOfMapOfStringToStruct) {
             listOfMapOfStringToStruct(Arrays.asList(listOfMapOfStringToStruct));
@@ -2613,7 +2590,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToIntegerList(Map<String, ? extends Collection<Integer>> mapOfStringToIntegerList) {
             this.mapOfStringToIntegerList = MapOfStringToIntegerListCopier.copy(mapOfStringToIntegerList);
             return this;
@@ -2631,7 +2607,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToString(Map<String, String> mapOfStringToString) {
             this.mapOfStringToString = MapOfStringToStringCopier.copy(mapOfStringToString);
             return this;
@@ -2651,7 +2626,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct) {
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToSimpleStruct);
             return this;
@@ -2669,14 +2643,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToEnum(Map<EnumType, EnumType> mapOfEnumToEnum) {
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copyEnumToString(mapOfEnumToEnum);
             return this;
@@ -2694,14 +2666,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToString(Map<EnumType, String> mapOfEnumToString) {
             this.mapOfEnumToString = MapOfEnumToStringCopier.copyEnumToString(mapOfEnumToString);
             return this;
@@ -2719,14 +2689,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToEnum(Map<String, EnumType> mapOfStringToEnum) {
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copyEnumToString(mapOfStringToEnum);
             return this;
@@ -2745,14 +2713,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copy(mapOfEnumToSimpleStruct);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToSimpleStruct(Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct) {
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyEnumToString(mapOfEnumToSimpleStruct);
             return this;
@@ -2770,14 +2736,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
             return this;
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToListOfEnums(Map<EnumType, ? extends Collection<EnumType>> mapOfEnumToListOfEnums) {
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copyEnumToString(mapOfEnumToListOfEnums);
             return this;
@@ -2795,7 +2759,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToMapOfStringToEnumWithStrings(
             Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copy(mapOfEnumToMapOfStringToEnum);
@@ -2803,7 +2766,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToMapOfStringToEnum(
             Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
             this.mapOfEnumToMapOfStringToEnum = MapOfEnumToMapOfStringToEnumCopier.copyEnumToString(mapOfEnumToMapOfStringToEnum);
@@ -2819,7 +2781,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder timestampMember(Instant timestampMember) {
             this.timestampMember = timestampMember;
             return this;
@@ -2835,7 +2796,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder structWithNestedTimestampMember(StructWithTimestamp structWithNestedTimestampMember) {
             this.structWithNestedTimestampMember = structWithNestedTimestampMember;
             return this;
@@ -2850,7 +2810,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder blobArg(SdkBytes blobArg) {
             this.blobArg = blobArg;
             return this;
@@ -2865,7 +2824,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder structWithNestedBlob(StructWithNestedBlobType structWithNestedBlob) {
             this.structWithNestedBlob = structWithNestedBlob;
             return this;
@@ -2885,7 +2843,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
             return this;
@@ -2904,14 +2861,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
@@ -2927,7 +2882,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder recursiveStruct(RecursiveStructType recursiveStruct) {
             this.recursiveStruct = recursiveStruct;
             return this;
@@ -2942,7 +2896,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder polymorphicTypeWithSubTypes(BaseType polymorphicTypeWithSubTypes) {
             this.polymorphicTypeWithSubTypes = polymorphicTypeWithSubTypes;
             return this;
@@ -2958,7 +2911,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder polymorphicTypeWithoutSubTypes(SubTypeOne polymorphicTypeWithoutSubTypes) {
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes;
             return this;
@@ -2973,14 +2925,12 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder enumType(String enumType) {
             this.enumType = enumType;
             return this;
         }
 
         @Override
-        @Transient
         public final Builder enumType(EnumType enumType) {
             this.enumType(enumType == null ? null : enumType.toString());
             return this;
@@ -2995,7 +2945,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder underscore_Name_Type(Underscore_Name_Type underscore_Name_Type) {
             this.underscore_Name_Type = underscore_Name_Type;
             return this;
@@ -3010,7 +2959,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder myDocument(Document myDocument) {
             this.myDocument = myDocument;
             return this;
@@ -3025,7 +2973,6 @@ public final class AllTypesResponse extends JsonProtocolTestsResponse implements
         }
 
         @Override
-        @Transient
         public final Builder allTypesUnionStructure(AllTypesUnionStructure allTypesUnionStructure) {
             this.allTypesUnionStructure = allTypesUnionStructure;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesunionstructure.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/alltypesunionstructure.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -2989,7 +2988,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             Object oldValue = this.stringMember;
             this.stringMember = stringMember;
@@ -3008,7 +3006,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder integerMember(Integer integerMember) {
             Object oldValue = this.integerMember;
             this.integerMember = integerMember;
@@ -3027,7 +3024,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder booleanMember(Boolean booleanMember) {
             Object oldValue = this.booleanMember;
             this.booleanMember = booleanMember;
@@ -3046,7 +3042,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder floatMember(Float floatMember) {
             Object oldValue = this.floatMember;
             this.floatMember = floatMember;
@@ -3065,7 +3060,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder doubleMember(Double doubleMember) {
             Object oldValue = this.doubleMember;
             this.doubleMember = doubleMember;
@@ -3084,7 +3078,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder longMember(Long longMember) {
             Object oldValue = this.longMember;
             this.longMember = longMember;
@@ -3103,7 +3096,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder shortMember(Short shortMember) {
             Object oldValue = this.shortMember;
             this.shortMember = shortMember;
@@ -3125,7 +3117,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder simpleList(Collection<String> simpleList) {
             Object oldValue = this.simpleList;
             this.simpleList = ListOfStringsCopier.copy(simpleList);
@@ -3134,7 +3125,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder simpleList(String... simpleList) {
             simpleList(Arrays.asList(simpleList));
@@ -3155,7 +3145,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfEnumsWithStrings(Collection<String> listOfEnums) {
             Object oldValue = this.listOfEnums;
             this.listOfEnums = ListOfEnumsCopier.copy(listOfEnums);
@@ -3164,7 +3153,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfEnumsWithStrings(String... listOfEnums) {
             listOfEnumsWithStrings(Arrays.asList(listOfEnums));
@@ -3172,7 +3160,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfEnums(Collection<EnumType> listOfEnums) {
             Object oldValue = this.listOfEnums;
             this.listOfEnums = ListOfEnumsCopier.copyEnumToString(listOfEnums);
@@ -3181,7 +3168,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfEnums(EnumType... listOfEnums) {
             listOfEnums(Arrays.asList(listOfEnums));
@@ -3202,7 +3188,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfMaps(Collection<? extends Map<String, String>> listOfMaps) {
             Object oldValue = this.listOfMaps;
             this.listOfMaps = ListOfMapStringToStringCopier.copy(listOfMaps);
@@ -3211,7 +3196,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMaps(Map<String, String>... listOfMaps) {
             listOfMaps(Arrays.asList(listOfMaps));
@@ -3233,7 +3217,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfStructs(Collection<SimpleStruct> listOfStructs) {
             Object oldValue = this.listOfStructs;
             this.listOfStructs = ListOfSimpleStructsCopier.copy(listOfStructs);
@@ -3242,7 +3225,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfStructs(SimpleStruct... listOfStructs) {
             listOfStructs(Arrays.asList(listOfStructs));
@@ -3250,7 +3232,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfStructs(Consumer<SimpleStruct.Builder>... listOfStructs) {
             listOfStructs(Stream.of(listOfStructs).map(c -> SimpleStruct.builder().applyMutation(c).build())
@@ -3272,7 +3253,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfMapOfEnumToStringWithStrings(Collection<? extends Map<String, String>> listOfMapOfEnumToString) {
             Object oldValue = this.listOfMapOfEnumToString;
             this.listOfMapOfEnumToString = ListOfMapOfEnumToStringCopier.copy(listOfMapOfEnumToString);
@@ -3281,7 +3261,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMapOfEnumToStringWithStrings(Map<String, String>... listOfMapOfEnumToString) {
             listOfMapOfEnumToStringWithStrings(Arrays.asList(listOfMapOfEnumToString));
@@ -3305,7 +3284,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfMapOfStringToStruct(Collection<? extends Map<String, SimpleStruct>> listOfMapOfStringToStruct) {
             Object oldValue = this.listOfMapOfStringToStruct;
             this.listOfMapOfStringToStruct = ListOfMapOfStringToStructCopier.copy(listOfMapOfStringToStruct);
@@ -3314,7 +3292,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfMapOfStringToStruct(Map<String, SimpleStruct>... listOfMapOfStringToStruct) {
             listOfMapOfStringToStruct(Arrays.asList(listOfMapOfStringToStruct));
@@ -3335,7 +3312,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToIntegerList(Map<String, ? extends Collection<Integer>> mapOfStringToIntegerList) {
             Object oldValue = this.mapOfStringToIntegerList;
             this.mapOfStringToIntegerList = MapOfStringToIntegerListCopier.copy(mapOfStringToIntegerList);
@@ -3357,7 +3333,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToString(Map<String, String> mapOfStringToString) {
             Object oldValue = this.mapOfStringToString;
             this.mapOfStringToString = MapOfStringToStringCopier.copy(mapOfStringToString);
@@ -3381,7 +3356,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToSimpleStruct(Map<String, SimpleStruct> mapOfStringToSimpleStruct) {
             Object oldValue = this.mapOfStringToSimpleStruct;
             this.mapOfStringToSimpleStruct = MapOfStringToSimpleStructCopier.copy(mapOfStringToSimpleStruct);
@@ -3403,7 +3377,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToEnumWithStrings(Map<String, String> mapOfEnumToEnum) {
             Object oldValue = this.mapOfEnumToEnum;
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copy(mapOfEnumToEnum);
@@ -3412,7 +3385,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToEnum(Map<EnumType, EnumType> mapOfEnumToEnum) {
             Object oldValue = this.mapOfEnumToEnum;
             this.mapOfEnumToEnum = MapOfEnumToEnumCopier.copyEnumToString(mapOfEnumToEnum);
@@ -3434,7 +3406,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToStringWithStrings(Map<String, String> mapOfEnumToString) {
             Object oldValue = this.mapOfEnumToString;
             this.mapOfEnumToString = MapOfEnumToStringCopier.copy(mapOfEnumToString);
@@ -3443,7 +3414,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToString(Map<EnumType, String> mapOfEnumToString) {
             Object oldValue = this.mapOfEnumToString;
             this.mapOfEnumToString = MapOfEnumToStringCopier.copyEnumToString(mapOfEnumToString);
@@ -3465,7 +3435,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToEnumWithStrings(Map<String, String> mapOfStringToEnum) {
             Object oldValue = this.mapOfStringToEnum;
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copy(mapOfStringToEnum);
@@ -3474,7 +3443,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToEnum(Map<String, EnumType> mapOfStringToEnum) {
             Object oldValue = this.mapOfStringToEnum;
             this.mapOfStringToEnum = MapOfStringToEnumCopier.copyEnumToString(mapOfStringToEnum);
@@ -3497,7 +3465,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToSimpleStructWithStrings(Map<String, SimpleStruct> mapOfEnumToSimpleStruct) {
             Object oldValue = this.mapOfEnumToSimpleStruct;
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copy(mapOfEnumToSimpleStruct);
@@ -3506,7 +3473,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToSimpleStruct(Map<EnumType, SimpleStruct> mapOfEnumToSimpleStruct) {
             Object oldValue = this.mapOfEnumToSimpleStruct;
             this.mapOfEnumToSimpleStruct = MapOfEnumToSimpleStructCopier.copyEnumToString(mapOfEnumToSimpleStruct);
@@ -3528,7 +3494,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToListOfEnumsWithStrings(Map<String, ? extends Collection<String>> mapOfEnumToListOfEnums) {
             Object oldValue = this.mapOfEnumToListOfEnums;
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copy(mapOfEnumToListOfEnums);
@@ -3537,7 +3502,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToListOfEnums(Map<EnumType, ? extends Collection<EnumType>> mapOfEnumToListOfEnums) {
             Object oldValue = this.mapOfEnumToListOfEnums;
             this.mapOfEnumToListOfEnums = MapOfEnumToListOfEnumsCopier.copyEnumToString(mapOfEnumToListOfEnums);
@@ -3559,7 +3523,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToMapOfStringToEnumWithStrings(
             Map<String, ? extends Map<String, String>> mapOfEnumToMapOfStringToEnum) {
             Object oldValue = this.mapOfEnumToMapOfStringToEnum;
@@ -3569,7 +3532,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder mapOfEnumToMapOfStringToEnum(
             Map<EnumType, ? extends Map<String, EnumType>> mapOfEnumToMapOfStringToEnum) {
             Object oldValue = this.mapOfEnumToMapOfStringToEnum;
@@ -3589,7 +3551,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder timestampMember(Instant timestampMember) {
             Object oldValue = this.timestampMember;
             this.timestampMember = timestampMember;
@@ -3609,7 +3570,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder structWithNestedTimestampMember(StructWithTimestamp structWithNestedTimestampMember) {
             Object oldValue = this.structWithNestedTimestampMember;
             this.structWithNestedTimestampMember = structWithNestedTimestampMember;
@@ -3626,7 +3586,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder blobArg(SdkBytes blobArg) {
             Object oldValue = this.blobArg;
             this.blobArg = blobArg;
@@ -3645,7 +3604,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder structWithNestedBlob(StructWithNestedBlobType structWithNestedBlob) {
             Object oldValue = this.structWithNestedBlob;
             this.structWithNestedBlob = structWithNestedBlob;
@@ -3667,7 +3625,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder blobMap(Map<String, SdkBytes> blobMap) {
             Object oldValue = this.blobMap;
             this.blobMap = BlobMapTypeCopier.copy(blobMap);
@@ -3688,7 +3645,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder listOfBlobs(Collection<SdkBytes> listOfBlobs) {
             Object oldValue = this.listOfBlobs;
             this.listOfBlobs = ListOfBlobsTypeCopier.copy(listOfBlobs);
@@ -3697,7 +3653,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfBlobs(SdkBytes... listOfBlobs) {
             listOfBlobs(Arrays.asList(listOfBlobs));
@@ -3715,7 +3670,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder recursiveStruct(RecursiveStructType recursiveStruct) {
             Object oldValue = this.recursiveStruct;
             this.recursiveStruct = recursiveStruct;
@@ -3734,7 +3688,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder polymorphicTypeWithSubTypes(BaseType polymorphicTypeWithSubTypes) {
             Object oldValue = this.polymorphicTypeWithSubTypes;
             this.polymorphicTypeWithSubTypes = polymorphicTypeWithSubTypes;
@@ -3754,7 +3707,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder polymorphicTypeWithoutSubTypes(SubTypeOne polymorphicTypeWithoutSubTypes) {
             Object oldValue = this.polymorphicTypeWithoutSubTypes;
             this.polymorphicTypeWithoutSubTypes = polymorphicTypeWithoutSubTypes;
@@ -3773,7 +3725,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder enumType(String enumType) {
             Object oldValue = this.enumType;
             this.enumType = enumType;
@@ -3782,7 +3733,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder enumType(EnumType enumType) {
             this.enumType(enumType == null ? null : enumType.toString());
             return this;
@@ -3799,7 +3749,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder underscore_Name_Type(Underscore_Name_Type underscore_Name_Type) {
             Object oldValue = this.underscore_Name_Type;
             this.underscore_Name_Type = underscore_Name_Type;
@@ -3818,7 +3767,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder myDocument(Document myDocument) {
             Object oldValue = this.myDocument;
             this.myDocument = myDocument;
@@ -3837,7 +3785,6 @@ public final class AllTypesUnionStructure implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder allTypesUnionStructure(AllTypesUnionStructure allTypesUnionStructure) {
             Object oldValue = this.allTypesUnionStructure;
             this.allTypesUnionStructure = allTypesUnionStructure;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/basetype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/basetype.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -147,7 +146,6 @@ public final class BaseType implements SdkPojo, Serializable, ToCopyableBuilder<
         }
 
         @Override
-        @Transient
         public final Builder baseMember(String baseMember) {
             this.baseMember = baseMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenamerequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenamerequest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -216,7 +215,6 @@ public final class DeprecatedRenameRequest extends JsonProtocolTestsRequest impl
         }
 
         @Override
-        @Transient
         public final Builder newNameNoDeprecation(String newNameNoDeprecation) {
             this.newNameNoDeprecation = newNameNoDeprecation;
             return this;
@@ -239,14 +237,12 @@ public final class DeprecatedRenameRequest extends JsonProtocolTestsRequest impl
         }
 
         @Override
-        @Transient
         public final Builder newName(String newName) {
             this.newName = newName;
             return this;
         }
 
         @Override
-        @Transient
         public final Builder originalNameDeprecated(String newName) {
             this.newName = newName;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenameresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/deprecatedrenameresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -187,7 +186,6 @@ public final class DeprecatedRenameResponse extends JsonProtocolTestsResponse im
         }
 
         @Override
-        @Transient
         public final Builder originalNameNoDeprecation(String originalNameNoDeprecation) {
             this.originalNameNoDeprecation = originalNameNoDeprecation;
             return this;
@@ -202,7 +200,6 @@ public final class DeprecatedRenameResponse extends JsonProtocolTestsResponse im
         }
 
         @Override
-        @Transient
         public final Builder originalNameDeprecated(String originalNameDeprecated) {
             this.originalNameDeprecated = originalNameDeprecated;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventone.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventone.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -164,7 +163,6 @@ public class EventOne implements SdkPojo, Serializable, ToCopyableBuilder<EventO
         }
 
         @Override
-        @Transient
         public final Builder foo(String foo) {
             this.foo = foo;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/eventtwo.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -164,7 +163,6 @@ public class EventTwo implements SdkPojo, Serializable, ToCopyableBuilder<EventT
         }
 
         @Override
-        @Transient
         public final Builder bar(String bar) {
             this.bar = bar;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingrequest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -399,14 +398,12 @@ public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest 
         }
 
         @Override
-        @Transient
         public final Builder build(Collection<String> build) {
             this.build = ListOfStringsCopier.copy(build);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder build(String... build) {
             build(Arrays.asList(build));
@@ -425,14 +422,12 @@ public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest 
         }
 
         @Override
-        @Transient
         public final Builder superValue(Collection<String> superValue) {
             this.superValue = ListOfStringsCopier.copy(superValue);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder superValue(String... superValue) {
             superValue(Arrays.asList(superValue));
@@ -451,7 +446,6 @@ public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest 
         }
 
         @Override
-        @Transient
         public final Builder toStringValue(Map<String, String> toStringValue) {
             this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
             return this;
@@ -469,7 +463,6 @@ public final class ExistenceCheckNamingRequest extends JsonProtocolTestsRequest 
         }
 
         @Override
-        @Transient
         public final Builder equalsValue(Map<String, String> equalsValue) {
             this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/existencechecknamingresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -391,14 +390,12 @@ public final class ExistenceCheckNamingResponse extends JsonProtocolTestsRespons
         }
 
         @Override
-        @Transient
         public final Builder build(Collection<String> build) {
             this.build = ListOfStringsCopier.copy(build);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder build(String... build) {
             build(Arrays.asList(build));
@@ -417,14 +414,12 @@ public final class ExistenceCheckNamingResponse extends JsonProtocolTestsRespons
         }
 
         @Override
-        @Transient
         public final Builder superValue(Collection<String> superValue) {
             this.superValue = ListOfStringsCopier.copy(superValue);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder superValue(String... superValue) {
             superValue(Arrays.asList(superValue));
@@ -443,7 +438,6 @@ public final class ExistenceCheckNamingResponse extends JsonProtocolTestsRespons
         }
 
         @Override
-        @Transient
         public final Builder toStringValue(Map<String, String> toStringValue) {
             this.toStringValue = MapOfStringToStringCopier.copy(toStringValue);
             return this;
@@ -461,7 +455,6 @@ public final class ExistenceCheckNamingResponse extends JsonProtocolTestsRespons
         }
 
         @Override
-        @Transient
         public final Builder equalsValue(Map<String, String> equalsValue) {
             this.equalsValue = MapOfStringToStringCopier.copy(equalsValue);
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputevent.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -161,7 +160,6 @@ public class InputEvent implements SdkPojo, Serializable, ToCopyableBuilder<Inpu
         }
 
         @Override
-        @Transient
         public final Builder explicitPayloadMember(SdkBytes explicitPayloadMember) {
             this.explicitPayloadMember = explicitPayloadMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/inputeventtwo.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -228,7 +227,6 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
         }
 
         @Override
-        @Transient
         public final Builder implicitPayloadMemberOne(SdkBytes implicitPayloadMemberOne) {
             this.implicitPayloadMemberOne = implicitPayloadMemberOne;
             return this;
@@ -243,7 +241,6 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
         }
 
         @Override
-        @Transient
         public final Builder implicitPayloadMemberTwo(String implicitPayloadMemberTwo) {
             this.implicitPayloadMemberTwo = implicitPayloadMemberTwo;
             return this;
@@ -258,7 +255,6 @@ public class InputEventTwo implements SdkPojo, Serializable, ToCopyableBuilder<I
         }
 
         @Override
-        @Transient
         public final Builder eventHeaderMember(String eventHeaderMember) {
             this.eventHeaderMember = eventHeaderMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersrequest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -404,14 +403,12 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         }
 
         @Override
-        @Transient
         public final Builder listOfListOfStrings(Collection<? extends Collection<String>> listOfListOfStrings) {
             this.listOfListOfStrings = ListOfListOfStringsCopier.copy(listOfListOfStrings);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfListOfStrings(Collection<String>... listOfListOfStrings) {
             listOfListOfStrings(Arrays.asList(listOfListOfStrings));
@@ -431,7 +428,6 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         }
 
         @Override
-        @Transient
         public final Builder listOfListOfListOfStrings(
             Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
             this.listOfListOfListOfStrings = ListOfListOfListOfStringsCopier.copy(listOfListOfListOfStrings);
@@ -439,7 +435,6 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfListOfListOfStrings(Collection<? extends Collection<String>>... listOfListOfListOfStrings) {
             listOfListOfListOfStrings(Arrays.asList(listOfListOfListOfStrings));
@@ -459,7 +454,6 @@ public final class NestedContainersRequest extends JsonProtocolTestsRequest impl
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToListOfListOfStrings(
             Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
             this.mapOfStringToListOfListOfStrings = MapOfStringToListOfListOfStringsCopier.copy(mapOfStringToListOfListOfStrings);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/nestedcontainersresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -397,14 +396,12 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         }
 
         @Override
-        @Transient
         public final Builder listOfListOfStrings(Collection<? extends Collection<String>> listOfListOfStrings) {
             this.listOfListOfStrings = ListOfListOfStringsCopier.copy(listOfListOfStrings);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfListOfStrings(Collection<String>... listOfListOfStrings) {
             listOfListOfStrings(Arrays.asList(listOfListOfStrings));
@@ -424,7 +421,6 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         }
 
         @Override
-        @Transient
         public final Builder listOfListOfListOfStrings(
             Collection<? extends Collection<? extends Collection<String>>> listOfListOfListOfStrings) {
             this.listOfListOfListOfStrings = ListOfListOfListOfStringsCopier.copy(listOfListOfListOfStrings);
@@ -432,7 +428,6 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder listOfListOfListOfStrings(Collection<? extends Collection<String>>... listOfListOfListOfStrings) {
             listOfListOfListOfStrings(Arrays.asList(listOfListOfListOfStrings));
@@ -452,7 +447,6 @@ public final class NestedContainersResponse extends JsonProtocolTestsResponse im
         }
 
         @Override
-        @Transient
         public final Builder mapOfStringToListOfListOfStrings(
             Map<String, ? extends Collection<? extends Collection<String>>> mapOfStringToListOfListOfStrings) {
             this.mapOfStringToListOfListOfStrings = MapOfStringToListOfListOfStringsCopier.copy(mapOfStringToListOfListOfStrings);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberrequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberrequest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -244,7 +243,6 @@ public final class OperationWithDeprecatedMemberRequest extends JsonProtocolTest
         }
 
         @Override
-        @Transient
         @Deprecated
         public final Builder memberModeledAsDeprecated(String memberModeledAsDeprecated) {
             this.memberModeledAsDeprecated = memberModeledAsDeprecated;
@@ -262,7 +260,6 @@ public final class OperationWithDeprecatedMemberRequest extends JsonProtocolTest
         }
 
         @Override
-        @Transient
         @Deprecated
         public final Builder memberModifiedAsDeprecated(String memberModifiedAsDeprecated) {
             this.memberModifiedAsDeprecated = memberModifiedAsDeprecated;
@@ -278,7 +275,6 @@ public final class OperationWithDeprecatedMemberRequest extends JsonProtocolTest
         }
 
         @Override
-        @Transient
         public final Builder undeprecatedMember(String undeprecatedMember) {
             this.undeprecatedMember = undeprecatedMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/operationwithdeprecatedmemberresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -232,7 +231,6 @@ public final class OperationWithDeprecatedMemberResponse extends JsonProtocolTes
         }
 
         @Override
-        @Transient
         @Deprecated
         public final Builder memberModeledAsDeprecated(String memberModeledAsDeprecated) {
             this.memberModeledAsDeprecated = memberModeledAsDeprecated;
@@ -248,7 +246,6 @@ public final class OperationWithDeprecatedMemberResponse extends JsonProtocolTes
         }
 
         @Override
-        @Transient
         public final Builder memberModifiedAsDeprecated(String memberModifiedAsDeprecated) {
             this.memberModifiedAsDeprecated = memberModifiedAsDeprecated;
             return this;
@@ -263,7 +260,6 @@ public final class OperationWithDeprecatedMemberResponse extends JsonProtocolTes
         }
 
         @Override
-        @Transient
         public final Builder undeprecatedMember(String undeprecatedMember) {
             this.undeprecatedMember = undeprecatedMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/recursivestructtype.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -362,7 +361,6 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder noRecurse(String noRecurse) {
             this.noRecurse = noRecurse;
             return this;
@@ -377,7 +375,6 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder recursiveStruct(RecursiveStructType recursiveStruct) {
             this.recursiveStruct = recursiveStruct;
             return this;
@@ -396,14 +393,12 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder recursiveList(Collection<RecursiveStructType> recursiveList) {
             this.recursiveList = RecursiveListTypeCopier.copy(recursiveList);
             return this;
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder recursiveList(RecursiveStructType... recursiveList) {
             recursiveList(Arrays.asList(recursiveList));
@@ -411,7 +406,6 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         @SafeVarargs
         public final Builder recursiveList(Consumer<Builder>... recursiveList) {
             recursiveList(Stream.of(recursiveList).map(c -> RecursiveStructType.builder().applyMutation(c).build())
@@ -432,7 +426,6 @@ public final class RecursiveStructType implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder recursiveMap(Map<String, RecursiveStructType> recursiveMap) {
             this.recursiveMap = RecursiveMapTypeCopier.copy(recursiveMap);
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/getrandompersonresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.sharedeventstream.model;
 
-import java.beans.Transient;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -187,7 +186,6 @@ public class GetRandomPersonResponse extends SharedEventStreamResponse implement
         }
 
         @Override
-        @Transient
         public final Builder name(String name) {
             this.name = name;
             return this;
@@ -202,7 +200,6 @@ public class GetRandomPersonResponse extends SharedEventStreamResponse implement
         }
 
         @Override
-        @Transient
         public final Builder birthday(Instant birthday) {
             this.birthday = birthday;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/sharedstream/person.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.sharedeventstream.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Arrays;
@@ -207,7 +206,6 @@ public class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.B
         }
 
         @Override
-        @Transient
         public final Builder name(String name) {
             this.name = name;
             return this;
@@ -222,7 +220,6 @@ public class Person implements SdkPojo, Serializable, ToCopyableBuilder<Person.B
         }
 
         @Override
-        @Transient
         public final Builder birthday(Instant birthday) {
             this.birthday = birthday;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/simplestruct.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/simplestruct.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -147,7 +146,6 @@ public final class SimpleStruct implements SdkPojo, Serializable, ToCopyableBuil
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             this.stringMember = stringMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithnestedblobtype.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -150,7 +149,6 @@ public final class StructWithNestedBlobType implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder nestedBlob(SdkBytes nestedBlob) {
             this.nestedBlob = nestedBlob;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithtimestamp.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/structwithtimestamp.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Arrays;
@@ -150,7 +149,6 @@ public final class StructWithTimestamp implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder nestedTimestamp(Instant nestedTimestamp) {
             this.nestedTimestamp = nestedTimestamp;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/subtypeone.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/subtypeone.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.jsonprotocoltests.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -148,7 +147,6 @@ public final class SubTypeOne implements SdkPojo, Serializable, ToCopyableBuilde
         }
 
         @Override
-        @Transient
         public final Builder subTypeOneMember(String subTypeOneMember) {
             this.subTypeOneMember = subTypeOneMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespacerequest.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespacerequest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.protocolrestxml.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -261,7 +260,6 @@ public final class TestXmlNamespaceRequest extends ProtocolRestXmlRequest implem
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             this.stringMember = stringMember;
             return this;
@@ -276,7 +274,6 @@ public final class TestXmlNamespaceRequest extends ProtocolRestXmlRequest implem
         }
 
         @Override
-        @Transient
         public final Builder integerMember(Integer integerMember) {
             this.integerMember = integerMember;
             return this;
@@ -291,7 +288,6 @@ public final class TestXmlNamespaceRequest extends ProtocolRestXmlRequest implem
         }
 
         @Override
-        @Transient
         public final Builder xmlNamespaceMember(XmlNamespaceMember xmlNamespaceMember) {
             this.xmlNamespaceMember = xmlNamespaceMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespaceresponse.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/testxmlnamespaceresponse.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.protocolrestxml.model;
 
-import java.beans.Transient;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -254,7 +253,6 @@ public final class TestXmlNamespaceResponse extends ProtocolRestXmlResponse impl
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             this.stringMember = stringMember;
             return this;
@@ -269,7 +267,6 @@ public final class TestXmlNamespaceResponse extends ProtocolRestXmlResponse impl
         }
 
         @Override
-        @Transient
         public final Builder integerMember(Integer integerMember) {
             this.integerMember = integerMember;
             return this;
@@ -284,7 +281,6 @@ public final class TestXmlNamespaceResponse extends ProtocolRestXmlResponse impl
         }
 
         @Override
-        @Transient
         public final Builder xmlNamespaceMember(XmlNamespaceMember xmlNamespaceMember) {
             this.xmlNamespaceMember = xmlNamespaceMember;
             return this;

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/xmlnamespacemember.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/xmlnamespace/xmlnamespacemember.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.services.protocolrestxml.model;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -189,7 +188,6 @@ public final class XmlNamespaceMember implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder type(String type) {
             this.type = type;
             return this;
@@ -204,7 +202,6 @@ public final class XmlNamespaceMember implements SdkPojo, Serializable,
         }
 
         @Override
-        @Transient
         public final Builder stringMember(String stringMember) {
             this.stringMember = stringMember;
             return this;

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullResponse.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/DefaultSdkHttpFullResponse.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.http;
 import static software.amazon.awssdk.utils.CollectionUtils.deepCopyMap;
 import static software.amazon.awssdk.utils.CollectionUtils.deepUnmodifiableMap;
 
-import java.beans.Transient;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -61,7 +60,6 @@ class DefaultSdkHttpFullResponse implements SdkHttpFullResponse, Serializable {
         return headers;
     }
 
-    @Transient
     @Override
     public Optional<AbortableInputStream> content() {
         return Optional.ofNullable(content);


### PR DESCRIPTION
This didn't remove all of the dependencies on such modules, just the unnecessary ones.

Also added a checkstyle rule to prevent such dependencies in the future (except where they are intentional).

Fixes #3041 .