### PR TITLE
Added Junit for request with HeadObject and gzipped enabled

### DIFF
--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/HeadObjectIntegrationTest.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/HeadObjectIntegrationTest.java
@@ -15,18 +15,22 @@
 
 package software.amazon.awssdk.http.urlconnection;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import java.util.zip.GZIPOutputStream;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 public class HeadObjectIntegrationTest extends UrlHttpConnectionS3IntegrationTestBase {
@@ -34,7 +38,7 @@ public class HeadObjectIntegrationTest extends UrlHttpConnectionS3IntegrationTes
 
     private static final String GZIPPED_KEY = "some-key";
 
-    @BeforeClass
+    @BeforeAll
     public static void setupFixture() throws IOException {
         createBucket(BUCKET);
 
@@ -50,15 +54,23 @@ public class HeadObjectIntegrationTest extends UrlHttpConnectionS3IntegrationTes
                      RequestBody.fromBytes(baos.toByteArray()));
     }
 
+    @AfterAll
+    public static void cleanup() {
+        deleteBucketAndAllContents(BUCKET);
+    }
+
     @Test
     public void syncClientSupportsGzippedObjects() {
         HeadObjectResponse response = s3.headObject(r -> r.bucket(BUCKET).key(GZIPPED_KEY));
-        assertThat(response.contentEncoding()).isEqualTo("gzip");
+        assertEquals(response.contentEncoding(), "gzip");
     }
 
-    @AfterClass
-    public static void cleanup() {
-        deleteBucketAndAllContents(BUCKET);
+    @Test
+    public void syncClient_throwsRightException_withGzippedObjects() {
+
+        assertThrows(NoSuchBucketException.class,
+                     () -> s3.headObject(r -> r.bucket(BUCKET + UUID.randomUUID()).key(GZIPPED_KEY)));
+
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Handle comment mentioned in https://github.com/aws/aws-sdk-java-v2/pull/3346#discussion_r941812708

## Modifications
<!--- Describe your changes in detail -->
- There is no need to add a specific check like `responseHasNoContent()` for errorStream as done for inputStream in https://github.com/aws/aws-sdk-java-v2/pull/3346 for following reasons

- Unlike inputStream where the InputStream is explicitly set to [emptyStream](https://github.com/JetBrains/jdk8u_jdk/blob/94318f9185757cc33d2b8d527d36be26ac6b7582/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L1858)  for `method.equals("HEAD")`  the HttpURLConnection does not do such thing for  error Responses , it straight away passed this to delegates as 
https://github.com/JetBrains/jdk8u_jdk/blob/master/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L1961-L1970

- Also the service sends error response as Null .
- Lets assume Service sends some error response in that case the Content-encoding will not be "gzip" for this error response.  [DeCompressCheck](https://github.com/aws/aws-sdk-java-v2/blob/2879b9581a5c4427665ce111478c81d0630cbb71/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/Crc32Validation.java#L78-L82) will fail for errorResponse since service will not send this for error cases , if they send this then it means they need actual decompression.

Thus if we forcefully set the errorStream as Null for  `method.equals("HEAD")`  then we will end up masking the error stream .




## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junit in case of error response.

## Screenshots (if appropriate)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
