### PR TITLE
Generate rules create at build + fixes

### DIFF
--- a/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
+++ b/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
@@ -47,6 +47,7 @@ public class GenerationMojo extends AbstractMojo {
     private static final String CUSTOMIZATION_CONFIG_FILE = "customization.config";
     private static final String WAITERS_FILE = "waiters-2.json";
     private static final String PAGINATORS_FILE = "paginators-1.json";
+    private static final String ENDPOINT_RULE_SET_FILE = "endpoint-rule-set.json";
 
     @Parameter(property = "codeGenResources", defaultValue = "${basedir}/src/main/resources/codegen-resources/")
     private File codeGenResources;

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -117,11 +117,6 @@
             <artifactId>protocol-core</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>json-utils</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
 
         <dependency>
             <artifactId>org.eclipse.jdt.core</artifactId>

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/GeneratorPathProvider.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/GeneratorPathProvider.java
@@ -68,4 +68,13 @@ public class GeneratorPathProvider {
     public String getWaitersInternalDirectory() {
         return sourceDirectory + "/" + Utils.packageToDirectory(model.getMetadata().getFullWaitersInternalPackageName());
     }
+
+    public String getEndpointRulesDirectory() {
+        return sourceDirectory + "/" + Utils.packageToDirectory(model.getMetadata().getFullEndpointRulesPackageName());
+    }
+
+
+    public String getEndpointRulesInternalDirectory() {
+        return sourceDirectory + "/" + Utils.packageToDirectory(model.getMetadata().getFullInternalEndpointRulesPackageName());
+    }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/ConditionModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/ConditionModel.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.rules.endpoints;
+
+import com.fasterxml.jackson.core.TreeNode;
+import java.util.List;
+
+public class ConditionModel {
+    private String fn;
+    private List<TreeNode> argv;
+    private String assign;
+
+    public String getFn() {
+        return fn;
+    }
+
+    public void setFn(String fn) {
+        this.fn = fn;
+    }
+
+    public String getAssign() {
+        return assign;
+    }
+
+    public void setAssign(String assign) {
+        this.assign = assign;
+    }
+
+    public List<TreeNode> getArgv() {
+        return argv;
+    }
+
+    public void setArgv(List<TreeNode> argv) {
+        this.argv = argv;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/EndpointModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/EndpointModel.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.rules.endpoints;
+
+import com.fasterxml.jackson.core.TreeNode;
+
+public class EndpointModel {
+    private TreeNode url;
+
+    public TreeNode getUrl() {
+        return url;
+    }
+
+    public void setUrl(TreeNode url) {
+        this.url = url;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/ParameterDeprecatedModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/ParameterDeprecatedModel.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.rules.endpoints;
+
+public class ParameterDeprecatedModel {
+    private String message;
+    private String since;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getSince() {
+        return since;
+    }
+
+    public void setSince(String since) {
+        this.since = since;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/ParameterModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/ParameterModel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.rules.endpoints;
+
+import com.fasterxml.jackson.core.TreeNode;
+
+public class ParameterModel {
+    private String type;
+    private String builtIn;
+    private TreeNode defaultValue;
+    private Boolean required;
+    private ParameterDeprecatedModel deprecated;
+    private String documentation;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getBuiltIn() {
+        return builtIn;
+    }
+
+    public void setBuiltIn(String builtIn) {
+        this.builtIn = builtIn;
+    }
+
+    public TreeNode getDefault() {
+        return defaultValue;
+    }
+
+    public void setDefault(TreeNode defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public Boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+
+    public ParameterDeprecatedModel getDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(ParameterDeprecatedModel deprecated) {
+        this.deprecated = deprecated;
+    }
+
+    public String getDocumentation() {
+        return documentation;
+    }
+
+    public void setDocumentation(String documentation) {
+        this.documentation = documentation;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/RuleModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/rules/endpoints/RuleModel.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.model.rules.endpoints;
+
+import java.util.List;
+
+public class RuleModel {
+    private String type;
+    private List<ConditionModel> conditions;
+
+    // for type == error
+    private String error;
+
+    // for type == tree
+    private List<RuleModel> rules;
+
+    // for type == endpoint
+    private EndpointModel endpoint;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<ConditionModel> getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(List<ConditionModel> conditions) {
+        this.conditions = conditions;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public List<RuleModel> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<RuleModel> rules) {
+        this.rules = rules;
+    }
+
+    public EndpointModel getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(EndpointModel endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/EndpointRuleSetModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/service/EndpointRuleSetModel.java
@@ -15,15 +15,16 @@
 
 package software.amazon.awssdk.codegen.model.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.RuleModel;
 
 public class EndpointRuleSetModel {
     private String serviceId;
     private String version;
     private Map<String, ParameterModel> parameters;
-    private List<JsonNode> rules;
+    private List<RuleModel> rules;
 
     public String getServiceId() {
         return serviceId;
@@ -49,11 +50,11 @@ public class EndpointRuleSetModel {
         this.parameters = parameters;
     }
 
-    public List<JsonNode> getRules() {
+    public List<RuleModel> getRules() {
         return rules;
     }
 
-    public void setRules(List<JsonNode> rules) {
+    public void setRules(List<RuleModel> rules) {
         this.rules = rules;
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -32,6 +32,7 @@ public class AsyncClientBuilderClass implements ClassSpec {
     private final ClassName builderInterfaceName;
     private final ClassName builderClassName;
     private final ClassName builderBaseClassName;
+    // private final EndpointRulesSpecUtils endpointRulesSpecUtils;
 
     public AsyncClientBuilderClass(IntermediateModel model) {
         String basePackage = model.getMetadata().getFullClientPackageName();
@@ -41,6 +42,7 @@ public class AsyncClientBuilderClass implements ClassSpec {
         this.builderInterfaceName = ClassName.get(basePackage, model.getMetadata().getAsyncBuilderInterface());
         this.builderClassName = ClassName.get(basePackage, model.getMetadata().getAsyncBuilder());
         this.builderBaseClassName = ClassName.get(basePackage, model.getMetadata().getBaseBuilder());
+        // this.endpointRulesSpecUtils = new EndpointRulesSpecUtils(model);
     }
 
     @Override
@@ -60,6 +62,8 @@ public class AsyncClientBuilderClass implements ClassSpec {
                 builder.addMethod(enableEndpointDiscovery());
             }
         }
+
+        // builder.addMethod(endpointProviderMethod());
 
         return builder.addMethod(buildClientMethod()).build();
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointParametersClassSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointParametersClassSpec.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
 
 public class EndpointParametersClassSpec implements ClassSpec {
     private final IntermediateModel intermediateModel;
@@ -125,7 +126,7 @@ public class EndpointParametersClassSpec implements ClassSpec {
     }
 
     private MethodSpec setterMethodDeclaration(String name, ParameterModel model) {
-        return MethodSpec.methodBuilder(Utils.unCapitalize(name))
+        return MethodSpec.methodBuilder(paramMethodName(name))
                          .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                          .addParameter(parameterSpec(name, model))
                          .returns(builderInterfaceName())
@@ -133,7 +134,7 @@ public class EndpointParametersClassSpec implements ClassSpec {
     }
 
     private MethodSpec accessorMethod(String name, ParameterModel model) {
-        return MethodSpec.methodBuilder(Utils.unCapitalize(name))
+        return MethodSpec.methodBuilder(paramMethodName(name))
                          .returns(endpointRulesSpecUtils.parameterType(model))
                          .addModifiers(Modifier.PUBLIC)
                          .addStatement("return $N", name)
@@ -141,7 +142,7 @@ public class EndpointParametersClassSpec implements ClassSpec {
     }
 
     private MethodSpec builderSetterMethod(String name, ParameterModel model) {
-        return MethodSpec.methodBuilder(Utils.unCapitalize(name))
+        return MethodSpec.methodBuilder(paramMethodName(name))
                          .addParameter(parameterSpec(name, model))
                          .addAnnotation(Override.class)
                          .addModifiers(Modifier.PUBLIC)
@@ -173,5 +174,8 @@ public class EndpointParametersClassSpec implements ClassSpec {
                          .build();
     }
 
+    private String paramMethodName(String name) {
+        return Utils.unCapitalize(CodegenNamingUtils.pascalCase(name));
+    }
 
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderInterfaceSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderInterfaceSpec.java
@@ -34,8 +34,10 @@ public class EndpointProviderInterfaceSpec implements ClassSpec {
     @Override
     public TypeSpec poetSpec() {
         return TypeSpec.interfaceBuilder(className())
+                       .addModifiers(Modifier.PUBLIC)
                        .addAnnotation(SdkPublicApi.class)
                        .addMethod(resolveEndpointMethod())
+                       .addMethod(defaultProviderMethod())
                        .build();
     }
 
@@ -44,6 +46,14 @@ public class EndpointProviderInterfaceSpec implements ClassSpec {
                          .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
             .addParameter(endpointRulesSpecUtils.parametersClassName(), "endpointParams")
             .returns(Endpoint.class)
+                         .build();
+    }
+
+    private MethodSpec defaultProviderMethod() {
+        return MethodSpec.methodBuilder("defaultProvider")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(className())
+            .addStatement("return new $T()", endpointRulesSpecUtils.providerDefaultImplName())
                          .build();
     }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -18,8 +18,13 @@ package software.amazon.awssdk.codegen.poet.rules;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
+import java.util.Locale;
+import software.amazon.awssdk.codegen.internal.Utils;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.Metadata;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.core.rules.Value;
+import software.amazon.awssdk.regions.Region;
 
 public class EndpointRulesSpecUtils {
     private final IntermediateModel intermediateModel;
@@ -40,8 +45,18 @@ public class EndpointRulesSpecUtils {
         return ClassName.get(basePackage(), intermediateModel.getMetadata().getServiceName() + "EndpointProvider");
     }
 
+    public ClassName providerDefaultImplName() {
+        Metadata md = intermediateModel.getMetadata();
+        return ClassName.get(md.getFullInternalEndpointRulesPackageName(),
+                             "Default" + providerInterfaceName().simpleName());
+    }
+
+    public String paramSetterName(String param) {
+        return Utils.unCapitalize(param);
+    }
+
     public TypeName toJavaType(String type) {
-        switch (type) {
+        switch (type.toLowerCase(Locale.ENGLISH)) {
             case "boolean":
                 return TypeName.get(Boolean.class);
             case "string":
@@ -53,7 +68,7 @@ public class EndpointRulesSpecUtils {
 
     public CodeBlock valueCreationCode(String type, CodeBlock param) {
         String methodName;
-        switch (type) {
+        switch (type.toLowerCase(Locale.ENGLISH)) {
             case "boolean":
                 methodName = "fromBool";
                 break;
@@ -67,5 +82,16 @@ public class EndpointRulesSpecUtils {
         return CodeBlock.builder()
                         .add("$T.$N($L)", Value.class, methodName, param)
                         .build();
+    }
+
+    public TypeName parameterType(ParameterModel param) {
+        if (param.getBuiltIn() == null) {
+            return toJavaType(param.getType());
+        }
+
+        if ("aws::region".equals(param.getBuiltIn().toLowerCase(Locale.ENGLISH))) {
+            return ClassName.get(Region.class);
+        }
+        return ClassName.get(Boolean.class);
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -38,7 +38,7 @@ public class EndpointRulesSpecUtils {
     }
 
     public ClassName parametersClassName() {
-        return ClassName.get(basePackage(), intermediateModel.getMetadata().getServiceName() + "EndpointParameters");
+        return ClassName.get(basePackage(), intermediateModel.getMetadata().getServiceName() + "EndpointParams");
     }
 
     public ClassName providerInterfaceName() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RuleSetCreationSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RuleSetCreationSpec.java
@@ -36,7 +36,7 @@ import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.model.rules.endpoints.RuleModel;
 import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
 import software.amazon.awssdk.core.rules.Condition;
-import software.amazon.awssdk.core.rules.Endpoint;
+import software.amazon.awssdk.core.rules.EndpointResult;
 import software.amazon.awssdk.core.rules.EndpointRuleset;
 import software.amazon.awssdk.core.rules.Expr;
 import software.amazon.awssdk.core.rules.FnNode;
@@ -163,7 +163,7 @@ public class RuleSetCreationSpec {
     private CodeBlock endpoint(EndpointModel model) {
         CodeBlock.Builder b = CodeBlock.builder();
 
-        b.add("$T.builder()", Endpoint.class);
+        b.add("$T.builder()", EndpointResult.class);
 
         TreeNode url = model.getUrl();
         b.add(".url($L)", expr(url));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RuleSetCreationSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RuleSetCreationSpec.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.rules;
+
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.jr.stree.JrsArray;
+import com.fasterxml.jackson.jr.stree.JrsBoolean;
+import com.fasterxml.jackson.jr.stree.JrsNumber;
+import com.fasterxml.jackson.jr.stree.JrsObject;
+import com.fasterxml.jackson.jr.stree.JrsString;
+import com.fasterxml.jackson.jr.stree.JrsValue;
+import com.squareup.javapoet.CodeBlock;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ConditionModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.EndpointModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterDeprecatedModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.RuleModel;
+import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
+import software.amazon.awssdk.core.rules.Condition;
+import software.amazon.awssdk.core.rules.Endpoint;
+import software.amazon.awssdk.core.rules.EndpointRuleset;
+import software.amazon.awssdk.core.rules.Expr;
+import software.amazon.awssdk.core.rules.FnNode;
+import software.amazon.awssdk.core.rules.Identifier;
+import software.amazon.awssdk.core.rules.Parameter;
+import software.amazon.awssdk.core.rules.ParameterType;
+import software.amazon.awssdk.core.rules.Parameters;
+import software.amazon.awssdk.core.rules.Rule;
+
+public class RuleSetCreationSpec {
+    private final EndpointRulesSpecUtils endpointRulesSpecUtils;
+    private final EndpointRuleSetModel ruleSetModel;
+
+    public RuleSetCreationSpec(IntermediateModel intermediateModel) {
+        this.endpointRulesSpecUtils = new EndpointRulesSpecUtils(intermediateModel);
+        this.ruleSetModel = intermediateModel.getEndpointRuleSetModel();
+    }
+
+    public CodeBlock ruleSetCreationExpr() {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", EndpointRuleset.class)
+            .add(".version($S)", ruleSetModel.getVersion())
+            .add(".serviceId($S)", ruleSetModel.getServiceId())
+            .add(".parameters($L)", parameters(ruleSetModel.getParameters()));
+
+        ruleSetModel.getRules().forEach(rm -> b.add(".addRule($L)", rule(rm)));
+
+        b.add(".build()");
+        return b.build();
+    }
+
+    private CodeBlock parameters(Map<String, ParameterModel> params) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", Parameters.class);
+
+        params.forEach((name, model) -> {
+            b.add(".addParameter($L)", parameter(name, model));
+        });
+
+        b.add(".build()");
+
+        return b.build();
+    }
+
+    private CodeBlock parameter(String name, ParameterModel model) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", Parameter.class)
+            .add(".name($S)", name)
+            .add(".type($T.fromValue($S))", ParameterType.class, model.getType())
+            .add(".required($L)", Boolean.TRUE.equals(model.isRequired()));
+
+        if (model.getBuiltIn() != null) {
+            b.add(".builtIn($S)", model.getBuiltIn());
+        }
+
+        if (model.getDocumentation() != null) {
+            b.add(".documentation($S)", model.getDocumentation());
+        }
+
+        if (model.getDefault() != null) {
+            TreeNode defaultValue = model.getDefault();
+            JsonToken token = defaultValue.asToken();
+            CodeBlock value;
+            if (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE) {
+                value = endpointRulesSpecUtils.valueCreationCode("boolean",
+                                                                 CodeBlock.builder()
+                                                                          .add("$L", ((JrsBoolean) defaultValue).booleanValue())
+                                                                          .build());
+            } else if (token == JsonToken.VALUE_STRING) {
+                value = endpointRulesSpecUtils.valueCreationCode("string",
+                                                                 CodeBlock.builder()
+                                                                          .add("$S", ((JrsString) defaultValue).getValue())
+                                                                          .build());
+            } else {
+                throw new RuntimeException("Can't set default value type " + token.name());
+            }
+            b.add(".defaultValue($L)", value);
+        }
+
+        if (model.getDeprecated() != null) {
+            ParameterDeprecatedModel deprecated = model.getDeprecated();
+            b.add(".deprecated(new $T($S, $S))", Parameter.Deprecated.class, deprecated.getMessage(), deprecated.getSince());
+        }
+
+        b.add(".build()");
+
+        return b.build();
+    }
+
+    private CodeBlock rule(RuleModel model) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", Rule.class);
+
+        model.getConditions().forEach(c -> b.add(".addCondition($L)", condition(c)));
+
+        if ("error".equals(model.getType())) {
+            b.add(".error($S)", model.getError());
+        } else if ("tree".equals(model.getType())) {
+            CodeBlock.Builder rulesArray = CodeBlock.builder()
+                                                    .add("$T.asList(", Arrays.class);
+
+            int nRules = model.getRules().size();
+            for (int i = 0; i < nRules; ++i) {
+                rulesArray.add(rule(model.getRules().get(i)));
+                if (i + 1 < nRules) {
+                    rulesArray.add(", ");
+                }
+            }
+            rulesArray.add(")");
+
+            b.add(".treeRule($L)", rulesArray.build());
+        } else if ("endpoint".equals(model.getType())) {
+            CodeBlock endpoint = endpoint(model.getEndpoint());
+            b.add(".endpoint($L)", endpoint);
+        }
+
+        return b.build();
+    }
+
+    private CodeBlock endpoint(EndpointModel model) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", Endpoint.class);
+
+        TreeNode url = model.getUrl();
+        b.add(".url($L)", expr(url));
+
+        b.add(".build()");
+        return b.build();
+    }
+
+    private CodeBlock condition(ConditionModel model) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", Condition.class)
+            .add(".fn($L.validate())", fnNode(model));
+
+        if (model.getAssign() != null) {
+            b.add(".result($S)", model.getAssign());
+        }
+
+        b.add(".build()");
+
+        return b.build();
+    }
+
+    private CodeBlock fnNode(ConditionModel model) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.builder()", FnNode.class)
+            .add(".fn($S)", model.getFn())
+            .add(".argv($T.asList(", Arrays.class);
+
+        List<TreeNode> args = model.getArgv();
+        for (int i = 0; i < args.size(); ++i) {
+            b.add("$L", expr(args.get(i)));
+            if (i + 1 < args.size()) {
+                b.add(",");
+            }
+        }
+        b.add("))");
+
+        b.add(".build()");
+
+        return b.build();
+    }
+
+    private CodeBlock expr(TreeNode n) {
+        if (n.isValueNode()) {
+            return valueExpr((JrsValue) n);
+        }
+
+        if (n.isObject()) {
+            return objectExpr((JrsObject) n);
+        }
+
+        throw new RuntimeException("Don't know how to create expression from " + n);
+    }
+
+    private CodeBlock valueExpr(JrsValue n) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        b.add("$T.of(", Expr.class);
+        JsonToken token = n.asToken();
+        switch (token) {
+            case VALUE_STRING:
+                b.add("$S", ((JrsString) n).getValue());
+                break;
+            case VALUE_NUMBER_INT:
+                b.add("$L", ((JrsNumber) n).getValue().intValue());
+                break;
+            case VALUE_TRUE:
+            case VALUE_FALSE:
+                b.add("$L", ((JrsBoolean) n).booleanValue());
+                break;
+            default:
+                throw new RuntimeException("Don't know how to create expression JSON type " + token);
+        }
+
+        b.add(")");
+
+        return b.build();
+    }
+
+    private CodeBlock objectExpr(JrsObject n) {
+        CodeBlock.Builder b = CodeBlock.builder();
+
+        JrsValue ref = n.get("ref");
+        JrsValue fn = n.get("fn");
+
+        if (ref != null) {
+            b.add("$T.ref($T.of($S))", Expr.class, Identifier.class, ref.asText());
+        } else if (fn != null) {
+            String name = fn.asText();
+            CodeBlock.Builder fnNode = CodeBlock.builder();
+            fnNode.add("$T.builder()", FnNode.class)
+                  .add(".fn($S)", name);
+
+            JrsArray argv = (JrsArray) n.get("argv");
+
+            fnNode.add(".argv($T.asList(", Arrays.class);
+            Iterator<JrsValue> iter = argv.elements();
+
+            while (iter.hasNext()) {
+                fnNode.add(expr(iter.next()));
+
+                if (iter.hasNext()) {
+                    fnNode.add(",");
+                }
+            }
+
+            fnNode.add(")).build().validate()");
+
+            b.add(fnNode.build());
+        }
+
+        return b.build();
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderClassSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderClassSpecTest.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.codegen.poet.ClientTestModels;
 
 public class EndpointProviderClassSpecTest {
     @Test
-    public void endpointProviderInterface() {
+    public void endpointProviderClass() {
         ClassSpec endpointProviderSpec = new EndpointProviderSpec(ClientTestModels.queryServiceModels());
         assertThat(endpointProviderSpec, generatesTo("endpoint-provider-class.java"));
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
@@ -5,7 +5,8 @@
     "region": {
       "type": "string",
       "builtIn": "AWS::Region",
-      "required": true
+      "required": true,
+      "documentation": "The region to send requests to"
     },
     "useDualStackEndpoint": {
       "type": "boolean",
@@ -17,6 +18,21 @@
     },
     "endpointId": {
       "type": "string"
+    },
+    "defaultTrueParam": {
+      "type": "boolean",
+      "default": true
+    },
+    "defaultStringParam": {
+      "type": "string",
+      "default": "hello endpoints"
+    },
+    "deprecatedParam": {
+      "type": "string",
+      "deprecated": {
+        "message": "Don't use!",
+        "since": "2021-01-01"
+      }
     }
   },
   "rules": [

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -9,7 +9,7 @@ import software.amazon.awssdk.regions.Region;
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkPublicApi
-public final class QueryEndpointParameters {
+public final class QueryEndpointParams {
     private final Region region;
 
     private final Boolean useDualStackEndpoint;
@@ -24,7 +24,7 @@ public final class QueryEndpointParameters {
 
     private final String deprecatedParam;
 
-    private QueryEndpointParameters(BuilderImpl builder) {
+    private QueryEndpointParams(BuilderImpl builder) {
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
         this.useFIPSEndpoint = builder.useFIPSEndpoint;
@@ -46,7 +46,7 @@ public final class QueryEndpointParameters {
         return useDualStackEndpoint;
     }
 
-    public Boolean useFIPSEndpoint() {
+    public Boolean useFipsEndpoint() {
         return useFIPSEndpoint;
     }
 
@@ -71,7 +71,7 @@ public final class QueryEndpointParameters {
 
         Builder useDualStackEndpoint(Boolean useDualStackEndpoint);
 
-        Builder useFIPSEndpoint(Boolean useFIPSEndpoint);
+        Builder useFipsEndpoint(Boolean useFIPSEndpoint);
 
         Builder endpointId(String endpointId);
 
@@ -81,7 +81,7 @@ public final class QueryEndpointParameters {
 
         Builder deprecatedParam(String deprecatedParam);
 
-        QueryEndpointParameters build();
+        QueryEndpointParams build();
     }
 
     private static class BuilderImpl implements Builder {
@@ -112,7 +112,7 @@ public final class QueryEndpointParameters {
         }
 
         @Override
-        public Builder useFIPSEndpoint(Boolean useFIPSEndpoint) {
+        public Builder useFipsEndpoint(Boolean useFIPSEndpoint) {
             this.useFIPSEndpoint = useFIPSEndpoint;
             return this;
         }
@@ -142,8 +142,8 @@ public final class QueryEndpointParameters {
         }
 
         @Override
-        public QueryEndpointParameters build() {
-            return new QueryEndpointParameters(this);
+        public QueryEndpointParams build() {
+            return new QueryEndpointParams(this);
         }
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-parameters.java
@@ -2,14 +2,15 @@ package software.amazon.awssdk.services.query.rules;
 
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.regions.Region;
 
 /**
- * The parameters object used to resolve an endpoint for the % service.
+ * The parameters object used to resolve an endpoint for the Query service.
  */
 @Generated("software.amazon.awssdk:codegen")
 @SdkPublicApi
 public final class QueryEndpointParameters {
-    private final String region;
+    private final Region region;
 
     private final Boolean useDualStackEndpoint;
 
@@ -17,18 +18,27 @@ public final class QueryEndpointParameters {
 
     private final String endpointId;
 
+    private final Boolean defaultTrueParam;
+
+    private final String defaultStringParam;
+
+    private final String deprecatedParam;
+
     private QueryEndpointParameters(BuilderImpl builder) {
         this.region = builder.region;
         this.useDualStackEndpoint = builder.useDualStackEndpoint;
         this.useFIPSEndpoint = builder.useFIPSEndpoint;
         this.endpointId = builder.endpointId;
+        this.defaultTrueParam = builder.defaultTrueParam;
+        this.defaultStringParam = builder.defaultStringParam;
+        this.deprecatedParam = builder.deprecatedParam;
     }
 
     public static Builder builder() {
-        new BuilderImpl();
+        return new BuilderImpl();
     }
 
-    public String region() {
+    public Region region() {
         return region;
     }
 
@@ -44,8 +54,20 @@ public final class QueryEndpointParameters {
         return endpointId;
     }
 
-    interface Builder {
-        Builder region(String region);
+    public Boolean defaultTrueParam() {
+        return defaultTrueParam;
+    }
+
+    public String defaultStringParam() {
+        return defaultStringParam;
+    }
+
+    public String deprecatedParam() {
+        return deprecatedParam;
+    }
+
+    public interface Builder {
+        Builder region(Region region);
 
         Builder useDualStackEndpoint(Boolean useDualStackEndpoint);
 
@@ -53,11 +75,17 @@ public final class QueryEndpointParameters {
 
         Builder endpointId(String endpointId);
 
+        Builder defaultTrueParam(Boolean defaultTrueParam);
+
+        Builder defaultStringParam(String defaultStringParam);
+
+        Builder deprecatedParam(String deprecatedParam);
+
         QueryEndpointParameters build();
     }
 
     private static class BuilderImpl implements Builder {
-        private String region;
+        private Region region;
 
         private Boolean useDualStackEndpoint;
 
@@ -65,32 +93,56 @@ public final class QueryEndpointParameters {
 
         private String endpointId;
 
+        private Boolean defaultTrueParam;
+
+        private String defaultStringParam;
+
+        private String deprecatedParam;
+
         @Override
-        public void region(String region) {
+        public Builder region(Region region) {
             this.region = region;
             return this;
         }
 
         @Override
-        public void useDualStackEndpoint(Boolean useDualStackEndpoint) {
+        public Builder useDualStackEndpoint(Boolean useDualStackEndpoint) {
             this.useDualStackEndpoint = useDualStackEndpoint;
             return this;
         }
 
         @Override
-        public void useFIPSEndpoint(Boolean useFIPSEndpoint) {
+        public Builder useFIPSEndpoint(Boolean useFIPSEndpoint) {
             this.useFIPSEndpoint = useFIPSEndpoint;
             return this;
         }
 
         @Override
-        public void endpointId(String endpointId) {
+        public Builder endpointId(String endpointId) {
             this.endpointId = endpointId;
             return this;
         }
 
         @Override
-        public void build() {
+        public Builder defaultTrueParam(Boolean defaultTrueParam) {
+            this.defaultTrueParam = defaultTrueParam;
+            return this;
+        }
+
+        @Override
+        public Builder defaultStringParam(String defaultStringParam) {
+            this.defaultStringParam = defaultStringParam;
+            return this;
+        }
+
+        @Override
+        public Builder deprecatedParam(String deprecatedParam) {
+            this.deprecatedParam = deprecatedParam;
+            return this;
+        }
+
+        @Override
+        public QueryEndpointParameters build() {
             return new QueryEndpointParameters(this);
         }
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.rules.Condition;
 import software.amazon.awssdk.core.rules.DefaultRuleEngine;
+import software.amazon.awssdk.core.rules.EndpointResult;
 import software.amazon.awssdk.core.rules.EndpointRuleset;
 import software.amazon.awssdk.core.rules.Expr;
 import software.amazon.awssdk.core.rules.FnNode;
@@ -186,14 +187,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                                             .build().validate())
                                                     .build())
                                             .endpoint(
-                                                software.amazon.awssdk.core.rules.Endpoint
+                                                EndpointResult
                                                     .builder()
                                                     .url(Expr
                                                              .of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
                                                     .build()),
                                         Rule.builder()
                                             .endpoint(
-                                                software.amazon.awssdk.core.rules.Endpoint
+                                                EndpointResult
                                                     .builder()
                                                     .url(Expr
                                                              .of("https://{endpointId}.query.{partitionResult#dnsSuffix}"))
@@ -253,7 +254,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                                             .build().validate())
                                                     .build())
                                             .endpoint(
-                                                software.amazon.awssdk.core.rules.Endpoint
+                                                EndpointResult
                                                     .builder()
                                                     .url(Expr
                                                              .of("https://query-fips.{region}.{partitionResult#dnsSuffix}"))
@@ -300,7 +301,7 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                                             .build().validate())
                                                     .build())
                                             .endpoint(
-                                                software.amazon.awssdk.core.rules.Endpoint
+                                                EndpointResult
                                                     .builder()
                                                     .url(Expr
                                                              .of("https://query.{region}.{partitionResult#dualStackDnsSuffix}"))
@@ -351,14 +352,14 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                                             .build().validate())
                                                     .build())
                                             .endpoint(
-                                                software.amazon.awssdk.core.rules.Endpoint
+                                                EndpointResult
                                                     .builder()
                                                     .url(Expr
                                                              .of("https://query-fips.{region}.{partitionResult#dualStackDnsSuffix}"))
                                                     .build()),
                                         Rule.builder()
                                             .endpoint(
-                                                software.amazon.awssdk.core.rules.Endpoint
+                                                EndpointResult
                                                     .builder()
                                                     .url(Expr
                                                              .of("https://query.{region}.{partitionResult#dnsSuffix}"))

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.core.rules.Rule;
 import software.amazon.awssdk.core.rules.RuleEngine;
 import software.amazon.awssdk.core.rules.Value;
 import software.amazon.awssdk.core.rules.model.Endpoint;
-import software.amazon.awssdk.services.query.rules.QueryEndpointParameters;
+import software.amazon.awssdk.services.query.rules.QueryEndpointParams;
 import software.amazon.awssdk.services.query.rules.QueryEndpointProvider;
 
 @Generated("software.amazon.awssdk:codegen")
@@ -31,12 +31,12 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
     private static final EndpointRuleset ENDPOINT_RULE_SET = ruleSet();
 
     @Override
-    public Endpoint resolveEndpoint(QueryEndpointParameters endpointParams) {
+    public Endpoint resolveEndpoint(QueryEndpointParams endpointParams) {
         Value res = RULES_ENGINE.evaluate(ENDPOINT_RULE_SET, toIdentifierValueMap(endpointParams));
         return ProviderUtils.fromEndpointValue(res.expectEndpoint());
     }
 
-    private static Map<Identifier, Value> toIdentifierValueMap(QueryEndpointParameters params) {
+    private static Map<Identifier, Value> toIdentifierValueMap(QueryEndpointParams params) {
         Map<Identifier, Value> paramsMap = new HashMap<>();
         String region = params.region().id();
         if (region != null) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -1,47 +1,43 @@
 package software.amazon.awssdk.services.query.rules.internal;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.rules.Condition;
 import software.amazon.awssdk.core.rules.DefaultRuleEngine;
 import software.amazon.awssdk.core.rules.EndpointRuleset;
+import software.amazon.awssdk.core.rules.Expr;
+import software.amazon.awssdk.core.rules.FnNode;
 import software.amazon.awssdk.core.rules.Identifier;
+import software.amazon.awssdk.core.rules.Parameter;
+import software.amazon.awssdk.core.rules.ParameterType;
+import software.amazon.awssdk.core.rules.Parameters;
+import software.amazon.awssdk.core.rules.ProviderUtils;
+import software.amazon.awssdk.core.rules.Rule;
 import software.amazon.awssdk.core.rules.RuleEngine;
 import software.amazon.awssdk.core.rules.Value;
 import software.amazon.awssdk.core.rules.model.Endpoint;
-import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.services.query.rules.QueryEndpointParameters;
 import software.amazon.awssdk.services.query.rules.QueryEndpointProvider;
-import software.amazon.awssdk.utils.Lazy;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
 public final class DefaultQueryEndpointProvider implements QueryEndpointProvider {
-    private static final Lazy<EndpointRuleset> ENDPOINT_RULE_SET = new Lazy<>(DefaultQueryEndpointProvider::loadRuleSet);
-
     private static final RuleEngine RULES_ENGINE = new DefaultRuleEngine();
+
+    private static final EndpointRuleset ENDPOINT_RULE_SET = ruleSet();
 
     @Override
     public Endpoint resolveEndpoint(QueryEndpointParameters endpointParams) {
-        RULES_ENGINE.evaluate(ENDPOINT_RULE_SET.getValue(), toIdentifierValueMap(endpointParams));
-    }
-
-    private static EndpointRuleset loadRuleSet() {
-        try (InputStream is = DefaultQueryEndpointProvider.class
-            .getResourceAsStream("/software/amazon/awssdk/services/query/internal/endpoint-rule-set.json")) {
-            return EndpointRuleset.fromNode(JsonNode.parser().parse(is));
-        } catch (IOException e) {
-            throw SdkClientException.create("Unable to close input stream", e);
-        }
+        Value res = RULES_ENGINE.evaluate(ENDPOINT_RULE_SET, toIdentifierValueMap(endpointParams));
+        return ProviderUtils.fromEndpointValue(res.expectEndpoint());
     }
 
     private static Map<Identifier, Value> toIdentifierValueMap(QueryEndpointParameters params) {
         Map<Identifier, Value> paramsMap = new HashMap<>();
-        String region = params.region();
+        String region = params.region().id();
         if (region != null) {
             paramsMap.put(Identifier.of("region"), Value.fromStr(region));
         }
@@ -57,6 +53,316 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
         if (endpointId != null) {
             paramsMap.put(Identifier.of("endpointId"), Value.fromStr(endpointId));
         }
+        Boolean defaultTrueParam = params.defaultTrueParam();
+        if (defaultTrueParam != null) {
+            paramsMap.put(Identifier.of("defaultTrueParam"), Value.fromBool(defaultTrueParam));
+        }
+        String defaultStringParam = params.defaultStringParam();
+        if (defaultStringParam != null) {
+            paramsMap.put(Identifier.of("defaultStringParam"), Value.fromStr(defaultStringParam));
+        }
+        String deprecatedParam = params.deprecatedParam();
+        if (deprecatedParam != null) {
+            paramsMap.put(Identifier.of("deprecatedParam"), Value.fromStr(deprecatedParam));
+        }
         return paramsMap;
+    }
+
+    private static EndpointRuleset ruleSet() {
+        return EndpointRuleset
+            .builder()
+            .version("1.2")
+            .serviceId("query")
+            .parameters(
+                Parameters
+                    .builder()
+                    .addParameter(
+                        Parameter.builder().name("region").type(ParameterType.fromValue("string")).required(true)
+                                 .builtIn("AWS::Region").documentation("The region to send requests to").build())
+                    .addParameter(
+                        Parameter.builder().name("useDualStackEndpoint").type(ParameterType.fromValue("boolean"))
+                                 .required(false).builtIn("AWS::UseDualStackEndpoint").build())
+                    .addParameter(
+                        Parameter.builder().name("useFIPSEndpoint").type(ParameterType.fromValue("boolean"))
+                                 .required(false).builtIn("AWS::UseFIPSEndpoint").build())
+                    .addParameter(
+                        Parameter.builder().name("endpointId").type(ParameterType.fromValue("string"))
+                                 .required(false).build())
+                    .addParameter(
+                        Parameter.builder().name("defaultTrueParam").type(ParameterType.fromValue("boolean"))
+                                 .required(false).defaultValue(Value.fromBool(true)).build())
+                    .addParameter(
+                        Parameter.builder().name("defaultStringParam").type(ParameterType.fromValue("string"))
+                                 .required(false).defaultValue(Value.fromStr("hello endpoints")).build())
+                    .addParameter(
+                        Parameter.builder().name("deprecatedParam").type(ParameterType.fromValue("string"))
+                                 .required(false).deprecated(new Parameter.Deprecated("Don't use!", "2021-01-01"))
+                                 .build()).build())
+            .addRule(
+                Rule.builder()
+                    .addCondition(
+                        Condition
+                            .builder()
+                            .fn(FnNode.builder().fn("partition")
+                                      .argv(Arrays.asList(Expr.ref(Identifier.of("region")))).build()
+                                      .validate()).result("partitionResult").build())
+                    .treeRule(
+                        Arrays.asList(
+                            Rule.builder()
+                                .addCondition(
+                                    Condition
+                                        .builder()
+                                        .fn(FnNode
+                                                .builder()
+                                                .fn("isSet")
+                                                .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                 .of("endpointId")))).build().validate())
+                                        .build())
+                                .treeRule(
+                                    Arrays.asList(
+                                        Rule.builder()
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("isSet")
+                                                            .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                             .of("useFIPSEndpoint"))))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("booleanEquals")
+                                                            .argv(Arrays.asList(
+                                                                Expr.ref(Identifier
+                                                                             .of("useFIPSEndpoint")),
+                                                                Expr.of(true)))
+                                                            .build().validate())
+                                                    .build())
+                                            .error("FIPS endpoints not supported with multi-region endpoints"),
+                                        Rule.builder()
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("not")
+                                                            .argv(Arrays
+                                                                      .asList(FnNode
+                                                                                  .builder()
+                                                                                  .fn("isSet")
+                                                                                  .argv(Arrays
+                                                                                            .asList(Expr
+                                                                                                        .ref(Identifier
+                                                                                                                 .of("useFIPSEndpoint"))))
+                                                                                  .build()
+                                                                                  .validate()))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("isSet")
+                                                            .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                             .of("useDualStackEndpoint"))))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("booleanEquals")
+                                                            .argv(Arrays.asList(
+                                                                Expr.ref(Identifier
+                                                                             .of("useDualStackEndpoint")),
+                                                                Expr.of(true)))
+                                                            .build().validate())
+                                                    .build())
+                                            .endpoint(
+                                                software.amazon.awssdk.core.rules.Endpoint
+                                                    .builder()
+                                                    .url(Expr
+                                                             .of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                                    .build()),
+                                        Rule.builder()
+                                            .endpoint(
+                                                software.amazon.awssdk.core.rules.Endpoint
+                                                    .builder()
+                                                    .url(Expr
+                                                             .of("https://{endpointId}.query.{partitionResult#dnsSuffix}"))
+                                                    .build()))),
+                            Rule.builder()
+                                .addCondition(
+                                    Condition
+                                        .builder()
+                                        .fn(FnNode
+                                                .builder()
+                                                .fn("isValidHostLabel")
+                                                .argv(Arrays.asList(
+                                                    Expr.ref(Identifier.of("region")),
+                                                    Expr.of(false))).build().validate())
+                                        .build())
+                                .treeRule(
+                                    Arrays.asList(
+                                        Rule.builder()
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("isSet")
+                                                            .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                             .of("useFIPSEndpoint"))))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("booleanEquals")
+                                                            .argv(Arrays.asList(
+                                                                Expr.ref(Identifier
+                                                                             .of("useFIPSEndpoint")),
+                                                                Expr.of(true)))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("not")
+                                                            .argv(Arrays
+                                                                      .asList(FnNode
+                                                                                  .builder()
+                                                                                  .fn("isSet")
+                                                                                  .argv(Arrays
+                                                                                            .asList(Expr
+                                                                                                        .ref(Identifier
+                                                                                                                 .of("useDualStackEndpoint"))))
+                                                                                  .build()
+                                                                                  .validate()))
+                                                            .build().validate())
+                                                    .build())
+                                            .endpoint(
+                                                software.amazon.awssdk.core.rules.Endpoint
+                                                    .builder()
+                                                    .url(Expr
+                                                             .of("https://query-fips.{region}.{partitionResult#dnsSuffix}"))
+                                                    .build()),
+                                        Rule.builder()
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("isSet")
+                                                            .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                             .of("useDualStackEndpoint"))))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("booleanEquals")
+                                                            .argv(Arrays.asList(
+                                                                Expr.ref(Identifier
+                                                                             .of("useDualStackEndpoint")),
+                                                                Expr.of(true)))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("not")
+                                                            .argv(Arrays
+                                                                      .asList(FnNode
+                                                                                  .builder()
+                                                                                  .fn("isSet")
+                                                                                  .argv(Arrays
+                                                                                            .asList(Expr
+                                                                                                        .ref(Identifier
+                                                                                                                 .of("useFIPSEndpoint"))))
+                                                                                  .build()
+                                                                                  .validate()))
+                                                            .build().validate())
+                                                    .build())
+                                            .endpoint(
+                                                software.amazon.awssdk.core.rules.Endpoint
+                                                    .builder()
+                                                    .url(Expr
+                                                             .of("https://query.{region}.{partitionResult#dualStackDnsSuffix}"))
+                                                    .build()),
+                                        Rule.builder()
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("isSet")
+                                                            .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                             .of("useDualStackEndpoint"))))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("isSet")
+                                                            .argv(Arrays.asList(Expr.ref(Identifier
+                                                                                             .of("useFIPSEndpoint"))))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("booleanEquals")
+                                                            .argv(Arrays.asList(
+                                                                Expr.ref(Identifier
+                                                                             .of("useDualStackEndpoint")),
+                                                                Expr.of(true)))
+                                                            .build().validate())
+                                                    .build())
+                                            .addCondition(
+                                                Condition
+                                                    .builder()
+                                                    .fn(FnNode
+                                                            .builder()
+                                                            .fn("booleanEquals")
+                                                            .argv(Arrays.asList(
+                                                                Expr.ref(Identifier
+                                                                             .of("useFIPSEndpoint")),
+                                                                Expr.of(true)))
+                                                            .build().validate())
+                                                    .build())
+                                            .endpoint(
+                                                software.amazon.awssdk.core.rules.Endpoint
+                                                    .builder()
+                                                    .url(Expr
+                                                             .of("https://query-fips.{region}.{partitionResult#dualStackDnsSuffix}"))
+                                                    .build()),
+                                        Rule.builder()
+                                            .endpoint(
+                                                software.amazon.awssdk.core.rules.Endpoint
+                                                    .builder()
+                                                    .url(Expr
+                                                             .of("https://query.{region}.{partitionResult#dnsSuffix}"))
+                                                    .build()))), Rule.builder()
+                                                                     .error("{region} is not a valid HTTP host-label")))).build();
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-interface.java
@@ -2,8 +2,13 @@ package software.amazon.awssdk.services.query.rules;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.rules.model.Endpoint;
+import software.amazon.awssdk.services.query.rules.internal.DefaultQueryEndpointProvider;
 
 @SdkPublicApi
-interface QueryEndpointProvider {
+public interface QueryEndpointProvider {
     Endpoint resolveEndpoint(QueryEndpointParameters endpointParams);
+
+    static QueryEndpointProvider defaultProvider() {
+        return new DefaultQueryEndpointProvider();
+    }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-interface.java
@@ -6,7 +6,7 @@ import software.amazon.awssdk.services.query.rules.internal.DefaultQueryEndpoint
 
 @SdkPublicApi
 public interface QueryEndpointProvider {
-    Endpoint resolveEndpoint(QueryEndpointParameters endpointParams);
+    Endpoint resolveEndpoint(QueryEndpointParams endpointParams);
 
     static QueryEndpointProvider defaultProvider() {
         return new DefaultQueryEndpointProvider();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/EndpointResult.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/EndpointResult.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 
 @SdkInternalApi
-public final class Endpoint {
+public final class EndpointResult {
     private static final String URL = "url";
     private static final String PROPERTIES = "properties";
     private static final String HEADERS = "headers";
@@ -32,7 +32,7 @@ public final class Endpoint {
     private Map<Identifier, Literal> properties;
     private Map<String, List<Literal>> headers;
 
-    private Endpoint(Builder builder) {
+    private EndpointResult(Builder builder) {
         this.url = builder.url;
         this.properties = builder.properties;
         this.headers = builder.headers;
@@ -50,7 +50,7 @@ public final class Endpoint {
         return headers;
     }
 
-    public static Endpoint fromNode(JsonNode node) {
+    public static EndpointResult fromNode(JsonNode node) {
         Map<String, JsonNode> objNode = node.asObject();
 
         Builder b = builder();
@@ -92,7 +92,7 @@ public final class Endpoint {
             return false;
         }
 
-        Endpoint endpoint = (Endpoint) o;
+        EndpointResult endpoint = (EndpointResult) o;
 
         if (url != null ? !url.equals(endpoint.url) : endpoint.url != null) {
             return false;
@@ -135,8 +135,8 @@ public final class Endpoint {
             return this;
         }
 
-        public Endpoint build() {
-            return new Endpoint(this);
+        public EndpointResult build() {
+            return new EndpointResult(this);
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/EndpointRule.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/EndpointRule.java
@@ -19,14 +19,14 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 
 @SdkInternalApi
 public final class EndpointRule extends Rule {
-    private final Endpoint endpoint;
+    private final EndpointResult endpoint;
 
-    protected EndpointRule(Builder builder, Endpoint endpoint) {
+    protected EndpointRule(Builder builder, EndpointResult endpoint) {
         super(builder);
         this.endpoint = endpoint;
     }
 
-    public Endpoint getEndpoint() {
+    public EndpointResult getEndpoint() {
         return endpoint;
     }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/ParameterType.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/ParameterType.java
@@ -38,13 +38,17 @@ public enum ParameterType {
     }
 
     public static ParameterType fromNode(JsonNode node) {
-        switch (node.asString().toLowerCase(Locale.ENGLISH)) {
+        return fromValue(node.asString());
+    }
+
+    public static ParameterType fromValue(String value) {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
             case "string":
                 return STRING;
             case "boolean":
                 return BOOLEAN;
             default:
-                throw SdkClientException.create("Unknown parameter type: " + node.asString());
+                throw SdkClientException.create("Unknown parameter type: " + value);
         }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/PartitionFn.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/PartitionFn.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.utils.MapUtils;
 
 @SdkInternalApi
 public class PartitionFn extends SingleArgFn {
-    public static final String ID = "partition";
+    public static final String ID = "aws.partition";
 
     public static final Identifier NAME = Identifier.of("name");
     public static final Identifier DNS_SUFFIX = Identifier.of("dnsSuffix");

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/ProviderUtils.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/ProviderUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.rules;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.rules.model.Endpoint;
+
+@SdkInternalApi
+public final class ProviderUtils {
+    private ProviderUtils() {
+    }
+
+    public static Endpoint fromEndpointValue(Value.Endpoint value) {
+        return Endpoint.builder()
+            .url(value.getUrl())
+            .build();
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/Rule.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/Rule.java
@@ -61,7 +61,7 @@ public abstract class Rule {
 
         String type = objNode.get(TYPE).asString();
         switch (type) {
-            case ENDPOINT: return builder.endpoint(Endpoint.fromNode(objNode.get(ENDPOINT)));
+            case ENDPOINT: return builder.endpoint(EndpointResult.fromNode(objNode.get(ENDPOINT)));
             case ERROR: return builder.error(objNode.get(ERROR).asString());
             case TREE: return builder.treeRule(objNode.get(RULES).asArray()
                                                  .stream()
@@ -89,7 +89,7 @@ public abstract class Rule {
             return this;
         }
 
-        public EndpointRule endpoint(Endpoint endpoint) {
+        public EndpointRule endpoint(EndpointResult endpoint) {
             return new EndpointRule(this, endpoint);
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/RuleEvaluator.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/RuleEvaluator.java
@@ -141,7 +141,7 @@ public class RuleEvaluator implements FnVisitor<Value>, ExprVisitor<Value> {
                         }
 
                         @Override
-                        public Value visitEndpointRule(Endpoint endpoint) {
+                        public Value visitEndpointRule(EndpointResult endpoint) {
                             return generateEndpoint(endpoint);
                         }
                     });
@@ -156,7 +156,7 @@ public class RuleEvaluator implements FnVisitor<Value>, ExprVisitor<Value> {
         return value;
     }
 
-    public Value generateEndpoint(Endpoint endpoint) {
+    public Value generateEndpoint(EndpointResult endpoint) {
         Value.Endpoint.Builder builder = Value.Endpoint.builder()
                                                        .url(endpoint.getUrl()
                                                                     .accept(this)

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/RuleValueVisitor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/rules/RuleValueVisitor.java
@@ -28,5 +28,5 @@ public interface RuleValueVisitor<R> {
 
     R visitErrorRule(Expr error);
 
-    R visitEndpointRule(Endpoint endpoint);
+    R visitEndpointRule(EndpointResult endpoint);
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/rules/DefaultVisitor.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/rules/DefaultVisitor.java
@@ -80,7 +80,7 @@ public abstract class DefaultVisitor<R> implements RuleValueVisitor<R>, ExprVisi
     }
 
     @Override
-    public R visitEndpointRule(Endpoint endpoint) {
+    public R visitEndpointRule(EndpointResult endpoint) {
         return getDefault();
     }
 

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/rules/TraversingVisitor.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/rules/TraversingVisitor.java
@@ -26,7 +26,7 @@ public abstract class TraversingVisitor<R> extends DefaultVisitor<Stream<R>> {
     }
 
     @Override
-    public Stream<R> visitEndpointRule(Endpoint endpoint) {
+    public Stream<R> visitEndpointRule(EndpointResult endpoint) {
         return visitEndpoint(endpoint);
     }
 
@@ -40,7 +40,7 @@ public abstract class TraversingVisitor<R> extends DefaultVisitor<Stream<R>> {
         return rules.stream().flatMap(subrule -> subrule.accept(this));
     }
 
-    public Stream<R> visitEndpoint(Endpoint endpoint) {
+    public Stream<R> visitEndpoint(EndpointResult endpoint) {
         return Stream.concat(
                 endpoint.getUrl()
                         .accept(this),

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/rules/ValidateUriScheme.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/rules/ValidateUriScheme.java
@@ -11,7 +11,7 @@ public class ValidateUriScheme extends TraversingVisitor<ValidationError> {
     boolean checkingEndpoint = false;
 
     @Override
-    public Stream<ValidationError> visitEndpoint(Endpoint endpoint) {
+    public Stream<ValidationError> visitEndpoint(EndpointResult endpoint) {
         checkingEndpoint = true;
         Stream<ValidationError> errors = endpoint.getUrl().accept(this);
         checkingEndpoint = false;


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

The primary change in this commit is to generate the creation of the
EndpointRuleSet as a static method in the default provider rather than loading
the rule set from JSON at runtime. This means we don't incur any disk I/O cost
at runtime and possibly even remove the dependency on json-util later.

There are also some other minor fixes included in this PR including a working
resolveEndpoint() implementation on the default provider.

<!--- Provide a general summary of your changes in the Title above -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
