### PR TITLE
Provide the ability to set a custom socket factory when building an HTTP client

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-1a1ccf3.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-1a1ccf3.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "dave-fn", 
+    "type": "feature", 
+    "description": "Provide the ability to set a custom socket factory when building an HTTP client"
+}

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -404,6 +404,11 @@ public final class ApacheHttpClient implements SdkHttpClient {
         Builder dnsResolver(DnsResolver dnsResolver);
 
         /**
+         * Configuration that defines a Socket Factory. If no matches are found, the default factory is used.
+         */
+        Builder socketFactory(ConnectionSocketFactory socketFactory);
+
+        /**
          * Configuration that defines an HTTP route planner that computes the route an HTTP request should take.
          * May not be used in conjunction with {@link #proxyConfiguration(ProxyConfiguration)}.
          */
@@ -452,6 +457,7 @@ public final class ApacheHttpClient implements SdkHttpClient {
         private HttpRoutePlanner httpRoutePlanner;
         private CredentialsProvider credentialsProvider;
         private DnsResolver dnsResolver;
+        private ConnectionSocketFactory socketFactory;
 
         private DefaultBuilder() {
         }
@@ -573,6 +579,16 @@ public final class ApacheHttpClient implements SdkHttpClient {
         }
 
         @Override
+        public Builder socketFactory(ConnectionSocketFactory socketFactory) {
+            this.socketFactory = socketFactory;
+            return this;
+        }
+
+        public void setSocketFactory(ConnectionSocketFactory socketFactory) {
+            socketFactory(socketFactory);
+        }
+
+        @Override
         public Builder httpRoutePlanner(HttpRoutePlanner httpRoutePlanner) {
             this.httpRoutePlanner = httpRoutePlanner;
             return this;
@@ -654,9 +670,9 @@ public final class ApacheHttpClient implements SdkHttpClient {
 
         private ConnectionSocketFactory getPreferredSocketFactory(ApacheHttpClient.DefaultBuilder configuration,
                                                                   AttributeMap standardOptions) {
-            // TODO v2 custom socket factory
-            return new SdkTlsSocketFactory(getSslContext(standardOptions),
-                                           getHostNameVerifier(standardOptions));
+            return Optional.ofNullable(configuration.socketFactory)
+                           .orElseGet(() -> new SdkTlsSocketFactory(getSslContext(standardOptions),
+                                                                    getHostNameVerifier(standardOptions)));
         }
 
         private HostnameVerifier getHostNameVerifier(AttributeMap standardOptions) {

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java
@@ -404,7 +404,10 @@ public final class ApacheHttpClient implements SdkHttpClient {
         Builder dnsResolver(DnsResolver dnsResolver);
 
         /**
-         * Configuration that defines a Socket Factory. If no matches are found, the default factory is used.
+         * Configuration that defines a custom Socket factory. If set to a null value, a default factory is used.
+         * <p>
+         * When set to a non-null value, the use of a custom factory implies the configuration options TRUST_ALL_CERTIFICATES,
+         * TLS_TRUST_MANAGERS_PROVIDER, and TLS_KEY_MANAGERS_PROVIDER are ignored.
          */
         Builder socketFactory(ConnectionSocketFactory socketFactory);
 

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheClientTlsAuthTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/ApacheClientTlsAuthTest.java
@@ -30,8 +30,16 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
 import org.apache.http.NoHttpResponseException;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -39,6 +47,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 import software.amazon.awssdk.http.FileStoreTlsKeyManagersProvider;
 import software.amazon.awssdk.http.HttpExecuteRequest;
 import software.amazon.awssdk.http.HttpExecuteResponse;
@@ -47,6 +56,7 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.TlsKeyManagersProvider;
+import software.amazon.awssdk.http.apache.internal.conn.SdkTlsSocketFactory;
 import software.amazon.awssdk.internal.http.NoneTlsKeyManagersProvider;
 
 /**
@@ -168,6 +178,45 @@ public class ApacheClientTlsAuthTest extends ClientTlsAuthTestBase {
             System.clearProperty(SSL_KEY_STORE_TYPE.property());
             System.clearProperty(SSL_KEY_STORE_PASSWORD.property());
         }
+    }
+
+    @Test
+    public void build_notSettingSocketFactory_configuresClientWithDefaultSocketFactory() throws IOException {
+        System.setProperty(SSL_KEY_STORE.property(), clientKeyStore.toAbsolutePath().toString());
+        System.setProperty(SSL_KEY_STORE_TYPE.property(), CLIENT_STORE_TYPE);
+        System.setProperty(SSL_KEY_STORE_PASSWORD.property(), STORE_PASSWORD);
+
+        client = ApacheHttpClient.builder().build();
+        try {
+            makeRequestWithHttpClient(client);
+        } finally {
+            System.clearProperty(SSL_KEY_STORE.property());
+            System.clearProperty(SSL_KEY_STORE_TYPE.property());
+            System.clearProperty(SSL_KEY_STORE_PASSWORD.property());
+        }
+    }
+
+    @Test
+    public void build_settingCustomSocketFactory_configuresClientWithGivenSocketFactory() throws IOException,
+                                                                                                 NoSuchAlgorithmException,
+                                                                                                 KeyManagementException {
+        TlsKeyManagersProvider provider = FileStoreTlsKeyManagersProvider.create(clientKeyStore,
+                                                                                 CLIENT_STORE_TYPE,
+                                                                                 STORE_PASSWORD);
+        KeyManager[] keyManagers = provider.keyManagers();
+
+        SSLContext sslcontext = SSLContext.getInstance("TLS");
+        sslcontext.init(keyManagers, null, null);
+
+        ConnectionSocketFactory socketFactory = new SdkTlsSocketFactory(sslcontext, NoopHostnameVerifier.INSTANCE);
+        ConnectionSocketFactory socketFactoryMock = Mockito.spy(socketFactory);
+
+        client = ApacheHttpClient.builder()
+                                 .socketFactory(socketFactoryMock)
+                                 .build();
+        makeRequestWithHttpClient(client);
+
+        Mockito.verify(socketFactoryMock).createSocket(Mockito.any());
     }
 
     private HttpExecuteResponse makeRequestWithHttpClient(SdkHttpClient httpClient) throws IOException {


### PR DESCRIPTION
## Motivation and Context
Provide SDK users more control of the TLS negotiation by setting a socket factory.
Fixes [#2966](https://github.com/aws/aws-sdk-java-v2/issues/2966)

## Modifications
Add method to the HTTP client builder for setting a socket factory.

## Testing
Added two tests to Apache HTTP TLS Auth suite.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
