### PR TITLE
Backport union types for pre-smithy services from smithy models into codegen customizations.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-6c20b9b.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-6c20b9b.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Extend union type improvements to additional services: dynamodb, dynamodbstreams, iot, sagemaker, clouddirectory, iotanalytics, kendra, marketplaceentitlement, quicksight, s3, xray."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ShapeModifiersProcessor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/customization/processors/ShapeModifiersProcessor.java
@@ -204,6 +204,10 @@ final class ShapeModifiersProcessor implements CodegenCustomizationProcessor {
                 shape.getMembers().putAll(injects);
             }
         }
+
+        if (modifier.isUnion() != null) {
+            shape.setUnion(modifier.isUnion());
+        }
     }
 
     private void doModifyShapeMembers(ServiceModel serviceModel, Shape shape, String memberToModify,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ShapeModifier.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/ShapeModifier.java
@@ -30,6 +30,7 @@ public class ShapeModifier {
     private List<Map<String, ModifyModelShapeModifier>> modify;
     private List<Map<String, Member>> inject;
     private Integer staxTargetDepthOffset;
+    private Boolean union;
 
     /**
      * @return true if the whole shape should be excluded.
@@ -86,5 +87,13 @@ public class ShapeModifier {
 
     public void setStaxTargetDepthOffset(Integer staxTargetDepthOffset) {
         this.staxTargetDepthOffset = staxTargetDepthOffset;
+    }
+
+    public Boolean isUnion() {
+        return union;
+    }
+
+    public void setUnion(Boolean union) {
+        this.union = union;
     }
 }

--- a/services/clouddirectory/src/main/resources/codegen-resources/customization.config
+++ b/services/clouddirectory/src/main/resources/codegen-resources/customization.config
@@ -4,5 +4,10 @@
         "listDirectories",
         "listManagedSchemaArns",
         "listPublishedSchemaArns"
-    ]
+    ],
+    "shapeModifiers": {
+        "TypedAttributeValue": {
+            "union": true
+        }
+    }
 }

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
@@ -8,7 +8,8 @@
                     "emitPropertyName": "NUL"
                 }
             }
-        ]
+        ],
+        "union": true
     }
   },
   "verifiedSimpleMethods" : [

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
@@ -8,7 +8,8 @@
                       "emitPropertyName": "NUL"
                   }
               }
-          ]
+          ],
+          "union": true
       }
     },
     "sdkModeledExceptionBaseClassName": "DynamoDbException",

--- a/services/iot/src/main/resources/codegen-resources/customization.config
+++ b/services/iot/src/main/resources/codegen-resources/customization.config
@@ -49,5 +49,10 @@
     "DetachPrincipalPolicy",
     "ListPolicyPrincipals",
     "ListPrincipalPolicies"
-  ]
+  ],
+  "shapeModifiers": {
+    "AssetPropertyVariant": {
+      "union": true
+    }
+  }
 }

--- a/services/iotanalytics/src/main/resources/codegen-resources/customization.config
+++ b/services/iotanalytics/src/main/resources/codegen-resources/customization.config
@@ -7,5 +7,10 @@
   ],
   "blacklistedSimpleMethods": [
     "describeLoggingOptions"
-  ]
+  ],
+  "shapeModifiers": {
+    "DatastoreStorage": {
+      "union": true
+    }
+  }
 }

--- a/services/kendra/src/main/resources/codegen-resources/customization.config
+++ b/services/kendra/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,7 @@
+{
+  "shapeModifiers": {
+    "DocumentAttributeValue": {
+      "union": true
+    }
+  }
+}

--- a/services/marketplaceentitlement/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplaceentitlement/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,7 @@
+{
+  "shapeModifiers": {
+    "EntitlementValue": {
+      "union": true
+    }
+  }
+}

--- a/services/quicksight/src/main/resources/codegen-resources/customization.config
+++ b/services/quicksight/src/main/resources/codegen-resources/customization.config
@@ -134,6 +134,15 @@
                     }
                 }
             ]
+        },
+        "TransformOperation": {
+            "union": true
+        },
+        "PhysicalTable": {
+            "union": true
+        },
+        "DataSourceParameters": {
+            "union": true
         }
     }
 }

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -111,6 +111,18 @@
           "suffix": { "emitEnumValue": "Suffix" }
         }
       ]
+    },
+    "ReplicationRuleFilter": {
+      "union": true
+    },
+    "MetricsFilter": {
+      "union": true
+    },
+    "AnalyticsFilter": {
+      "union": true
+    },
+    "LifecycleRuleFilter": {
+      "union": true
     }
   },
   "serviceConfig": {

--- a/services/sagemaker/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemaker/src/main/resources/codegen-resources/customization.config
@@ -15,5 +15,10 @@
         "listTrainingJobs",
         "listTransformJobs",
         "listWorkteams"
-    ]
+    ],
+    "shapeModifiers": {
+        "TrialComponentParameterValue": {
+            "union": true
+        }
+    }
 }

--- a/services/xray/src/main/resources/codegen-resources/customization.config
+++ b/services/xray/src/main/resources/codegen-resources/customization.config
@@ -8,5 +8,10 @@
   "blacklistedSimpleMethods": [
     "deleteSamplingRule",
     "getGroup"
-  ]
+  ],
+  "shapeModifiers": {
+    "AnnotationValue": {
+      "union": true
+    }
+  }
 }


### PR DESCRIPTION
Verified that each of the shapes had the union type helper methods added.