### PR TITLE
Add proxy environment variable support to Apache HTTP client

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-224f530.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-224f530.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "haslam22",
+    "description": "Add proxy environment variable support to Apache HTTP client."
+}

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -223,7 +223,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
             return Collections.unmodifiableSet(nonProxyHosts);
         }
         if (useSystemPropertyValues) {
-            if(ProxySystemSetting.NON_PROXY_HOSTS.getStringValue().isPresent()) {
+            if (ProxySystemSetting.NON_PROXY_HOSTS.getStringValue().isPresent()) {
                 return Collections.unmodifiableSet(parseNonProxyHostsProperty());
             }
         }
@@ -336,15 +336,15 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
     }
 
     public String resolveScheme() {
-        if(endpoint != null) {
+        if (endpoint != null) {
             return endpoint.getScheme();
         }
-        if(useSystemPropertyValues) {
-            if(ProxySystemSetting.PROXY_HOST.getStringValue().isPresent()) {
+        if (useSystemPropertyValues) {
+            if (ProxySystemSetting.PROXY_HOST.getStringValue().isPresent()) {
                 return "http";
             }
         }
-        if(useEnvironmentVariables) {
+        if (useEnvironmentVariables) {
             Optional<String> httpsProxy = ProxyEnvironmentSetting.HTTPS_PROXY.getStringValue();
             Optional<String> httpProxy = ProxyEnvironmentSetting.HTTP_PROXY.getStringValue();
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/EnvironmentProxyUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/EnvironmentProxyUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+@SdkProtectedApi
+public final class EnvironmentProxyUtils {
+
+    private EnvironmentProxyUtils() {
+    }
+
+    public static Optional<String> parseHost(String proxyEnvValue) {
+        try {
+            URL proxyUrl = new URL(proxyEnvValue);
+            return Optional.of(proxyUrl.getHost());
+        } catch (MalformedURLException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<Integer> parsePort(String proxyEnvValue) {
+        try {
+            URL proxyUrl = new URL(proxyEnvValue);
+            return Optional.of(proxyUrl.getPort());
+        } catch (MalformedURLException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<String> parseUsername(String proxyEnvValue) {
+        String[] proxyUserParts = parseProxyUserInfoParts(proxyEnvValue);
+        return proxyUserParts != null ? Optional.of(proxyUserParts[0]) : Optional.empty();
+    }
+
+    public static Optional<String> parsePassword(String proxyEnvValue) {
+        String[] proxyUserParts = parseProxyUserInfoParts(proxyEnvValue);
+        return proxyUserParts != null ? Optional.of(proxyUserParts[1]) : Optional.empty();
+    }
+
+    public static Set<String> parseNonProxyHosts(String noProxyEnvValue) {
+        return Stream.of(noProxyEnvValue.split(",")).collect(Collectors.toSet());
+    }
+
+    private static String[] parseProxyUserInfoParts(String proxyEnvValue) {
+        try {
+            URL proxyUrl = new URL(proxyEnvValue);
+            if (proxyUrl.getUserInfo() != null) {
+                return proxyUrl.getUserInfo().split(":", 2);
+            }
+        } catch (MalformedURLException e) {
+            return null;
+        }
+        return null;
+    }
+
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/EnvironmentProxyUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/EnvironmentProxyUtils.java
@@ -41,7 +41,16 @@ public final class EnvironmentProxyUtils {
     public static Optional<Integer> parsePort(String proxyEnvValue) {
         try {
             URL proxyUrl = new URL(proxyEnvValue);
-            return Optional.of(proxyUrl.getPort());
+            return proxyUrl.getPort() == -1 ? Optional.empty() : Optional.of(proxyUrl.getPort());
+        } catch (MalformedURLException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<String> parseProtocol(String proxyEnvValue) {
+        try {
+            URL proxyUrl = new URL(proxyEnvValue);
+            return Optional.of(proxyUrl.getProtocol());
         } catch (MalformedURLException e) {
             return Optional.empty();
         }

--- a/utils/src/main/java/software/amazon/awssdk/utils/ProxyEnvironmentSetting.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ProxyEnvironmentSetting.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import static software.amazon.awssdk.utils.internal.SystemSettingUtils.resolveEnvironmentVariable;
+
+import java.util.Locale;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * Environment variables used to set a proxy
+ */
+@SdkProtectedApi
+public enum ProxyEnvironmentSetting implements SystemSetting {
+
+    HTTP_PROXY("http_proxy"),
+    HTTPS_PROXY("https_proxy"),
+    NO_PROXY("no_proxy")
+    ;
+
+    private final String environmentVariable;
+
+    ProxyEnvironmentSetting(String environmentVariable) {
+        this.environmentVariable = environmentVariable;
+    }
+
+    @Override
+    public Optional<String> getStringValue() {
+        Optional<String> envVarLowercase = resolveEnvironmentVariable(environmentVariable);
+        if (envVarLowercase.isPresent() && !envVarLowercase.get().trim().isEmpty()) {
+            return envVarLowercase.map(String::trim);
+        }
+
+        Optional<String> envVarUppercase = resolveEnvironmentVariable(environmentVariable.toUpperCase(Locale.getDefault()));
+        if (envVarUppercase.isPresent() && !envVarUppercase.get().trim().isEmpty()) {
+            return envVarUppercase.map(String::trim);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String property() {
+        return null;
+    }
+
+    @Override
+    public String environmentVariable() {
+        return environmentVariable;
+    }
+
+    @Override
+    public String defaultValue() {
+        return null;
+    }
+
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/EnvironmentProxyUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/EnvironmentProxyUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class EnvironmentProxyUtilsTest {
+
+    @Test
+    void testParseHost() {
+        assertEquals("1.2.3.4", EnvironmentProxyUtils.parseHost("http://1.2.3.4:8080").get());
+        assertEquals("localhost", EnvironmentProxyUtils.parseHost("http://localhost:8080").get());
+        assertEquals("subdomain.proxy.com", EnvironmentProxyUtils.parseHost("http://subdomain.proxy.com:8080").get());
+        assertEquals("proxy.com", EnvironmentProxyUtils.parseHost("http://proxy.com:8080").get());
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parseHost("invalid-value"));
+    }
+
+    @Test
+    void testParsePort() {
+        assertEquals(8080, EnvironmentProxyUtils.parsePort("http://username:password@host.com:8080").get());
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parsePort("http://username:password@host.com:-2000"));
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parsePort("http://username:password@host.com"));
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parsePort("invalid-value"));
+    }
+
+    @Test
+    void testParseProtocol() {
+        assertEquals("http", EnvironmentProxyUtils.parseProtocol("http://host.com:8080").get());
+        assertEquals("https", EnvironmentProxyUtils.parseProtocol("https://host.com:8080").get());
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parseProtocol("host.com:8080"));
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parseProtocol("invalid-value"));
+    }
+
+    @Test
+    void testParseUsername() {
+        assertEquals("username", EnvironmentProxyUtils.parseUsername("http://username:password@host.com:8080").get());
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parseUsername("http://host.com:8080"));
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parseUsername("invalid-value"));
+    }
+
+    @Test
+    void testParsePassword() {
+        assertEquals("password", EnvironmentProxyUtils.parsePassword("http://username:password@host.com:8080").get());
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parsePassword("http://host.com:8080"));
+        assertEquals(Optional.empty(), EnvironmentProxyUtils.parsePassword("invalid-value"));
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
SDK v2 does not have any built-in functionality to detect and parse proxies defined in the environment:

```
http_proxy=http://myproxy.com:8080
https_proxy=http://myproxy.com:8080
no_proxy=host1,host,host3
```

This makes upgrading from SDK v1 to SDK v2 a pain because SDK v1 automatically detected these proxies and configured them appropriately.

Fixes #2958

## Modifications
<!--- Describe your changes in detail -->

The `ProxyConfiguration` class now exposes a `useEnvironmentVariables` field similar to the existing `useSystemProperties` field.
When enabled, the following environment variables are queried: `https_proxy, http_proxy, no_proxy` and the appropriate values (host, port, protocol, etc) are extracted and used in `ProxyConfiguration`.

Some further notes:
- `https_proxy` takes priority over `http_proxy` - by default the SDK seems to make HTTPS connections.
- Explicit configuration takes precedence, followed by system property values, followed by environment variables.
- Both lowercase and uppercase environment variables are detected, with lowercase being checked first.
- Present but empty environment variables are treated as not present.
- The `useEnvironmentVariables` field is set to disabled by default to be non-breaking and not surprise users with new environment variables being picked up. Drawback is that this needs to be explicitly set to `true`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added to `ProxyConfigurationTest` to cover:

- Environment variables are parsed correctly (incl. `no_proxy`)
- Malformed environment variables do not break the SDK and are ignored
- Precedence is respected (explicit configuration first, then system properties, then environment variables)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
