### PR TITLE
Reduced resource consumption of async credential providers.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-36b8c47.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-36b8c47.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Share background refresh threads across async credential providers to reduce base SDK resource consumption."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-8f6d13b.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-8f6d13b.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Log a warning when an extreme number of async credential providers are running in parallel, because it could indicate that the user is not closing their clients or credential providers when they are done using them."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-d28e3ad.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-d28e3ad.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Jitter credential provider cache refresh times."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/HttpCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/HttpCredentialsProvider.java
@@ -28,12 +28,11 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 public interface HttpCredentialsProvider extends AwsCredentialsProvider, SdkAutoCloseable {
     interface Builder<TypeToBuildT extends HttpCredentialsProvider, BuilderT extends Builder<?, ?>> {
         /**
-         * Configure whether this provider should fetch credentials asynchronously in the background. If this is true, threads are
-         * less likely to block when {@link #resolveCredentials()} is called, but additional resources are used to maintain the
-         * provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
+         * threads are less likely to block when credentials are loaded, but additional resources are used to maintain
+         * the provider.
          *
-         * <p>
-         * By default, this is disabled.
+         * <p>By default, this is disabled.</p>
          */
         BuilderT asyncCredentialUpdateEnabled(Boolean asyncCredentialUpdateEnabled);
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -16,7 +16,7 @@
 package software.amazon.awssdk.auth.credentials;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
-import static software.amazon.awssdk.utils.ComparableUtils.minimum;
+import static software.amazon.awssdk.utils.ComparableUtils.maximum;
 
 import java.io.IOException;
 import java.net.URI;
@@ -191,7 +191,7 @@ public final class InstanceProfileCredentialsProvider
             return now.plus(5, MINUTES);
         }
 
-        return now.plus(minimum(timeUntilExpiration.abs().dividedBy(2), Duration.ofMinutes(5)));
+        return now.plus(maximum(timeUntilExpiration.abs().dividedBy(2), Duration.ofMinutes(5)));
     }
 
     @Override

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ProcessCredentialsProvider.java
@@ -249,8 +249,9 @@ public final class ProcessCredentialsProvider
         }
 
         /**
-         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true, threads are
-         * less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
+         * Configure whether the provider should fetch credentials asynchronously in the background. If this is true,
+         * threads are less likely to block when credentials are loaded, but additional resources are used to maintain
+         * the provider.
          *
          * <p>By default, this is disabled.</p>
          */

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProviderTest.java
@@ -361,10 +361,10 @@ public class InstanceProfileCredentialsProviderTest {
         stubCredentialsResponse(aResponse().withBody(successfulCredentialsResponse1));
         AwsCredentials credentials24HoursAgo = credentialsProvider.resolveCredentials();
 
-        // Set the time to 3 minutes before expiration, and fail to call IMDS
-        clock.time = now.minus(3, MINUTES);
+        // Set the time to 10 minutes before expiration, and fail to call IMDS
+        clock.time = now.minus(10, MINUTES);
         stubCredentialsResponse(aResponse().withStatus(500));
-        AwsCredentials credentials3MinutesAgo = credentialsProvider.resolveCredentials();
+        AwsCredentials credentials10MinutesAgo = credentialsProvider.resolveCredentials();
 
         // Set the time to 10 seconds before expiration, and verify that we still call IMDS to try to get credentials in at the
         // last moment before expiration
@@ -372,7 +372,7 @@ public class InstanceProfileCredentialsProviderTest {
         stubCredentialsResponse(aResponse().withBody(successfulCredentialsResponse2));
         AwsCredentials credentials10SecondsAgo = credentialsProvider.resolveCredentials();
 
-        assertThat(credentials24HoursAgo).isEqualTo(credentials3MinutesAgo);
+        assertThat(credentials24HoursAgo).isEqualTo(credentials10MinutesAgo);
         assertThat(credentials24HoursAgo.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY");
         assertThat(credentials10SecondsAgo.secretAccessKey()).isEqualTo("SECRET_ACCESS_KEY2");
     }

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/SsoCredentialsProvider.java
@@ -20,7 +20,6 @@ import static software.amazon.awssdk.utils.Validate.notNull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.java
@@ -30,12 +30,13 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * An implementation of {@link AwsCredentialsProvider} that periodically sends an {@link AssumeRoleRequest} to the AWS
- * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated asynchronously
- * in the background as they get close to expiring. If the credentials are not successfully updated asynchronously in the
- * background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials synchronously.
+ * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated using a single
+ * calling thread (by default) or asynchronously (if {@link Builder#asyncCredentialUpdateEnabled(Boolean)} is set).
  *
- * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
- * the background thread can be shut down using {@link #close()}.
+ * If the credentials are not successfully updated before expiration, calls to {@link #resolveCredentials()} will block until
+ * they are updated successfully.
+ *
+ * Users of this provider must {@link #close()} it when they are finished using it.
  *
  * This is created using {@link StsAssumeRoleCredentialsProvider#builder()}.
  */

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithSamlCredentialsProvider.java
@@ -29,14 +29,14 @@ import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link AssumeRoleWithSamlRequest}
- * to the AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
- * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
- * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
- * synchronously.
+ * An implementation of {@link AwsCredentialsProvider} that periodically sends an {@link AssumeRoleWithSamlRequest} to the AWS
+ * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated using a single
+ * calling thread (by default) or asynchronously (if {@link Builder#asyncCredentialUpdateEnabled(Boolean)} is set).
  *
- * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
- * the background thread can be shut down using {@link #close()}.
+ * If the credentials are not successfully updated before expiration, calls to {@link #resolveCredentials()} will block until
+ * they are updated successfully.
+ *
+ * Users of this provider must {@link #close()} it when they are finished using it.
  *
  * This is created using {@link StsAssumeRoleWithSamlCredentialsProvider#builder()}.
  */

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsAssumeRoleWithWebIdentityCredentialsProvider.java
@@ -30,16 +30,16 @@ import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link AssumeRoleWithWebIdentityRequest}
- * to the AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
- * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
- * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
- * synchronously.
+ * An implementation of {@link AwsCredentialsProvider} that periodically sends an {@link AssumeRoleWithWebIdentityRequest} to the
+ * AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated using a
+ * single calling thread (by default) or asynchronously (if {@link Builder#asyncCredentialUpdateEnabled(Boolean)} is set).
  *
- * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
- * the background thread can be shut down using {@link #close()}.
+ * If the credentials are not successfully updated before expiration, calls to {@link #resolveCredentials()} will block until
+ * they are updated successfully.
  *
- * This is created using {@link StsAssumeRoleWithWebIdentityCredentialsProvider#builder()}.
+ * Users of this provider must {@link #close()} it when they are finished using it.
+ *
+ * This is created using {@link #builder()}.
  */
 @SdkPublicApi
 @ThreadSafe

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetFederationTokenCredentialsProvider.java
@@ -28,16 +28,16 @@ import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link GetFederationTokenRequest} to the
- * AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated
- * asynchronously in the background as they get close to expiring. If the credentials are not successfully updated asynchronously
- * in the background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials
- * synchronously.
+ * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link GetFederationTokenRequest} to the AWS
+ * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated using a single
+ * calling thread (by default) or asynchronously (if {@link Builder#asyncCredentialUpdateEnabled(Boolean)} is set).
  *
- * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
- * the background thread can be shut down using {@link #close()}.
+ * If the credentials are not successfully updated before expiration, calls to {@link #resolveCredentials()} will block until
+ * they are updated successfully.
  *
- * This is created using {@link StsGetFederationTokenCredentialsProvider#builder()}.
+ * Users of this provider must {@link #close()} it when they are finished using it.
+ *
+ * This is created using {@link #builder()}.
  */
 @SdkPublicApi
 @ThreadSafe

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsGetSessionTokenCredentialsProvider.java
@@ -29,14 +29,15 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
  * An implementation of {@link AwsCredentialsProvider} that periodically sends a {@link GetSessionTokenRequest} to the AWS
- * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated asynchronously
- * in the background as they get close to expiring. If the credentials are not successfully updated asynchronously in the
- * background, calls to {@link #resolveCredentials()} will begin to block in an attempt to update the credentials synchronously.
+ * Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated using a single
+ * calling thread (by default) or asynchronously (if {@link Builder#asyncCredentialUpdateEnabled(Boolean)} is set).
  *
- * This provider creates a thread in the background to periodically update credentials. If this provider is no longer needed,
- * the background thread can be shut down using {@link #close()}.
+ * If the credentials are not successfully updated before expiration, calls to {@link #resolveCredentials()} will block until
+ * they are updated successfully.
  *
- * This is created using {@link StsGetSessionTokenCredentialsProvider#builder()}.
+ * Users of this provider must {@link #close()} it when they are finished using it.
+ *
+ * This is created using {@link #builder()}.
  */
 @SdkPublicApi
 @ThreadSafe

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsWebIdentityTokenFileCredentialsProvider.java
@@ -31,29 +31,24 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.internal.AssumeRoleWithWebIdentityRequestSupplier;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithWebIdentityRequest;
 import software.amazon.awssdk.services.sts.model.Credentials;
-import software.amazon.awssdk.services.sts.model.IdpCommunicationErrorException;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 
 /**
- * A credential provider that will read web identity token file path, aws role arn, aws session name from system properties or
- * environment variables  and StsClient for using web identity token credentials with STS
- * <p>
- * StsWebIdentityTokenFileCredentialsProvider allows passing of a custom StsClient at the time of instantiation of the provider.
- * The user needs to make sure that this StsClient handles {@link IdpCommunicationErrorException} in retry policy.
- * </p>
- * <p>
- * This Web Identity Token File Credentials Provider extends {@link StsCredentialsProvider} that supports  periodically
- * updating session credentials. Refer {@link StsCredentialsProvider} for more details.
- * </p>
- * <p>STWebIdentityTokenFileCredentialsProvider differs from StsWebIdentityTokenFileCredentialsProvider which is in sts package:
- * <ol>
- *   <li>This Credentials Provider supports custom StsClient</li>
- *   <li>This Credentials Provider supports periodically updating session credentials. Refer {@link StsCredentialsProvider}</li>
- * </ol>
- * If asyncCredentialUpdateEnabled is set to true then this provider creates a thread in the background to periodically update
- * credentials. If this provider is no longer needed, the background thread can be shut down using {@link #close()}.
- * @see StsCredentialsProvider
+ * An implementation of {@link AwsCredentialsProvider} that periodically sends an {@link AssumeRoleWithWebIdentityRequest} to the
+ * AWS Security Token Service to maintain short-lived sessions to use for authentication. These sessions are updated using a
+ * single calling thread (by default) or asynchronously (if {@link Builder#asyncCredentialUpdateEnabled(Boolean)} is set).
+ *
+ * Unlike {@link StsAssumeRoleWithWebIdentityCredentialsProvider}, this reads the web identity information, including AWS role
+ * ARN, AWS session name and the location of a web identity token file from system properties and environment variables. The
+ * web identity token file is expected to contain the web identity token to use with each request.
+ *
+ * If the credentials are not successfully updated before expiration, calls to {@link #resolveCredentials()} will block until
+ * they are updated successfully.
+ *
+ * Users of this provider must {@link #close()} it when they are finished using it.
+ *
+ * This is created using {@link #builder()}.
  */
 @SdkPublicApi
 public final class StsWebIdentityTokenFileCredentialsProvider

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -94,6 +94,27 @@
             <artifactId>reactive-streams-tck</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+            <version>${slf4j.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/utils/src/main/java/software/amazon/awssdk/utils/ComparableUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ComparableUtils.java
@@ -57,4 +57,15 @@ public final class ComparableUtils {
         return values == null ? null : Stream.of(values).min(Comparable::compareTo).orElse(null);
     }
 
+    /**
+     * Get the maximum value from a list of comparable vales.
+     *
+     * @param values The values from which the maximum should be extracted.
+     * @return The maximum value in the list.
+     */
+    @SafeVarargs
+    public static <T extends Comparable<T>> T maximum(T... values) {
+        return values == null ? null : Stream.of(values).max(Comparable::compareTo).orElse(null);
+    }
+
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/NonBlocking.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/NonBlocking.java
@@ -15,17 +15,26 @@
 
 package software.amazon.awssdk.utils.cache;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
 
 import java.time.Duration;
-import java.util.concurrent.ScheduledExecutorService;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * A {@link CachedSupplier.PrefetchStrategy} that will run a single thread in the background to update the value. A call to
@@ -38,79 +47,203 @@ public class NonBlocking implements CachedSupplier.PrefetchStrategy {
     private static final Logger log = Logger.loggerFor(NonBlocking.class);
 
     /**
+     * The maximum number of concurrent refreshes before we start logging warnings and skipping refreshes.
+     */
+    private static final int MAX_CONCURRENT_REFRESHES = 100;
+
+    /**
+     * The {@link Random} instance used for calculating jitter of the background prefetches.
+     */
+    private static final Random JITTER_RANDOM = new Random();
+
+    /**
+     * Thread used to kick off refreshes during the prefetch window. This does not do the actual refreshing. That's left for
+     * the {@link #EXECUTOR}.
+     */
+    private static final ScheduledThreadPoolExecutor SCHEDULER =
+        new ScheduledThreadPoolExecutor(1, new ThreadFactoryBuilder().daemonThreads(true).build());
+
+    /**
+     * Threads used to do the actual work of refreshing the values (because the cached supplier might block, so we don't
+     * want the work to be done by a small thread pool). This executor is created as unbounded, but we start complaining and
+     * skipping refreshes when there are more than {@link #MAX_CONCURRENT_REFRESHES} running.
+     */
+    private static final ThreadPoolExecutor EXECUTOR =
+        new ThreadPoolExecutor(0, Integer.MAX_VALUE,
+                               60L, TimeUnit.SECONDS,
+                               new SynchronousQueue<>(),
+                               new ThreadFactoryBuilder().daemonThreads(true).build());
+
+    /**
+     * An incrementing number, used to uniquely identify an instance of NonBlocking in the {@link #asyncThreadName}.
+     */
+    private static final AtomicLong THREAD_NUMBER = new AtomicLong(0);
+
+    /**
      * Whether we are currently refreshing the supplier. This is used to make sure only one caller is blocking at a time.
      */
-    private final AtomicBoolean currentlyRefreshing = new AtomicBoolean(false);
+    private final AtomicBoolean currentlyPrefetching = new AtomicBoolean(false);
 
     /**
-     * How frequently to automatically refresh the supplier in the background.
+     * Name of the thread refreshing the cache for this strategy.
      */
-    private final Duration asyncRefreshFrequency;
+    private final String asyncThreadName;
 
     /**
-     * Single threaded executor to asynchronous refresh the value.
+     * The refresh task currently scheduled for this non-blocking instance. We ensure that no more than one task is scheduled
+     * per instance.
      */
-    private final ScheduledExecutorService executor;
+    private final AtomicReference<ScheduledFuture<?>> refreshTask = new AtomicReference<>();
+
+    /**
+     * The minimum amount of time allowed between async refreshes, primarily adjustable for testing purposes.
+     */
+    private final Duration minimumRefreshFrequency;
+
+    /**
+     * Whether this strategy has been shutdown (and should stop doing background refreshes)
+     */
+    private volatile boolean shutdown = false;
+
+    /**
+     * The cached supplier using this non-blocking instance.
+     */
+    private volatile CachedSupplier<?> cachedSupplier;
+
+    static {
+        // Ensure that cancelling a task actually removes it from the queue.
+        SCHEDULER.setRemoveOnCancelPolicy(true);
+    }
 
     /**
      * Create a non-blocking prefetch strategy that uses the provided value for the name of the background thread that will be
      * performing the update.
      */
     public NonBlocking(String asyncThreadName) {
-        this(asyncThreadName, Duration.ofMinutes(1));
+        this(asyncThreadName, Duration.ofSeconds(60));
     }
 
     @SdkTestInternalApi
-    NonBlocking(String asyncThreadName, Duration asyncRefreshFrequency) {
-        this.executor = newExecutor(asyncThreadName);
-        this.asyncRefreshFrequency = asyncRefreshFrequency;
+    NonBlocking(String asyncThreadName, Duration minimumRefreshFrequency) {
+        this.asyncThreadName = asyncThreadName + "-" + THREAD_NUMBER.getAndIncrement();
+        this.minimumRefreshFrequency = minimumRefreshFrequency;
     }
 
-    private static ScheduledExecutorService newExecutor(String asyncThreadName) {
-        Validate.paramNotBlank(asyncThreadName, "asyncThreadName");
-        return new ScheduledThreadPoolExecutor(1, new ThreadFactoryBuilder().daemonThreads(true)
-                                                                            .threadNamePrefix(asyncThreadName)
-                                                                            .build());
+    @SdkTestInternalApi
+    static ThreadPoolExecutor executor() {
+        return EXECUTOR;
     }
 
     @Override
     public void initializeCachedSupplier(CachedSupplier<?> cachedSupplier) {
-        scheduleRefresh(cachedSupplier);
-    }
-
-    private void scheduleRefresh(CachedSupplier<?> cachedSupplier) {
-        executor.schedule(() -> {
-            try {
-                cachedSupplier.get();
-            } finally {
-                scheduleRefresh(cachedSupplier);
-            }
-        }, asyncRefreshFrequency.toMillis(), MILLISECONDS);
+        this.cachedSupplier = cachedSupplier;
     }
 
     @Override
     public void prefetch(Runnable valueUpdater) {
-        // Only run one async refresh at a time.
-        if (currentlyRefreshing.compareAndSet(false, true)) {
-            try {
-                executor.submit(() -> {
-                    try {
-                        valueUpdater.run();
-                    } catch (RuntimeException e) {
-                        log.warn(() -> "Exception occurred in AWS SDK background task.", e);
-                    } finally {
-                        currentlyRefreshing.set(false);
-                    }
-                });
-            } catch (Throwable e) {
-                currentlyRefreshing.set(false);
-                throw e;
-            }
+        // Only run one async prefetch at a time.
+        if (currentlyPrefetching.compareAndSet(false, true)) {
+            tryRunBackgroundTask(valueUpdater, () -> currentlyPrefetching.set(false));
+        }
+    }
+
+    @Override
+    public <T> RefreshResult<T> fetch(Supplier<RefreshResult<T>> supplier) {
+        RefreshResult<T> result = supplier.get();
+        if (result.staleTime() == null || result.prefetchTime() == null) {
+            return result;
+        }
+
+        getRefreshTime(result).ifPresent(this::schedulePrefetch);
+        return result;
+    }
+
+    private Optional<Instant> getRefreshTime(RefreshResult<?> result) {
+        Instant minStart = Instant.now().plus(minimumRefreshFrequency);
+        Instant rangeStart = result.prefetchTime().isBefore(minStart) ? minStart : result.prefetchTime();
+
+        if (Duration.between(Instant.now(), rangeStart).toDays() > 7) {
+            log.debug(() -> "Skipping background refresh because the prefetch time is too far in the future: " + rangeStart);
+            return Optional.empty();
+        }
+
+        Instant maxEnd = rangeStart.plus(1, HOURS);
+        Instant rangeEnd = result.staleTime().isAfter(maxEnd) ? maxEnd : result.staleTime().minus(1, MINUTES);
+
+        if (rangeEnd.isBefore(rangeStart)) {
+            return Optional.of(rangeStart);
+        }
+
+        return Optional.of(randomTimeBetween(rangeStart, rangeEnd));
+    }
+
+    private Instant randomTimeBetween(Instant rangeStart, Instant rangeEnd) {
+        Duration timeBetween = Duration.between(rangeStart, rangeEnd);
+        return rangeStart.plusMillis(Math.abs(JITTER_RANDOM.nextLong() % timeBetween.toMillis()));
+    }
+
+    private void schedulePrefetch(Instant refreshTime) {
+        if (shutdown) {
+            return;
+        }
+
+        Duration waitTime = Duration.between(Instant.now(), refreshTime);
+        log.debug(() -> "Scheduling refresh attempt for " + refreshTime + " (in " + waitTime.toMillis() + " ms)");
+        updateTask(SCHEDULER.schedule(() -> {
+            Thread.currentThread().setName(asyncThreadName + "-scheduler");
+            log.debug(() -> "Executing refresh attempt scheduled for " + refreshTime);
+
+            // If the supplier has already been prefetched, this will just be a cache hit.
+            tryRunBackgroundTask(cachedSupplier::get);
+        }, waitTime.toMillis(), TimeUnit.MILLISECONDS));
+
+        if (shutdown) {
+            updateTask(null);
         }
     }
 
     @Override
     public void close() {
-        executor.shutdown();
+        shutdown = true;
+        updateTask(null);
+    }
+
+    public void updateTask(ScheduledFuture<?> newTask) {
+        ScheduledFuture<?> currentTask;
+        do {
+            currentTask = refreshTask.get();
+            if (currentTask != null && !currentTask.isDone()) {
+                currentTask.cancel(false);
+            }
+        } while (!refreshTask.compareAndSet(currentTask, newTask));
+    }
+
+    public void tryRunBackgroundTask(Runnable runnable) {
+        tryRunBackgroundTask(runnable, () -> {
+        });
+    }
+
+    public void tryRunBackgroundTask(Runnable runnable, Runnable finallyRunnable) {
+        try {
+            if (EXECUTOR.getActiveCount() > MAX_CONCURRENT_REFRESHES) {
+                log.warn(() -> "Skipping a background refresh task because there are too many other tasks running.");
+                return;
+            }
+
+            EXECUTOR.submit(() -> {
+                try {
+                    Thread.currentThread().setName(asyncThreadName);
+                    runnable.run();
+                } catch (Throwable t) {
+                    log.warn(() -> "Exception occurred in AWS SDK background task.", t);
+                } finally {
+                    finallyRunnable.run();
+                }
+            });
+        } catch (Throwable t) {
+            log.warn(() -> "Exception occurred when submitting AWS SDK background task.", t);
+        } finally {
+            finallyRunnable.run();
+        }
     }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
@@ -342,14 +342,14 @@ public class CachedSupplierTest {
             for (int i = 0; i < 1000; i++) {
                 CachedSupplier<String> supplier =
                     CachedSupplier.builder(() -> {
-                        invokeSafely(() -> Thread.sleep(100));
-                        return RefreshResult.builder("foo")
-                                            .prefetchTime(now())
-                                            .staleTime(now())
-                                            .build();
-                    }).prefetchStrategy(new NonBlocking("test"))
-                      .prefetchJitterEnabled(false)
-                      .build();
+                                      invokeSafely(() -> Thread.sleep(100));
+                                      return RefreshResult.builder("foo")
+                                                          .prefetchTime(now().plusMillis(1))
+                                                          .staleTime(now().plusSeconds(60))
+                                                          .build();
+                                  }).prefetchStrategy(new NonBlocking("test"))
+                                  .prefetchJitterEnabled(false)
+                                  .build();
                 executor.submit(supplier::get);
                 css.add(supplier);
             }

--- a/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.io.Closeable;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -198,7 +197,7 @@ public class CachedSupplierTest {
         try (WaitingSupplier waitingSupplier = new WaitingSupplier(future(), past())) {
             CachedSupplier<String> cachedSupplier = CachedSupplier.builder(waitingSupplier)
                                                                   .prefetchStrategy(new OneCallerBlocks())
-                                                                  .maxPrefetchJitter(Duration.ZERO)
+                                                                  .prefetchJitterEnabled(false)
                                                                   .build();
 
             // Perform one successful "get" to prime the cache.
@@ -226,7 +225,7 @@ public class CachedSupplierTest {
         try (WaitingSupplier waitingSupplier = new WaitingSupplier(future(), past());
              CachedSupplier<String> cachedSupplier = CachedSupplier.builder(waitingSupplier)
                                                                    .prefetchStrategy(new NonBlocking("test-%s"))
-                                                                   .maxPrefetchJitter(Duration.ZERO)
+                                                                   .prefetchJitterEnabled(false)
                                                                    .build()) {
             // Perform one successful "get" to prime the cache.
             waitingSupplier.permits.release(1);
@@ -248,7 +247,7 @@ public class CachedSupplierTest {
         try (WaitingSupplier waitingSupplier = new WaitingSupplier(now().plusSeconds(62), now());
              CachedSupplier<String> cachedSupplier = CachedSupplier.builder(waitingSupplier)
                                                                    .prefetchStrategy(new NonBlocking("test-%s"))
-                                                                   .maxPrefetchJitter(Duration.ZERO)
+                                                                   .prefetchJitterEnabled(false)
                                                                    .build()) {
             waitingSupplier.permits.release(2);
             cachedSupplier.get();
@@ -315,7 +314,7 @@ public class CachedSupplierTest {
                                                               .staleTime(future())
                                                               .build())
                                   .prefetchStrategy(new NonBlocking("test"))
-                                  .maxPrefetchJitter(Duration.ofMillis(10))
+                                  .prefetchJitterEnabled(false)
                                   .build();
                 supplier.get();
                 css.add(supplier);
@@ -349,7 +348,7 @@ public class CachedSupplierTest {
                                             .staleTime(now())
                                             .build();
                     }).prefetchStrategy(new NonBlocking("test"))
-                      .maxPrefetchJitter(Duration.ZERO)
+                      .prefetchJitterEnabled(false)
                       .build();
                 executor.submit(supplier::get);
                 css.add(supplier);

--- a/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
@@ -310,7 +310,7 @@ public class CachedSupplierTest {
             for (int i = 0; i < 99; i++) {
                 CachedSupplier<String> supplier =
                     CachedSupplier.builder(() -> RefreshResult.builder("foo")
-                                                              .prefetchTime(now())
+                                                              .prefetchTime(now().plusMillis(1))
                                                               .staleTime(future())
                                                               .build())
                                   .prefetchStrategy(new NonBlocking("test"))

--- a/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
@@ -325,7 +325,7 @@ public class CachedSupplierTest {
             }
 
             // Make sure we used less-than 99 to do the refreshes.
-            assertThat(maxActive).isBetween(1, 99);
+            assertThat(maxActive).isBetween(2, 99);
         } finally {
             css.forEach(CachedSupplier::close);
         }
@@ -363,8 +363,7 @@ public class CachedSupplierTest {
             // In a perfect world this would be capped to 100, but the mechanism we use to limit concurrent refreshes usually
             // means more than 100 can get created. 150 should be a reasonable limit to check for, because without the limiter
             // it would be ~1000.
-            System.out.print(maxActive);
-            assertThat(maxActive).isBetween(1, 150);
+            assertThat(maxActive).isBetween(2, 150);
         } finally {
             css.forEach(CachedSupplier::close);
             executor.shutdownNow();

--- a/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/cache/CachedSupplierTest.java
@@ -244,7 +244,7 @@ public class CachedSupplierTest {
 
     @Test
     public void nonBlockingPrefetchStrategyRefreshesInBackground() {
-        try (WaitingSupplier waitingSupplier = new WaitingSupplier(now().plusSeconds(62), now());
+        try (WaitingSupplier waitingSupplier = new WaitingSupplier(now().plusSeconds(62), now().plusSeconds(1));
              CachedSupplier<String> cachedSupplier = CachedSupplier.builder(waitingSupplier)
                                                                    .prefetchStrategy(new NonBlocking("test-%s"))
                                                                    .prefetchJitterEnabled(false)

--- a/utils/src/test/resources/log4j2.properties
+++ b/utils/src/test/resources/log4j2.properties
@@ -1,0 +1,24 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+status = warn
+
+appender.console.type = Console
+appender.console.name = ConsoleAppender
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n%throwable
+
+rootLogger.level = error
+rootLogger.appenderRef.stdout.ref = ConsoleAppender


### PR DESCRIPTION
Fixes #3259.

1. Share thread pools across async credential providers (anything using CachedSupplier's NonBlocking prefetch strategy).
2. Log a warning if an extreme number of concurrent refreshes are happening, to help users detect when they're not closing their credential providers.

Even though this is an increase in resource sharing, it should not cause increased availability risks. Because these threads are only used for background refreshes, if one particular type of credential provider has availability problems (e.g. SSO or STS high latency), it only disables background refreshes, not prefetches or synchronous fetches.