### PR TITLE
Skip Signing of requests which are defined with authtype as none

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-52c39b2.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-52c39b2.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Requests which are defined with AuthType as None should not be signed or authorized by the SDK."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/JsonProtocolSpec.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.NoneAuthTypeRequestTrait;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
 import software.amazon.awssdk.core.SdkPojoBuilder;
@@ -177,7 +178,8 @@ public class JsonProtocolSpec implements ProtocolSpec {
                      .add(".withInput($L)\n", opModel.getInput().getVariableName())
                      .add(".withMetricCollector(apiCallMetricCollector)")
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
-                     .add(HttpChecksumTrait.create(opModel));
+                     .add(HttpChecksumTrait.create(opModel))
+                     .add(NoneAuthTypeRequestTrait.create(opModel));
 
         if (opModel.hasStreamingInput()) {
             codeBlock.add(".withRequestBody(requestBody)")
@@ -245,6 +247,7 @@ public class JsonProtocolSpec implements ProtocolSpec {
                .add(asyncRequestBody)
                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
                .add(HttpChecksumTrait.create(opModel))
+               .add(NoneAuthTypeRequestTrait.create(opModel))
                .add(".withInput($L)$L);",
                     opModel.getInput().getVariableName(), asyncResponseTransformerVariable(isStreaming, isRestJson, opModel));
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/QueryProtocolSpec.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.NoneAuthTypeRequestTrait;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
@@ -113,7 +114,9 @@ public class QueryProtocolSpec implements ProtocolSpec {
                      .add(".withInput($L)", opModel.getInput().getVariableName())
                      .add(".withMetricCollector(apiCallMetricCollector)")
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
-                     .add(HttpChecksumTrait.create(opModel));
+                     .add(HttpChecksumTrait.create(opModel))
+                     .add(NoneAuthTypeRequestTrait.create(opModel));
+
 
         if (opModel.hasStreamingInput()) {
             return codeBlock.add(".withRequestBody(requestBody)")
@@ -145,7 +148,9 @@ public class QueryProtocolSpec implements ProtocolSpec {
                      .add(".withErrorResponseHandler(errorResponseHandler)\n")
                      .add(".withMetricCollector(apiCallMetricCollector)\n")
                      .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
-                     .add(HttpChecksumTrait.create(opModel));
+                     .add(HttpChecksumTrait.create(opModel))
+                     .add(NoneAuthTypeRequestTrait.create(opModel));
+
 
         builder.add(hostPrefixExpression(opModel) + asyncRequestBody + ".withInput($L)$L);",
                     opModel.getInput().getVariableName(),

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/specs/XmlProtocolSpec.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumRequiredTrait;
 import software.amazon.awssdk.codegen.poet.client.traits.HttpChecksumTrait;
+import software.amazon.awssdk.codegen.poet.client.traits.NoneAuthTypeRequestTrait;
 import software.amazon.awssdk.codegen.poet.eventstream.EventStreamUtils;
 import software.amazon.awssdk.codegen.poet.model.EventStreamSpecHelper;
 import software.amazon.awssdk.core.SdkPojoBuilder;
@@ -132,7 +133,9 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                                                     discoveredEndpoint(opModel))
                                                .add(".withInput($L)", opModel.getInput().getVariableName())
                                                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
-                                               .add(HttpChecksumTrait.create(opModel));
+                                               .add(HttpChecksumTrait.create(opModel))
+                                               .add(NoneAuthTypeRequestTrait.create(opModel));
+
 
         s3ArnableFields(opModel, model).ifPresent(codeBlock::add);
 
@@ -207,7 +210,8 @@ public final class XmlProtocolSpec extends QueryProtocolSpec {
                .add(".withMetricCollector(apiCallMetricCollector)\n")
                .add(asyncRequestBody(opModel))
                .add(HttpChecksumRequiredTrait.putHttpChecksumAttribute(opModel))
-               .add(HttpChecksumTrait.create(opModel));
+               .add(HttpChecksumTrait.create(opModel))
+               .add(NoneAuthTypeRequestTrait.create(opModel));
 
         s3ArnableFields(opModel, model).ifPresent(builder::add);
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/NoneAuthTypeRequestTrait.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/traits/NoneAuthTypeRequestTrait.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.client.traits;
+
+import com.squareup.javapoet.CodeBlock;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.model.service.AuthType;
+import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+
+/**
+ * Trait which defines if a given request needs to be authenticated.
+ * A request is not authenticated only if it has "auththpe" trait  explicitly marked as "none"
+ */
+@SdkInternalApi
+public class NoneAuthTypeRequestTrait {
+
+    private NoneAuthTypeRequestTrait() {
+    }
+
+    /**
+     * Generate a ".putExecutionAttribute(...)" code-block for the provided operation model. This should be used within the
+     * context of initializing {@link ClientExecutionParams}. If and only if "authType" trait is explicitly set as "none" the set
+     * the execution attribute as false.
+     */
+    public static CodeBlock create(OperationModel operationModel) {
+
+        if (operationModel.getAuthType() == AuthType.NONE) {
+            CodeBlock.Builder codeBuilder = CodeBlock.builder();
+            codeBuilder.add(CodeBlock.of(".putExecutionAttribute($T.IS_NONE_AUTH_TYPE_REQUEST, $L)",
+                                         SdkInternalExecutionAttribute.class, operationModel.getAuthType() != AuthType.NONE));
+            return codeBuilder.build();
+        } else {
+            return CodeBlock.of("");
+        }
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/json/service-2.json
@@ -22,6 +22,14 @@
       },
       "httpChecksumRequired": true
     },
+    "OperationWithNoneAuthType": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "authtype": "none"
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/service-2.json
@@ -21,6 +21,14 @@
       },
       "httpChecksumRequired": true
     },
+    "OperationWithNoneAuthType": {
+      "name": "APostOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "authtype": "none"
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/xml/service-2.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/xml/service-2.json
@@ -21,6 +21,14 @@
       },
       "httpChecksumRequired": true
     },
+    "OperationWithNoneAuthType": {
+      "name": "NoneAuthTypeOperation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "authtype": "none"
+    },
     "APostOperation": {
       "name": "APostOperation",
       "http": {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -75,6 +75,8 @@ import software.amazon.awssdk.services.json.model.JsonException;
 import software.amazon.awssdk.services.json.model.JsonRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.json.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.json.model.OperationWithNoneAuthTypeRequest;
+import software.amazon.awssdk.services.json.model.OperationWithNoneAuthTypeResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyRequest;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithResultKeyResponse;
 import software.amazon.awssdk.services.json.model.PaginatedOperationWithoutResultKeyRequest;
@@ -99,6 +101,7 @@ import software.amazon.awssdk.services.json.transform.GetWithoutRequiredMembersR
 import software.amazon.awssdk.services.json.transform.InputEventMarshaller;
 import software.amazon.awssdk.services.json.transform.InputEventTwoMarshaller;
 import software.amazon.awssdk.services.json.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.json.transform.OperationWithNoneAuthTypeRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.PaginatedOperationWithoutResultKeyRequestMarshaller;
 import software.amazon.awssdk.services.json.transform.StreamingInputOperationRequestMarshaller;
@@ -607,6 +610,63 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                             .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                     HttpChecksumRequired.create()).withInput(operationWithChecksumRequiredRequest));
             CompletableFuture<OperationWithChecksumRequiredResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);
+            return executeFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithNoneAuthType operation asynchronously.
+     *
+     * @param operationWithNoneAuthTypeRequest
+     * @return A Java Future containing the result of the OperationWithNoneAuthType operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>JsonException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample JsonAsyncClient.OperationWithNoneAuthType
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/json-service-2010-05-08/OperationWithNoneAuthType"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithNoneAuthTypeResponse> operationWithNoneAuthType(
+        OperationWithNoneAuthTypeRequest operationWithNoneAuthTypeRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, operationWithNoneAuthTypeRequest
+            .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Json Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithNoneAuthType");
+            JsonOperationMetadata operationMetadata = JsonOperationMetadata.builder().hasStreamingSuccessResponse(false)
+                                                                           .isPayloadJson(true).build();
+
+            HttpResponseHandler<OperationWithNoneAuthTypeResponse> responseHandler = protocolFactory.createResponseHandler(
+                operationMetadata, OperationWithNoneAuthTypeResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = createErrorResponseHandler(protocolFactory,
+                                                                                                       operationMetadata);
+
+            CompletableFuture<OperationWithNoneAuthTypeResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithNoneAuthTypeRequest, OperationWithNoneAuthTypeResponse>()
+                             .withOperationName("OperationWithNoneAuthType")
+                             .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
+                             .withInput(operationWithNoneAuthTypeRequest));
+            CompletableFuture<OperationWithNoneAuthTypeResponse> whenCompleted = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });
             executeFuture = CompletableFutureUtils.forwardExceptionTo(whenCompleted, executeFuture);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -44,6 +44,8 @@ import software.amazon.awssdk.services.query.model.GetOperationWithChecksumRespo
 import software.amazon.awssdk.services.query.model.InvalidInputException;
 import software.amazon.awssdk.services.query.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.query.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeRequest;
+import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeResponse;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.query.model.QueryException;
@@ -56,6 +58,7 @@ import software.amazon.awssdk.services.query.transform.APostOperationRequestMars
 import software.amazon.awssdk.services.query.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.OperationWithNoneAuthTypeRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.StreamingOutputOperationRequestMarshaller;
@@ -312,6 +315,60 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                                     HttpChecksumRequired.create()).withInput(operationWithChecksumRequiredRequest));
             CompletableFuture<OperationWithChecksumRequiredResponse> whenCompleteFuture = null;
