### PR TITLE
Disable MD5 checksum at S3 CRT client creation time and propagate checksum algorithm

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.s3.internal.crt;
 
 import static software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute.SDK_HTTP_EXECUTION_ATTRIBUTES;
 import static software.amazon.awssdk.services.s3.internal.crt.S3InternalSdkHttpExecutionAttribute.OPERATION_NAME;
+import static software.amazon.awssdk.services.s3.internal.crt.S3InternalSdkHttpExecutionAttribute.CHECKSUM_SPECS;
 
 import java.net.URI;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -160,10 +161,11 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                 SdkHttpExecutionAttributes.builder()
                                           .put(OPERATION_NAME,
                                                executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME))
+                                          .put(CHECKSUM_SPECS,
+                                               executionAttributes.getAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS))
                                           .build();
 
-            executionAttributes.putAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES,
-                                             attributes);
+            executionAttributes.putAttribute(SDK_HTTP_EXECUTION_ATTRIBUTES, attributes);
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3InternalSdkHttpExecutionAttribute.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3InternalSdkHttpExecutionAttribute.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.services.s3.internal.crt;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.checksums.Algorithm;
+import software.amazon.awssdk.core.checksums.ChecksumSpecs;
 import software.amazon.awssdk.http.SdkHttpExecutionAttribute;
 
 @SdkInternalApi
@@ -26,6 +28,12 @@ public final class S3InternalSdkHttpExecutionAttribute<T> extends SdkHttpExecuti
      */
     public static final S3InternalSdkHttpExecutionAttribute<String> OPERATION_NAME =
         new S3InternalSdkHttpExecutionAttribute<>(String.class);
+
+    /**
+     * The key to indicate the name of the operation
+     */
+    public static final S3InternalSdkHttpExecutionAttribute<ChecksumSpecs> CHECKSUM_SPECS =
+        new S3InternalSdkHttpExecutionAttribute<>(ChecksumSpecs.class);
 
     private S3InternalSdkHttpExecutionAttribute(Class<T> valueClass) {
         super(valueClass);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -52,6 +52,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final int maxConcurrency;
     private final URI endpointOverride;
     private final Executor futureCompletionExecutor;
+    private final boolean contentMd5;
 
     public S3NativeClientConfiguration(Builder builder) {
         this.signingRegion = builder.signingRegion == null ? DefaultAwsRegionProviderChain.builder().build().getRegion().id() :
@@ -76,6 +77,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         this.endpointOverride = builder.endpointOverride;
 
         this.futureCompletionExecutor = resolveAsyncFutureCompletionExecutor(builder.asynConfiguration);
+
+        this.contentMd5 = builder.contentMd5 == null ? false : builder.contentMd5;
     }
 
     public static Builder builder() {
@@ -112,6 +115,10 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
     public Executor futureCompletionExecutor() {
         return futureCompletionExecutor;
+    }
+
+    public boolean isContentMd5() {
+        return contentMd5;
     }
 
     /**
@@ -164,6 +171,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private Integer maxConcurrency;
         private URI endpointOverride;
         private ClientAsyncConfiguration asynConfiguration;
+        private Boolean contentMd5;
 
         private Builder() {
         }
@@ -200,6 +208,11 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         public Builder asyncConfiguration(ClientAsyncConfiguration asyncConfiguration) {
             this.asynConfiguration = asyncConfiguration;
+            return this;
+        }
+
+        public Builder contentMd5(Boolean contentMd5) {
+            this.contentMd5 = contentMd5;
             return this;
         }
 


### PR DESCRIPTION
## Modifications
- Disables MD5 checksum when S3 CRT native client is created. 
- MD5 checksum parameter is added to the native configuration in order to use it more easily if needed
- Propagates the resolved checksum specification to the async client

## Testing
- Verifies an async request with the SDK checksum algorithm set will translate to the correct checksum

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
