### PR TITLE
Could software.amazon.awssdk:build-tools:1.0 drop off redundant dependencies?

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -68,11 +68,39 @@
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
             <version>8.42</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
             <version>4.2.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.jcip</groupId>
+                    <artifactId>jcip-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/168512787-45b40b12-32d0-4fee-b45e-5d896603328d.png)
Hi! I found the pom file of project **_software.amazon.awssdk:build-tools:1.0_** introduced **_33_** dependencies. However, among them, **_5_** libraries (**_15%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.code.findbugs:jsr305:jar:3.0.2:compile
net.jcip:jcip-annotations:jar:1.0:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
com.google.errorprone:error_prone_annotations:jar:2.5.1:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_com.google.code.findbugs:jsr305:jar:3.0.2:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_software.amazon.awssdk:build-tools:1.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_software.amazon.awssdk:build-tools:1.0_**’s maven tests.

Best regards