### PR TITLE
Added customization in codegen to generate additional builder methods

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/AdditionalBuilderMethod.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/AdditionalBuilderMethod.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.config.customization;
+
+import java.util.Locale;
+import software.amazon.awssdk.core.ClientType;
+
+/**
+ * Config required to generate the additional static methods in Client interface.
+ */
+public class AdditionalBuilderMethod {
+
+    /**
+     * Name of the additional static method.
+     */
+    private String methodName;
+
+    /**
+     * Fqcn of the return type
+     */
+    private String returnType;
+
+    /**
+     * Fqcn of the class that will delegate the static method call
+     */
+    private String instanceType;
+
+    /**
+     * JavaDoc for the method
+     */
+    private String javaDoc;
+
+    /**
+     * The clientType for which the builder needs to be added.
+     */
+    private ClientType clientType;
+
+    public String getReturnType() {
+        return returnType;
+    }
+
+    public void setReturnType(String returnType) {
+        this.returnType = returnType;
+    }
+
+    public String getJavaDoc() {
+        return javaDoc;
+    }
+
+    public void setJavaDoc(String javaDoc) {
+        this.javaDoc = javaDoc;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public String getInstanceType() {
+        return instanceType;
+    }
+
+    public void setInstanceType(String instanceType) {
+        this.instanceType = instanceType;
+    }
+
+    public String getClientType() {
+        return clientType != null ? clientType.toString() : null;
+    }
+
+    public void setClientType(String clientType) {
+        this.clientType = clientType != null ? ClientType.valueOf(clientType.toUpperCase(Locale.US)) : null;
+    }
+
+    public ClientType getClientTypeEnum() {
+        return clientType;
+    }
+
+    public void setClientTypeEnum(ClientType clientType) {
+        this.clientType = clientType;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -161,6 +161,11 @@ public class CustomizationConfig {
     private UtilitiesMethod utilitiesMethod;
 
     /**
+     * Config to generate a additional Builder methods in the client interface.
+     */
+    private List<AdditionalBuilderMethod> additionalBuilderMethods;
+
+    /**
      * Force generation of deprecated client builder method 'enableEndpointDiscovery'. Only services that already had
      * this method when it was deprecated require this flag to be set.
      */
@@ -423,6 +428,15 @@ public class CustomizationConfig {
 
     public void setUtilitiesMethod(UtilitiesMethod utilitiesMethod) {
         this.utilitiesMethod = utilitiesMethod;
+    }
+
+
+    public List<AdditionalBuilderMethod> getAdditionalBuilderMethods() {
+        return additionalBuilderMethods;
+    }
+
+    public void setAdditionalBuilderMethods(List<AdditionalBuilderMethod> additionalBuilderMethods) {
+        this.additionalBuilderMethods = additionalBuilderMethods;
     }
 
     public boolean isEnableEndpointDiscoveryMethodRequired() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/rest-json/customization.config
@@ -18,6 +18,32 @@
     "returnType": "software.amazon.awssdk.services.json.JsonUtilities",
     "createMethodParams": ["param1", "param2", "param3"]
   },
+    "additionalBuilderMethods": [
+        {
+          "methodName": "builderOne",
+          "clientType": "ASYNC",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
+          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder"
+        },
+        {
+          "methodName": "builderTwo",
+          "clientType": "ASYNC",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilderTwo",
+          "returnType": "software.amazon.awssdk.services.builder.Builder"
+        },
+
+        {
+          "methodName": "builderThree",
+          "clientType": "SYNC",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
+          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder"
+        },
+        {
+          "methodName": "builderFour",
+          "instanceType": "software.amazon.awssdk.services.builder.DefaultBuilder",
+          "returnType": "software.amazon.awssdk.services.builder.CustomBuilder"
+        }
+    ],
   "useLegacyEventGenerationScheme": {
     "EventStream": ["EventOne", "event-two", "eventThree"]
   },

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-interface.java
@@ -10,6 +10,10 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.builder.Builder;
+import software.amazon.awssdk.services.builder.CustomBuilder;
+import software.amazon.awssdk.services.builder.DefaultBuilder;
+import software.amazon.awssdk.services.builder.DefaultBuilderTwo;
 import software.amazon.awssdk.services.json.model.APostOperationRequest;
 import software.amazon.awssdk.services.json.model.APostOperationResponse;
 import software.amazon.awssdk.services.json.model.APostOperationWithOutputRequest;
@@ -1696,5 +1700,19 @@ public interface JsonAsyncClient extends SdkClient {
      */
     default JsonUtilities utilities() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link DefaultBuilder}
+     */
+    static CustomBuilder builderOne() {
+        return DefaultBuilder.builder();
+    }
+
+    /**
+     * Create a builder that can be used to configure and create a {@link DefaultBuilderTwo}
+     */
+    static Builder builderTwo() {
+        return DefaultBuilderTwo.builder();
     }
 }

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtGetObjectIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtGetObjectIntegrationTest.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.http.async.SimpleSubscriber;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -52,10 +53,10 @@ public class S3CrtGetObjectIntegrationTest extends S3IntegrationTestBase {
     public static void setup() throws Exception {
         S3IntegrationTestBase.setUp();
         S3IntegrationTestBase.createBucket(BUCKET);
-        crtClient = S3CrtAsyncClient.builder()
-                                    .region(S3IntegrationTestBase.DEFAULT_REGION)
-                                    .credentialsProvider(AwsTestBase.CREDENTIALS_PROVIDER_CHAIN)
-                                    .build();
+        crtClient = S3AsyncClient.crtBuilder()
+                                 .region(S3IntegrationTestBase.DEFAULT_REGION)
+                                 .credentialsProvider(AwsTestBase.CREDENTIALS_PROVIDER_CHAIN)
+                                 .build();
         file = new RandomTempFile(10_000);
         S3IntegrationTestBase.s3.putObject(PutObjectRequest.builder()
                                                            .bucket(BUCKET)

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -172,5 +172,13 @@
       "clientConfiguration"
     ]
   },
+  "additionalBuilderMethods": [
+      {
+        "methodName": "crtBuilder",
+        "clientType": "async",
+        "instanceType": "software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient",
+        "returnType": "software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient.S3CrtAsyncClientBuilder"
+      }
+  ],
   "delegateAsyncClientClass": true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- Provide API in  S3AsyncClient to create instance of  S3CrtAsyncClient .


#### Customization.config
```json
  "additionalBuilderMethods": [
      {
        "methodName": "crtBuilder",
        "clientTypes": ["async"],
        "instanceType": "software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient",
        "returnType": "software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient.S3CrtAsyncClientBuilder"
      }
  ],
```

#### S3AsyncClient.java
```java

    /**
     * Create a builder that can be used to configure and create a {@link S3CrtAsyncClient}
     */
    static S3CrtAsyncClientBuilder crtBuilder() {
        return S3CrtAsyncClient.builder();
    }
```

## Modifications
<!--- Describe your changes in detail -->
- Added custom config in codegen to generate additional builders if specified.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Junits
- Integ test updated with the new builder.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
