### PR TITLE
Use JDK 18 to build Javadocs so that we can use snippet

### DIFF
--- a/buildspecs/release-javadoc.yml
+++ b/buildspecs/release-javadoc.yml
@@ -1,11 +1,11 @@
 version: 0.2
 env:
   variables:
-    JAVA_HOME: "/usr/lib/jvm/java-17-amazon-corretto/"
+    JAVA_HOME: "/usr/lib/jvm/java-18-amazon-corretto/"
 phases:
   install:
     commands:
-    - apt-get update; apt-get install -y java-17-amazon-corretto-jdk
+    - apt-get update; apt-get install -y java-18-amazon-corretto-jdk
     - update-alternatives --auto javac
     - update-alternatives --auto java
     - pip install awscli==1.19.34 --upgrade --user


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Use JDK 18 to build Javadocs so that we can use snippet 

## Testing
Tested on CodeBuild job

