### PR TITLE
Replace inline snippets with external compilable snippets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,11 @@
                                 <doclint>none</doclint>
                                 <!-- Exclude service packages to accelerate build -->
                                 <excludePackageNames>software.amazon.awssdk.services.*:*.codegen</excludePackageNames>
+                                <additionalOptions>
+                                    <additionalOption>
+                                        --snippet-path=${basedir}/src/test/java
+                                    </additionalOption>
+                                </additionalOptions>
                             </configuration>
                         </execution>
                     </executions>
@@ -930,6 +935,11 @@
                             <doctitle>AWS SDK for Java API Reference - ${awsjavasdk.version}</doctitle>
                             <packagesheader>AWS SDK for Java</packagesheader>
                             <excludePackageNames>:*.codegen:software.amazon.awssdk.services.protocol*</excludePackageNames>
+                            <additionalOptions>
+                                <additionalOption>
+                                    --snippet-path=${basedir}/src/test/java
+                                </additionalOption>
+                            </additionalOptions>
                             <groups>
                                 <group>
                                     <title>Greengrass</title>

--- a/pom.xml
+++ b/pom.xml
@@ -232,11 +232,9 @@
                                 <doclint>none</doclint>
                                 <!-- Exclude service packages to accelerate build -->
                                 <excludePackageNames>software.amazon.awssdk.services.*:*.codegen</excludePackageNames>
-                                <additionalOptions>
-                                    <additionalOption>
-                                        --snippet-path=${basedir}/src/test/java
-                                    </additionalOption>
-                                </additionalOptions>
+                                <additionalJOption>
+                                    ${additionalJavadocOption}
+                                </additionalJOption>
                             </configuration>
                         </execution>
                     </executions>
@@ -716,6 +714,17 @@
         </profile>
 
         <profile>
+            <id>jdk-18-plus</id>
+            <activation>
+                <jdk>[18,)</jdk>
+            </activation>
+            <properties>
+                <!-- snippet-path only works with JDK 18+ -->
+                <additionalJavadocOption>--snippet-path=${basedir}/src/test/java</additionalJavadocOption>
+            </properties>
+        </profile>
+
+        <profile>
             <id>quick</id>
             <properties>
                 <checkstyle.skip>true</checkstyle.skip>
@@ -928,6 +937,9 @@
                             <nodeprecatedlist>true</nodeprecatedlist>
                             <additionalJOptions>
                                 <additionalJOption>--allow-script-in-comments</additionalJOption>
+                                <additionalJOption>
+                                    ${additionalJavadocOption}
+                                </additionalJOption>
                             </additionalJOptions>
                             <windowtitle>AWS SDK for Java - ${awsjavasdk.version}</windowtitle>
                             <encoding>UTF-8</encoding>
@@ -935,11 +947,6 @@
                             <doctitle>AWS SDK for Java API Reference - ${awsjavasdk.version}</doctitle>
                             <packagesheader>AWS SDK for Java</packagesheader>
                             <excludePackageNames>:*.codegen:software.amazon.awssdk.services.protocol*</excludePackageNames>
-                            <additionalOptions>
-                                <additionalOption>
-                                    --snippet-path=${basedir}/src/test/java
-                                </additionalOption>
-                            </additionalOptions>
                             <groups>
                                 <group>
                                     <title>Greengrass</title>

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -103,6 +103,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-client-spi</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
@@ -59,10 +59,10 @@ import software.amazon.awssdk.utils.Validate;
  * small parts from a single object. The Transfer Manager is built on top of the Java bindings of the AWS Common Runtime S3 client
  * and leverages Amazon S3 multipart upload and byte-range fetches for parallel transfers.
  *
- * <h1>Instantiate a Transfer Manager</h1>
- * <b>Create a transfer manager with SDK default settings</b>
+ * <h1>Instantiate Transfer Manager</h1>
+ * <b>Create a transfer manager instance with SDK default settings</b>
  * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = defaultTM}
- * <b>Create a transfer manager with custom settings</b>
+ * <b>Create a transfer manager instance with custom settings</b>
  * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = customTM}
  * <h1>Common Usage Patterns</h1>
  * <b>Upload a file to S3</b>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
