### PR TITLE
Errors should not be wrapped - S3 Transfer Manager

### DIFF
--- a/.changes/next-release/bugfix-S3TransferManager-f1c2208.json
+++ b/.changes/next-release/bugfix-S3TransferManager-f1c2208.json
@@ -1,0 +1,6 @@
+{
+    "category": "S3 Transfer Manager", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Fixed issue where errors were being wrapped by SdkClientException"
+}

--- a/.changes/next-release/bugfix-S3TransferManager-f1c2208.json
+++ b/.changes/next-release/bugfix-S3TransferManager-f1c2208.json
@@ -2,5 +2,6 @@
     "category": "S3 Transfer Manager", 
     "contributor": "", 
     "type": "bugfix", 
-    "description": "Fixed issue where errors were being wrapped by SdkClientException"
+    "description": "Fixed issues in S3 Transfer Manager resumeDownloadFile 
+API where errors were being wrapped by SdkClientException"
 }

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
@@ -461,18 +461,16 @@ public final class DefaultS3TransferManager implements S3TransferManager {
                                         CompletableFuture<TransferProgress> progressFuture,
                                         CompletableFuture<DownloadFileRequest> newDownloadFileRequestFuture,
                                         Throwable throwable) {
-        Throwable cause = throwable instanceof CompletionException ? throwable.getCause() : throwable;
+        Throwable exceptionCause = throwable instanceof CompletionException ? throwable.getCause() : throwable;
 
-        if (cause instanceof SdkException || cause instanceof Error) {
-            returnFuture.completeExceptionally(cause);
-            progressFuture.completeExceptionally(cause);
-            newDownloadFileRequestFuture.completeExceptionally(cause);
-        } else {
-            SdkClientException exception = SdkClientException.create("Failed to resume the request", cause);
-            returnFuture.completeExceptionally(exception);
-            progressFuture.completeExceptionally(exception);
-            newDownloadFileRequestFuture.completeExceptionally(exception);
-        }
+        Throwable propagatedException = exceptionCause instanceof SdkException || exceptionCause instanceof Error
+                                        ? exceptionCause
+                                        : SdkClientException.create("Failed to resume the request", exceptionCause);
+
+        returnFuture.completeExceptionally(propagatedException);
+        progressFuture.completeExceptionally(propagatedException);
+        newDownloadFileRequestFuture.completeExceptionally(propagatedException);
+
 
     }
 

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
@@ -467,6 +467,10 @@ public final class DefaultS3TransferManager implements S3TransferManager {
                                         ? exceptionCause
                                         : SdkClientException.create("Failed to resume the request", exceptionCause);
 
+        if (propagatedException instanceof SdkException) {
+            propagatedException = SdkException.create("Failed to resume the request", propagatedException);
+        }
+
         returnFuture.completeExceptionally(propagatedException);
         progressFuture.completeExceptionally(propagatedException);
         newDownloadFileRequestFuture.completeExceptionally(propagatedException);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/DefaultS3TransferManager.java
@@ -468,7 +468,7 @@ public final class DefaultS3TransferManager implements S3TransferManager {
             progressFuture.completeExceptionally(cause);
             newDownloadFileRequestFuture.completeExceptionally(cause);
         } else {
-            SdkClientException exception = SdkClientException.create("Failed to resume the request", throwable);
+            SdkClientException exception = SdkClientException.create("Failed to resume the request", cause);
             returnFuture.completeExceptionally(exception);
             progressFuture.completeExceptionally(exception);
             newDownloadFileRequestFuture.completeExceptionally(exception);

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPauseAndResumeTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerPauseAndResumeTest.java
@@ -153,7 +153,7 @@ class S3TransferManagerPauseAndResumeTest {
                                                                      .getObjectRequest(getObjectRequest)
                                                                      .destination(file)
                                                                      .build();
-        SdkException sdkException = SdkException.create("failed", new Throwable());
+        SdkException sdkException = SdkException.create("Failed to resume the request", new Throwable());
         when(mockS3Crt.headObject(any(Consumer.class)))
             .thenReturn(CompletableFutureUtils.failedFuture(sdkException));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Errors should not be wrapped by SdkClientException

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Partial fix to https://github.com/aws/aws-sdk-java-v2/issues/3381, for s3 Transfer Manager

## Modifications
<!--- Describe your changes in detail -->
Update handleException() to perform instance check of throwable, and handle accordingly

## Testing
<!--- Please describe in detail how you tested your changes -->
Test added
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
