### PR TITLE
Pass endpoint override to S3 CRT Async HTTP client. 

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.internal.crt;
 
 import static software.amazon.awssdk.services.s3.internal.crt.S3InternalSdkHttpExecutionAttribute.OPERATION_NAME;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -91,13 +92,18 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         S3MetaRequestOptions requestOptions = new S3MetaRequestOptions()
             .withHttpRequest(httpRequest)
             .withMetaRequestType(requestType)
-            .withResponseHandler(responseHandler);
+            .withResponseHandler(responseHandler)
+            .withEndpoint(getEndpoint(uri));
 
         try (S3MetaRequest s3MetaRequest = crtS3Client.makeMetaRequest(requestOptions)) {
             closeResourcesWhenComplete(executeFuture, s3MetaRequest, responseHandler);
         }
 
         return executeFuture;
+    }
+
+    private static URI getEndpoint(URI uri) {
+        return invokeSafely(() -> new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), null, null, null));
     }
 
     @Override

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
@@ -84,6 +84,7 @@ public class S3CrtAsyncHttpClientTest {
         S3MetaRequestOptions actual = s3MetaRequestOptionsArgumentCaptor.getValue();
         assertThat(actual.getMetaRequestType()).isEqualTo(S3MetaRequestOptions.MetaRequestType.DEFAULT);
         assertThat(actual.getCredentialsProvider()).isNull();
+        assertThat(actual.getEndpoint()).isEqualTo(URI.create(DEFAULT_ENDPOINT.getScheme() + "://" + DEFAULT_ENDPOINT.getHost()));
 
         HttpRequest httpRequest = actual.getHttpRequest();
         assertThat(httpRequest.getEncodedPath()).isEqualTo("/key");


### PR DESCRIPTION
This is the first part of fixing endpoint overrides in transfer manager. The next part will be in the CRT.