### PR TITLE
Bump CRT version to 0.16.10, which contains M1 support #2942

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-019753e.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-019753e.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Bump CRT version to 0.16.10, which contains M1 support [#2942](https://github.com/aws/aws-sdk-java-v2/issues/2942)"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.10</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.16.8</awscrt.version>
+        <awscrt.version>0.16.10</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3CrtAsyncHttpClient.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/S3CrtAsyncHttpClient.java
@@ -67,6 +67,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withCredentialsProvider(s3NativeClientConfiguration.credentialsProvider())
                                  .withClientBootstrap(s3NativeClientConfiguration.clientBootstrap())
                                  .withPartSize(s3NativeClientConfiguration.partSizeBytes())
+                                 .withComputeContentMd5(true)
                                  .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps());
         this.crtS3Client = new S3Client(s3ClientOptions);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Bump CRT version to 0.16.10, which contains M1 support #2942


## Testing
~~Running test suites now~~ integ tests and stability tests passed

