### PR TITLE
Disable index 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -914,6 +914,9 @@
                             <show>public</show>
                             <author>false</author>
                             <version>true</version>
+                            <!-- Disable index because jquery-ui version used is old -->
+                            <!-- Re-enable it when it's fixed in newer versions of JDK -->
+                            <noindex>true</noindex>
                             <use>false</use>
                             <source>8</source>
                             <notree>true</notree>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Disable [index](https://openjdk.org/jeps/225#:~:text=The%20%2Dnoindex%20option%20to%20javadoc,files%20in%20the%20output%20directory.) to disable search 
functionality on the javadoc site because Javadoc is using an older version of jquery-ui. We can re-enable it once it's fixed in JDK

## Testing

Tested on CodeBuild

