### PR TITLE
Bump CRT to 0.16.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.10</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.16.15</awscrt.version>
+        <awscrt.version>0.16.16</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.s3.S3FinishedResponseContext;
 import software.amazon.awssdk.crt.s3.S3MetaRequestResponseHandler;
 import software.amazon.awssdk.http.SdkCancellationException;
 import software.amazon.awssdk.http.SdkHttpResponse;
@@ -68,7 +69,10 @@ public class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseHandler
     }
 
     @Override
-    public void onFinished(int crtCode, int responseStatus, byte[] errorPayload) {
+    public void onFinished(S3FinishedResponseContext context) {
+        int crtCode = context.getErrorCode();
+        int responseStatus = context.getResponseStatus();
+        byte[] errorPayload = context.getErrorPayload();
         if (crtCode != CRT.AWS_CRT_SUCCESS) {
             handleError(crtCode, responseStatus, errorPayload);
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
CRT changed the API as part of https://github.com/awslabs/aws-crt-java/pull/458 
This PR bumps up the CRT version and fixes the compilation error


## Testing
Running test suites now