@@ -54,58 +54,27 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.Validate;
 
 /**
- * The S3 Transfer Manager is a library that allows users to easily and
- * optimally upload and downloads to and from S3.
+ * The S3 Transfer Manager is a library that allows users to easily perform accelerated uploads and downloads of objects to and
+ * from Amazon S3 and benefit from enhanced throughput and reliability, which is achieved through concurrent transfers of a set of
+ * small parts from a single object. The Transfer Manager is built on top of the Java bindings of the AWS Common Runtime S3 client
+ * and leverages Amazon S3 multipart upload and byte-range fetches for parallel transfers.
  *
- * <b>Usage Example:</b>
- *
- * <pre>
- * {@code
- * // Create using all default configuration values
- * S3TransferManager tm = S3TransferManager.create();
- *
- * // If you wish to configure settings, we recommend using the builder instead
- * S3TransferManager tm =
- *     S3TransferManager.builder()
- *                      .s3AsyncClient(S3CrtAsyncClient.builder()
- *                                                     .credentialsProvider(credentialProvider)
- *                                                     .region(Region.US_WEST_2)
- *                                                     .targetThroughputInGbps(20.0)
- *                                                     .minimumPartSizeInBytes(8 * MB))
- *                      .build();
- *
- * // Upload a file to S3
- * FileUpload upload =
- *     tm.uploadFile(u -> u.source(Paths.get("myFile.txt"))
- *                         .putObjectRequest(p -> p.bucket("bucket").key("key")));
- * upload.completionFuture().join();
- *
- * // Download an S3 object to a file
- * FileDownload download =
- *     tm.downloadFile(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key"))
- *                           .destination(Paths.get("myFile.txt")));
- * download.completionFuture().join();
- * 
- * // Upload any content to S3
- * Upload upload =
- *     tm.upload(u -> u.requestBody(AsyncRequestBody.fromString("Hello world"))
- *                     .putObjectRequest(p -> p.bucket("bucket").key("key")));
- * upload.completionFuture().join();
- * 
- * // Download an S3 object to a custom destination
- * Download<ResponseBytes<GetObjectResponse>> download =
- *     tm.download(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key"))
- *                       .responseTransformer(AsyncResponseTransformer.toBytes()));
- * download.completionFuture().join();
- * 
- * // Attach a TransferListener
- * FileUpload upload =
- *     tm.uploadFile(u -> u.source(Paths.get("myFile.txt"))
- *                         .putObjectRequest(p -> p.bucket("bucket").key("key"))
- *                         .addTransferListener(LoggingTransferListener.create()));
- * upload.completionFuture().join();
- * }
- * </pre>
+ * <h1>Instantiate a Transfer Manager</h1>
+ * <b>Create a transfer manager with SDK default settings</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = defaultTM}
+ * <b>Create a transfer manager with custom settings</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = customTM}
+ * <h1>Common Usage Patterns</h1>
+ * <b>Upload a file to S3</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = uploadFile}
+ * <b>Download an S3 object to a local file</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = downloadFile}
+ * <b>Upload a local directory to an S3 bucket</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = uploadDirectory}
+ * <b>Download S3 objects to a local directory</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = downloadDirectory}
+ * <b>Copy an S3 object to a different location in S3</b>
+ * {@snippet class = software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region = copy}
  */
 @SdkPublicApi
 @SdkPreviewApi
@@ -119,16 +88,7 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *  event of an error, the SDK will NOT attempt to delete the file, leaving it as-is.
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * // Initiate the transfer
-     * FileDownload download =
-     *     tm.downloadFile(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key"))
-     *                           .destination(Paths.get("myFile.txt")));
-     * // Wait for the transfer to complete
-     * download.completionFuture().join();
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=downloadFile }
      *
      * @see #downloadFile(Consumer)
      * @see #download(DownloadRequest)
