### PR TITLE
Give permissions to Github Actions

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -5,6 +5,8 @@ on:
 jobs:
     auto_comment:
         runs-on: ubuntu-latest
+        permissions:
+          issues: write
         steps:
         - uses: aws-actions/closed-issue-message@v1
           with:

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -9,6 +9,9 @@ jobs:
   cleanup:
     name: Stale issue job
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@v4
       with:
@@ -29,7 +32,7 @@ jobs:
 
         # These labels are required
         stale-issue-label: closing-soon
-        exempt-issue-labels: no-auto-closure
+        exempt-issue-labels: no-auto-closure, help wanted
         stale-pr-label: closing-soon
         exempt-pr-labels: no-auto-closure
         response-requested-label: response-requested


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Github Actions don't get write permission by default anymore. This PR explicitly gives write permission to issues and pull-requests scopes to the `Close Stale Issues` action and `Comment on closed issues` action.

Additionally, included the `help wanted` label to the list of exempt labels.

For more info on GH Action permissions: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
