### PR TITLE
Use RFC 822 format for marshalling date shapes

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-83d35fd.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-83d35fd.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "dave-fn", 
+    "type": "bugfix", 
+    "description": "Build headers with two-digit day of month to meet RFC 822 reporting requirement"
+}

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/exception/AwsServiceExceptionTest.java
@@ -87,7 +87,7 @@ public class AwsServiceExceptionTest {
                              int statusCode,
                              Instant serverDate) {
         AwsServiceException exception = exception(clientSideTimeOffset, errorCode, statusCode,
-                                                  DateUtils.formatRfc1123Date(serverDate));
+                                                  DateUtils.formatRfc822Date(serverDate));
         assertThat(exception.isClockSkewException()).isTrue();
     }
 
@@ -96,7 +96,7 @@ public class AwsServiceExceptionTest {
                                 int statusCode,
                                 Instant serverDate) {
         AwsServiceException exception = exception(clientSideTimeOffset, errorCode, statusCode,
-                                                  DateUtils.formatRfc1123Date(serverDate));
+                                                  DateUtils.formatRfc822Date(serverDate));
         assertThat(exception.isClockSkewException()).isFalse();
     }
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/retry/AwsRetryPolicyTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/retry/AwsRetryPolicyTest.java
@@ -125,7 +125,7 @@ public class AwsRetryPolicyTest {
 
     private Consumer<RetryPolicyContext.Builder> applyErrorCode(String errorCode, Duration clockSkew, Instant dateHeader) {
         SdkHttpFullResponse response = SdkHttpFullResponse.builder()
-                                                          .putHeader("Date", DateUtils.formatRfc1123Date(dateHeader))
+                                                          .putHeader("Date", DateUtils.formatRfc822Date(dateHeader))
                                                           .build();
 
         AwsErrorDetails errorDetails = AwsErrorDetails.builder()

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java
@@ -113,7 +113,7 @@ public final class SimpleTypeJsonMarshaller {
                     jsonGenerator.writeNumber(DateUtils.formatUnixTimestampInstant(val));
                     break;
                 case RFC_822:
-                    jsonGenerator.writeValue(DateUtils.formatRfc1123Date(val));
+                    jsonGenerator.writeValue(DateUtils.formatRfc822Date(val));
                     break;
                 case ISO_8601:
                     jsonGenerator.writeValue(DateUtils.formatIso8601Date(val));

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/InstantToString.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/InstantToString.java
@@ -51,7 +51,7 @@ public final class InstantToString implements ValueToString<Instant> {
             case ISO_8601:
                 return DateUtils.formatIso8601Date(val);
             case RFC_822:
-                return DateUtils.formatRfc1123Date(val);
+                return DateUtils.formatRfc822Date(val);
             case UNIX_TIMESTAMP:
                 return DateUtils.formatUnixTimestampInstant(val);
             default:

--- a/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/StringToInstant.java
+++ b/core/protocols/protocol-core/src/main/java/software/amazon/awssdk/protocols/core/StringToInstant.java
@@ -55,7 +55,7 @@ public final class StringToInstant implements StringToValueConverter.StringToVal
             case UNIX_TIMESTAMP_MILLIS:
                 return safeParseDate(DateUtils::parseUnixTimestampMillisInstant).apply(value);
             case RFC_822:
-                return DateUtils.parseRfc1123Date(value);
+                return DateUtils.parseRfc822Date(value);
             default:
                 throw SdkClientException.create("Unrecognized timestamp format - " + format);
         }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/ClockSkew.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/ClockSkew.java
@@ -76,7 +76,7 @@ public final class ClockSkew {
             log.debug(() -> "Reported service date: " + serverDate);
 
             try {
-                return Optional.of(DateUtils.parseRfc1123Date(serverDate));
+                return Optional.of(DateUtils.parseRfc822Date(serverDate));
             } catch (RuntimeException e) {
                 log.warn(() -> "Unable to parse clock skew offset from response: " + serverDate, e);
                 return Optional.empty();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/retry/ClockSkewAdjusterTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/retry/ClockSkewAdjusterTest.java
@@ -47,7 +47,7 @@ public class ClockSkewAdjusterTest {
 
     private SdkHttpFullResponse responseWithDateOffset(int value, ChronoUnit unit) {
         return SdkHttpFullResponse.builder()
-                                  .putHeader("Date", DateUtils.formatRfc1123Date(Instant.now().plus(value, unit)))
+                                  .putHeader("Date", DateUtils.formatRfc822Date(Instant.now().plus(value, unit)))
                                   .build();
     }
 

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/clockskew/ClockSkewAdjustmentTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/clockskew/ClockSkewAdjustmentTest.java
@@ -166,7 +166,7 @@ public class ClockSkewAdjustmentTest {
                         .willReturn(aResponse()
                                             .withStatus(statusCode)
                                             .withHeader("x-amzn-ErrorType", errorCode)
-                                            .withHeader("Date", DateUtils.formatRfc1123Date(serviceTime))
+                                            .withHeader("Date", DateUtils.formatRfc822Date(serviceTime))
                                             .withBody("{}")));
     }
 
@@ -180,7 +180,7 @@ public class ClockSkewAdjustmentTest {
                         .willReturn(aResponse()
                                             .withStatus(statusCode)
                                             .withHeader("x-amzn-ErrorType", errorCode)
-                                            .withHeader("Date", DateUtils.formatRfc1123Date(serviceTime))
+                                            .withHeader("Date", DateUtils.formatRfc822Date(serviceTime))
                                             .withBody("{}")));
 
         stubFor(post(urlEqualTo(PATH))

--- a/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
@@ -25,9 +25,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -59,7 +61,9 @@ public final class DateUtils {
         .appendLiteral(' ')
         .appendOffset("+HHMM", "GMT")
         .toFormatter()
-        .withLocale(Locale.US);
+        .withLocale(Locale.US)
+        .withResolverStyle(ResolverStyle.SMART)
+        .withChronology(IsoChronology.INSTANCE);
 
     // ISO_INSTANT does not handle offsets in Java 12-. See https://bugs.openjdk.java.net/browse/JDK-8166138
     private static final List<DateTimeFormatter> ALTERNATE_ISO_8601_FORMATTERS =

--- a/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/DateUtils.java
@@ -30,6 +30,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 
@@ -47,6 +48,18 @@ public final class DateUtils {
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
             .toFormatter()
             .withZone(UTC);
+
+    /**
+     * RFC 822 date/time formatter.
+     */
+    static final DateTimeFormatter RFC_822_DATE_TIME = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .parseLenient()
+        .appendPattern("EEE, dd MMM yyyy HH:mm:ss")
+        .appendLiteral(' ')
+        .appendOffset("+HHMM", "GMT")
+        .toFormatter()
+        .withLocale(Locale.US);
 
     // ISO_INSTANT does not handle offsets in Java 12-. See https://bugs.openjdk.java.net/browse/JDK-8166138
     private static final List<DateTimeFormatter> ALTERNATE_ISO_8601_FORMATTERS =
@@ -100,6 +113,33 @@ public final class DateUtils {
      */
     public static String formatIso8601Date(Instant date) {
         return ISO_INSTANT.format(date);
+    }
+
+    /**
+     * Parses the specified date string as an RFC 822 date and returns the Date object.
+     *
+     * @param dateString
+     *            The date string to parse.
+     *
+     * @return The parsed Date object.
+     */
+    public static Instant parseRfc822Date(String dateString) {
+        if (dateString == null) {
+            return null;
+        }
+        return parseInstant(dateString, RFC_822_DATE_TIME);
+    }
+
+    /**
+     * Formats the specified date as an RFC 822 string.
+     *
+     * @param instant
+     *            The instant to format.
+     *
+     * @return The RFC 822 string representing the specified date.
+     */
+    public static String formatRfc822Date(Instant instant) {
+        return RFC_822_DATE_TIME.format(ZonedDateTime.ofInstant(instant, UTC));
     }
 
     /**

--- a/utils/src/test/java/software/amazon/awssdk/utils/DateUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/DateUtilsTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.utils;
 import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static software.amazon.awssdk.utils.DateUtils.ALTERNATE_ISO_8601_DATE_FORMAT;
@@ -73,6 +74,44 @@ public class DateUtilsTest {
     }
 
     @Test
+    public void formatRfc822Date_DateWithTwoDigitDayOfMonth_ReturnsFormattedString() throws ParseException {
+        String string = DateUtils.formatRfc822Date(INSTANT);
+        Instant parsedDateAsInstant = LONG_DATE_FORMAT.parse(string).toInstant();
+        assertThat(parsedDateAsInstant).isEqualTo(INSTANT);
+    }
+
+    @Test
+    public void formatRfc822Date_DateWithSingleDigitDayOfMonth_ReturnsFormattedString() throws ParseException {
+        Instant INSTANT_SINGLE_DIGIT_DAY_OF_MONTH = Instant.ofEpochMilli(1399484606000L);;
+        String string = DateUtils.formatRfc822Date(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH);
+        Instant parsedDateAsInstant = LONG_DATE_FORMAT.parse(string).toInstant();
+        assertThat(parsedDateAsInstant).isEqualTo(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH);
+    }
+
+    @Test
+    public void formatRfc822Date_DateWithSingleDigitDayOfMonth_ReturnsStringWithZeroLeadingDayOfMonth() throws ParseException {
+        final Instant INSTANT_SINGLE_DIGIT_DAY_OF_MONTH = Instant.ofEpochMilli(1399484606000L);;
+        String string = DateUtils.formatRfc822Date(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH);
+        String expectedString = "Wed, 07 May 2014 17:43:26 GMT";
+        assertThat(string).isEqualTo(expectedString);
+    }
+
+    @Test
+    public void parseRfc822Date_DateWithTwoDigitDayOfMonth_ReturnsInstantObject() throws ParseException {
+        String formattedDate = LONG_DATE_FORMAT.format(Date.from(INSTANT));
+        Instant parsedInstant = DateUtils.parseRfc822Date(formattedDate);
+        assertThat(parsedInstant).isEqualTo(INSTANT);
+    }
+
+    @Test
+    public void parseRfc822Date_DateWithSingleDigitDayOfMonth_ReturnsInstantObject() throws ParseException {
+        final Instant INSTANT_SINGLE_DIGIT_DAY_OF_MONTH = Instant.ofEpochMilli(1399484606000L);;
+        String formattedDate = LONG_DATE_FORMAT.format(Date.from(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH));
+        Instant parsedInstant = DateUtils.parseRfc822Date(formattedDate);
+        assertThat(parsedInstant).isEqualTo(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH);
+    }
+
+    @Test
     public void formatRfc1123Date() throws ParseException {
         String string = DateUtils.formatRfc1123Date(INSTANT);
         Instant parsedDateAsInstant = LONG_DATE_FORMAT.parse(string).toInstant();
@@ -84,7 +123,7 @@ public class DateUtilsTest {
     }
 
     @Test
-    public void parseRfc822Date() throws ParseException {
+    public void parseRfc1123Date() throws ParseException {
         String formatted = LONG_DATE_FORMAT.format(Date.from(INSTANT));
         Instant expected = LONG_DATE_FORMAT.parse(formatted).toInstant();
         Instant actual = DateUtils.parseRfc1123Date(formatted);

--- a/utils/src/test/java/software/amazon/awssdk/utils/DateUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/DateUtilsTest.java
@@ -18,10 +18,12 @@ package software.amazon.awssdk.utils;
 import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static software.amazon.awssdk.utils.DateUtils.ALTERNATE_ISO_8601_DATE_FORMAT;
+import static software.amazon.awssdk.utils.DateUtils.RFC_822_DATE_TIME;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -109,6 +111,42 @@ public class DateUtilsTest {
         String formattedDate = LONG_DATE_FORMAT.format(Date.from(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH));
         Instant parsedInstant = DateUtils.parseRfc822Date(formattedDate);
         assertThat(parsedInstant).isEqualTo(INSTANT_SINGLE_DIGIT_DAY_OF_MONTH);
+    }
+
+    @Test
+    public void parseRfc822Date_DateWithInvalidDayOfMonth_IsParsedWithSmartResolverStyle() {
+        String badDateString = "Wed, 31 Apr 2014 17:43:26 GMT";
+        String validDateString = "Wed, 30 Apr 2014 17:43:26 GMT";
+        Instant badDateParsedInstant = DateUtils.parseRfc822Date(badDateString);
+        Instant validDateParsedInstant = DateUtils.parseRfc1123Date(validDateString);
+        assertThat(badDateParsedInstant).isEqualTo(validDateParsedInstant);
+    }
+
+    @Test
+    public void parseRfc822Date_DateWithInvalidDayOfMonth_MatchesRfc1123Behavior() {
+        String dateString = "Wed, 31 Apr 2014 17:43:26 GMT";
+        Instant parsedInstantFromRfc822Parser = DateUtils.parseRfc822Date(dateString);
+        Instant parsedInstantFromRfc1123arser = DateUtils.parseRfc1123Date(dateString);
+        assertThat(parsedInstantFromRfc822Parser).isEqualTo(parsedInstantFromRfc1123arser);
+    }
+    
+    @Test
+    public void parseRfc822Date_DateWithDayOfMonthLessThan10th_MatchesRfc1123Behavior() {
+        String rfc822DateString = "Wed, 02 Apr 2014 17:43:26 GMT";
+        String rfc1123DateString = "Wed, 2 Apr 2014 17:43:26 GMT";
+        Instant parsedInstantFromRfc822Parser = DateUtils.parseRfc822Date(rfc822DateString);
+        Instant parsedInstantFromRfc1123arser = DateUtils.parseRfc1123Date(rfc1123DateString);
+        assertThat(parsedInstantFromRfc822Parser).isEqualTo(parsedInstantFromRfc1123arser);
+    }
+
+    @Test
+    public void resolverStyleOfRfc822FormatterMatchesRfc1123Formatter() {
+        assertThat(RFC_822_DATE_TIME.getResolverStyle()).isSameAs(RFC_1123_DATE_TIME.getResolverStyle());
+    }
+
+    @Test
+    public void chronologyOfRfc822FormatterMatchesRfc1123Formatter() {
+        assertThat(RFC_822_DATE_TIME.getChronology()).isSameAs(RFC_1123_DATE_TIME.getChronology());
     }
 
     @Test


### PR DESCRIPTION
Add utility method so that dates are marshalled using RFC 822 format.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The formatted representation of dates with single-digit day of month also includes a single-digit. This code fix will change the representation to two-digit day of month.

Current:
```
Expires: Fri, 1 Sep 2023 01:01:01 GMT.
```

Expected:
```
Expires: Fri, 01 Sep 2023 01:01:01 GMT
```


## Modifications
Modified DateUtils.java to add parse and format methods specific to RFC 822. Cascaded these changes to other modules.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license