### PR TITLE
Add LRU Cache to utilities

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -80,6 +80,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/lru/LruCache.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/lru/LruCache.java
@@ -18,8 +18,6 @@ package software.amazon.awssdk.utils.cache.lru;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.utils.Validate;
@@ -27,7 +25,7 @@ import software.amazon.awssdk.utils.Validate;
 /**
  * An LRU (Least Recently Used) cache implementation.
  * <p>
- * The user can configure the maximum size of the cache, which is set to a default of 100.
+ * The user can configure the maximum size of the cache, which is set to a default of 100. Null values are accepted.
  */
 @SdkProtectedApi
 public final class LruCache<K, V>  {
@@ -39,7 +37,7 @@ public final class LruCache<K, V>  {
 
     private CacheEntry<K, V> leastRecentlyUsed = null;
     private CacheEntry<K, V> mostRecentlyUsed = null;
-    private final Lock listLock = new ReentrantLock();
+    private final Object listLock = new Object();
     private final int maxCacheSize;
 
     private LruCache(Builder<K, V> b) {
@@ -49,52 +47,72 @@ public final class LruCache<K, V>  {
         this.cache = new ConcurrentHashMap<>();
     }
 
+
+    /**
+     * Get a value based on the key. If the value exists in the cache, it's returned, and it's position in the cache is updated.
+     * Otherwise, the value is calculated based on the supplied function {@link Builder#builder(Function)}.
+     */
     public V get(K key) {
-        CacheEntry<K, V> cachedEntry = cache.get(key);
-        if (cachedEntry != null) {
-            moveToFront(cachedEntry);
-            return cachedEntry.value();
-        }
+        CacheEntry<K, V> cachedEntry = cache.computeIfAbsent(key, this::newEntry);
+        updateCacheOrder(cachedEntry);
+        return cachedEntry.value();
+    }
+
+    private CacheEntry<K, V> newEntry(K key) {
         V value = valueSupplier.apply(key);
-        CacheEntry<K, V> newEntry = new CacheEntry<>(key, value);
-        addToFront(newEntry);
-        return newEntry.value();
+        return new CacheEntry<>(key, value);
     }
 
     /**
-     * Sets an existing entry as the most recently used.
-     *
-     * 1) Remove the entry from its current place in the double linked list by letting its previous neighbor point to its
-     *    next neighbor, and vice versa.
-     * 2) This is the new most recently used item so there is no previous entry. Point to the most recently used entry.
-     * 3) Set the most recently used pointer to point to the new entry.
-     *
+     * Sets an existing entry as the most recently used (MRU). If the entry is already the MRU, do nothing.
+     * <p>
+     * If the entry is the least recently used item (LRU), set the LRU pointer to the item before the current LRU; the list is
+     * guaranteed to have at least 2 items otherwise execution would have returned already (if only one item it was the MRU too).
+     * <p>
+     * Summary of cache update:
+     * <ol>
+     * <li>Detach the entry from its current place in the double linked list by letting its previous neighbor point to its
+     *    next neighbor, and vice versa.</li>
+     * <li>This is the new most recently used item so there is no previous entry. Point to the most recently used entry.</li>
+     * <li>Set the most recently used pointer to point to the new entry.</li>
+     *</ol>
      */
-    private void moveToFront(CacheEntry<K, V> entry) {
-        if (entry.equals(mostRecentlyUsed)) {
-            return;
-        }
-
-        boolean lockAcquired = listLock.tryLock();
-
-        try {
-            remove(entry);
-            entry.setPrevious(null);
-            entry.setNext(mostRecentlyUsed);
-            mostRecentlyUsed.setPrevious(entry);
+    private void updateCacheOrder(CacheEntry<K, V> entry) {
+        synchronized (listLock) {
+            if (entry.equals(mostRecentlyUsed)) {
+                return;
+            }
+            if (entry.equals(leastRecentlyUsed)) {
+                leastRecentlyUsed = entry.previous();
+            }
+            detachIfNeeded(entry);
+            if (listIsNotInitialized()) {
+                leastRecentlyUsed = entry;
+            } else {
+                entry.setNext(mostRecentlyUsed);
+                mostRecentlyUsed.setPrevious(entry);
+            }
             mostRecentlyUsed = entry;
-        } finally {
-            if (lockAcquired) {
-                listLock.unlock();
+            if (size() > maxCacheSize) {
+                evict();
             }
         }
     }
 
+    private boolean listIsNotInitialized() {
+        return mostRecentlyUsed == null && leastRecentlyUsed == null;
+    }
+
     /**
-     * Removes an entry from the cache. Remove the entry from its current place in the double linked list
+     * Detaches an entry from its neighbors in the cache. Remove the entry from its current place in the double linked list
      * by letting its previous neighbor point to its next neighbor, and vice versa, if those exist.
+     * <p>
+     * An entry may not have a previous neighbor if it's currently the first one in the list. It may not have a next neighbor
+     * if it's the last entry.
+     * <p>
+     * <b>Note:</b> Detaching an entry does not delete it from the cache hash map.
      */
-    private void remove(CacheEntry<K, V> entry) {
+    private void detachIfNeeded(CacheEntry<K, V> entry) {
         CacheEntry<K, V> previousEntry = entry.previous();
         if (previousEntry != null) {
             previousEntry.setNext(entry.next());
@@ -103,51 +121,20 @@ public final class LruCache<K, V>  {
         if (nextEntry != null) {
             nextEntry.setPrevious(entry.previous());
         }
-    }
-
-    /**
-     * Adds an entry to the cache and sets the most recently used pointer to the new entry.
-     */
-    private void addToFront(CacheEntry<K, V> newEntry) {
-        boolean lockAcquired = listLock.tryLock();
-        try {
-            if (mostRecentlyUsed != null) {
-                newEntry.setNext(mostRecentlyUsed);
-                mostRecentlyUsed.setPrevious(newEntry);
-            }
-            mostRecentlyUsed = newEntry;
-            if (leastRecentlyUsed == null) {
-                leastRecentlyUsed = newEntry;
-            }
-            if (size() >= maxCacheSize) {
-                evict();
-            }
-            cache.put(newEntry.key(), newEntry);
-        } finally {
-            if (lockAcquired) {
-                listLock.unlock();
-            }
-        }
+        entry.setPrevious(null);
     }
 
     /**
      * Removes the least recently used entry from the cache.
-     *
      * The pointer to the least recently used entry is updated to point to the next-but-last entry.
      * The next pointer of the new least recently used entry is updated to null, since it's last.
-     *
-     * @return The value of the evicted entry
      */
-    private V evict() {
-        CacheEntry<K, V> evictedEntry = leastRecentlyUsed;
-        leastRecentlyUsed = evictedEntry.previous();
-        leastRecentlyUsed.setNext(null);
-        evictedEntry.setPrevious(null);
-        cache.remove(evictedEntry.key());
-        return evictedEntry.value();
+    private void evict() {
+        cache.remove(leastRecentlyUsed.key());
+        leastRecentlyUsed = leastRecentlyUsed.previous();
     }
 
-    public Integer size() {
+    public int size() {
         return cache.size();
     }
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/lru/LruCache.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/lru/LruCache.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.cache.lru;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * An LRU (Least Recently Used) cache implementation.
+ * <p>
+ * The user can configure the maximum size of the cache, which is set to a default of 100.
+ */
+@SdkProtectedApi
+public final class LruCache<K, V>  {
+
+    private static final int DEFAULT_SIZE = 100;
+
+    private final Map<K, CacheEntry<K, V>> cache;
+    private final Function<K, V> valueSupplier;
+
+    private CacheEntry<K, V> leastRecentlyUsed = null;
+    private CacheEntry<K, V> mostRecentlyUsed = null;
+    private final Lock listLock = new ReentrantLock();
+    private final int maxCacheSize;
+
+    private LruCache(Builder<K, V> b) {
+        this.valueSupplier = b.supplier;
+        Integer customSize = Validate.isPositiveOrNull(b.maxSize, "size");
+        this.maxCacheSize = customSize != null ? customSize : DEFAULT_SIZE;
+        this.cache = new ConcurrentHashMap<>();
+    }
+
+    public V get(K key) {
+        CacheEntry<K, V> cachedEntry = cache.get(key);
+        if (cachedEntry != null) {
+            moveToFront(cachedEntry);
+            return cachedEntry.value();
+        }
+        V value = valueSupplier.apply(key);
+        CacheEntry<K, V> newEntry = new CacheEntry<>(key, value);
+        addToFront(newEntry);
+        return newEntry.value();
+    }
+
+    /**
+     * Sets an existing entry as the most recently used.
+     *
+     * 1) Remove the entry from its current place in the double linked list by letting its previous neighbor point to its
+     *    next neighbor, and vice versa.
+     * 2) This is the new most recently used item so there is no previous entry. Point to the most recently used entry.
+     * 3) Set the most recently used pointer to point to the new entry.
+     *
+     */
+    private void moveToFront(CacheEntry<K, V> entry) {
+        if (entry.equals(mostRecentlyUsed)) {
+            return;
+        }
+
+        boolean lockAcquired = listLock.tryLock();
+
+        try {
+            remove(entry);
+            entry.setPrevious(null);
+            entry.setNext(mostRecentlyUsed);
+            mostRecentlyUsed.setPrevious(entry);
+            mostRecentlyUsed = entry;
+        } finally {
+            if (lockAcquired) {
+                listLock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Removes an entry from the cache. Remove the entry from its current place in the double linked list
+     * by letting its previous neighbor point to its next neighbor, and vice versa, if those exist.
+     */
+    private void remove(CacheEntry<K, V> entry) {
+        CacheEntry<K, V> previousEntry = entry.previous();
+        if (previousEntry != null) {
+            previousEntry.setNext(entry.next());
+        }
+        CacheEntry<K, V> nextEntry = entry.next();
+        if (nextEntry != null) {
+            nextEntry.setPrevious(entry.previous());
+        }
+    }
+
+    /**
+     * Adds an entry to the cache and sets the most recently used pointer to the new entry.
+     */
+    private void addToFront(CacheEntry<K, V> newEntry) {
+        boolean lockAcquired = listLock.tryLock();
+        try {
+            if (mostRecentlyUsed != null) {
+                newEntry.setNext(mostRecentlyUsed);
+                mostRecentlyUsed.setPrevious(newEntry);
+            }
+            mostRecentlyUsed = newEntry;
+            if (leastRecentlyUsed == null) {
+                leastRecentlyUsed = newEntry;
+            }
+            if (size() >= maxCacheSize) {
+                evict();
+            }
+            cache.put(newEntry.key(), newEntry);
+        } finally {
+            if (lockAcquired) {
+                listLock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Removes the least recently used entry from the cache.
+     *
+     * The pointer to the least recently used entry is updated to point to the next-but-last entry.
+     * The next pointer of the new least recently used entry is updated to null, since it's last.
+     *
+     * @return The value of the evicted entry
+     */
+    private V evict() {
+        CacheEntry<K, V> evictedEntry = leastRecentlyUsed;
+        leastRecentlyUsed = evictedEntry.previous();
+        leastRecentlyUsed.setNext(null);
+        evictedEntry.setPrevious(null);
+        cache.remove(evictedEntry.key());
+        return evictedEntry.value();
+    }
+
+    public Integer size() {
+        return cache.size();
+    }
+
+    public static <K, V> LruCache.Builder<K, V> builder(Function<K, V> supplier) {
+        return new Builder<>(supplier);
+    }
+
+    public static final class Builder<K, V> {
+
+        private final Function<K, V> supplier;
+        private int maxSize;
+
+        private Builder(Function<K, V> supplier) {
+            this.supplier = supplier;
+        }
+
+        public Builder<K, V> maxSize(int maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public LruCache<K, V> build() {
+            return new LruCache<>(this);
+        }
+    }
+
+    private static final class CacheEntry<K, V> {
+
+        private final K key;
+        private final V value;
+
+        private CacheEntry<K, V> previous;
+        private CacheEntry<K, V> next;
+
+        private CacheEntry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        K key() {
+            return key;
+        }
+
+        V value() {
+            return value;
+        }
+
+        CacheEntry<K, V> next() {
+            return next;
+        }
+
+        void setNext(CacheEntry<K, V> next) {
+            this.next = next;
+        }
+
+        CacheEntry<K, V> previous() {
+            return previous;
+        }
+
+        void setPrevious(CacheEntry<K, V> previous) {
+            this.previous = previous;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if ((o == null) || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheEntry<?, ?> that = (CacheEntry<?, ?>) o;
+            return Objects.equals(key, that.key)
+                   && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key != null ? key.hashCode() : 0;
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            return result;
+        }
+
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/cache/lru/LruCacheTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/cache/lru/LruCacheTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.cache.lru;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class LruCacheTest {
+
+    private static final int MAX_SIMPLE_TEST_ENTRIES = 10;
+    private static final int MAX_SIMPLE_CACHE_SIZE = 3;
+    private static final List<Key> simpleTestKeys = IntStream.range(0, MAX_SIMPLE_TEST_ENTRIES)
+                                                             .mapToObj(Key::new)
+                                                             .collect(Collectors.toList());
+    private static final List<Value> simpleTestValues = IntStream.range(0, MAX_SIMPLE_TEST_ENTRIES)
+                                                                 .mapToObj(Integer::toString)
+                                                                 .map(Value::new)
+                                                                 .collect(Collectors.toList());
+    @Spy
+    private Function<Key, Value> simpleValueSupplier = new SimpleValueSupplier(simpleTestValues);
+
+    /**
+     * An implementation of {@link Function} that allows us to (more or less) manually schedule threads so that we can make sure
+     * the cache is only calling the underlying supplier when we expect it to.
+     */
+    private static class WaitingSupplier implements Function<Key, Value>, Closeable {
+        /**
+         * A semaphore that is counted up each time a "get" is started. This is useful during testing for waiting for a certain
+         * number of "gets" to start.
+         */
+        private final Semaphore startedGetPermits = new Semaphore(0);
+
+        /**
+         * A semaphore that is counted down each time a "get" is started. This is useful during testing for blocking the threads
+         * performing the "get" until it is time for them to complete.
+         */
+        private final Semaphore permits = new Semaphore(0);
+
+        /**
+         * A semaphore that is counted up each time a "get" is finished. This is useful during testing for waiting for a certain
+         * number of "gets" to finish.
+         */
+        private final Semaphore finishedGetPermits = new Semaphore(0);
+
+        private WaitingSupplier() {
+        }
+
+        @Override
+        public Value apply(Key key) {
+            startedGetPermits.release(1);
+
+            try {
+                permits.acquire(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                fail();
+            }
+
+            finishedGetPermits.release(1);
+            return simpleTestValues.get(key.key());
+        }
+
+        /**
+         * Wait for a certain number of "gets" to have started. This will time out and fail the test after a certain amount of
+         * time if the "gets" never actually start.
+         */
+        public void waitForGetsToHaveStarted(int numExpectedGets) {
+            assertTrue(invokeSafely(() -> startedGetPermits.tryAcquire(numExpectedGets, 10, TimeUnit.SECONDS)));
+        }
+
+        /**
+         * Wait for a certain number of "gets" to have finished. This will time out and fail the test after a certain amount of
+         * time if the "gets" never finish.
+         */
+        public void waitForGetsToHaveFinished(int numExpectedGets) {
+            assertTrue(invokeSafely(() -> finishedGetPermits.tryAcquire(numExpectedGets, 10, TimeUnit.SECONDS)));
+        }
+
+        /**
+         * Release all threads blocked in this supplier.
+         */
+        @Override
+        public void close() {
+            permits.release(50);
+        }
+    }
+
+
+    private ExecutorService executorService;
+    private List<Future<?>> allExecutions;
+    private Supplier<LruCache<Key, Value>> simpleCache = () -> LruCache.builder(simpleValueSupplier)
+                                                                       .maxSize(MAX_SIMPLE_CACHE_SIZE)
+                                                                       .build();
+
+
+
+    @BeforeEach
+    public void setup() {
+        executorService = Executors.newFixedThreadPool(50);
+        allExecutions = new ArrayList<>();
+    }
+
+
+    @AfterEach
+    public void shutdown() {
+        executorService.shutdown();
+    }
+
+    @Test
+    void when_cacheHasMiss_ValueIsCalculatedAndCached() {
+        LruCache<Key, Value> cache = simpleCache.get();
+        populateAndVerify(cache, 1);
+    }
+
+    @Test
+    void when_cacheHasHit_ValueIsRetrievedFromCache() {
+        LruCache<Key, Value> cache = simpleCache.get();
+
+        populateAndVerify(cache, MAX_SIMPLE_CACHE_SIZE);
+        Value result = cache.get(simpleTestKeys.get(2));
+        assertThat(cache.size()).isEqualTo(MAX_SIMPLE_CACHE_SIZE);
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(simpleTestValues.get(2));
+
+        cache.get(simpleTestKeys.get(2));
+
+        int onlyOneInvocation = 1;
+        verify(simpleValueSupplier, times(onlyOneInvocation)).apply(simpleTestKeys.get(2));
+    }
+
+    @Test
+    void when_cacheFillsUp_ValuesAreEvictedFromCache() {
+        LruCache<Key, Value> cache = simpleCache.get();
+
+        populateAndVerify(cache, MAX_SIMPLE_CACHE_SIZE);
+
+        //evict 1
+        Value result = cache.get(simpleTestKeys.get(4));
+        assertCacheState(cache, result, MAX_SIMPLE_CACHE_SIZE, 4);
+
+        //move 3 up
+        result = cache.get(simpleTestKeys.get(3));
+        assertCacheState(cache, result, MAX_SIMPLE_CACHE_SIZE, 3);
+
+        //evict 2
+        result = cache.get(simpleTestKeys.get(5));
+        assertCacheState(cache, result, MAX_SIMPLE_CACHE_SIZE, 5);
+
+        //move 4 up
+        result = cache.get(simpleTestKeys.get(4));
+        assertCacheState(cache, result, MAX_SIMPLE_CACHE_SIZE, 4);
+
+        //evict 3
+        result = cache.get(simpleTestKeys.get(2));
+        assertCacheState(cache, result, MAX_SIMPLE_CACHE_SIZE, 2);
+
+        verify(simpleValueSupplier, times(1)).apply(simpleTestKeys.get(1));
+        verify(simpleValueSupplier, times(2)).apply(simpleTestKeys.get(2));
+        verify(simpleValueSupplier, times(1)).apply(simpleTestKeys.get(3));
+        verify(simpleValueSupplier, times(1)).apply(simpleTestKeys.get(4));
+        verify(simpleValueSupplier, times(1)).apply(simpleTestKeys.get(5));
+    }
+
+    @Test
+    void when_multipleCallers_oneCallerBlocks_simple() throws InterruptedException {
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try  {
+            LruCache<Key, Value> cache = simpleCache.get();
+
+            for (int i = 0; i < 1000; i++) {
+                int numEntry = ThreadLocalRandom.current().nextInt(MAX_SIMPLE_TEST_ENTRIES - 1);
+                executor.submit(() -> cache.get(simpleTestKeys.get(numEntry)));
+            }
+
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void when_multipleCallers_oneCallerBlock_doesnt_Work() {
+
+        try (WaitingSupplier waitingSupplier = new WaitingSupplier()) {
+            LruCache<Key, Value> cachedSupplier = LruCache.builder(waitingSupplier)
+                                                          .maxSize(5)
+                                                          .build();
+
+            waitingSupplier.permits.release(5);
+            waitFor(performAsyncGets(cachedSupplier, 8));
+
+            // Make extra sure only 2 "gets" actually happened.
+            waitingSupplier.waitForGetsToHaveFinished(2);
+        }
+    }
+
+    private void assertCacheState(LruCache<Key, Value> cache, Value result, int size, int index) {
+        assertThat(cache.size()).isEqualTo(size);
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(simpleTestValues.get(index));
+    }
+
+    private void populateAndVerify(LruCache<Key, Value> cache, int numEntries) {
+        IntStream.range(0, numEntries).forEach(i -> {
+            Value result = cache.get(simpleTestKeys.get(i));
+            assertThat(cache.size()).isEqualTo(i + 1);
+            assertThat(result).isNotNull();
+            assertThat(result).isEqualTo(simpleTestValues.get(i));
+            verify(simpleValueSupplier).apply(simpleTestKeys.get(i));
+        });
+    }
+
+    /**
+     * Asynchronously perform a "get" on the provided supplier, returning the future that will be completed when the "get"
+     * finishes.
+     */
+    private Future<Value> performAsyncGet(LruCache<Key, Value> supplier, Key key) {
+        return executorService.submit(() -> supplier.get(key));
+    }
+
+    /**
+     * Asynchronously perform multiple "gets" on the provided supplier, returning the collection of futures to be completed when
+     * the "get" finishes.
+     */
+    private List<Future<?>> performAsyncGets(LruCache<Key, Value> supplier, int count) {
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < count; ++i) {
+            futures.add(performAsyncGet(supplier, simpleTestKeys.get(count % 2)));
+        }
+        allExecutions.addAll(futures);
+        return futures;
+    }
+
+    /**
+     * Wait for the provided future to complete, failing the test if it does not.
+     */
+    private void waitFor(Future<?> future) {
+        invokeSafely(() -> future.get(10, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Wait for all futures in the provided collection fo complete, failing the test if they do not all complete.
+     */
+    private void waitFor(Collection<Future<?>> futures) {
+        futures.forEach(this::waitFor);
+    }
+
+    /**
+     * Wait for all async gets ever created by this class to complete, failing the test if they do not all complete.
+     */
+    private void waitForAsyncGetsToFinish() {
+        waitFor(allExecutions);
+    }
+
+    private static final class Key {
+        private final Integer key;
+
+        private Key(Integer key) {
+            this.key = key;
+        }
+
+        static Key create(Integer key) {
+            return new Key(key);
+        }
+
+        Integer key() {
+            return key;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if ((o == null) || getClass() != o.getClass()) {
+                return false;
+            }
+            Key that = (Key) o;
+            return Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return key != null? key.hashCode() : 0;
+        }
+    }
+
+    private static final class Value {
+        private final String param1;
+
+        Value(String param1) {
+            this.param1 = param1;
+        }
+
+        String param1() {
+            return param1;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if ((o == null) || getClass() != o.getClass()) {
+                return false;
+            }
+            Value that = (Value) o;
+            return Objects.equals(param1, that.param1);
+        }
+
+        @Override
+        public int hashCode() {
+            return param1 != null ? param1.hashCode() : 0;
+        }
+    }
+
+    private static class SimpleValueSupplier implements Function<Key, Value> {
+
+        List<Value> values;
+
+        SimpleValueSupplier(List<Value> values) {
+            this.values = values;
+        }
+
+        @Override
+        public Value apply(Key key) {
+            return values.get(key.key());
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
An LRU (Least Recently Used) cache is needed when you need to store resources in memory in order of when they've been accessed. No existing utility exists for this functionality within our dependencies. 

## Modifications
The LRU cache 
- has a standard size of 100 (configurable)
- returns the value for the key that is given. 
  - If the value exists, the cache will move it to the front (most-recently-used) part of the cache before returning it
  - If no value exists, the cache will used the supplied function to retrieve a value and add it to the front of the cache. If the cache is full, the least recently value will be evicted. 
- Supports concurrency
- Does not (yet) support individual refresh of the cached values. This is a planned feature add-on.

## Testing
Unit tested

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
