### PR TITLE
Prevent IndexOutOfBoundsException when PutObject tagging is an empty …

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-1625e88.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-1625e88.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Prevent IndexOutOfBoundsException when PutObject tagging is an empty set."
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ObjectTaggingIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ObjectTaggingIntegrationTest.java
@@ -238,6 +238,26 @@ public class ObjectTaggingIntegrationTest extends S3IntegrationTestBase {
         assertThat(getTaggingResult.size()).isEqualTo(0);
     }
 
+    @Test
+    public void testEmptyTagging_shouldNotThrowException() {
+        Tagging tags = Tagging.builder().build();
+
+        String key = makeNewKey();
+        s3.putObject(PutObjectRequest.builder()
+                                     .bucket(BUCKET)
+                                     .key(key)
+                                     .tagging(tags)
+                                     .build(), RequestBody.empty());
+
+        List<Tag> getTaggingResult = s3.getObjectTagging(GetObjectTaggingRequest.builder()
+                                                                                .bucket(BUCKET)
+                                                                                .key(key)
+                                                                                .build())
+                                       .tagSet();
+
+        assertThat(getTaggingResult.size()).isEqualTo(0);
+    }
+
     private String makeNewKey() {
         return KEY_PREFIX + System.currentTimeMillis();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/TaggingAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/TaggingAdapter.java
@@ -39,19 +39,21 @@ public final class TaggingAdapter implements TypeAdapter<Tagging, String> {
     public String adapt(Tagging tagging) {
         StringBuilder tagBuilder = new StringBuilder();
 
-        Tagging taggingClone = tagging.toBuilder().build();
+        if (tagging != null && !tagging.tagSet().isEmpty()) {
+            Tagging taggingClone = tagging.toBuilder().build();
 
-        Tag firstTag = taggingClone.tagSet().get(0);
-        tagBuilder.append(SdkHttpUtils.urlEncode(firstTag.key()));
-        tagBuilder.append("=");
-        tagBuilder.append(SdkHttpUtils.urlEncode(firstTag.value()));
-
-        for (int i = 1; i < taggingClone.tagSet().size(); i++) {
-            Tag t = taggingClone.tagSet().get(i);
-            tagBuilder.append("&");
-            tagBuilder.append(SdkHttpUtils.urlEncode(t.key()));
+            Tag firstTag = taggingClone.tagSet().get(0);
+            tagBuilder.append(SdkHttpUtils.urlEncode(firstTag.key()));
             tagBuilder.append("=");
-            tagBuilder.append(SdkHttpUtils.urlEncode(t.value()));
+            tagBuilder.append(SdkHttpUtils.urlEncode(firstTag.value()));
+
+            for (int i = 1; i < taggingClone.tagSet().size(); i++) {
+                Tag t = taggingClone.tagSet().get(i);
+                tagBuilder.append("&");
+                tagBuilder.append(SdkHttpUtils.urlEncode(t.key()));
+                tagBuilder.append("=");
+                tagBuilder.append(SdkHttpUtils.urlEncode(t.value()));
+            }
         }
 
         return tagBuilder.toString();


### PR DESCRIPTION
…set.

<!--- Provide a general summary of your changes in the Title above -->
Fixes https://github.com/aws/aws-sdk-java-v2/issues/3026.


### Current Behavior

Setting an empty tagging in S3 PutObject throws `IndexOutOfBoundsException`
```
PutObjectRequest request = PutObjectRequest.builder()
                                           .bucket(BUCKET)
                                           .key(KEY)
                                           .tagging(Tagging.builder().build())
                                           .build();
```

```
java.lang.IndexOutOfBoundsException: Index: 0

	at java.util.Collections$EmptyList.get(Collections.java:4456)
	at software.amazon.awssdk.core.util.DefaultSdkAutoConstructList.get(DefaultSdkAutoConstructList.java:118)
	at software.amazon.awssdk.services.s3.internal.TaggingAdapter.adapt(TaggingAdapter.java:44)
	at software.amazon.awssdk.services.s3.model.PutObjectRequest$BuilderImpl.tagging(PutObjectRequest.java:2927)
```
### Modifications
<!--- Describe your changes in detail -->

Exception will not be thrown anymore, and an empty tagging header will be sent in the request (see `x-amz-tagging`):

```
>> "PUT /test-file.txt HTTP/1.1[\r][\n]"
>> "Host: bucket-test.s3.us-west-2.amazonaws.com[\r][\n]"
>> "amz-sdk-invocation-id: 02b01cc2-dae6-880c-775c-fabe0e0cfd11[\r][\n]"
>> "amz-sdk-request: attempt=1; max=4[\r][\n]"
>> "Authorization: AWS4-HMAC-SHA256 Credential=xxx/20220412/us-west-2/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-tagging, Signature=xxx[\r][\n]"
>> "Content-Type: text/plain[\r][\n]"
>> "Expect: 100-continue[\r][\n]"
>> "User-Agent: xxx[\r][\n]"
>> "x-amz-content-sha256: UNSIGNED-PAYLOAD[\r][\n]"
>> "X-Amz-Date: 20220412T212754Z[\r][\n]"
>> "x-amz-tagging: [\r][\n]"
>> "Content-Length: 31[\r][\n]"
>> "Connection: Keep-Alive[\r][\n]"
>> "[\r][\n]"
<< "HTTP/1.1 100 Continue[\r][\n]"
<< "[\r][\n]"
>> "    __[\n]"
>> "___( o)>[\n]"
>> "\ <_. )[\n]"
>> " `---'[\n]"
<< "HTTP/1.1 200 OK[\r][\n]"
```
### Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Only found existing integration tests for TaggingAdapter, so added a new test in there.
\> mvn clean install

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
