### PR TITLE
Splitting endpoint resolution and modifying the request URI into two …

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/EndpointProviderTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/EndpointProviderTasks.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.codegen.emitters.tasks;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.codegen.emitters.GeneratorTask;
@@ -25,11 +27,12 @@ import software.amazon.awssdk.codegen.model.config.customization.CustomizationCo
 import software.amazon.awssdk.codegen.model.service.ClientContextParam;
 import software.amazon.awssdk.codegen.poet.rules.ClientContextParamsClassSpec;
 import software.amazon.awssdk.codegen.poet.rules.EndpointParametersClassSpec;
-import software.amazon.awssdk.codegen.poet.rules.EndpointProviderInterceptorSpec;
 import software.amazon.awssdk.codegen.poet.rules.EndpointProviderInterfaceSpec;
 import software.amazon.awssdk.codegen.poet.rules.EndpointProviderSpec;
 import software.amazon.awssdk.codegen.poet.rules.EndpointProviderTestSpec;
+import software.amazon.awssdk.codegen.poet.rules.EndpointResolverInterceptorSpec;
 import software.amazon.awssdk.codegen.poet.rules.EndpointRulesClientTestSpec;
+import software.amazon.awssdk.codegen.poet.rules.RequestEndpointInterceptorSpec;
 
 public final class EndpointProviderTasks extends BaseGeneratorTasks {
     private final GeneratorTaskParams generatorTaskParams;
@@ -45,7 +48,7 @@ public final class EndpointProviderTasks extends BaseGeneratorTasks {
         tasks.add(generateInterface());
         tasks.add(generateParams());
         tasks.add(generateDefaultProvider());
-        tasks.add(generateInterceptor());
+        tasks.addAll(generateInterceptors());
         if (shouldGenerateTests()) {
             tasks.add(generateClientTests());
             tasks.add(generateProviderTests());
@@ -69,9 +72,10 @@ public final class EndpointProviderTasks extends BaseGeneratorTasks {
         return new PoetGeneratorTask(endpointRulesInternalDir(), model.getFileHeader(), new EndpointProviderSpec(model));
     }
 
-    private GeneratorTask generateInterceptor() {
-        return new PoetGeneratorTask(endpointRulesInternalDir(), model.getFileHeader(),
-                                     new EndpointProviderInterceptorSpec(model));
+    private Collection<GeneratorTask> generateInterceptors() {
+        return Arrays.asList(
+            new PoetGeneratorTask(endpointRulesInternalDir(), model.getFileHeader(), new EndpointResolverInterceptorSpec(model)),
+            new PoetGeneratorTask(endpointRulesInternalDir(), model.getFileHeader(), new RequestEndpointInterceptorSpec(model)));
     }
 
     private GeneratorTask generateClientTests() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -239,7 +239,8 @@ public class BaseClientBuilderClass implements ClassSpec {
                                                        ExecutionInterceptor.class),
                              ArrayList.class);
 
-        builder.addStatement("additionalInterceptors.add(new $T())", endpointRulesSpecUtils.interceptorName());
+        builder.addStatement("additionalInterceptors.add(new $T())", endpointRulesSpecUtils.resolverInterceptorName());
+        builder.addStatement("additionalInterceptors.add(new $T())", endpointRulesSpecUtils.requestModifierInterceptorName());
 
         if (model.getMetadata().isQueryProtocol()) {
             builder.addStatement("additionalInterceptors.add(new $T())", QueryParametersToBodyInterceptor.class);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -56,10 +56,16 @@ public class EndpointRulesSpecUtils {
                              "Default" + providerInterfaceName().simpleName());
     }
 
-    public ClassName interceptorName() {
+    public ClassName resolverInterceptorName() {
         Metadata md = intermediateModel.getMetadata();
         return ClassName.get(md.getFullInternalEndpointRulesPackageName(),
-                             md.getServiceName() + "EndpointInterceptor");
+                             md.getServiceName() + "ResolveEndpointInterceptor");
+    }
+
+    public ClassName requestModifierInterceptorName() {
+        Metadata md = intermediateModel.getMetadata();
+        return ClassName.get(md.getFullInternalEndpointRulesPackageName(),
+                             md.getServiceName() + "RequestSetEndpointInterceptor");
     }
 
     public ClassName clientEndpointTestsName() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RequestEndpointInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/RequestEndpointInterceptorSpec.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.rules;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import javax.lang.model.element.Modifier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.rules.AwsProviderUtils;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.rules.model.Endpoint;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+public class RequestEndpointInterceptorSpec implements ClassSpec {
+    private final EndpointRulesSpecUtils endpointRulesSpecUtils;
+
+    public RequestEndpointInterceptorSpec(IntermediateModel model) {
+        this.endpointRulesSpecUtils = new EndpointRulesSpecUtils(model);
+    }
+
+    @Override
+    public TypeSpec poetSpec() {
+        TypeSpec.Builder b = PoetUtils.createClassBuilder(className())
+                                      .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                                      .addAnnotation(SdkInternalApi.class)
+                                      .addSuperinterface(ExecutionInterceptor.class);
+
+        b.addMethod(modifyHttpRequestMethod());
+
+        return b.build();
+    }
+
+    @Override
+    public ClassName className() {
+        return endpointRulesSpecUtils.requestModifierInterceptorName();
+    }
+
+    private MethodSpec modifyHttpRequestMethod() {
+
+        MethodSpec.Builder b = MethodSpec.methodBuilder("modifyHttpRequest")
+                                         .addModifiers(Modifier.PUBLIC)
+                                         .addAnnotation(Override.class)
+                                         .returns(SdkHttpRequest.class)
+                                         .addParameter(Context.ModifyHttpRequest.class, "context")
+                                         .addParameter(ExecutionAttributes.class, "executionAttributes");
+
+
+        // We skip setting the endpoint here if the source of the endpoint is the endpoint discovery call
+        b.beginControlFlow("if ($1T.endpointIsDiscovered(executionAttributes))",
+                           AwsProviderUtils.class)
+         .addStatement("return context.httpRequest()")
+         .endControlFlow().build();
+
+        b.addStatement("$1T endpoint = ($1T) executionAttributes.getAttribute($2T.RESOLVED_ENDPOINT)",
+                       Endpoint.class,
+                       SdkInternalExecutionAttribute.class);
+        b.addStatement("return $T.setUri(context.httpRequest(), endpoint.url())", AwsProviderUtils.class);
+        return b.build();
+    }
+
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpecTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.ClientTestModels;
 
-public class EndpointProviderInterceptorSpecTest {
+public class EndpointResolverInterceptorSpecTest {
     @Test
-    public void endpointProviderInterceptorClass() {
-        ClassSpec endpointProviderInterceptor = new EndpointProviderInterceptorSpec(ClientTestModels.queryServiceModels());
-        assertThat(endpointProviderInterceptor, generatesTo("endpoint-provider-interceptor.java"));
+    public void endpointResolverInterceptorClass() {
+        ClassSpec endpointProviderInterceptor = new EndpointResolverInterceptorSpec(ClientTestModels.queryServiceModels());
+        assertThat(endpointProviderInterceptor, generatesTo("endpoint-resolve-interceptor.java"));
     }
 }

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/RequestEndpointProviderInterceptorSpecTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/rules/RequestEndpointProviderInterceptorSpecTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.rules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.ClientTestModels;
+
+public class RequestEndpointProviderInterceptorSpecTest {
+    @Test
+    public void requestSetEndpointInterceptorClass() {
+        ClassSpec endpointProviderInterceptor = new RequestEndpointInterceptorSpec(ClientTestModels.queryServiceModels());
+        assertThat(endpointProviderInterceptor, generatesTo("request-set-endpoint-interceptor.java"));
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -16,7 +16,8 @@ import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.services.json.rules.JsonEndpointProvider;
-import software.amazon.awssdk.services.json.rules.internal.JsonEndpointInterceptor;
+import software.amazon.awssdk.services.json.rules.internal.JsonRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.json.rules.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
@@ -51,7 +52,8 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         List<ExecutionInterceptor> interceptors = interceptorFactory
             .getInterceptors("software/amazon/awssdk/services/json/execution.interceptors");
         List<ExecutionInterceptor> additionalInterceptors = new ArrayList<>();
-        additionalInterceptors.add(new JsonEndpointInterceptor());
+        additionalInterceptors.add(new JsonResolveEndpointInterceptor());
+        additionalInterceptors.add(new JsonRequestSetEndpointInterceptor());
         interceptors = CollectionUtils.mergeLists(interceptors, additionalInterceptors);
         interceptors = CollectionUtils.mergeLists(interceptors, config.option(SdkClientOption.EXECUTION_INTERCEPTORS));
         ServiceConfiguration.Builder c = ((ServiceConfiguration) config.option(SdkClientOption.SERVICE_CONFIGURATION))

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -14,7 +14,8 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.services.json.rules.JsonEndpointProvider;
-import software.amazon.awssdk.services.json.rules.internal.JsonEndpointInterceptor;
+import software.amazon.awssdk.services.json.rules.internal.JsonRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.json.rules.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
 
 /**
@@ -54,7 +55,8 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         List<ExecutionInterceptor> interceptors = interceptorFactory
             .getInterceptors("software/amazon/awssdk/services/json/execution.interceptors");
         List<ExecutionInterceptor> additionalInterceptors = new ArrayList<>();
-        additionalInterceptors.add(new JsonEndpointInterceptor());
+        additionalInterceptors.add(new JsonResolveEndpointInterceptor());
+        additionalInterceptors.add(new JsonRequestSetEndpointInterceptor());
         interceptors = CollectionUtils.mergeLists(interceptors, additionalInterceptors);
         interceptors = CollectionUtils.mergeLists(interceptors, config.option(SdkClientOption.EXECUTION_INTERCEPTORS));
         return config.toBuilder().option(SdkClientOption.EXECUTION_INTERCEPTORS, interceptors).build();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -15,7 +15,8 @@ import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.protocols.query.interceptor.QueryParametersToBodyInterceptor;
 import software.amazon.awssdk.services.query.rules.QueryClientContextParams;
 import software.amazon.awssdk.services.query.rules.QueryEndpointProvider;
-import software.amazon.awssdk.services.query.rules.internal.QueryEndpointInterceptor;
+import software.amazon.awssdk.services.query.rules.internal.QueryRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.query.rules.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
 
 /**
@@ -47,7 +48,8 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
         List<ExecutionInterceptor> interceptors = interceptorFactory
             .getInterceptors("software/amazon/awssdk/services/query/execution.interceptors");
         List<ExecutionInterceptor> additionalInterceptors = new ArrayList<>();
-        additionalInterceptors.add(new QueryEndpointInterceptor());
+        additionalInterceptors.add(new QueryResolveEndpointInterceptor());
+        additionalInterceptors.add(new QueryRequestSetEndpointInterceptor());
         additionalInterceptors.add(new QueryParametersToBodyInterceptor());
         interceptors = CollectionUtils.mergeLists(interceptors, additionalInterceptors);
         interceptors = CollectionUtils.mergeLists(interceptors, config.option(SdkClientOption.EXECUTION_INTERCEPTORS));

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -11,7 +11,6 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.rules.model.Endpoint;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.query.model.OperationWithContextParamRequest;
 import software.amazon.awssdk.services.query.rules.QueryClientContextParams;
 import software.amazon.awssdk.services.query.rules.QueryEndpointParams;
@@ -20,19 +19,20 @@ import software.amazon.awssdk.utils.AttributeMap;
 
 @Generated("software.amazon.awssdk:codegen")
 @SdkInternalApi
-public final class QueryEndpointInterceptor implements ExecutionInterceptor {
+public final class QueryResolveEndpointInterceptor implements ExecutionInterceptor {
     @Override
-    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         if (AwsProviderUtils.endpointIsDiscovered(executionAttributes)) {
-            return context.httpRequest();
+            return context.request();
         }
         QueryEndpointProvider provider = (QueryEndpointProvider) executionAttributes
             .getAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER);
         Endpoint result = provider.resolveEndpoint(ruleParams(context, executionAttributes));
-        return AwsProviderUtils.setUri(context.httpRequest(), result.url());
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, result);
+        return context.request();
     }
 
-    private static QueryEndpointParams ruleParams(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    private static QueryEndpointParams ruleParams(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
         QueryEndpointParams.Builder builder = QueryEndpointParams.builder();
         setStaticContextParams(builder, executionAttributes.getAttribute(AwsExecutionAttribute.OPERATION_NAME));
         setContextParams(builder, executionAttributes.getAttribute(AwsExecutionAttribute.OPERATION_NAME), context.request());

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/request-set-endpoint-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/request-set-endpoint-interceptor.java
@@ -1,0 +1,24 @@
+package software.amazon.awssdk.services.query.rules.internal;
+
+import software.amazon.awssdk.annotations.Generated;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.rules.AwsProviderUtils;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.rules.model.Endpoint;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+@Generated("software.amazon.awssdk:codegen")
+@SdkInternalApi
+public final class QueryRequestSetEndpointInterceptor implements ExecutionInterceptor {
+    @Override
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        if (AwsProviderUtils.endpointIsDiscovered(executionAttributes)) {
+            return context.httpRequest();
+        }
+        Endpoint endpoint = (Endpoint) executionAttributes.getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
+        return AwsProviderUtils.setUri(context.httpRequest(), endpoint.url());
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.interceptor;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksumRequired;
+import software.amazon.awssdk.core.rules.model.Endpoint;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -44,7 +45,7 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("HttpChecksumRequired");
 
     /**
-     * Whether host prefix injection has been disbabled on the client.
+     * Whether host prefix injection has been disabled on the client.
      * See {@link software.amazon.awssdk.core.client.config.SdkAdvancedClientOption#DISABLE_HOST_PREFIX_INJECTION}
      */
     public static final ExecutionAttribute<Boolean> DISABLE_HOST_PREFIX_INJECTION =
@@ -70,6 +71,12 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
      */
     public static final ExecutionAttribute<Object> ENDPOINT_PROVIDER =
         new ExecutionAttribute<>("EndpointProvider");
+
+    /**
+     * The resolved destination endpoint.
+     */
+    public static final ExecutionAttribute<Endpoint> RESOLVED_ENDPOINT =
+        new ExecutionAttribute<>("ResolvedEndpoint");
 
     public static final ExecutionAttribute<AttributeMap> CLIENT_CONTEXT_PARAMS =
         new ExecutionAttribute<>("ClientContextParams");

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/endpointproviders/EndpointInterceptorTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.endpointproviders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.core.rules.model.Endpoint;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersAsyncClient;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersAsyncClientBuilder;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClient;
+import software.amazon.awssdk.services.restjsonendpointproviders.RestJsonEndpointProvidersClientBuilder;
+
+public class EndpointInterceptorTests {
+
+    @Test
+    public void sync_clientContextParamsSetOnBuilder_includedInExecutionAttributes() {
+        CapturingInterceptor interceptor = new CapturingInterceptor();
+        RestJsonEndpointProvidersClient client = syncClientBuilder()
+            .overrideConfiguration(o -> o.addExecutionInterceptor(interceptor))
+            .build();
+
+        assertThatThrownBy(() -> client.operationWithNoInputOrOutput(r -> {
+        })).hasMessageContaining("stop");
+
+        Endpoint endpoint = interceptor.executionAttributes().getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
+        assertThat(endpoint).isNotNull();
+    }
+
+    @Test
+    public void async_clientContextParamsSetOnBuilder_includedInExecutionAttributes() {
+        CapturingInterceptor interceptor = new CapturingInterceptor();
+        RestJsonEndpointProvidersAsyncClient client = asyncClientBuilder()
+            .overrideConfiguration(o -> o.addExecutionInterceptor(interceptor))
+            .build();
+
+        assertThatThrownBy(() -> client.operationWithNoInputOrOutput(r -> {
+        }).join()).hasMessageContaining("stop");
+
+        Endpoint endpoint = interceptor.executionAttributes().getAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT);
+        assertThat(endpoint).isNotNull();
+    }
+
+    public static class CapturingInterceptor implements ExecutionInterceptor {
+
+        private ExecutionAttributes executionAttributes;
+
+        @Override
+        public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+            this.executionAttributes = executionAttributes;
+            throw new CaptureCompletedException("stop");
+        }
+
+        public ExecutionAttributes executionAttributes() {
+            return executionAttributes;
+        }
+
+        public class CaptureCompletedException extends RuntimeException {
+            CaptureCompletedException(String message) {
+                super(message);
+            }
+        }
+    }
+    private RestJsonEndpointProvidersClientBuilder syncClientBuilder() {
+        return RestJsonEndpointProvidersClient.builder()
+                                              .region(Region.US_WEST_2)
+                                              .credentialsProvider(
+                                                  StaticCredentialsProvider.create(
+                                                      AwsBasicCredentials.create("akid", "skid")));
+    }
+
+    private RestJsonEndpointProvidersAsyncClientBuilder asyncClientBuilder() {
+        return RestJsonEndpointProvidersAsyncClient.builder()
+                                            .region(Region.US_WEST_2)
+                                            .credentialsProvider(
+                                                StaticCredentialsProvider.create(
+                                                    AwsBasicCredentials.create("akid", "skid")));
+    }
+}


### PR DESCRIPTION
…separate interceptors

- does not extract context params into separate class because we will resolve only once