+            whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            return CompletableFutureUtils.forwardExceptionTo(whenCompleteFuture, executeFuture);
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithNoneAuthType operation asynchronously.
+     *
+     * @param operationWithNoneAuthTypeRequest
+     * @return A Java Future containing the result of the OperationWithNoneAuthType operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>QueryException Base class for all service exceptions. Unknown exceptions will be thrown as an
+     *         instance of this type.</li>
+     *         </ul>
+     * @sample QueryAsyncClient.OperationWithNoneAuthType
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/OperationWithNoneAuthType"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithNoneAuthTypeResponse> operationWithNoneAuthType(
+        OperationWithNoneAuthTypeRequest operationWithNoneAuthTypeRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, operationWithNoneAuthTypeRequest
+            .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Query Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithNoneAuthType");
+
+            HttpResponseHandler<OperationWithNoneAuthTypeResponse> responseHandler = protocolFactory
+                .createResponseHandler(OperationWithNoneAuthTypeResponse::builder);
+
+            HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+
+            CompletableFuture<OperationWithNoneAuthTypeResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithNoneAuthTypeRequest, OperationWithNoneAuthTypeResponse>()
+                             .withOperationName("OperationWithNoneAuthType")
+                             .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory))
+                             .withResponseHandler(responseHandler).withErrorResponseHandler(errorResponseHandler)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
+                             .withInput(operationWithNoneAuthTypeRequest));
+            CompletableFuture<OperationWithNoneAuthTypeResponse> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -34,6 +34,8 @@ import software.amazon.awssdk.services.query.model.GetOperationWithChecksumRespo
 import software.amazon.awssdk.services.query.model.InvalidInputException;
 import software.amazon.awssdk.services.query.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.query.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeRequest;
