### PR TITLE
Fix to ignore empty strings while marshalling list of strings in header field

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-61bbbf3.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-61bbbf3.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fix to ignore empty strings while marshalling list of strings in header field."
+}

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/HeaderMarshaller.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.core.traits.JsonValueTrait;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.StringUtils;
 
 @SdkInternalApi
 public final class HeaderMarshaller {
@@ -51,19 +52,26 @@ public final class HeaderMarshaller {
         = new SimpleHeaderMarshaller<>(JsonProtocolMarshaller.INSTANT_VALUE_TO_STRING);
 
     public static final JsonMarshaller<List<?>> LIST = (list, context, paramName, sdkField) -> {
-        // Null or empty lists cannot be meaningfully (or safely) represented in an HTTP header message since header-fields must 
+        // Null or empty lists cannot be meaningfully (or safely) represented in an HTTP header message since header-fields must
         // typically have a non-empty field-value. https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
         if (isNullOrEmpty(list)) {
             return;
         }
         SdkField memberFieldInfo = sdkField.getRequiredTrait(ListTrait.class).memberFieldInfo();
         for (Object listValue : list) {
+            if (shouldSkipElement(listValue)) {
+                continue;
+            }
             JsonMarshaller marshaller = context.marshallerRegistry().getMarshaller(MarshallLocation.HEADER, listValue);
             marshaller.marshall(listValue, context, paramName, memberFieldInfo);
         }
     };
 
     private HeaderMarshaller() {
+    }
+
+    private static boolean shouldSkipElement(Object element) {
+        return element instanceof String && StringUtils.isBlank((String) element);
     }
 
     private static class SimpleHeaderMarshaller<T> implements JsonMarshaller<T> {

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/HeaderMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/HeaderMarshaller.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
+import software.amazon.awssdk.utils.StringUtils;
 
 @SdkInternalApi
 public final class HeaderMarshaller {
@@ -78,9 +79,16 @@ public final class HeaderMarshaller {
             }
             SdkField memberFieldInfo = sdkField.getRequiredTrait(ListTrait.class).memberFieldInfo();
             for (Object listValue : list) {
+                if (shouldSkipElement(listValue)) {
+                    continue;
+                }
                 XmlMarshaller marshaller = context.marshallerRegistry().getMarshaller(MarshallLocation.HEADER, listValue);
                 marshaller.marshall(listValue, context, paramName, memberFieldInfo);
             }
+        }
+
+        private boolean shouldSkipElement(Object element) {
+            return element instanceof String && StringUtils.isBlank((String) element);
         }
 
         @Override

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-json-input.json
@@ -176,6 +176,69 @@
     }
   },
   {
+    "description": "ListOfStrings in header is serialized as multi-valued header with commas, quotes and double quotes",
+    "given": {
+      "input": {
+        "ListOfStringsMember": [
+          "listValue1,listValue2",
+          "\"listValueTwo\"",
+          "\"\"",
+          "'listValueThree'"
+        ]
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "MembersInHeaders"
+    },
+    "then": {
+      "serializedAs": {
+        "uri": "/2016-03-11/membersInHeaders",
+        "headers": {
+          "contains": {
+            "x-amz-string-list": [
+              "listValue1,listValue2",
+              "\"listValueTwo\"",
+              "\"\"",
+              "'listValueThree'"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "description": "ListOfStrings in header serializes only non empty Strings",
+    "given": {
+      "input": {
+        "ListOfStringsMember": [
+          "listValue1",
+          null,
+          "",
+          "",
+          "listValue6"
+        ]
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "MembersInHeaders"
+    },
+    "then": {
+      "serializedAs": {
+        "uri": "/2016-03-11/membersInHeaders",
+        "headers": {
+          "contains": {
+            "x-amz-string-list": [
+              "listValue1",
+              "listValue6"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
     "description": "Null string header member is not serialized",
     "given": {
       "input": {

--- a/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-xml-input.json
+++ b/test/protocol-tests-core/src/main/resources/software/amazon/awssdk/protocol/suites/cases/rest-xml-input.json
@@ -507,6 +507,69 @@
         }
       }
     }
+  },
+  {
+    "description": "ListOfStrings in header is serialized as multi-valued header with commas, quotes and double quotes",
+    "given": {
+      "input": {
+        "ListOfStringsMember": [
+          "listValue1,listValue2",
+          "\"listValueTwo\"",
+          "\"\"",
+          "'listValueThree'"
+        ]
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "MembersInHeaders"
+    },
+    "then": {
+      "serializedAs": {
+        "uri": "/2016-03-11/membersInHeaders",
+        "headers": {
+          "contains": {
+            "x-amz-string-list": [
+              "listValue1,listValue2",
+              "\"listValueTwo\"",
+              "\"\"",
+              "'listValueThree'"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "description": "ListOfStrings in header serializes only non empty Strings",
+    "given": {
+      "input": {
+        "ListOfStringsMember": [
+          "listValue1",
+          null,
+          "",
+          "",
+          "listValue6"
+        ]
+      }
+    },
+    "when": {
+      "action": "marshall",
+      "operation": "MembersInHeaders"
+    },
+    "then": {
+      "serializedAs": {
+        "uri": "/2016-03-11/membersInHeaders",
+        "headers": {
+          "contains": {
+            "x-amz-string-list": [
+              "listValue1",
+              "listValue6"
+            ]
+          }
+        }
+      }
+    }
   }
   //  TODO this is not possible, payloads can only be structures or blobs. Only S3 utilizes this
   //  {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
-  Empty strings in list of strings  to be ignored while marshalling this list to a header field.
- Test cases for inputs with double quotes , single quotes and empty string were missing.

## Modifications
<!--- Describe your changes in detail -->
- Added skipPredicateMap that will skip Marshlling of of String element if its empty,
- Added new test cases with special characters like comma, double quotes and single quotes

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
