### PR TITLE
Fix FIPS configuration handling

### DIFF
--- a/.changes/next-release/bugfix-WSSDKforJavav2-fface60.json
+++ b/.changes/next-release/bugfix-WSSDKforJavav2-fface60.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "WS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix bug in FIPS configuration handling where setting a non-FIPS region clears the setting."
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -294,7 +294,7 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
             defaultsMode = autoDefaultsModeDiscovery.discover(config.option(AwsClientOption.AWS_REGION));
             DefaultsMode finalDefaultsMode = defaultsMode;
             log.debug(() -> String.format("Resolved %s client's AUTO configuration mode to %s", serviceName(),
-                      finalDefaultsMode));
+                                          finalDefaultsMode));
         }
 
         return defaultsMode;
@@ -389,7 +389,9 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
         }
 
         clientConfiguration.option(AwsClientOption.AWS_REGION, regionToSet);
-        clientConfiguration.option(AwsClientOption.FIPS_ENDPOINT_ENABLED, fipsEnabled);
+        if (fipsEnabled != null) {
+            clientConfiguration.option(AwsClientOption.FIPS_ENDPOINT_ENABLED, fipsEnabled);
+        }
         return thisBuilder();
     }
 

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/DefaultAwsClientBuilderTest.java
@@ -105,14 +105,25 @@ public class DefaultAwsClientBuilderTest {
     }
 
     @Test
-    public void buildWithFipsRegionThenNonFipsFipsEnabledFlagUnset() {
+    public void buildWithFipsRegionThenNonFipsFipsEnabledRemainsSet() {
         TestClient client = testClientBuilder()
             .region(Region.of("us-west-2-fips")) // first call to setter sets the flag
             .region(Region.of("us-west-2"))// second call should clear
             .build();
 
         assertThat(client.clientConfiguration.option(AwsClientOption.AWS_REGION)).isEqualTo(Region.US_WEST_2);
-        assertThat(client.clientConfiguration.option(AwsClientOption.FIPS_ENDPOINT_ENABLED)).isNull();
+        assertThat(client.clientConfiguration.option(AwsClientOption.FIPS_ENDPOINT_ENABLED)).isTrue();
+    }
+
+    @Test
+    public void buildWithSetFipsTrueAndNonFipsRegionFipsEnabledRemainsSet() {
+        TestClient client = testClientBuilder()
+            .fipsEnabled(true)
+            .region(Region.of("us-west-2"))
+            .build();
+
+        assertThat(client.clientConfiguration.option(AwsClientOption.AWS_REGION)).isEqualTo(Region.US_WEST_2);
+        assertThat(client.clientConfiguration.option(AwsClientOption.FIPS_ENDPOINT_ENABLED)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
Fix bug in FIPS configuration handling where setting a non-FIPS region clears the setting.

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
