### PR TITLE
Upgrading all the Integ test case of UrlHttpClient to junit 5

### DIFF
--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/EmptyFileS3IntegrationTest.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/EmptyFileS3IntegrationTest.java
@@ -18,21 +18,21 @@ package software.amazon.awssdk.http.urlconnection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class EmptyFileS3IntegrationTest extends UrlHttpConnectionS3IntegrationTestBase {
     private static final String BUCKET = temporaryBucketName(EmptyFileS3IntegrationTest.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         createBucket(BUCKET);
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         deleteBucketAndAllContents(BUCKET);
     }

--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/HeadObjectIntegrationTest.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/HeadObjectIntegrationTest.java
@@ -16,17 +16,20 @@
 package software.amazon.awssdk.http.urlconnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.awssdk.testutils.service.S3BucketUtils.temporaryBucketName;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import java.util.zip.GZIPOutputStream;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 public class HeadObjectIntegrationTest extends UrlHttpConnectionS3IntegrationTestBase {
@@ -34,7 +37,7 @@ public class HeadObjectIntegrationTest extends UrlHttpConnectionS3IntegrationTes
 
     private static final String GZIPPED_KEY = "some-key";
 
-    @BeforeClass
+    @BeforeAll
     public static void setupFixture() throws IOException {
         createBucket(BUCKET);
 
@@ -56,7 +59,14 @@ public class HeadObjectIntegrationTest extends UrlHttpConnectionS3IntegrationTes
         assertThat(response.contentEncoding()).isEqualTo("gzip");
     }
 
-    @AfterClass
+    @Test
+    public void syncClient_throwsRightException_withGzippedObjects() {
+        assertThrows(NoSuchKeyException.class,
+                     () -> s3.headObject(r -> r.bucket(BUCKET + UUID.randomUUID()).key(GZIPPED_KEY)));
+
+    }
+
+    @AfterAll
     public static void cleanup() {
         deleteBucketAndAllContents(BUCKET);
     }

--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/S3WithUrlHttpClientIntegrationTest.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/S3WithUrlHttpClientIntegrationTest.java
@@ -24,11 +24,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -38,7 +37,6 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketConfiguration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
@@ -64,7 +62,7 @@ public class S3WithUrlHttpClientIntegrationTest {
     /**
      * Creates all the test resources for the tests.
      */
-    @BeforeClass
+    @BeforeAll
     public static void createResources() throws Exception {
         S3ClientBuilder s3ClientBuilder = S3Client.builder()
                                                   .region(REGION)
@@ -82,13 +80,13 @@ public class S3WithUrlHttpClientIntegrationTest {
     /**
      * Releases all resources created in this test.
      */
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         deleteObject(BUCKET_NAME, KEY);
         deleteBucket(BUCKET_NAME);
     }
 
-    @Before
+    @BeforeEach
     public void methodSetup() {
         capturingInterceptor.reset();
     }

--- a/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/UrlHttpConnectionS3IntegrationTestBase.java
+++ b/http-clients/url-connection-client/src/it/java/software/amazon/awssdk/http/urlconnection/UrlHttpConnectionS3IntegrationTestBase.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.http.urlconnection;
 
 import java.util.Iterator;
 import java.util.List;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -48,7 +48,7 @@ public class UrlHttpConnectionS3IntegrationTestBase extends AwsTestBase {
      * Loads the AWS account info for the integration tests and creates an S3
      * client for tests to use.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         s3 = s3ClientBuilder().build();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- UrlHttp Client's Integ test cases were failing because base class was of Junit 4 and main class had junit 5 annotations

## Modifications
<!--- Describe your changes in detail -->
