### PR TITLE
Enable JDK9+ code and builds to produce Java8 compatible jar

### DIFF
--- a/.changes/next-release/feature-build-3721bfb.json
+++ b/.changes/next-release/feature-build-3721bfb.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "build",
+    "contributor": "DavidOgunsAWS",
+    "description": "Enable JDK9+ builds to produce JRE8 compatible jar."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 # __2.17.292__ __2022-10-14__
 ## __AWS Elemental MediaConvert__
   - ### Features
-    - Enable JDK9+ builds to produce JRE8 compatible jar.
-
-# __2.17.292__ __2022-10-14__
-## __AWS Elemental MediaConvert__
-  - ### Features
     - MediaConvert now supports specifying the minimum percentage of the HRD buffer available at the end of each encoded video segment.
 
 ## __AWS SDK for Java v2__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # __2.17.292__ __2022-10-14__
 ## __AWS Elemental MediaConvert__
   - ### Features
+    - Enable JDK9+ builds to produce JRE8 compatible jar.
+
+# __2.17.292__ __2022-10-14__
+## __AWS Elemental MediaConvert__
+  - ### Features
     - MediaConvert now supports specifying the minimum percentage of the HRD buffer available at the end of each encoded video segment.
 
 ## __AWS SDK for Java v2__

--- a/core/sdk-core/pom.xml
+++ b/core/sdk-core/pom.xml
@@ -248,6 +248,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
-        <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
@@ -191,29 +191,6 @@
         </resources>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven-compiler-plugin.version}</version>
-                    <configuration>
-                        <source>${jre.version}</source>
-                        <target>${jre.version}</target>
-                        <encoding>UTF-8</encoding>
-                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                        <compilerArgument>-proc:none</compilerArgument>
-                        <fork>false</fork>
-                        <compilerArgument>-proc:none</compilerArgument>
-                        <excludes>
-                            <exclude>software/amazon/awssdk/services/kinesis/model/SubscribeToShardEvent.java</exclude>
-                            <exclude>software/amazon/awssdk/services/kinesis/KinesisAsyncClient.java</exclude>
-                            <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisAsyncClient.java</exclude>
-                            <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisBaseClientBuilder.java</exclude>
-                            <exclude>software/amazon/awssdk/services/sms/model/InternalError.java</exclude>
-                            <exclude>software/amazon/awssdk/services/kinesis/transform/SubscribeToShardResponseUnmarshaller.java</exclude>
-                        </excludes>
-                    </configuration>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -691,6 +668,145 @@
             <properties>
                 <additionalparam>-Xdoclint:none</additionalparam>
             </properties>
+        </profile>
+
+
+        <profile>
+            <id>java9plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Don't compile module-info.java, see java 9 profile -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <configuration>
+                                    <release>9</release>
+                                    <encoding>UTF-8</encoding>
+                                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <fork>false</fork>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>java-9-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>9</release>
+                                    <!-- no excludes: compile everything to ensure module-info contains right entries -->
+                                    <encoding>UTF-8</encoding>
+                                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <fork>false</fork>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <excludes>
+                                        <exclude>software/amazon/awssdk/services/kinesis/model/SubscribeToShardEvent.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/KinesisAsyncClient.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisAsyncClient.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisBaseClientBuilder.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/sms/model/InternalError.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/transform/SubscribeToShardResponseUnmarshaller.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>java-8-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${jre.version}</source>
+                                    <target>${jre.version}</target>
+                                    <encoding>UTF-8</encoding>
+                                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <fork>false</fork>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <excludes>
+                                        <exclude>software/amazon/awssdk/services/kinesis/model/SubscribeToShardEvent.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/KinesisAsyncClient.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisAsyncClient.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisBaseClientBuilder.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/sms/model/InternalError.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/transform/SubscribeToShardResponseUnmarshaller.java</exclude>
+                                        <!-- recompile everything for target VM except the module-info.java -->
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>[1.8,9)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <configuration>
+                                    <source>${jre.version}</source>
+                                    <target>${jre.version}</target>
+                                    <encoding>UTF-8</encoding>
+                                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <fork>false</fork>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>java-8-compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${jre.version}</source>
+                                    <target>${jre.version}</target>
+                                    <encoding>UTF-8</encoding>
+                                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <fork>false</fork>
+                                    <compilerArgument>-proc:none</compilerArgument>
+                                    <excludes>
+                                        <exclude>software/amazon/awssdk/services/kinesis/model/SubscribeToShardEvent.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/KinesisAsyncClient.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisAsyncClient.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/DefaultKinesisBaseClientBuilder.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/sms/model/InternalError.java</exclude>
+                                        <exclude>software/amazon/awssdk/services/kinesis/transform/SubscribeToShardResponseUnmarshaller.java</exclude>
+                                        <!-- recompile everything for target VM except the module-info.java -->
+                                        <exclude>module-info.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>

--- a/test/module-path-tests/pom.xml
+++ b/test/module-path-tests/pom.xml
@@ -144,6 +144,10 @@
                                     <release>9</release>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>java-8-compile</id>
+                                <phase>none</phase>
+                            </execution>
                         </executions>
                         <configuration>
                             <jdkToolchain>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Newly developed Java9 code written with module-info.java/.class should still produce jars that run compatibly on JRE8 as this SDK is still required to support it.

<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
* Maven profile enabled JDK9+ build also triggers a separate java-8-compile excluding module-info.java
* maven-compiler-plugin executions are in the parent pom
* maven-jar-plugin needed to be at least 3.1.2 to enable ModuleMainClass in tested submodule not included in PR so this is an unnecessary change
* module-path-tests adjusted to suppress java-8-compile execution.

## Testing
<!--- Please describe in detail how you tested your changes -->
1. Added new test sub-module under core/<module> set up with module-info.java and main method
1. Verify build succeeds when JAVA_HOME and PATH points to JDK8 and JDK9+ (tested with 17)
1. Execute main method through JRE8 classpath successfully
1. Execute main method through JRE8 with module-path successfully

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
*  Changes impacted module-path-tests submodule. Suppressed java-8-compile execution
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
