### PR TITLE
Only enable CRT checksum for getObject and putObject

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/util/SignerMethodResolver.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/util/SignerMethodResolver.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.auth.signer.internal.AbstractAwsS3V4Signer;
 import software.amazon.awssdk.core.CredentialType;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.internal.signer.SigningMethod;
+import software.amazon.awssdk.core.signer.NoOpSigner;
 import software.amazon.awssdk.core.signer.Signer;
 
 @SdkInternalApi
@@ -56,7 +57,7 @@ public final class SignerMethodResolver {
                 signingMethod = SigningMethod.PROTOCOL_STREAMING_SIGNING_AUTH;
             } else if (isProtocolBasedUnsigned(signer, executionAttributes)) {
                 signingMethod = SigningMethod.PROTOCOL_BASED_UNSIGNED;
-            } else if (isAnonymous(credentials)) {
+            } else if (isAnonymous(credentials) || signer instanceof NoOpSigner) {
                 signingMethod = SigningMethod.UNSIGNED_PAYLOAD;
             } else {
                 signingMethod = SigningMethod.HEADER_BASED_AUTH;

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3IntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3IntegrationTestBase.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.BeforeClass;
 import software.amazon.awssdk.core.ClientType;
+import software.amazon.awssdk.core.client.config.ClientAsyncConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3IntegrationTestBase.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/S3IntegrationTestBase.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.BeforeClass;
 import software.amazon.awssdk.core.ClientType;
-import software.amazon.awssdk.core.client.config.ClientAsyncConfiguration;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -124,7 +124,7 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      * {@link S3AsyncClient#getObject(GetObjectRequest, Path)}
      * and {@link S3AsyncClient#putObject(PutObjectRequest, Path)}
      *
-     * <p> //TODO: update algorithm once determined
+     * <p>
      * Checksum validation using CRC32 is enabled by default.
      *
      */

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtils.java
@@ -19,8 +19,6 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.crt.s3.ChecksumAlgorithm;
 import software.amazon.awssdk.crt.s3.S3MetaRequestOptions;
-import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.awssdk.utils.StringUtils;
 
 @SdkInternalApi
 public final class CrtChecksumUtils {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtils.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crt;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
+import software.amazon.awssdk.crt.s3.ChecksumAlgorithm;
+import software.amazon.awssdk.crt.s3.S3MetaRequestOptions;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.StringUtils;
+
+@SdkInternalApi
+public final class CrtChecksumUtils {
+    private static final ChecksumAlgorithm DEFAULT_CHECKSUM_ALGO = ChecksumAlgorithm.CRC32;
+
+    private CrtChecksumUtils() {
+    }
+
+    public static ChecksumAlgorithm crtChecksumAlgorithm(HttpChecksum httpChecksum,
+                                                         S3MetaRequestOptions.MetaRequestType requestType,
+                                                         boolean checksumValidationEnabled) {
+        if (httpChecksum == null || requestType != S3MetaRequestOptions.MetaRequestType.PUT_OBJECT) {
+            return null;
+        }
+
+        if (httpChecksum.requestAlgorithm() == null) {
+            return checksumValidationEnabled ? DEFAULT_CHECKSUM_ALGO : null;
+        }
+
+        return ChecksumAlgorithm.valueOf(httpChecksum.requestAlgorithm().toUpperCase());
+    }
+
+    /**
+     * Only validate response checksum if this is getObject operation AND it supports checksum validation AND if either of the
+     * following applies: 1. checksum validation is enabled at request level via request validation mode OR 2. checksum validation
+     * is enabled at client level
+     */
+    public static boolean validateResponseChecksum(HttpChecksum httpChecksum,
+                                                   S3MetaRequestOptions.MetaRequestType requestType,
+                                                   boolean checksumValidationEnabled) {
+        if (requestType != S3MetaRequestOptions.MetaRequestType.GET_OBJECT || httpChecksum == null) {
+            return false;
+        }
+
+        return checksumValidationEnabled || httpChecksum.requestValidationMode() != null;
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -212,7 +212,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                              attributes);
         }
 
-        private static void disableChecksumForPutAndGet(Context.AfterMarshalling context, ExecutionAttributes executionAttributes) {
+        private static void disableChecksumForPutAndGet(Context.AfterMarshalling context,
+                                                        ExecutionAttributes executionAttributes) {
             if (context.request() instanceof PutObjectRequest || context.request() instanceof GetObjectRequest) {
                 // TODO: is there a better way to disable SDK flexible checksum implementation
                 // Clear HTTP_CHECKSUM and RESOLVED_CHECKSUM_SPECS to disable SDK flexible checksum implementation.

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.s3.internal.crt;
 
+import static software.amazon.awssdk.services.s3.internal.crt.CrtChecksumUtils.crtChecksumAlgorithm;
+import static software.amazon.awssdk.services.s3.internal.crt.CrtChecksumUtils.validateResponseChecksum;
 import static software.amazon.awssdk.services.s3.internal.crt.S3InternalSdkHttpExecutionAttribute.CRT_PAUSE_RESUME_TOKEN;
 import static software.amazon.awssdk.services.s3.internal.crt.S3InternalSdkHttpExecutionAttribute.HTTP_CHECKSUM;
 import static software.amazon.awssdk.services.s3.internal.crt.S3InternalSdkHttpExecutionAttribute.METAREQUEST_PAUSE_OBSERVABLE;
@@ -51,7 +53,9 @@ import software.amazon.awssdk.utils.Logger;
 @SdkInternalApi
 public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
     private static final Logger log = Logger.loggerFor(S3CrtAsyncHttpClient.class);
+
     private final S3Client crtS3Client;
+
     private final S3NativeClientConfiguration s3NativeClientConfiguration;
 
     private S3CrtAsyncHttpClient(Builder builder) {
@@ -87,9 +91,9 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         S3MetaRequestOptions.MetaRequestType requestType = requestType(asyncRequest);
 
         HttpChecksum httpChecksum = asyncRequest.httpExecutionAttributes().getAttribute(HTTP_CHECKSUM);
-        ChecksumAlgorithm checksumAlgorithm = crtChecksumAlgorithm(httpChecksum);
+        ChecksumAlgorithm checksumAlgorithm = crtChecksumAlgorithm(httpChecksum, requestType, s3NativeClientConfiguration.checksumValidationEnabled());
 
-        boolean validateChecksum = validateResponseChecksum(httpChecksum);
+        boolean validateChecksum = validateResponseChecksum(httpChecksum, requestType,  s3NativeClientConfiguration.checksumValidationEnabled());
         String resumeToken = asyncRequest.httpExecutionAttributes().getAttribute(CRT_PAUSE_RESUME_TOKEN);
 
         S3MetaRequestOptions requestOptions = new S3MetaRequestOptions()
@@ -110,19 +114,6 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         addCancelCallback(executeFuture, s3MetaRequest, responseHandler);
 
         return executeFuture;
-    }
-
-    /**
-     * Only validate response checksum if this operation supports checksum validation AND either of the following applies
-     * 1. checksum validation is enabled at request level via request validation mode OR
-     * 2. checksum validation is enabled at client level
-     */
-    private boolean validateResponseChecksum(HttpChecksum httpChecksum) {
-        if (httpChecksum == null || CollectionUtils.isNullOrEmpty(httpChecksum.responseAlgorithms())) {
-            return false;
-        }
-
-        return s3NativeClientConfiguration.checksumValidationEnabled() || httpChecksum.requestValidationMode() != null;
     }
 
     private static URI getEndpoint(URI uri) {
@@ -147,36 +138,6 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
             }
         }
         return S3MetaRequestOptions.MetaRequestType.DEFAULT;
-    }
-
-    private ChecksumAlgorithm crtChecksumAlgorithm(HttpChecksum httpChecksum) {
-        if (requestChecksumAlgoNotApplicable(httpChecksum)) {
-            return null;
-        }
-
-        if (httpChecksum.requestAlgorithm() == null) {
-            // Only set checksum algorithm by default for streaming operations and operations that require checksum
-            if (!(httpChecksum.isRequestStreaming() || httpChecksum.isRequestChecksumRequired())) {
-                return null;
-            }
-
-            // TODO: revisit default checksum
-            return ChecksumAlgorithm.CRC32;
-        }
-
-        return ChecksumAlgorithm.valueOf(httpChecksum.requestAlgorithm().toUpperCase());
-    }
-
-    /**
-     * Checksum algorithm is not applicable to the following situations:
-     * 1. Checksum validation is disabled OR
-     * 2. No HttpChecksum Trait for this operation OR
-     * 3. It's a GET operation
-     */
-    private boolean requestChecksumAlgoNotApplicable(HttpChecksum httpChecksum) {
-        return !s3NativeClientConfiguration.checksumValidationEnabled() ||
-               httpChecksum == null ||
-               httpChecksum.responseAlgorithms() != null;
     }
 
     private static void addCancelCallback(CompletableFuture<Void> executeFuture,

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -43,7 +43,6 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.utils.AttributeMap;
-import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Logger;
 
 /**
@@ -91,9 +90,11 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         S3MetaRequestOptions.MetaRequestType requestType = requestType(asyncRequest);
 
         HttpChecksum httpChecksum = asyncRequest.httpExecutionAttributes().getAttribute(HTTP_CHECKSUM);
-        ChecksumAlgorithm checksumAlgorithm = crtChecksumAlgorithm(httpChecksum, requestType, s3NativeClientConfiguration.checksumValidationEnabled());
+        ChecksumAlgorithm checksumAlgorithm =
+            crtChecksumAlgorithm(httpChecksum, requestType, s3NativeClientConfiguration.checksumValidationEnabled());
 
-        boolean validateChecksum = validateResponseChecksum(httpChecksum, requestType,  s3NativeClientConfiguration.checksumValidationEnabled());
+        boolean validateChecksum =
+            validateResponseChecksum(httpChecksum, requestType,  s3NativeClientConfiguration.checksumValidationEnabled());
         String resumeToken = asyncRequest.httpExecutionAttributes().getAttribute(CRT_PAUSE_RESUME_TOKEN);
 
         S3MetaRequestOptions requestOptions = new S3MetaRequestOptions()

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtilsTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtChecksumUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
+import software.amazon.awssdk.crt.s3.ChecksumAlgorithm;
+import software.amazon.awssdk.crt.s3.S3MetaRequestOptions;
+
+class CrtChecksumUtilsTest {
+
+    private static Stream<Arguments> crtChecksumAlgorithmInput() {
+        return Stream.of(
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.DEFAULT, true, null),
+            Arguments.of(HttpChecksum.builder()
+                                     .requestAlgorithm("sha256")
+                                     .build(),
+                         S3MetaRequestOptions.MetaRequestType.PUT_OBJECT,
+                         true,
+                         ChecksumAlgorithm.SHA256),
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.PUT_OBJECT, true,
+                         ChecksumAlgorithm.CRC32),
+            Arguments.of(null, S3MetaRequestOptions.MetaRequestType.PUT_OBJECT, true, null),
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.PUT_OBJECT, false, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("crtChecksumAlgorithmInput")
+    void crtChecksumAlgorithm_differentInput(HttpChecksum checksum,
+                                             S3MetaRequestOptions.MetaRequestType type,
+                                             boolean checksumValidationEnabled,
+                                             ChecksumAlgorithm expected) {
+        assertThat(CrtChecksumUtils.crtChecksumAlgorithm(checksum,
+                                                         type,
+                                                         checksumValidationEnabled)).isEqualTo(expected);
+
+    }
+
+    private static Stream<Arguments> validateResponseChecksumInput() {
+        return Stream.of(
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.DEFAULT, true, false),
+            Arguments.of(HttpChecksum.builder()
+                             .requestValidationMode("true").build(),
+                         S3MetaRequestOptions.MetaRequestType.GET_OBJECT,
+                         false,
+                         true),
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.GET_OBJECT, true,
+                         true),
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.GET_OBJECT, true, true),
+            Arguments.of(HttpChecksum.builder().build(), S3MetaRequestOptions.MetaRequestType.GET_OBJECT, false, false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateResponseChecksumInput")
+    void validateResponseChecksum_differentInput(HttpChecksum checksum,
+                                                 S3MetaRequestOptions.MetaRequestType type,
+                                                 boolean checksumValidationEnabled,
+                                                 boolean expected) {
+        assertThat(CrtChecksumUtils.validateResponseChecksum(checksum,
+                                                             type,
+                                                             checksumValidationEnabled)).isEqualTo(expected);
+
+    }
+
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClientTest.java
@@ -142,7 +142,7 @@ public class S3CrtAsyncHttpClientTest {
     }
 
     @Test
-    public void nonStreamingOperation_checksumAlgoProvided_shouldHonor() {
+    public void nonStreamingOperation_checksumAlgoProvided_shouldNotPassToCrt() {
         HttpChecksum httpChecksum = HttpChecksum.builder()
                                                 .isRequestStreaming(false)
                                                 .requestAlgorithm("SHA1")
@@ -155,7 +155,7 @@ public class S3CrtAsyncHttpClientTest {
                                                                             .build();
 
         S3MetaRequestOptions actual = makeRequest(asyncExecuteRequest);
-        assertThat(actual.getChecksumAlgorithm()).isEqualTo(ChecksumAlgorithm.SHA1);
+        assertThat(actual.getChecksumAlgorithm()).isNull();
     }
 
     @Test
@@ -255,22 +255,6 @@ public class S3CrtAsyncHttpClientTest {
 
         S3MetaRequestOptions actual = makeRequest(asyncExecuteRequest);
         assertThat(actual.getValidateChecksum()).isTrue();
-    }
-
-    @Test
-    public void operationWithoutResponseAlgorithms_shouldNotValidate() {
-        HttpChecksum httpChecksum = HttpChecksum.builder()
-                                                .build();
-
-        AsyncExecuteRequest asyncExecuteRequest = getExecuteRequestBuilder().putHttpExecutionAttribute(OPERATION_NAME,
-                                                                                                       "GetObject")
-
-                                                                            .putHttpExecutionAttribute(HTTP_CHECKSUM,
-                                                                                                       httpChecksum)
-                                                                            .build();
-
-        S3MetaRequestOptions actual = makeRequest(asyncExecuteRequest);
-        assertThat(actual.getValidateChecksum()).isFalse();
     }
 
     private S3MetaRequestOptions makeRequest(AsyncExecuteRequest asyncExecuteRequest) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
CRT does not support flexible checksum for non-streaming operation. After this change, we only pass checksum algorithm and isValidateChecksum for `getObject` and `putObject`

## Modifications
Only enable CRT checksum for getObject and putObject

## Testing
Integ tests passed

