### PR TITLE
Set Accept header for UrlConnectionHttpClient

### DIFF
--- a/.changes/next-release/bugfix-URLConnectionClient-98f14e7.json
+++ b/.changes/next-release/bugfix-URLConnectionClient-98f14e7.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "URL Connection Client",
+    "contributor": "",
+    "description": "Set the `Accept` header for `UrlConnectionHttpClient` because the default one does not comply with RFC 7231. See https://bugs.openjdk.org/browse/JDK-8163921"
+}

--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/Header.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/Header.java
@@ -39,6 +39,8 @@ public final class Header {
 
     public static final String KEEP_ALIVE_VALUE = "keep-alive";
 
+    public static final String ACCEPT = "Accept";
+
     private Header() {
     }
 

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.http.urlconnection;
 
+import static software.amazon.awssdk.http.Header.ACCEPT;
 import static software.amazon.awssdk.http.Header.CONTENT_LENGTH;
 import static software.amazon.awssdk.http.HttpStatusFamily.CLIENT_ERROR;
 import static software.amazon.awssdk.http.HttpStatusFamily.SERVER_ERROR;
@@ -60,6 +61,7 @@ import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.HttpStatusFamily;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.TlsKeyManagersProvider;
 import software.amazon.awssdk.http.TlsTrustManagersProvider;
@@ -148,10 +150,17 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
     }
 
     private HttpURLConnection createAndConfigureConnection(HttpExecuteRequest request) {
-        HttpURLConnection connection = connectionFactory.createConnection(request.httpRequest().getUri());
-        request.httpRequest()
-               .forEachHeader((key, values) -> values.forEach(value -> connection.setRequestProperty(key, value)));
-        invokeSafely(() -> connection.setRequestMethod(request.httpRequest().method().name()));
+        SdkHttpRequest sdkHttpRequest = request.httpRequest();
+        HttpURLConnection connection = connectionFactory.createConnection(sdkHttpRequest.getUri());
+        sdkHttpRequest.forEachHeader((key, values) -> values.forEach(value -> connection.setRequestProperty(key, value)));
+
+        if (!sdkHttpRequest.firstMatchingHeader(ACCEPT).isPresent()) {
+            // Override Accept header because the default one in JDK does not comply with RFC 7231
+            // See: https://bugs.openjdk.org/browse/JDK-8163921
+            connection.setRequestProperty(ACCEPT, "*/*");
+        }
+
+        invokeSafely(() -> connection.setRequestMethod(sdkHttpRequest.method().name()));
         if (request.contentStreamProvider().isPresent()) {
             connection.setDoOutput(true);
         }
@@ -160,8 +169,8 @@ public final class UrlConnectionHttpClient implements SdkHttpClient {
         // See: https://github.com/aws/aws-sdk-java-v2/issues/975
         connection.setInstanceFollowRedirects(false);
 
-        request.httpRequest().firstMatchingHeader(CONTENT_LENGTH).map(Long::parseLong)
-               .ifPresent(connection::setFixedLengthStreamingMode);
+        sdkHttpRequest.firstMatchingHeader(CONTENT_LENGTH).map(Long::parseLong)
+                      .ifPresent(connection::setFixedLengthStreamingMode);
 
         return connection;
     }

--- a/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
+++ b/http-clients/url-connection-client/src/test/java/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClientWireMockTest.java
@@ -14,17 +14,23 @@
  */
 package software.amazon.awssdk.http.urlconnection;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static software.amazon.awssdk.http.Header.ACCEPT;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES;
 
+import java.io.IOException;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.After;
 import org.junit.Test;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpClientTestSuite;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.utils.AttributeMap;
 
 public final class UrlConnectionHttpClientWireMockTest extends SdkHttpClientTestSuite {
@@ -49,6 +55,43 @@ public final class UrlConnectionHttpClientWireMockTest extends SdkHttpClientTest
     public void connectionsAreNotReusedOn5xxErrors() {
         // We cannot support this because the URL connection client doesn't allow us to disable connection reuse
     }
+
+    // https://bugs.openjdk.org/browse/JDK-8163921
+    @Test
+    public void noAcceptHeader_shouldSet() throws IOException {
+        SdkHttpClient client = createSdkHttpClient();
+
+        stubForMockRequest(200);
+
+        SdkHttpFullRequest req = mockSdkRequest("http://localhost:" + mockServer.port(), SdkHttpMethod.POST);
+        HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                          .request(req)
+                                                                          .contentStreamProvider(req.contentStreamProvider()
+                                                                                                    .orElse(null))
+                                                                          .build())
+                                        .call();
+
+        mockServer.verify(postRequestedFor(urlPathEqualTo("/")).withHeader(ACCEPT, equalTo("*/*")));
+    }
+
+    @Test
+    public void hasAcceptHeader_shouldNotOverride() throws IOException {
+        SdkHttpClient client = createSdkHttpClient();
+
+        stubForMockRequest(200);
+
+        SdkHttpFullRequest req = mockSdkRequest("http://localhost:" + mockServer.port(), SdkHttpMethod.POST);
+        req = req.toBuilder().putHeader(ACCEPT, "text/html").build();
+        HttpExecuteResponse rsp = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                          .request(req)
+                                                                          .contentStreamProvider(req.contentStreamProvider()
+                                                                                                    .orElse(null))
+                                                                          .build())
+                                        .call();
+
+        mockServer.verify(postRequestedFor(urlPathEqualTo("/")).withHeader(ACCEPT, equalTo("text/html")));
+    }
+
 
     @After
     public void reset() {

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/SdkHttpClientTestSuite.java
@@ -239,7 +239,7 @@ public abstract class SdkHttpClientTestSuite {
         validateResponse(rsp, returnCode, sdkHttpMethod);
     }
 
-    private void stubForMockRequest(int returnCode) {
+    protected void stubForMockRequest(int returnCode) {
         ResponseDefinitionBuilder responseBuilder = aResponse().withStatus(returnCode)
                                                                .withHeader("Some-Header", "With Value")
                                                                .withBody("hello");
@@ -277,7 +277,7 @@ public abstract class SdkHttpClientTestSuite {
         mockServer.resetMappings();
     }
 
-    private SdkHttpFullRequest mockSdkRequest(String uriString, SdkHttpMethod method) {
+    protected SdkHttpFullRequest mockSdkRequest(String uriString, SdkHttpMethod method) {
         URI uri = URI.create(uriString);
         SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder()
                                                             .uri(uri)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Modifications
Set the `Accept` header for `UrlConnectionHttpClient` because the default one does not comply with RFC 7231. See https://bugs.openjdk.org/browse/JDK-8163921

The change upstream has only been released in JDK 19.  https://github.com/openjdk/jdk/commit/28796cbd1d15de678b80295418f5d1f9f59176a6 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
