### PR TITLE
cleaning up url connection http client dependencies

### DIFF
--- a/http-clients/url-connection-client/pom.xml
+++ b/http-clients/url-connection-client/pom.xml
@@ -61,18 +61,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-            <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <artifactId>service-test-utils</artifactId>
-            <groupId>software.amazon.awssdk</groupId>
-            <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -80,12 +68,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>${awsjavasdk.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>regions</artifactId>
             <version>${awsjavasdk.version}</version>
             <scope>test</scope>
         </dependency>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -143,5 +143,11 @@
             <artifactId>eventstream</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/urlconnection/S3WithUrlHttpClientIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/urlconnection/S3WithUrlHttpClientIntegrationTest.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.http.urlconnection;
+package software.amazon.awssdk.services.s3.urlconnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.testutils.service.AwsTestBase.CREDENTIALS_PROVIDER_CHAIN;
@@ -28,17 +28,16 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpHeaders;
 import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
@@ -65,7 +64,7 @@ public class S3WithUrlHttpClientIntegrationTest {
      * Creates all the test resources for the tests.
      */
     @BeforeClass
-    public static void createResources() throws Exception {
+    public static void createResources() {
         S3ClientBuilder s3ClientBuilder = S3Client.builder()
                                                   .region(REGION)
                                                   .httpClient(UrlConnectionHttpClient.builder().build())


### PR DESCRIPTION
## Motivation and Context
Moving the only integration test to the S3 module removes several dependencies on modules and decreases the risk of circular dependencies. An HTTP client should not need dependencies on a specific service, nor knowledge of AWS regions. 

## Modifications
- Moved the integration test
- Removed the  integration test folder
- Removed dependencies on S3, service test utils and regions

