### PR TITLE
Automatically refresh async credential sources in the background.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-ff80eee.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-ff80eee.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Automatically refresh credentials in the background when async credential refreshes are enabled, even if traffic is low."
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/CachedSupplier.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/CachedSupplier.java
@@ -72,6 +72,9 @@ public final class CachedSupplier<T> implements Supplier<T>, SdkAutoCloseable {
     private CachedSupplier(Builder<T> builder) {
         this.valueSupplier = Validate.notNull(builder.supplier, "builder.supplier");
         this.prefetchStrategy = Validate.notNull(builder.prefetchStrategy, "builder.prefetchStrategy");
+
+        // Because we pass 'this', ensure this is always the last line in the constructor.
+        this.prefetchStrategy.initializeCachedSupplier(this);
     }
 
     /**
@@ -203,6 +206,12 @@ public final class CachedSupplier<T> implements Supplier<T>, SdkAutoCloseable {
          * Execute the provided value updater to update the cache. The specific implementation defines how this is invoked.
          */
         void prefetch(Runnable valueUpdater);
+
+        /**
+         * Invoked when the prefetch strategy is registered with a {@link CachedSupplier}.
+         */
+        default void initializeCachedSupplier(CachedSupplier<?> cachedSupplier) {
+        }
 
         /**
          * Free any resources associated with the strategy. This is invoked when the {@link CachedSupplier#close()} method is


### PR DESCRIPTION
Today, if customers have async credential refreshes enabled, refreshes only kicked off when new credentials are requested. This causes an issue for very low-traffic credential providers, because they may never refresh credentials until those credentials are actually needed, and then it's too late.

With this change, we periodically prime all CachedSuppliers configured with a NonBlocking prefetch strategy and stale credentials.

One additional change was made to simplify the prefetch timings of InstanceProfileCredentialsProvider so they are easier to understand and reason about.