### PR TITLE
Adding New StsWebIdentityTokenFileCredentialsProvider in sts module that accepts STSClien

### DIFF
--- a/.changes/next-release/feature-AWSSTS-e86cc0d.json
+++ b/.changes/next-release/feature-AWSSTS-e86cc0d.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS STS",
+    "contributor": "",
+    "description": "Adding New WebIdentityTokenFileCredentialsProvider in sts that accepts STSClient"
+}

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -315,6 +315,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.junit5.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit4.version}</version>

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java
@@ -29,8 +29,17 @@ import software.amazon.awssdk.utils.ToString;
 /**
  * A credential provider that will read web identity token file path, aws role arn
  * and aws session name from system properties or environment variables for using
- * web identity token credentials with STS. Use of this credentials provider requires
- * the 'sts' module to be on the classpath.
+ * web identity token credentials with STS.
+ * <p>
+ *     Use of this credentials provider requires the 'sts' module to be on the classpath.
+ * </p>
+ * <p>
+ * StsWebIdentityTokenFileCredentialsProvider in sts package can be used instead of this class if any one of following is required
+ *<ul>
+ *     <li>Pass a custom StsClient to the provider. </li>
+ *     <li>Periodically update credentials </li>
+ *</ul>
+ * @see AwsCredentialsProvider
  */
 @SdkPublicApi
 public class WebIdentityTokenFileCredentialsProvider implements AwsCredentialsProvider {

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>
+        <mockito.junit5.version>4.6.0</mockito.junit5.version>
         <junit4.version>4.13.2</junit4.version> <!-- Used to resolve conflicts in transitive dependencies -->
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>4.3.1</mockito.version>

--- a/services/sts/pom.xml
+++ b/services/sts/pom.xml
@@ -80,6 +80,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.auth;
+
+import static software.amazon.awssdk.utils.StringUtils.trim;
+import static software.amazon.awssdk.utils.Validate.notNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.internal.WebIdentityTokenCredentialProperties;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.internal.AssumeRoleWithWebIdentityRequestSupplier;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.IdpCommunicationErrorException;
+import software.amazon.awssdk.utils.ToString;
+
+/**
+ * A credential provider that will read web identity token file path, aws role arn, aws session name from system properties or
+ * environment variables  and StsClient for using web identity token credentials with STS
+ * <p>
+ * StsWebIdentityTokenFileCredentialsProvider allows passing of a custom StsClient at the time of instantiation of the provider.
+ * The user needs to make sure that this StsClient handles {@link IdpCommunicationErrorException} in retry policy.
+ * </p>
+ * <p>
+ * This Web Identity Token File Credentials Provider extends {@link StsCredentialsProvider} that supports  periodically
+ * updating session credentials. Refer {@link StsCredentialsProvider} for more details.
+ * </p>
+ * <p>STWebIdentityTokenFileCredentialsProvider differs from StsWebIdentityTokenFileCredentialsProvider which is in sts package:
+ * <ol>
+ *   <li>This Credentials Provider supports custom StsClient</li>
+ *   <li>This Credentials Provider supports periodically updating session credentials. Refer {@link StsCredentialsProvider}</li>
+ * </ol>
+ * If asyncCredentialUpdateEnabled is set to true then this provider creates a thread in the background to periodically update
+ * credentials. If this provider is no longer needed, the background thread can be shut down using {@link #close()}.
+ * @see StsCredentialsProvider
+ */
+@SdkPublicApi
+public final class StsWebIdentityTokenFileCredentialsProvider extends StsCredentialsProvider {
+
+    private final AwsCredentialsProvider credentialsProvider;
+    private final RuntimeException loadException;
+    private final Supplier<AssumeRoleWithWebIdentityRequest> assumeRoleWithWebIdentityRequest;
+
+    private StsWebIdentityTokenFileCredentialsProvider(Builder builder) {
+        super(builder, "sts-assume-role-with-web-identity-credentials-provider");
+        Path webIdentityTokenFile =
+            builder.webIdentityTokenFile != null ? builder.webIdentityTokenFile
+                                                 : Paths.get(trim(SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE
+                                                                      .getStringValueOrThrow()));
+
+        String roleArn = builder.roleArn != null ? builder.roleArn
+                                                 : trim(SdkSystemSetting.AWS_ROLE_ARN.getStringValueOrThrow());
+
+        String sessionName = builder.roleSessionName != null ? builder.roleSessionName :
+                             SdkSystemSetting.AWS_ROLE_SESSION_NAME.getStringValue()
+                                                                   .orElse("aws-sdk-java-" + System.currentTimeMillis());
+
+        WebIdentityTokenCredentialProperties credentialProperties =
+            WebIdentityTokenCredentialProperties.builder()
+                                                .roleArn(roleArn)
+                                                .roleSessionName(builder.roleSessionName)
+                                                .webIdentityTokenFile(webIdentityTokenFile)
+                                                .build();
+
+        this.assumeRoleWithWebIdentityRequest = builder.assumeRoleWithWebIdentityRequestSupplier != null
+                                                ? builder.assumeRoleWithWebIdentityRequestSupplier
+                                                : () -> AssumeRoleWithWebIdentityRequest.builder()
+                                                                                        .roleArn(credentialProperties.roleArn())
+                                                                                        .roleSessionName(sessionName)
+                                                                                        .build();
+
+        AwsCredentialsProvider credentialsProviderLocal = null;
+        RuntimeException loadExceptionLocal = null;
+        try {
+            AssumeRoleWithWebIdentityRequestSupplier supplier =
+                AssumeRoleWithWebIdentityRequestSupplier.builder()
+                                                        .assumeRoleWithWebIdentityRequest(assumeRoleWithWebIdentityRequest.get())
+                                                        .webIdentityTokenFile(credentialProperties.webIdentityTokenFile())
+                                                        .build();
+            credentialsProviderLocal =
+                StsAssumeRoleWithWebIdentityCredentialsProvider.builder()
+                                                               .stsClient(builder.stsClient)
+                                                               .refreshRequest(supplier)
+                                                               .build();
+        } catch (RuntimeException e) {
+            // If we couldn't load the credentials provider for some reason, save an exception describing why. This exception
+            // will only be raised on calls to getCredentials. We don't want to raise an exception here because it may be
+            // expected (eg. in the default credential chain).
+            loadExceptionLocal = e;
+        }
+        this.loadException = loadExceptionLocal;
+        this.credentialsProvider = credentialsProviderLocal;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        if (loadException != null) {
+            throw loadException;
+        }
+        return credentialsProvider.resolveCredentials();
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("StsWebIdentityTokenFileCredentialsProvider")
+                       .add("refreshRequest", assumeRoleWithWebIdentityRequest)
+                       .build();
+    }
+
+    @Override
+    protected Credentials getUpdatedCredentials(StsClient stsClient) {
+        AssumeRoleWithWebIdentityRequest request = assumeRoleWithWebIdentityRequest.get();
+        notNull(request, "AssumeRoleWithWebIdentityRequest can't be null");
+        return stsClient.assumeRoleWithWebIdentity(request).credentials();
+    }
+
+    public static final class Builder extends BaseBuilder<Builder, StsWebIdentityTokenFileCredentialsProvider> {
+        private String roleArn;
+        private String roleSessionName;
+        private Path webIdentityTokenFile;
+        private Supplier<AssumeRoleWithWebIdentityRequest> assumeRoleWithWebIdentityRequestSupplier;
+        private StsClient stsClient;
+
+        private Builder() {
+            super(StsWebIdentityTokenFileCredentialsProvider::new);
+        }
+
+        /**
+         * The Custom {@link StsClient} that will be used to fetch AWS service credentials.
+         * <ul>
+         *     <li>This SDK client must be closed by the caller when it is ready to be disposed.</li>
+         *     <li>This SDK client's retry policy should handle IdpCommunicationErrorException </li>
+         * </ul>
+         * @param stsClient The STS client to use for communication with STS.
+         *                  Make sure IdpCommunicationErrorException is retried in the retry policy for this client.
+         *                  Make sure the custom STS client is closed when it is ready to be disposed.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        @Override
+        public Builder stsClient(StsClient stsClient) {
+            this.stsClient = stsClient;
+            return super.stsClient(stsClient);
+        }
+
+        /**
+         * <p>
+         * The Amazon Resource Name (ARN) of the IAM role that is associated with the Sts.
+         * If not provided this will be read from SdkSystemSetting.AWS_ROLE_ARN.
+         * </p>
+         *
+         * @param roleArn The Amazon Resource Name (ARN) of the IAM role that is associated with the Sts cluster.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        public Builder roleArn(String roleArn) {
+            this.roleArn = roleArn;
+            return this;
+        }
+
+        /**
+         * <p>
+         * Sets Amazon Resource Name (ARN) of the IAM role that is associated with the Sts.
+         * By default this will be read from SdkSystemSetting.AWS_ROLE_ARN.
+         * </p>
+         *
+         * @param roleArn The Amazon Resource Name (ARN) of the IAM role that is associated with the Sts cluster.
+         */
+        public void setRoleArn(String roleArn) {
+            roleArn(roleArn);
+        }
+
+        /**
+         * <p>
+         * Sets the role session name that should be used by this credentials provider.
+         * By default this is read from SdkSystemSetting.AWS_ROLE_SESSION_NAME
+         * </p>
+         *
+         * @param roleSessionName role session name that should be used by this credentials provider
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        public Builder roleSessionName(String roleSessionName) {
+            this.roleSessionName = roleSessionName;
+            return this;
+        }
+
+        /**
+         * <p>
+         * Sets the role session name that should be used by this credentials provider.
+         * By default this is read from SdkSystemSetting.AWS_ROLE_SESSION_NAME
+         * </p>
+         *
+         * @param roleSessionName role session name that should be used by this credentials provider.
+         */
+        public void setRoleSessionName(String roleSessionName) {
+            roleSessionName(roleSessionName);
+        }
+
+        /**
+         * <p>
+         * Sets the absolute path to the web identity token file that should be used by this credentials provider.
+         * By default this will be read from SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.
+         * </p>
+         *
+         * @param webIdentityTokenFile absolute path to the web identity token file that should be used by this credentials
+         *                             provider.
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        public Builder webIdentityTokenFile(Path webIdentityTokenFile) {
+            this.webIdentityTokenFile = webIdentityTokenFile;
+            return this;
+        }
+
+        public void setWebIdentityTokenFile(Path webIdentityTokenFile) {
+            webIdentityTokenFile(webIdentityTokenFile);
+        }
+
+
+        /**
+         * Configure the {@link AssumeRoleWithWebIdentityRequest} that should be periodically sent to the STS service to update
+         * the session token when it gets close to expiring.
+         *
+         * @param assumeRoleWithWebIdentityRequest The request to send to STS whenever the assumed session expires.
+         * @return This object for chained calls.
+         */
+        public Builder refreshRequest(AssumeRoleWithWebIdentityRequest assumeRoleWithWebIdentityRequest) {
+            return refreshRequest(() -> assumeRoleWithWebIdentityRequest);
+        }
+
+        /**
+         * Similar to {@link #refreshRequest(AssumeRoleWithWebIdentityRequest)}, but takes a {@link Supplier} to supply the
+         * request to STS.
+         *
+         * @param assumeRoleWithWebIdentityRequestSupplier A supplier
+         * @return This object for chained calls.
+         */
+        public Builder refreshRequest(Supplier<AssumeRoleWithWebIdentityRequest> assumeRoleWithWebIdentityRequestSupplier) {
+            this.assumeRoleWithWebIdentityRequestSupplier = assumeRoleWithWebIdentityRequestSupplier;
+            return this;
+        }
+
+        /**
+         * Similar to {@link #refreshRequest(AssumeRoleWithWebIdentityRequest)}, but takes a lambda to configure a new {@link
+         * AssumeRoleWithWebIdentityRequest.Builder}. This removes the need to call {@link
+         * AssumeRoleWithWebIdentityRequest#builder()} and {@link AssumeRoleWithWebIdentityRequest.Builder#build()}.
+         */
+        public Builder refreshRequest(Consumer<AssumeRoleWithWebIdentityRequest.Builder> assumeRoleWithWebIdentityRequest) {
+            return refreshRequest(AssumeRoleWithWebIdentityRequest.builder().applyMutation(assumeRoleWithWebIdentityRequest)
+                                                                  .build());
+        }
+
+        @Override
+        public StsWebIdentityTokenFileCredentialsProvider build() {
+            return new StsWebIdentityTokenFileCredentialsProvider(this);
+        }
+
+    }
+}

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/AssumeRoleWithWebIdentityRequestSupplier.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/AssumeRoleWithWebIdentityRequestSupplier.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.utils.IoUtils;
+
+@SdkInternalApi
+public class AssumeRoleWithWebIdentityRequestSupplier implements Supplier<AssumeRoleWithWebIdentityRequest> {
+
+
+    private final AssumeRoleWithWebIdentityRequest request;
+    private final Path webIdentityTokenFile;
+
+    public AssumeRoleWithWebIdentityRequestSupplier(Builder builder) {
+
+        this.request = builder.request;
+        this.webIdentityTokenFile = builder.webIdentityTokenFile;
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public AssumeRoleWithWebIdentityRequest get() {
+        return request.toBuilder().webIdentityToken(getToken(webIdentityTokenFile)).build();
+    }
+
+    //file extraction
+    private String getToken(Path file) {
+        try (InputStream webIdentityTokenStream = Files.newInputStream(file)) {
+            return IoUtils.toUtf8String(webIdentityTokenStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static class Builder {
+
+        private AssumeRoleWithWebIdentityRequest request;
+
+        private Path webIdentityTokenFile;
+
+
+        public Builder assumeRoleWithWebIdentityRequest(AssumeRoleWithWebIdentityRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder webIdentityTokenFile(Path webIdentityTokenFile) {
+            this.webIdentityTokenFile = webIdentityTokenFile;
+            return this;
+        }
+
+        public AssumeRoleWithWebIdentityRequestSupplier build() {
+            return new AssumeRoleWithWebIdentityRequestSupplier(this);
+        }
+
+
+    }
+}

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProviderTestBase.java
@@ -20,13 +20,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.Credentials;
@@ -34,7 +36,7 @@ import software.amazon.awssdk.services.sts.model.Credentials;
 /**
  * Validates the functionality of {@link StsCredentialsProvider} and its subclasses.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class StsCredentialsProviderTestBase<RequestT, ResponseT> {
     @Mock
     protected StsClient stsClient;

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialProviderTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialProviderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.auth;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import java.nio.file.Paths;
+import java.time.Instant;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StsWebIdentityTokenCredentialProviderTest {
+
+    @Mock
+    StsClient stsClient;
+
+    private EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+
+    @BeforeEach
+    public   void setUp() {
+        String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_ROLE_ARN.environmentVariable(), "someRole");
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.environmentVariable(), webIdentityTokenPath);
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_ROLE_SESSION_NAME.environmentVariable(), "tempRoleSession");
+    }
+
+    @AfterEach
+    public void cleanUp(){
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+    }
+
+    @Test
+    void createAssumeRoleWithWebIdentityTokenCredentialsProviderWithoutStsClient_throws_Exception() {
+
+        Assert.assertThrows(NullPointerException.class,
+                            () -> StsWebIdentityTokenFileCredentialsProvider.builder().refreshRequest(r -> r.build()).build());
+    }
+
+    @Test
+    void createAssumeRoleWithWebIdentityTokenCredentialsProviderCreateStsClient() {
+        StsWebIdentityTokenFileCredentialsProvider provider =
+            StsWebIdentityTokenFileCredentialsProvider.builder().stsClient(stsClient).refreshRequest(r -> r.build())
+                                                      .build();
+        when(stsClient.assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class)))
+            .thenReturn(AssumeRoleWithWebIdentityResponse.builder()
+                                                         .credentials(Credentials.builder().accessKeyId("key")
+                                                                                 .expiration(Instant.now())
+                                                                                 .sessionToken("session").secretAccessKey("secret").build()).build());
+        provider.resolveCredentials();
+        Mockito.verify(stsClient, Mockito.times(1)).assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class));
+    }
+
+    @Test
+    void createAssumeRoleWithWebIdentityTokenCredentialsProviderStsClientBuilder() {
+
+        String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
+        StsWebIdentityTokenFileCredentialsProvider provider =
+            StsWebIdentityTokenFileCredentialsProvider.builder().stsClient(stsClient)
+                .refreshRequest(r -> r.build())
+                                                      .roleArn("someRole")
+                                                      .webIdentityTokenFile(Paths.get(webIdentityTokenPath))
+                                                      .roleSessionName("tempRoleSession")
+                                                      .build();
+        when(stsClient.assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class)))
+            .thenReturn(AssumeRoleWithWebIdentityResponse.builder()
+                                                         .credentials(Credentials.builder().accessKeyId("key")
+                                                                                 .expiration(Instant.now())
+                                                                                 .sessionToken("session").secretAccessKey("secret").build()).build());
+        provider.resolveCredentials();
+        Mockito.verify(stsClient, Mockito.times(1)).assumeRoleWithWebIdentity(Mockito.any(AssumeRoleWithWebIdentityRequest.class));
+    }
+}

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialsProviderBaseTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenCredentialsProviderBaseTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sts.auth;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider.Builder;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Validate the functionality of {@link StsWebIdentityTokenFileCredentialsProvider}. Inherits tests from {@link
+ * StsCredentialsProviderTestBase}.
+ */
+public class StsWebIdentityTokenCredentialsProviderBaseTest
+    extends StsCredentialsProviderTestBase<AssumeRoleWithWebIdentityRequest, AssumeRoleWithWebIdentityResponse> {
+
+    private EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
+
+    @BeforeEach
+    public   void setUp() {
+        String webIdentityTokenPath = Paths.get("src/test/resources/token.jwt").toAbsolutePath().toString();
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_ROLE_ARN.environmentVariable(), "someRole");
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.environmentVariable(), webIdentityTokenPath);
+        ENVIRONMENT_VARIABLE_HELPER.set(SdkSystemSetting.AWS_ROLE_SESSION_NAME.environmentVariable(), "tempRoleSession");
+    }
+
+    @AfterEach
+    public void cleanUp(){
+        ENVIRONMENT_VARIABLE_HELPER.reset();
+    }
+
+    @Override
+    protected AssumeRoleWithWebIdentityRequest getRequest() {
+        return AssumeRoleWithWebIdentityRequest.builder().webIdentityToken(getToken(Paths.get("src/test/resources"
+                                                                                              + "/token.jwt").toAbsolutePath())).build();
+    }
+
+    @Override
+    protected AssumeRoleWithWebIdentityResponse getResponse(Credentials credentials) {
+        return AssumeRoleWithWebIdentityResponse.builder().credentials(credentials).build();
+    }
+
+    @Override
+    protected Builder createCredentialsProviderBuilder(AssumeRoleWithWebIdentityRequest request) {
+        return StsWebIdentityTokenFileCredentialsProvider.builder().stsClient(stsClient).refreshRequest(request);
+    }
+
+    @Override
+    protected AssumeRoleWithWebIdentityResponse callClient(StsClient client, AssumeRoleWithWebIdentityRequest request) {
+        return client.assumeRoleWithWebIdentity(request);
+    }
+
+    private String getToken(Path file) {
+        try (InputStream webIdentityTokenStream = Files.newInputStream(file)) {
+            return IoUtils.toUtf8String(webIdentityTokenStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
Extension of [PR #2488](https://github.com/aws/aws-sdk-java-v2/pull/2488)


Adding New WebIdentityTokenFileCredentialsProvider  in sts that accepts STSClient

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Currently the WebIdentityTokenFileCredentialsProvider is in core module and it creates AwsCredentialsProvider with Default Sts Client.
- We cannot modify the [WebIdentityTokenCredentialsProviderFactory](https://github.com/aws/aws-sdk-java-v2/blob/584ccb59e770177aeaa4c3b6bda4e24015b8ece9/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenCredentialsProviderFactory.java) because  the interface is marked as @FunctionalInterface  and also StsClient is not available in core package so would need to pass SdkClient which would be confusing.
- Thus we have added a new WebIdentityTokenFileCredentialsProvider in Sts module and named it as StsWebIdentityTokenFileCredentialsProvider

### Usage

1. Credential provider that will read web identity token file path, aws role arn, aws session name from system properties or environment variables And DefaultStsClient
 ```
 StsWebIdentityTokenFileCredentialsProvider.builder().build();
 ```

2. Credential provider that will read web identity token file path, aws role arn, aws session name from system properties or environment variables And StsClient will be used as it is passed in the constructor.

 ```
 StsWebIdentityTokenFileCredentialsProviderbuilder().stsClient(stsClient).build();
 ```


3 . Credential provider that will read web identity token file path, aws role arn, aws session name from Builders And StsClient will be used as it is passed in the Builder.
 ```
                StsWebIdentityTokenFileCredentialsProvider.builder()
                        .stsClient(stsClient)
                        .roleArn("someRole")
                        .webIdentityTokenFile(Paths.get(webIdentityTokenPath))
                        .roleSessionName("tempRoleSession")
                        .build();
 ```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Please refer Pr #1881 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added JUnit Test cases.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
