### PR TITLE
Bug fix for S3AsyncClient.putObject hangs if there is a connection reset while uploading of objects

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHttpClient-b7e834c.json
+++ b/.changes/next-release/bugfix-NettyNIOHttpClient-b7e834c.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO Http Client",
+    "contributor": "",
+    "description": "Fix for Netty based client request getting stuck if connection is reset after recieveing Http Continue response."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ChannelAttributeKey.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameStream;
@@ -72,6 +73,12 @@ public final class ChannelAttributeKey {
 
     public static final AttributeKey<ChannelDiagnostics> CHANNEL_DIAGNOSTICS = NettyUtils.getOrCreateAttributeKey(
         "aws.http.nio.netty.async.channelDiagnostics");
+
+    /**
+     * {@link AttributeKey} to keep track of whether we have received Continue in {@link HttpResponseStatus}.
+     */
+    public static final AttributeKey<Boolean> RESPONSE_100_CONTINUE_MESSAGE = NettyUtils.getOrCreateAttributeKey(
+        "aws.http.nio.netty.async.100ContinueMessage");
 
     /**
      * {@link AttributeKey} to keep track of whether we should close the connection after this request

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NettyRequestExecutor.java
@@ -23,6 +23,7 @@ import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.KEEP_ALIVE;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.LAST_HTTP_CONTENT_RECEIVED_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.REQUEST_CONTEXT_KEY;
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_100_CONTINUE_MESSAGE;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_COMPLETE_KEY;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_CONTENT_LENGTH;
 import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_DATA_READ;
@@ -196,6 +197,7 @@ public final class NettyRequestExecutor {
         channel.attr(REQUEST_CONTEXT_KEY).set(context);
         channel.attr(RESPONSE_COMPLETE_KEY).set(false);
         channel.attr(LAST_HTTP_CONTENT_RECEIVED_KEY).set(false);
+        channel.attr(RESPONSE_100_CONTINUE_MESSAGE).set(false);
         channel.attr(RESPONSE_CONTENT_LENGTH).set(null);
         channel.attr(RESPONSE_DATA_READ).set(null);
         channel.attr(CHANNEL_DIAGNOSTICS).get().incrementRequestCount();

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HttpStreamsClientHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HttpStreamsClientHandler.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.http.nio.netty.internal.nrs;
 
+import static software.amazon.awssdk.http.nio.netty.internal.ChannelAttributeKey.RESPONSE_100_CONTINUE_MESSAGE;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -168,6 +170,7 @@ public class HttpStreamsClientHandler extends HttpStreamsHandler<HttpResponse, H
             ReferenceCountUtil.release(msg);
             if (msg instanceof LastHttpContent) {
                 ignoreResponseBody = false;
+                ctx.channel().attr(RESPONSE_100_CONTINUE_MESSAGE).set(true);
             }
         } else {
             super.channelRead(ctx, msg);

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/SdkTestHttpContentPublisher.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/fault/SdkTestHttpContentPublisher.java
@@ -1,0 +1,56 @@
+package software.amazon.awssdk.http.nio.netty.fault;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+
+public class SdkTestHttpContentPublisher implements SdkHttpContentPublisher {
+    private final byte[] body;
+    private final AtomicReference<Subscriber<? super ByteBuffer>> subscriber = new AtomicReference<>(null);
+    private final AtomicBoolean complete = new AtomicBoolean(false);
+
+    public SdkTestHttpContentPublisher(byte[] body) {
+        this.body = body;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        boolean wasFirstSubscriber = subscriber.compareAndSet(null, s);
+
+        SdkTestHttpContentPublisher publisher = this;
+
+        if (wasFirstSubscriber) {
+            s.onSubscribe(new Subscription() {
+                @Override
+                public void request(long n) {
+                    publisher.request(n);
+                }
+
+                @Override
+                public void cancel() {
+                    // Do nothing
+                }
+            });
+        } else {
+            s.onError(new RuntimeException("Only allow one subscriber"));
+        }
+    }
+
+    protected void request(long n) {
+        // Send the whole body if they request >0 ByteBuffers
+        if (n >  0 && !complete.get()) {
+            complete.set(true);
+            subscriber.get().onNext(ByteBuffer.wrap(body));
+            subscriber.get().onComplete();
+        }
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.of((long)body.length);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Bug fix for S3AsyncClient.putObject hangs if there is a connection reset while uploading of objects
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->


### Root Cause 

-  [PR# 1481 ](https://github.com/aws/aws-sdk-java-v2/pull/1481) added logic to skip RunError steps in  ResponseHandler.#notifyIfResponseNotCompleted.
- In the case of PutObject call, the putObject request sends Http100Continue 
- When Http100Continue is sent `HttpResponseStatus CONTINUE = newStatus(100, "Continue")` is received  , which actually ignores the body, sends the lastByte and immediately starts reading the request stream.
- If there was a connection reset because of PR# 1481 it only checked that lastByte was set and thus skipped the Run Error steps.
- Since it skipped RunError the error was not propagated and it got stuck.


## Modifications
<!--- Describe your changes in detail -->

- Added a new Flag to indicate the HttpResponseStatus.CONTINUE(HTTP 100 Status code) is recieved.
- This flag is used in combination to lastByte flag such that We need to report error even if its last byte and if it was part of 100 status code response.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested by sending a huge object in S3Asycn.putObject and then disconnecting from VPN in between transfer. Expected outcome is it throws TimeOut Exceptions rather than waiting infinitely.
- Added J units for this case by mocking server disconnects when transfer is in progress.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
