### PR TITLE
Add maven.compiler.release property for JDK11+ build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -700,11 +700,12 @@
         </profile>
 
         <profile>
-            <id>jdk-13-plus</id>
+            <id>jdk-11-plus</id>
             <activation>
-                <jdk>[13,)</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
+                <maven.compiler.release>8</maven.compiler.release>
                 <!-- Blockhound doesn't support Java 13+ without flags: https://github.com/reactor/BlockHound/issues/33 -->
                 <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -706,6 +706,15 @@
             </activation>
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+      
+        <profile>
+            <id>jdk-13-plus</id>
+            <activation>
+                <jdk>[13,)</jdk>
+            </activation>
+            <properties>
                 <!-- Blockhound doesn't support Java 13+ without flags: https://github.com/reactor/BlockHound/issues/33 -->
                 <argLine>-XX:+AllowRedefinitionToAddDeleteMethods</argLine>
             </properties>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Set release target version to JDK8 to avoid getting `NoSuchMethodException for ByteBuffer.position.` error when we run tests using JDK 8 after we build the SDK using JDK11+ 


## Modifications
Add maven.compiler.release property for JDK11+ build

## Testing
Tested locally