+import software.amazon.awssdk.services.query.model.OperationWithNoneAuthTypeResponse;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.query.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.query.model.QueryException;
@@ -45,6 +47,7 @@ import software.amazon.awssdk.services.query.transform.APostOperationRequestMars
 import software.amazon.awssdk.services.query.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.query.transform.OperationWithNoneAuthTypeRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.query.transform.StreamingOutputOperationRequestMarshaller;
@@ -268,6 +271,51 @@ final class DefaultQueryClient implements QueryClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                                     HttpChecksumRequired.create())
                              .withMarshaller(new OperationWithChecksumRequiredRequestMarshaller(protocolFactory)));
+        } finally {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+        }
+    }
+
+    /**
+     * Invokes the OperationWithNoneAuthType operation.
+     *
+     * @param operationWithNoneAuthTypeRequest
+     * @return Result of the OperationWithNoneAuthType operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws QueryException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample QueryClient.OperationWithNoneAuthType
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/query-service-2010-05-08/OperationWithNoneAuthType"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public OperationWithNoneAuthTypeResponse operationWithNoneAuthType(
+        OperationWithNoneAuthTypeRequest operationWithNoneAuthTypeRequest) throws AwsServiceException, SdkClientException,
+                                                                                  QueryException {
+
+        HttpResponseHandler<OperationWithNoneAuthTypeResponse> responseHandler = protocolFactory
+            .createResponseHandler(OperationWithNoneAuthTypeResponse::builder);
+
+        HttpResponseHandler<AwsServiceException> errorResponseHandler = protocolFactory.createErrorResponseHandler();
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, operationWithNoneAuthTypeRequest
+            .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Query Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithNoneAuthType");
+
+            return clientHandler
+                .execute(new ClientExecutionParams<OperationWithNoneAuthTypeRequest, OperationWithNoneAuthTypeResponse>()
+                             .withOperationName("OperationWithNoneAuthType").withResponseHandler(responseHandler)
+                             .withErrorResponseHandler(errorResponseHandler).withInput(operationWithNoneAuthTypeRequest)
+                             .withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
+                             .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -55,6 +55,8 @@ import software.amazon.awssdk.services.xml.model.GetOperationWithChecksumRespons
 import software.amazon.awssdk.services.xml.model.InvalidInputException;
 import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeRequest;
+import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeResponse;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.xml.model.StreamingInputOperationRequest;
@@ -68,6 +70,7 @@ import software.amazon.awssdk.services.xml.transform.APostOperationWithOutputReq
 import software.amazon.awssdk.services.xml.transform.EventStreamOperationRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.xml.transform.OperationWithNoneAuthTypeRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingOutputOperationRequestMarshaller;
@@ -395,6 +398,59 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                                     HttpChecksumRequired.create()).withInput(operationWithChecksumRequiredRequest));
             CompletableFuture<OperationWithChecksumRequiredResponse> whenCompleteFuture = null;
+            whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
+                metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            });
+            CompletableFutureUtils.forwardExceptionTo(whenCompleteFuture, executeFuture);
+            return whenCompleteFuture;
+        } catch (Throwable t) {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+            return CompletableFutureUtils.failedFuture(t);
+        }
+    }
+
+    /**
+     * Invokes the OperationWithNoneAuthType operation asynchronously.
+     *
+     * @param operationWithNoneAuthTypeRequest
+     * @return A Java Future containing the result of the OperationWithNoneAuthType operation returned by the service.<br/>
+     *         The CompletableFuture returned by this method can be completed exceptionally with the following
+     *         exceptions.
+     *         <ul>
+     *         <li>SdkException Base class for all exceptions that can be thrown by the SDK (both service and client).
+     *         Can be used for catch all scenarios.</li>
+     *         <li>SdkClientException If any client side error occurs such as an IO related failure, failure to get
+     *         credentials, etc.</li>
+     *         <li>XmlException Base class for all service exceptions. Unknown exceptions will be thrown as an instance
+     *         of this type.</li>
+     *         </ul>
+     * @sample XmlAsyncClient.OperationWithNoneAuthType
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/xml-service-2010-05-08/OperationWithNoneAuthType"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public CompletableFuture<OperationWithNoneAuthTypeResponse> operationWithNoneAuthType(
+        OperationWithNoneAuthTypeRequest operationWithNoneAuthTypeRequest) {
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, operationWithNoneAuthTypeRequest
+            .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Xml Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithNoneAuthType");
+
+            HttpResponseHandler<Response<OperationWithNoneAuthTypeResponse>> responseHandler = protocolFactory
+                .createCombinedResponseHandler(OperationWithNoneAuthTypeResponse::builder,
+                                               new XmlOperationMetadata().withHasStreamingSuccessResponse(false));
+
+            CompletableFuture<OperationWithNoneAuthTypeResponse> executeFuture = clientHandler
+                .execute(new ClientExecutionParams<OperationWithNoneAuthTypeRequest, OperationWithNoneAuthTypeResponse>()
+                             .withOperationName("OperationWithNoneAuthType")
+                             .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory))
+                             .withCombinedResponseHandler(responseHandler).withMetricCollector(apiCallMetricCollector)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
+                             .withInput(operationWithNoneAuthTypeRequest));
+            CompletableFuture<OperationWithNoneAuthTypeResponse> whenCompleteFuture = null;
             whenCompleteFuture = executeFuture.whenComplete((r, e) -> {
                 metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
             });

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -36,6 +36,8 @@ import software.amazon.awssdk.services.xml.model.GetOperationWithChecksumRespons
 import software.amazon.awssdk.services.xml.model.InvalidInputException;
 import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredRequest;
 import software.amazon.awssdk.services.xml.model.OperationWithChecksumRequiredResponse;
+import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeRequest;
+import software.amazon.awssdk.services.xml.model.OperationWithNoneAuthTypeResponse;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumRequest;
 import software.amazon.awssdk.services.xml.model.PutOperationWithChecksumResponse;
 import software.amazon.awssdk.services.xml.model.StreamingInputOperationRequest;
@@ -47,6 +49,7 @@ import software.amazon.awssdk.services.xml.transform.APostOperationRequestMarsha
 import software.amazon.awssdk.services.xml.transform.APostOperationWithOutputRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.GetOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.OperationWithChecksumRequiredRequestMarshaller;
+import software.amazon.awssdk.services.xml.transform.OperationWithNoneAuthTypeRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.PutOperationWithChecksumRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingInputOperationRequestMarshaller;
 import software.amazon.awssdk.services.xml.transform.StreamingOutputOperationRequestMarshaller;
@@ -260,6 +263,49 @@ final class DefaultXmlClient implements XmlClient {
                              .putExecutionAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM_REQUIRED,
                                                     HttpChecksumRequired.create())
                              .withMarshaller(new OperationWithChecksumRequiredRequestMarshaller(protocolFactory)));
+        } finally {
+            metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
+        }
+    }
+
+    /**
+     * Invokes the OperationWithNoneAuthType operation.
+     *
+     * @param operationWithNoneAuthTypeRequest
+     * @return Result of the OperationWithNoneAuthType operation returned by the service.
+     * @throws SdkException
+     *         Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *         catch all scenarios.
+     * @throws SdkClientException
+     *         If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws XmlException
+     *         Base class for all service exceptions. Unknown exceptions will be thrown as an instance of this type.
+     * @sample XmlClient.OperationWithNoneAuthType
+     * @see <a href="https://docs.aws.amazon.com/goto/WebAPI/xml-service-2010-05-08/OperationWithNoneAuthType"
+     *      target="_top">AWS API Documentation</a>
+     */
+    @Override
+    public OperationWithNoneAuthTypeResponse operationWithNoneAuthType(
+        OperationWithNoneAuthTypeRequest operationWithNoneAuthTypeRequest) throws AwsServiceException, SdkClientException,
+                                                                                  XmlException {
+
+        HttpResponseHandler<Response<OperationWithNoneAuthTypeResponse>> responseHandler = protocolFactory
+            .createCombinedResponseHandler(OperationWithNoneAuthTypeResponse::builder,
+                                           new XmlOperationMetadata().withHasStreamingSuccessResponse(false));
+        List<MetricPublisher> metricPublishers = resolveMetricPublishers(clientConfiguration, operationWithNoneAuthTypeRequest
+            .overrideConfiguration().orElse(null));
+        MetricCollector apiCallMetricCollector = metricPublishers.isEmpty() ? NoOpMetricCollector.create() : MetricCollector
+            .create("ApiCall");
+        try {
+            apiCallMetricCollector.reportMetric(CoreMetric.SERVICE_ID, "Xml Service");
+            apiCallMetricCollector.reportMetric(CoreMetric.OPERATION_NAME, "OperationWithNoneAuthType");
+
+            return clientHandler
+                .execute(new ClientExecutionParams<OperationWithNoneAuthTypeRequest, OperationWithNoneAuthTypeResponse>()
+                             .withOperationName("OperationWithNoneAuthType").withCombinedResponseHandler(responseHandler)
+                             .withMetricCollector(apiCallMetricCollector).withInput(operationWithNoneAuthTypeRequest)
+                             .putExecutionAttribute(SdkInternalExecutionAttribute.IS_NONE_AUTH_TYPE_REQUEST, false)
+                             .withMarshaller(new OperationWithNoneAuthTypeRequestMarshaller(protocolFactory)));
         } finally {
             metricPublishers.forEach(p -> p.publish(apiCallMetricCollector.collect()));
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -61,6 +61,10 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
     public static final ExecutionAttribute<SdkHttpExecutionAttributes> SDK_HTTP_EXECUTION_ATTRIBUTES =
         new ExecutionAttribute<>("SdkHttpExecutionAttributes");
 
+    public static final ExecutionAttribute<Boolean> IS_NONE_AUTH_TYPE_REQUEST =
+        new ExecutionAttribute<>("IsNoneAuthTypeRequest");
+
+
     private SdkInternalExecutionAttribute() {
     }
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
@@ -185,6 +185,16 @@
       "output":{"shape":"AllTypesStructure"},
       "httpChecksumRequired": true
     },
+    "OperationWithNoneAuthType":{
+      "name":"OperationWithNoneAuthType",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypes"
+      },
+      "input":{"shape":"AllTypesStructure"},
+      "output":{"shape":"AllTypesStructure"},
+      "authtype": "none"
+    },
     "OperationWithRequestChecksumRequired":{
       "name":"OperationWithRequestChecksumRequired",
       "http":{

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
@@ -171,6 +171,16 @@
       "output":{"shape":"AllTypesStructure"},
       "httpChecksumRequired": true
     },
+    "OperationWithNoneAuthType":{
+      "name":"OperationWithNoneAuthType",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2016-03-11/allTypes"
+      },
+      "input":{"shape":"AllTypesStructure"},
+      "output":{"shape":"AllTypesStructure"},
+      "authtype": "none"
+    },
     "StreamingInputOperation":{
       "name":"StreamingInputOperation",
       "http":{

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/NoneAuthTypeRequestTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import io.reactivex.Flowable;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlAsyncClient;
+import software.amazon.awssdk.services.protocolrestxml.ProtocolRestXmlClient;
+
+/**
+ * Verify that the "authtype" C2J trait for request type is honored for each requests.
+ */
+public class NoneAuthTypeRequestTest {
+
+    private SdkHttpClient httpClient;
+    private SdkAsyncHttpClient httpAsyncClient;
+    private ProtocolRestJsonClient jsonClient;
+    private ProtocolRestJsonAsyncClient jsonAsyncClient;
+    private ProtocolRestXmlClient xmlClient;
+    private ProtocolRestXmlAsyncClient xmlAsyncClient;
+
+
+    @Before
+    public void setup() throws IOException {
+        httpClient = Mockito.mock(SdkHttpClient.class);
+        httpAsyncClient = Mockito.mock(SdkAsyncHttpClient.class);
+        jsonClient = initializeSync(ProtocolRestJsonClient.builder()).build();
+        jsonAsyncClient = initializeAsync(ProtocolRestJsonAsyncClient.builder()).build();
+        xmlClient = initializeSync(ProtocolRestXmlClient.builder()).build();
+        xmlAsyncClient = initializeAsync(ProtocolRestXmlAsyncClient.builder()).build();
+
+        SdkHttpFullResponse successfulHttpResponse = SdkHttpResponse.builder()
+                                                                    .statusCode(200)
+                                                                    .putHeader("Content-Length", "0")
+                                                                    .build();
+
+        ExecutableHttpRequest request = Mockito.mock(ExecutableHttpRequest.class);
+
+        Mockito.when(request.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                   .response(successfulHttpResponse)
+                                                                   .build());
+        Mockito.when(httpClient.prepareRequest(any())).thenReturn(request);
+        Mockito.when(httpAsyncClient.execute(any())).thenAnswer(invocation -> {
+            AsyncExecuteRequest asyncExecuteRequest = invocation.getArgument(0, AsyncExecuteRequest.class);
+            asyncExecuteRequest.responseHandler().onHeaders(successfulHttpResponse);
+            asyncExecuteRequest.responseHandler().onStream(Flowable.empty());
+            return CompletableFuture.completedFuture(null);
+        });
+    }
+
+    @Test
+    public void sync_json_authorization_is_absent_for_noneAuthType() {
+        jsonClient.operationWithNoneAuthType(o -> o.booleanMember(true));
+        assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+    }
+
+    @Test
+    public void sync_json_authorization_is_present_for_defaultAuth() {
+        jsonClient.jsonValuesOperation();
+        assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isPresent();
+    }
+
+    @Test
+    public void async_json_authorization_is_absent_for_noneAuthType() {
+        jsonAsyncClient.operationWithNoneAuthType(o -> o.booleanMember(true));
+        assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+    }
+
+    @Test
+    public void async_json_authorization_is_present_for_defaultAuth() {
+        jsonAsyncClient.jsonValuesOperation();
+        assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isPresent();
+    }
+
+    @Test
+    public void sync_xml_authorization_is_absent_for_noneAuthType() {
+        xmlClient.operationWithNoneAuthType(o -> o.booleanMember(true));
+        assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+    }
+
+    @Test
+    public void sync_xml_authorization_is_present_for_defaultAuth() {
+        xmlClient.jsonValuesOperation(json -> json.jsonValueMember("one"));
+        assertThat(getSyncRequest().firstMatchingHeader("Authorization")).isPresent();
+    }
+
+    @Test
+    public void async_xml_authorization_is_absent_for_noneAuthType() {
+        xmlAsyncClient.operationWithNoneAuthType(o -> o.booleanMember(true));
+        assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isNotPresent();
+    }
+
+    @Test
+    public void async_xml_authorization_is_present_for_defaultAuth() {
+        xmlAsyncClient.jsonValuesOperation(json -> json.jsonValueMember("one"));
+        assertThat(getAsyncRequest().firstMatchingHeader("Authorization")).isPresent();
+    }
+
+    private SdkHttpRequest getSyncRequest() {
+        ArgumentCaptor<HttpExecuteRequest> captor = ArgumentCaptor.forClass(HttpExecuteRequest.class);
+        Mockito.verify(httpClient).prepareRequest(captor.capture());
+        return captor.getValue().httpRequest();
+    }
+
+    private SdkHttpRequest getAsyncRequest() {
+        ArgumentCaptor<AsyncExecuteRequest> captor = ArgumentCaptor.forClass(AsyncExecuteRequest.class);
+        Mockito.verify(httpAsyncClient).execute(captor.capture());
+        return captor.getValue().request();
+    }
+
+    private <T extends AwsSyncClientBuilder<T, ?> & AwsClientBuilder<T, ?>> T initializeSync(T syncClientBuilder) {
+        return initialize(syncClientBuilder.httpClient(httpClient).credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("123", "12344"))));
+    }
+
+    private <T extends AwsAsyncClientBuilder<T, ?> & AwsClientBuilder<T, ?>> T initializeAsync(T asyncClientBuilder) {
+        return initialize(asyncClientBuilder.httpClient(httpAsyncClient));
+    }
+
+    private <T extends AwsClientBuilder<T, ?>> T initialize(T clientBuilder) {
+        return clientBuilder.region(Region.US_WEST_2);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
```json

    "SignUp":{
      "name":"SignUp",
      "http":{
        "method":"POST",
        "requestUri":"/"
      },
      "input":{"shape":"SignUpRequest"},
      "output":{"shape":"SignUpResponse"},
      "errors":[
        {"shape":"ResourceNotFoundException"},
      ],
      "authtype":"none"
    },
```
Operations as above explicitly mentions that the `authtype` should be `none`. In such cases the requests should not be authorized and credentials should not be resolved for such requests.

## Modifications
<!--- Describe your changes in detail -->

- Added a new executionAttribute to mark the operations which are authtype as none.
- This executionAttribute is then used while assigning signers and credentials.
- Note that signer is assigned as Null because if we assign a Dumy or NoOp signer its still a signer and should be considered in merics collection, thus to avoid unecessary metrics collection its best to allocate signer as null.
- Credentials as assigned to Annonymous credentials if Auth type is none.

## Testing
- Added Junits
-  Tested cognitoidentityprovider service which had AuthType as none.
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [x] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
