### PR TITLE
Fixed a bug in transfer manager directory transfer where failedUpload…

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManagerDeveloperPreview-6413c4c.json
+++ b/.changes/next-release/bugfix-S3TransferManagerDeveloperPreview-6413c4c.json
@@ -1,0 +1,6 @@
+{
+    "category": "S3 Transfer Manager (Developer Preview)", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed cancellation logic in `S3TransferManager#downloadDirectory`"
+}

--- a/.changes/next-release/bugfix-S3TransferManagerDevelperPreview-15eb79a.json
+++ b/.changes/next-release/bugfix-S3TransferManagerDevelperPreview-15eb79a.json
@@ -1,5 +1,5 @@
 {
-    "category": "S3 Transfer Manager (Develper Preview)", 
+    "category": "S3 Transfer Manager (Developer Preview)",
     "contributor": "", 
     "type": "bugfix", 
     "description": "Fixed a bug in `S3TransferManager#uploadDirectory` and `S3TransferManager#downloadDirectory` where failedUploads or failedDownloads did not contain all failed transfers"

--- a/.changes/next-release/bugfix-S3TransferManagerDevelperPreview-15eb79a.json
+++ b/.changes/next-release/bugfix-S3TransferManagerDevelperPreview-15eb79a.json
@@ -1,0 +1,6 @@
+{
+    "category": "S3 Transfer Manager (Develper Preview)", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed a bug in `S3TransferManager#uploadDirectory` and `S3TransferManager#downloadDirectory` where failedUploads or failedDownloads did not contain all failed transfers"
+}

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DownloadDirectoryHelper.java
@@ -107,10 +107,10 @@ public class DownloadDirectoryHelper {
         Queue<FailedFileDownload> failedFileDownloads = new ConcurrentLinkedQueue<>();
 
         CompletableFuture<Void> allOfFutures = new CompletableFuture<>();
+
         AsyncBufferingSubscriber<DownloadFileContext> asyncBufferingSubscriber =
-            new AsyncBufferingSubscriber<>(downloadContext -> downloadSingleFile(downloadDirectoryRequest,
-                                                                                 failedFileDownloads,
-                                                                                 downloadContext),
+            new AsyncBufferingSubscriber<>(downloadSingleFile(returnFuture, downloadDirectoryRequest,
+                                                              failedFileDownloads),
                                            allOfFutures,
                                            DEFAULT_DOWNLOAD_DIRECTORY_MAX_CONCURRENCY);
         listObjectsHelper.listS3ObjectsRecursively(request)
@@ -129,6 +129,20 @@ public class DownloadDirectoryHelper {
         });
     }
 
+    private Function<DownloadFileContext, CompletableFuture<?>> downloadSingleFile(
+        CompletableFuture<CompletedDirectoryDownload> returnFuture,
+        DownloadDirectoryRequest downloadDirectoryRequest,
+        Queue<FailedFileDownload> failedFileDownloads) {
+
+        return downloadContext -> {
+            CompletableFuture<CompletedFileDownload> future = doDownloadSingleFile(downloadDirectoryRequest,
+                                                                                   failedFileDownloads,
+                                                                                   downloadContext);
+            CompletableFutureUtils.forwardExceptionTo(returnFuture, future);
+            return future;
+        };
+    }
+
     private DownloadFileContext determineDestinationPath(DownloadDirectoryRequest downloadDirectoryRequest, S3Object s3Object) {
         FileSystem fileSystem = downloadDirectoryRequest.destinationDirectory().getFileSystem();
         String delimiter = downloadDirectoryRequest.delimiter().orElse(null);
@@ -138,18 +152,18 @@ public class DownloadDirectoryHelper {
         return new DefaultDownloadFileContext(s3Object, destinationPath);
     }
 
-    private CompletableFuture<CompletedFileDownload> downloadSingleFile(DownloadDirectoryRequest downloadDirectoryRequest,
-                                                                        Collection<FailedFileDownload> failedFileDownloads,
-                                                                        DownloadFileContext downloadContext) {
+    private CompletableFuture<CompletedFileDownload> doDownloadSingleFile(DownloadDirectoryRequest downloadDirectoryRequest,
+                                                                          Collection<FailedFileDownload> failedFileDownloads,
+                                                                          DownloadFileContext downloadContext) {
         DownloadFileRequest downloadFileRequest = downloadFileRequest(downloadDirectoryRequest, downloadContext);
 
         try {
             log.debug(() -> "Sending download request " + downloadFileRequest);
             createParentDirectoriesIfNeeded(downloadContext.destination());
 
-            CompletableFuture<CompletedFileDownload> future =
+            CompletableFuture<CompletedFileDownload> executionFuture =
                 downloadFileFunction.apply(downloadFileRequest).completionFuture();
-            return future.whenComplete((r, t) -> {
+            CompletableFuture<CompletedFileDownload> future = executionFuture.whenComplete((r, t) -> {
                 if (t != null) {
                     failedFileDownloads.add(FailedFileDownload.builder()
                                                               .exception(t instanceof CompletionException ? t.getCause() : t)
@@ -157,6 +171,9 @@ public class DownloadDirectoryHelper {
                                                               .build());
                 }
             });
+            CompletableFutureUtils.forwardExceptionTo(future, executionFuture);
+            return future;
+
         } catch (Throwable throwable) {
             failedFileDownloads.add(FailedFileDownload.builder()
                                                       .exception(throwable)


### PR DESCRIPTION
…s and failedDownloads did not contain all failed transfers

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Fixed a bug in `S3TransferManager#uploadDirectory` and `S3TransferManager#downloadDirectory` where failedUploads or failedDownloads did not contain all failed transfers. #3180 
- Fixed cancellation logic in `S3TransferManager#downloadDirectory`

## Modifications
Wait for the callback to add failed transfer if any


## Testing
Added integ test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
