### PR TITLE
Return previously resolved ChecksumSpecs with HttpChecksumResolver#getResolvedChecksumSpecs

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-3c99b83.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-3c99b83.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "HttpChecksumResolver.getResolvedChecksumSpecs() first attempts retrieval of checksum from ExecutionAttributes before resolving it"
+}

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilder.java
@@ -99,7 +99,7 @@ public final class AwsExecutionContextBuilder {
             .putAttribute(SdkExecutionAttribute.SIGNER_OVERRIDDEN, clientConfig.option(SdkClientOption.SIGNER_OVERRIDDEN))
             .putAttribute(AwsExecutionAttribute.USE_GLOBAL_ENDPOINT,
                           clientConfig.option(AwsClientOption.USE_GLOBAL_ENDPOINT))
-            .putAttribute(RESOLVED_CHECKSUM_SPECS, HttpChecksumResolver.getResolvedChecksumSpecs(executionAttributes));
+            .putAttribute(RESOLVED_CHECKSUM_SPECS, HttpChecksumResolver.resolveChecksumSpecs(executionAttributes));
 
         ExecutionInterceptorChain executionInterceptorChain =
                 new ExecutionInterceptorChain(clientConfig.option(SdkClientOption.EXECUTION_INTERCEPTORS));

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/HttpChecksumResolver.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/util/HttpChecksumResolver.java
@@ -16,11 +16,13 @@
 package software.amazon.awssdk.core.internal.util;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.checksums.Algorithm;
 import software.amazon.awssdk.core.checksums.ChecksumSpecs;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.trait.HttpChecksum;
 import software.amazon.awssdk.utils.StringUtils;
@@ -35,6 +37,11 @@ public final class HttpChecksumResolver {
     }
 
     public static ChecksumSpecs getResolvedChecksumSpecs(ExecutionAttributes executionAttributes) {
+        return Optional.ofNullable(executionAttributes.getAttribute(SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS))
+                       .orElseGet(() -> resolveChecksumSpecs(executionAttributes));
+    }
+
+    public static ChecksumSpecs resolveChecksumSpecs(ExecutionAttributes executionAttributes) {
         HttpChecksum httpChecksumTraitInOperation = executionAttributes.getAttribute(SdkInternalExecutionAttribute.HTTP_CHECKSUM);
         if (httpChecksumTraitInOperation == null) {
             return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In order to avoid constantly resolving the `ChecksumSpecs` object for a given request, `HttpChecksumResolver#getResolvedChecksumSpecs` will first attempt to retrieve said object from the `ExecutionAttributes`. Only when it is missing, will it be resolved.

## Motivation and Context
Optimize `HttpChecksumUtils` calls delegated to `HttpChecksumResolver` in order to avoid recomputing the same object.

## Modifications
<!--- Describe your changes in detail -->
Method `HttpChecksumResolver#getResolvedChecksumSpecs` has been renamed `resolveChecksumSpecs`. A replacement `getResolvedChecksumSpecs` now attempts to retrieved the cached `ChecksumSpecs` object.

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
