### PR TITLE
mockServer in WaitersUserAgentTest attached to dynamicPort to prevent failed to bind 8080 exceptions

### DIFF
--- a/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/WaitersUserAgentTest.java
+++ b/services/dynamodb/src/test/java/software/amazon/awssdk/services/dynamodb/WaitersUserAgentTest.java
@@ -48,7 +48,7 @@ import software.amazon.awssdk.services.dynamodb.waiters.DynamoDbWaiter;
 public class WaitersUserAgentTest {
 
     @Rule
-    public WireMockRule mockServer = new WireMockRule(options().notifier(new ConsoleNotifier(true)).dynamicHttpsPort());
+    public WireMockRule mockServer = new WireMockRule(options().notifier(new ConsoleNotifier(true)).dynamicHttpsPort().dynamicPort());
 
     private DynamoDbClient dynamoDbClient;
     private DynamoDbAsyncClient dynamoDbAsyncClient;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
```
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 1.175 s <<< FAILURE! - in software.amazon.awssdk.services.dynamodb.WaitersUserAgentTest
[ERROR] software.amazon.awssdk.services.dynamodb.WaitersUserAgentTest.syncWaiters_shouldHaveWaitersUserAgent  Time elapsed: 1.15 s  <<< ERROR!
com.github.tomakehurst.wiremock.common.FatalStartupException: java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
Caused by: java.lang.RuntimeException: java.io.IOException: Failed to bind to /0.0.0.0:8080
Caused by: java.io.IOException: Failed to bind to /0.0.0.0:8080
Caused by: java.net.BindException: Address already in use
```


## Modifications
<!--- Describe your changes in detail -->
Attaching to dynamic port to prevent the above mentioned exception

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
