### PR TITLE
Enable configuration of the connection timeout for AwsCrtAsyncHttpClient

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-29af98e.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-29af98e.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "L-Applin",
+    "description": "Enable configuration of the connection timeout for AwsCrtAsyncHttpClient"
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBuilderTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBuilderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.testng.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.platform.commons.support.ReflectionSupport;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+
+class AwsCrtHttpClientBuilderTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(TimeoutArgumentProvider.class)
+    void createBuilder_withConnectionTimeout_updateClientTimeout(Duration timeout, int millis) throws Exception {
+        SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.builder().connectionTimeout(timeout).build();
+        validateTimeoutValue(client, millis);
+        client.close();
+    }
+
+    @Test
+    void createBuilder_withoutConnectionTimeout_shouldUseDefaultValue() throws Exception {
+        SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.create();
+        int globalDefaultConnectionTimeout =
+            (int) SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toMillis();
+        validateTimeoutValue(client, globalDefaultConnectionTimeout);
+        client.close();
+    }
+
+    private void validateTimeoutValue(SdkAsyncHttpClient client, int expected) throws Exception {
+        Field socketOptionsField = AwsCrtAsyncHttpClient.class.getDeclaredField("socketOptions");
+        SocketOptions options = (SocketOptions) ReflectionSupport.tryToReadFieldValue(socketOptionsField, client)
+                                                                 .ifFailure(e -> fail("Cannot read field socketOptions from class "
+                                                                                      + "AwsCrtAsyncHttpClient", e))
+                                                                 .get();
+        assertThat(options.connectTimeoutMs).isEqualTo(expected);
+    }
+
+    private static class TimeoutArgumentProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                arguments(Duration.ofSeconds(0), 0),
+                arguments(Duration.ofSeconds(1), 1_000),
+                arguments(Duration.ofSeconds(10), 10_000),
+                arguments(Duration.ofDays(40), Integer.MAX_VALUE)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
This pull-request intent is to resolve #3251 

## Modifications
Update the `AwsCrtAsyncHttpClient.Builder` class with a method to set the connection timeout. If not specified, will default to the value in `SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS` which is 2 seconds. This change will therefore overwrite the default value of 3 seconds specified in the `SocketOption`.

## Testing
Created new unit test to validate field was set correctly.

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
