### PR TITLE
Fix sdk-benchmarks version

### DIFF
--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -234,7 +234,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>9.4.15.v20190215</version>
+                <version>${jetty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix `java.lang.NoClassDefFoundError: org/eclipse/jetty/util/component/AttributeContainerMap` caused by mixed version of jetty

## Testing
Tested locally