@@ -155,27 +115,8 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * // Initiate the transfer
-     * FileDownload download =
-     *     tm.downloadFile(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key"))
-     *                           .destination(Paths.get("myFile.txt")));
-     *
-     * // Pause the download
-     * ResumableFileDownload resumableFileDownload = download.pause();
-     *
-     * //Optionally, persist the download object
-     * resumableFileDownload.writeToFile(file);
-     * ResumableFileDownload resumableFileDownload2 = ResumableFileDownload.fromFile(file);
-     *
-     * // Resume the download
-     * FileDownload resumedDownload = tm.resumeDownloadFile(resumableFileDownload2);
-     *
-     * // Wait for the transfer to complete
-     * resumedDownload.completionFuture().join();
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=resumeDownloadFile }
      * }
-     * </pre>
      *
      * @param resumableFileDownload the download to resume.
      * @return A new {@code FileDownload} object to use to check the state of the download.
@@ -201,16 +142,8 @@ public interface S3TransferManager extends SdkAutoCloseable {
      * downloading to a file, you may use {@link #downloadFile(DownloadFileRequest)} instead.
      * <p>
      * <b>Usage Example (this example buffers the entire object in memory and is not suitable for large objects):</b>
-     * <pre>
-     * {@code
-     * // Initiate the transfer
-     * Download<ResponseBytes<GetObjectResponse>> download =
-     *     tm.download(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key"))
-     *                       .responseTransformer(AsyncResponseTransformer.toBytes()));
-     * // Wait for the transfer to complete
-     * download.completionFuture().join();
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=download }
+     *
      * See the static factory methods available in {@link AsyncResponseTransformer} for other use cases.
      *
      * @param downloadRequest the download request, containing a {@link GetObjectRequest} and {@link AsyncResponseTransformer}
@@ -238,16 +171,8 @@ public interface S3TransferManager extends SdkAutoCloseable {
      * Upload a local file to an object in S3. For non-file-based uploads, you may use {@link #upload(UploadRequest)} instead.
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * FileUpload upload =
-     *     tm.uploadFile(u -> u.source(Paths.get("myFile.txt"))
-     *                         .putObjectRequest(p -> p.bucket("bucket").key("key")));
-     * // Wait for the transfer to complete
-     * upload.completionFuture().join();
-     * }
-     * </pre>
-     * 
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=uploadFile }
+     *
      * @see #uploadFile(Consumer) 
      * @see #upload(UploadRequest) 
      */
@@ -273,28 +198,7 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * // Initiate the transfer
-     * FileUpload upload =
-     *     tm.uploadFile(d -> d.putObjectRequest(g -> g.bucket("bucket").key("key"))
-     *                           .source(Paths.get("myFile.txt")));
-     *
-     * // Pause the download
-     * ResumableFileUpload resumableFileUpload = upload.pause();
-     *
-     * //Optionally, persist the download object
-     * resumableFileUpload.writeToFile(file);
-     *
-     * ResumableFileUpload persistedResumableFileUpload = ResumableFileUpload.fromFile(file);
-     *
-     * // Resume the download
-     * FileUpload resumedUpload = tm.resumeUploadFile(persistedResumableFileUpload);
-     *
-     * // Wait for the transfer to complete
-     * resumedUpload.completionFuture().join();
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=resumeUploadFile }
      *
      * @param resumableFileUpload the upload to resume.
      * @return A new {@code FileUpload} object to use to check the state of the download.
@@ -320,15 +224,8 @@ public interface S3TransferManager extends SdkAutoCloseable {
      * {@link #uploadFile(UploadFileRequest)} instead.
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * Upload upload =
-     *     tm.upload(u -> u.requestBody(AsyncRequestBody.fromString("Hello world"))
-     *                     .putObjectRequest(p -> p.bucket("bucket").key("key")));
-     * // Wait for the transfer to complete
-     * upload.completionFuture().join();
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=upload }
+     *
      * See the static factory methods available in {@link AsyncRequestBody} for other use cases.
      *
      * @param uploadRequest the upload request, containing a {@link PutObjectRequest} and {@link AsyncRequestBody}
@@ -396,22 +293,7 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * DirectoryUpload directoryUpload =
-     *       transferManager.uploadDirectory(UploadDirectoryRequest.builder()
-     *                                                             .sourceDirectory(Paths.get("."))
-     *                                                             .bucket("bucket")
-     *                                                             .prefix("prefix")
-     *                                                             .build());
-     * // Wait for the transfer to complete
-     * CompletedDirectoryUpload completedDirectoryUpload = directoryUpload.completionFuture().join();
-     *
-     * // Print out the failed uploads
-     * completedDirectoryUpload.failedTransfers().forEach(System.out::println);
-     *
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=uploadDirectory }
      *
      * @param uploadDirectoryRequest the upload directory request
      * @see #uploadDirectory(Consumer)
@@ -477,22 +359,7 @@ public interface S3TransferManager extends SdkAutoCloseable {
      *
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * DirectoryDownload directoryDownload =
-     *       transferManager.downloadDirectory(DownloadDirectoryRequest.builder()
-     *                                                                 .destination(Paths.get("."))
-     *                                                                 .bucket("bucket")
-     *                                                                 .prefix("prefix")
-     *                                                                 .build());
-     * // Wait for the transfer to complete
-     * CompletedDirectoryDownload completedDirectoryDownload = directoryDownload.completionFuture().join();
-     *
-     * // Print out the failed downloads
-     * completedDirectoryDownload.failedTransfers().forEach(System.out::println);
-     *
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=downloadDirectory }
      *
      * @param downloadDirectoryRequest the download directory request
      * @see #downloadDirectory(Consumer)
@@ -528,18 +395,7 @@ public interface S3TransferManager extends SdkAutoCloseable {
      * describing the outcome.
      * <p>
      * <b>Usage Example:</b>
-     * <pre>
-     * {@code
-     * Copy copy = tm.copy(c -> c
-     *     .copyObjectRequest(r -> r
-     *         .sourceBucket(BUCKET)
-     *         .sourceKey(ORIGINAL_OBJ)
-     *         .destinationBucket(BUCKET)
-     *         .destinationKey(COPIED_OBJ)));
-     * // Wait for the transfer to complete
-     * CompletedCopy completedCopy = copy.completionFuture().join();
-     * }
-     * </pre>
+     * {@snippet class=software.amazon.awssdk.transfer.s3.samples.S3TransferManagerSamples region=copy }
      *
      * @param copyRequest the copy request, containing a {@link CopyObjectRequest}
      * @return A {@link Copy} that can be used to track the ongoing transfer

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/TransferRequestOverrideConfiguration.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/config/TransferRequestOverrideConfiguration.java
@@ -99,9 +99,7 @@ public final class TransferRequestOverrideConfiguration
          * transferListeners that have already been set. Add an optional request override configuration.
          *
          * @param transferListeners     the collection of transferListeners
-         * @param configuration The override configuration.
          * @return Returns a reference to this object so that method calls can be chained together.
-         * @return This builder for method chaining.
          * @see TransferListener
          */
         Builder transferListeners(Collection<TransferListener> transferListeners);

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/CopyRequest.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/model/CopyRequest.java
@@ -142,7 +142,7 @@ public final class CopyRequest
          *
          * @param copyRequestBuilder the copyRequest consumer builder
          * @return Returns a reference to this object so that method calls can be chained together.
-         * @see #copyRequest(CopyRequest)
+         * @see #copyObjectRequest(CopyObjectRequest) 
          */
         default Builder copyObjectRequest(Consumer<CopyObjectRequest.Builder> copyRequestBuilder) {
             return copyObjectRequest(CopyObjectRequest.builder()

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/samples/S3TransferManagerSamples.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/samples/S3TransferManagerSamples.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.transfer.s3.samples;
+
+import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedCopy;
+import software.amazon.awssdk.transfer.s3.model.CompletedDirectoryDownload;
+import software.amazon.awssdk.transfer.s3.model.CompletedDirectoryUpload;
+import software.amazon.awssdk.transfer.s3.model.Copy;
+import software.amazon.awssdk.transfer.s3.model.DirectoryDownload;
+import software.amazon.awssdk.transfer.s3.model.DirectoryUpload;
+import software.amazon.awssdk.transfer.s3.model.Download;
+import software.amazon.awssdk.transfer.s3.model.DownloadDirectoryRequest;
+import software.amazon.awssdk.transfer.s3.model.FileDownload;
+import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
+import software.amazon.awssdk.transfer.s3.model.ResumableFileUpload;
+import software.amazon.awssdk.transfer.s3.model.Upload;
+import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
+import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
+
+/**
+ * Contains code snippets that will be used in the Javadocs of {@link S3TransferManager}
+ */
+public class S3TransferManagerSamples {
+
+    public void defaultClient() {
+        // @start region=defaultTM
+        S3TransferManager transferManager = S3TransferManager.create();
+        // @end region=defaultTM
+    }
+
+    public void customClient() {
+        // @start region=customTM
+        S3AsyncClient s3AsyncClient = S3AsyncClient.crtBuilder()
+                                                   .credentialsProvider(DefaultCredentialsProvider.create())
+                                                   .region(Region.US_WEST_2)
+                                                   .targetThroughputInGbps(20.0)
+                                                   .minimumPartSizeInBytes(8 * MB)
+                                                   .build();
+
+        S3TransferManager transferManager =
+            S3TransferManager.builder()
+                             .s3AsyncClient(s3AsyncClient)
+                             .build();
+        // @end region=customTM
+    }
+
+    public void downloadFile() {
+        // @start region=downloadFile
+        S3TransferManager transferManager = S3TransferManager.create();
+
+        FileDownload download =
+            transferManager.downloadFile(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key")).destination(Paths.get(
+                "myFile.txt")));
+
+        // Wait for the transfer to complete
+        download.completionFuture().join();
+        // @end region=downloadFile
+    }
+
+    public void download() {
+        // @start region=download
+        S3TransferManager transferManager = S3TransferManager.create();
+
+        // Initiate the transfer
+        Download<ResponseBytes<GetObjectResponse>> download =
+            transferManager.download(d -> d.getObjectRequest(g -> g.bucket("bucket")
+                                                                   .key("key"))
+                                           .responseTransformer(AsyncResponseTransformer.toBytes()));
+        // Wait for the transfer to complete
+        download.completionFuture().join();
+        // @end region=download
+    }
+
+    public void resumeDownloadFile() {
+        // @start region=resumeDownloadFile
+        S3TransferManager transferManager = S3TransferManager.create();
+
+        // Initiate the transfer
+        FileDownload download =
+            transferManager.downloadFile(d -> d.getObjectRequest(g -> g.bucket("bucket").key("key")).destination(Paths.get(
+                "myFile.txt")));
+
+        // Pause the download
+        ResumableFileDownload resumableFileDownload = download.pause(); // @link substring="pause" target="software.amazon.awssdk.transfer.s3.model.FileDownload#pause()"
+
+        // Optionally, persist the download object
+        Path path = Paths.get("resumableFileDownload.json");
+        resumableFileDownload.serializeToFile(path);
+
+        // Retrieve the resumableFileDownload from the file
+        resumableFileDownload = ResumableFileDownload.fromFile(path);
+
+        // Resume the download
+        FileDownload resumedDownload = transferManager.resumeDownloadFile(resumableFileDownload);
+
+        // Wait for the transfer to complete
+        resumedDownload.completionFuture().join();
+        // @end region=resumeDownloadFile
+    }
+
+    public void resumeUploadFile() {
+        // @start region=resumeUploadFile
+        S3TransferManager transferManager = S3TransferManager.create();
+
+        // Initiate the transfer
+        FileUpload upload =
+            transferManager.uploadFile(d -> d.putObjectRequest(g -> g.bucket("bucket").key("key")).source(Paths.get("myFile"
+                                                                                                                    + ".txt")));
+        // Pause the upload
+        ResumableFileUpload resumableFileUpload = upload.pause();
+
+        // Optionally, persist the resumableFileUpload
+        Path path = Paths.get("resumableFileUpload.json");
+        resumableFileUpload.serializeToFile(path);
+
+        // Retrieve the resumableFileUpload from the file
+        ResumableFileUpload persistedResumableFileUpload = ResumableFileUpload.fromFile(path);
+
+        // Resume the upload
+        FileUpload resumedUpload = transferManager.resumeUploadFile(persistedResumableFileUpload);
+
+        // Wait for the transfer to complete
+        resumedUpload.completionFuture().join();
+        // @end region=resumeUploadFile
+    }
+
+    public void uploadFile() {
+        // @start region=uploadFile
+        S3TransferManager transferManager = S3TransferManager.create();
+
+        FileUpload upload = transferManager.uploadFile(u -> u.source(Paths.get("myFile.txt"))
+                                                             .putObjectRequest(p -> p.bucket("bucket").key(
+                                                                 "key")));
+        upload.completionFuture().join();
+        // @end region=uploadFile
+    }
+
+    public void upload() {
+        // @start region=upload
+        S3TransferManager transferManager = S3TransferManager.create();
+
+        Upload upload = transferManager.upload(u -> u.requestBody(AsyncRequestBody.fromString("Hello world"))
+                                                     .putObjectRequest(p -> p.bucket("bucket").key("key")));
+        // Wait for the transfer to complete
+        upload.completionFuture().join();
+        // @end region=upload
+    }
+
+    public void uploadDirectory() {
+        // @start region=uploadDirectory
+        S3TransferManager transferManager = S3TransferManager.create();
+        DirectoryUpload directoryUpload =
+            transferManager.uploadDirectory(UploadDirectoryRequest.builder()
+                                                                  .sourceDirectory(Paths.get("source/directory"))
+                                                                  .bucket("bucket")
+                                                                  .s3Prefix("prefix")
+                                                                  .build());
+
+        // Wait for the transfer to complete
+        CompletedDirectoryUpload completedDirectoryUpload = directoryUpload.completionFuture().join();
+
+        // Print out the failed uploads
+        completedDirectoryUpload.failedTransfers().forEach(System.out::println);
+        // @end region=uploadDirectory
+    }
+
+    public void downloadDirectory() {
+        // @start region=downloadDirectory
+        S3TransferManager transferManager = S3TransferManager.create();
+        DirectoryDownload directoryDownload =
+            transferManager.downloadDirectory(DownloadDirectoryRequest.builder()
+                                                                      .destination(Paths.get("destination/directory"))
+                                                                      .bucket("bucket")
+                                                                      .listObjectsV2RequestTransformer(l -> l.prefix("prefix"))
+                                                                      .build());
+        // Wait for the transfer to complete
+        CompletedDirectoryDownload completedDirectoryDownload = directoryDownload.completionFuture().join();
+
+        // Print out the failed downloads
+        completedDirectoryDownload.failedTransfers().forEach(System.out::println);
+        // @end region=downloadDirectory
+    }
+
+    public void copy() {
+        // @start region=copy
+        S3TransferManager transferManager = S3TransferManager.create();
+        Copy copy =
+            transferManager.copy(c -> c.copyObjectRequest(r -> r.sourceBucket("source_bucket")
+                                                                .sourceKey("source_key")
+                                                                .destinationBucket("dest_bucket")
+                                                                .destinationKey("dest_key")));
+        // Wait for the transfer to complete
+        CompletedCopy completedCopy = copy.completionFuture().join();
+        // @end region=copy
+    }
+}

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/samples/S3TransferManagerSamples.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/samples/S3TransferManagerSamples.java
@@ -41,7 +41,6 @@ import software.amazon.awssdk.transfer.s3.model.ResumableFileDownload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadDirectoryRequest;
-import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
 
 /**
  * Contains code snippets that will be used in the Javadocs of {@link S3TransferManager}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Replace inline snippets with external snippets so that we can make sure sample code compiles

## Modifications
Use `@snippet` introduced in Java 18 in S3 transfer manager for code snippets 
https://docs.oracle.com/en/java/javase/18/code-snippet/index.html#external-snippets

## Testing
Tested it locally and verified the generated Javadoc, will test it using CodeBuild

