### PR TITLE
Fix for NPE when Http Checksum algorithm  is set for Empty payload

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-0f4a264.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-0f4a264.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix for NPE when Http Checksum algorithm  is set for a request with Empty payload."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/HttpChecksumInHeaderInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/HttpChecksumInHeaderInterceptor.java
@@ -66,8 +66,13 @@ public class HttpChecksumInHeaderInterceptor implements ExecutionInterceptor {
         if (shouldSkipHttpChecksumInHeader(context, executionAttributes, checksumSpecs)) {
             return context.httpRequest();
         }
+
         String httpChecksumValue = executionAttributes.getAttribute(HTTP_CHECKSUM_VALUE);
-        return context.httpRequest().copy(r -> r.putHeader(checksumSpecs.headerName(), httpChecksumValue));
+        if (httpChecksumValue != null) {
+            return context.httpRequest().copy(r -> r.putHeader(checksumSpecs.headerName(), httpChecksumValue));
+        }
+        return context.httpRequest();
+
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
```
java.lang.NullPointerException
    at software.amazon.awssdk.auth.signer.internal.AbstractAws4Signer$CanonicalRequest.addAndTrim(AbstractAws4Signer.java:561)
    at software.amazon.awssdk.auth.signer.internal.AbstractAws4Signer$CanonicalRequest.lambda$addCanonicalizedHeaderString$0(AbstractAws4Signer.java:518)
    at java.util.ArrayList.forEach(ArrayList.java:1259)
    at software.amazon.awssdk.auth.signer.internal.AbstractAws4Signer$CanonicalRequest.addCanonicalizedHeaderString(AbstractAws4Signer.java:514)
    at software.amazon.awssdk.auth.signer.internal.AbstractAws4Signer$CanonicalRequest.string(AbstractAws4Signer.java:481)
    at software.amazon.awssdk.auth.signer.internal.AbstractAws4Signer.doSign(AbstractAws4Signer.java:104)
    at software.amazon.awssdk.auth.signer.internal.AbstractAws4Signer.doSign(AbstractAws4Signer.java:74)
    at software.amazon.awssdk.auth.signer.internal.AbstractAwsS3V4Signer.sign(AbstractAwsS3V4Signer.java:80)
    at software.amazon.awssdk.auth.signer.internal.AbstractAwsS3V4Signer.sign(AbstractAwsS3V4Signer.java:61)
    at software.amazon.awssdk.core.internal.http.pipeline.stages.SigningStage.lambda$signRequest$0(SigningStage.java:71)
    at software.amazon.awssdk.core.internal.util.MetricUtils.measureDuration(MetricUtils.java:50)
    at software.amazon.awssdk.core.internal.http.pipeline.stages.SigningStage.signRequest(SigningStage.java:70)
    at software.amazon.awssdk.core.internal.http.pipeline.stages.SigningStage.execute(SigningStage.java:55)
    at software.amazon.awssdk.core.internal.http.pipeline.stages.SigningStage.execute(SigningStage.java:40)
    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
```

## Root cause
The HttpChecksumInHeaderInterceptor didnot handle the case when Request body content is empty.
- This issue is specific to putBucketAcl because this API does not have required fields for payload and thus allows empty payload.

## Modifications
<!--- Describe your changes in detail -->
- Similar to [HttpChecksumRequiredInterceptor](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/HttpChecksumRequiredInterceptor.java#L69-L71) we need to make sure that calculated checksum is not null before the header value is set.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added Junit test cases.
Note :- Even this value is seen in putBucketAcl , I have not added integ test because this is not handled at service side.
The server checks for Checksum if the algorithm is set even though the payload is empty, will work with S3 on this.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
