### PR TITLE
Enable backpressure in TM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.10</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.19.2</awscrt.version>
+        <awscrt.version>1.0.0-SNAPSHOT</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>
@@ -699,6 +699,16 @@
             </activation>
             <properties>
                 <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jdk-11-plus</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.10</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>1.0.0-SNAPSHOT</awscrt.version>
+        <awscrt.version>0.19.6</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>

--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerDownloadIntegrationTest.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +48,7 @@ import software.amazon.awssdk.utils.Md5Utils;
 public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestBase {
     private static final String BUCKET = temporaryBucketName(S3TransferManagerDownloadIntegrationTest.class);
     private static final String KEY = "key";
-    private static final int OBJ_SIZE = 16 * 1024 * 1024;
+    private static final int OBJ_SIZE = 18 * 1024 * 1024;
     private static File file;
 
     @BeforeAll
@@ -66,7 +67,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
     }
 
     @Test
-    void download_toFile() throws IOException {
+    void download_toFile() throws Exception {
         Path path = RandomTempFile.randomUncreatedFile().toPath();
         FileDownload download =
             tm.downloadFile(DownloadFileRequest.builder()
@@ -74,7 +75,7 @@ public class S3TransferManagerDownloadIntegrationTest extends S3IntegrationTestB
                                                .destination(path)
                                                .addTransferListener(LoggingTransferListener.create())
                                                .build());
-        CompletedFileDownload completedFileDownload = download.completionFuture().join();
+        CompletedFileDownload completedFileDownload = download.completionFuture().get(1, TimeUnit.MINUTES);
         assertThat(Md5Utils.md5AsBase64(path.toFile())).isEqualTo(Md5Utils.md5AsBase64(file));
         assertThat(completedFileDownload.response().responseMetadata().requestId()).isNotNull();
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.s3;
 
 import java.net.URI;
 import java.nio.file.Path;
+import software.amazon.awssdk.annotations.SdkPreviewApi;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -28,6 +29,7 @@ import software.amazon.awssdk.utils.builder.SdkBuilder;
  * Builder API to build instance of Common Run Time based S3AsyncClient.
  */
 @SdkPublicApi
+@SdkPreviewApi
 public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuilder, S3AsyncClient> {
 
 
@@ -130,7 +132,18 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      */
     S3CrtAsyncClientBuilder checksumValidationEnabled(Boolean checksumValidationEnabled);
 
-    S3CrtAsyncClientBuilder readBufferSizeInBytes(Long readBufferSizeInBytes);
+    /**
+     * Configure the starting buffer size the client will use to buffer the parts downloaded from S3. Maintain a larger window to
+     * keep up a high download throughput; parts cannot download in parallel unless the window is large enough to hold multiple
+     * parts. Maintain a smaller window to limit the amount of data buffered in memory.
+     *
+     * <p>
+     * By default, it is equal to the resolved part size * 10
+     *
+     * @param initialReadBufferSizeInBytes the initial read buffer size
+     * @return this builder for method chaining.
+     */
+    S3CrtAsyncClientBuilder initialReadBufferSizeInBytes(Long initialReadBufferSizeInBytes);
 
     @Override
     S3AsyncClient build();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -130,6 +130,11 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      */
     S3CrtAsyncClientBuilder checksumValidationEnabled(Boolean checksumValidationEnabled);
 
+    /**
+     * Enabled by default
+     */
+    S3CrtAsyncClientBuilder backpressureForDownloadEnabled(Boolean backpressureForDownload);
+
     @Override
     S3AsyncClient build();
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3CrtAsyncClientBuilder.java
@@ -130,10 +130,7 @@ public interface S3CrtAsyncClientBuilder extends SdkBuilder<S3CrtAsyncClientBuil
      */
     S3CrtAsyncClientBuilder checksumValidationEnabled(Boolean checksumValidationEnabled);
 
-    /**
-     * Enabled by default
-     */
-    S3CrtAsyncClientBuilder backpressureForDownloadEnabled(Boolean backpressureForDownload);
+    S3CrtAsyncClientBuilder readBufferSizeInBytes(Long readBufferSizeInBytes);
 
     @Override
     S3AsyncClient build();

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -188,7 +188,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         }
 
         @Override
-        public S3CrtAsyncClientBuilder readBufferSizeInBytes(Long readBufferSizeInBytes) {
+        public S3CrtAsyncClientBuilder initialReadBufferSizeInBytes(Long readBufferSizeInBytes) {
             this.readBufferSizeInBytes = readBufferSizeInBytes;
             return this;
         }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -96,7 +96,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                        .signingRegion(builder.region == null ? null : builder.region.id())
                                        .endpointOverride(builder.endpointOverride)
                                        .credentialsProvider(builder.credentialsProvider)
-                .backpressureForDownload(builder.backpressureForDownloadEnabled)
+                                       .readBufferSizeInBytes(builder.readBufferSizeInBytes)
                                        .build();
         return S3CrtAsyncHttpClient.builder()
                                    .s3ClientConfiguration(s3NativeClientConfiguration);
@@ -108,6 +108,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
     }
 
     public static final class DefaultS3CrtClientBuilder implements S3CrtAsyncClientBuilder {
+        private Long readBufferSizeInBytes;
         private AwsCredentialsProvider credentialsProvider;
         private Region region;
         private Long minimalPartSizeInBytes;
@@ -115,7 +116,6 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         private Integer maxConcurrency;
         private URI endpointOverride;
         private Boolean checksumValidationEnabled;
-        private Boolean backpressureForDownloadEnabled;
 
         public AwsCredentialsProvider credentialsProvider() {
             return credentialsProvider;
@@ -141,8 +141,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
             return endpointOverride;
         }
 
-        public Boolean backpressureForDownloadEnabled() {
-            return backpressureForDownloadEnabled;
+        public Long readBufferSizeInBytes() {
+            return readBufferSizeInBytes;
         }
 
         @Override
@@ -188,8 +188,8 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         }
 
         @Override
-        public S3CrtAsyncClientBuilder backpressureForDownloadEnabled(Boolean backpressureForDownloadEnabled) {
-            this.backpressureForDownloadEnabled = backpressureForDownloadEnabled;
+        public S3CrtAsyncClientBuilder readBufferSizeInBytes(Long readBufferSizeInBytes) {
+            this.readBufferSizeInBytes = readBufferSizeInBytes;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -96,6 +96,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                                        .signingRegion(builder.region == null ? null : builder.region.id())
                                        .endpointOverride(builder.endpointOverride)
                                        .credentialsProvider(builder.credentialsProvider)
+                .backpressureForDownload(builder.backpressureForDownloadEnabled)
                                        .build();
         return S3CrtAsyncHttpClient.builder()
                                    .s3ClientConfiguration(s3NativeClientConfiguration);
@@ -114,6 +115,7 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         private Integer maxConcurrency;
         private URI endpointOverride;
         private Boolean checksumValidationEnabled;
+        private Boolean backpressureForDownloadEnabled;
 
         public AwsCredentialsProvider credentialsProvider() {
             return credentialsProvider;
@@ -139,6 +141,9 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
             return endpointOverride;
         }
 
+        public Boolean backpressureForDownloadEnabled() {
+            return backpressureForDownloadEnabled;
+        }
 
         @Override
         public S3CrtAsyncClientBuilder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
@@ -179,6 +184,12 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         @Override
         public S3CrtAsyncClientBuilder checksumValidationEnabled(Boolean checksumValidationEnabled) {
             this.checksumValidationEnabled = checksumValidationEnabled;
+            return this;
+        }
+
+        @Override
+        public S3CrtAsyncClientBuilder backpressureForDownloadEnabled(Boolean backpressureForDownloadEnabled) {
+            this.backpressureForDownloadEnabled = backpressureForDownloadEnabled;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -47,6 +47,7 @@ import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient implements S3CrtAsyncClient {
@@ -87,6 +88,11 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
 
     private static S3CrtAsyncHttpClient.Builder initializeS3CrtAsyncHttpClient(DefaultS3CrtClientBuilder builder) {
         validateCrtInClassPath();
+        Validate.isPositiveOrNull(builder.readBufferSizeInBytes, "initialReadBufferSizeInBytes");
+        Validate.isPositiveOrNull(builder.maxConcurrency, "maxConcurrency");
+        Validate.isPositiveOrNull(builder.targetThroughputInGbps, "targetThroughputInGbps");
+        Validate.isPositiveOrNull(builder.minimalPartSizeInBytes, "minimalPartSizeInBytes");
+
         s3NativeClientConfiguration =
             S3NativeClientConfiguration.builder()
                                        .checksumValidationEnabled(builder.checksumValidationEnabled)

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -72,7 +72,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withClientBootstrap(s3NativeClientConfiguration.clientBootstrap())
                                  .withPartSize(s3NativeClientConfiguration.partSizeBytes())
                                  .withComputeContentMd5(false)
-                                 .withInitialReadWindowSize(initialWindowSize)
+                                 .withInitialReadWindowSize(s3NativeClientConfiguration.readBufferSizeInBytes())
                                  .withReadBackpressureEnabled(s3NativeClientConfiguration.backpressureForDownloadEnabled())
                                  .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps());
         this.crtS3Client = new S3Client(s3ClientOptions);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -51,7 +51,6 @@ import software.amazon.awssdk.utils.Logger;
  */
 @SdkInternalApi
 public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
-    private static final long MAX_WINDOW_SIZE = 100 * 1024 * 1024; // 100 MB //TODO: Run some perf tests
     private static final Logger log = Logger.loggerFor(S3CrtAsyncHttpClient.class);
 
     private final S3Client crtS3Client;
@@ -62,7 +61,6 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         s3NativeClientConfiguration = builder.clientConfiguration;
         Long initialWindowSize = s3NativeClientConfiguration.readBufferSizeInBytes();
 
-        log.info(() -> "initial window size " + initialWindowSize);
         S3ClientOptions s3ClientOptions =
             new S3ClientOptions().withRegion(s3NativeClientConfiguration.signingRegion())
                                  .withEndpoint(s3NativeClientConfiguration.endpointOverride() == null ? null :
@@ -71,12 +69,9 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withClientBootstrap(s3NativeClientConfiguration.clientBootstrap())
                                  .withPartSize(s3NativeClientConfiguration.partSizeBytes())
                                  .withComputeContentMd5(false)
-                                 .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps());
-
-        if (initialWindowSize != null) {
-            s3ClientOptions.withInitialReadWindowSize(initialWindowSize);
-            s3ClientOptions.withReadBackpressureEnabled(true);
-        }
+                                 .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps())
+                                 .withInitialReadWindowSize(initialWindowSize)
+                                 .withReadBackpressureEnabled(true);
         this.crtS3Client = new S3Client(s3ClientOptions);
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -60,7 +60,8 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
     private S3CrtAsyncHttpClient(Builder builder) {
         s3NativeClientConfiguration = builder.clientConfiguration;
-        long initialWindowSize = (Runtime.getRuntime().freeMemory()/2);
+        long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        long initialWindowSize = Runtime.getRuntime().maxMemory() - usedMemory - s3NativeClientConfiguration.partSizeBytes();
 
         log.info(() -> "initial window size " + initialWindowSize);
         S3ClientOptions s3ClientOptions =

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -60,7 +60,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
     private S3CrtAsyncHttpClient(Builder builder) {
         s3NativeClientConfiguration = builder.clientConfiguration;
-        long initialWindowSize = Math.min(MAX_WINDOW_SIZE, s3NativeClientConfiguration.partSizeBytes() * 5);
+        long initialWindowSize = Math.min(MAX_WINDOW_SIZE, s3NativeClientConfiguration.partSizeBytes() * 10);
 
         S3ClientOptions s3ClientOptions =
             new S3ClientOptions().withRegion(s3NativeClientConfiguration.signingRegion())

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -60,7 +60,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
     private S3CrtAsyncHttpClient(Builder builder) {
         s3NativeClientConfiguration = builder.clientConfiguration;
-        long initialWindowSize = s3NativeClientConfiguration.partSizeBytes() * 16; // 128
+        long initialWindowSize = s3NativeClientConfiguration.partSizeBytes() * 32; // 256
 
         log.info(() -> "initial window size " + initialWindowSize);
         S3ClientOptions s3ClientOptions =

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -60,7 +60,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
     private S3CrtAsyncHttpClient(Builder builder) {
         s3NativeClientConfiguration = builder.clientConfiguration;
-        long initialWindowSize = s3NativeClientConfiguration.partSizeBytes() * 32; // 256
+        long initialWindowSize = Runtime.getRuntime().maxMemory();
 
         log.info(() -> "initial window size " + initialWindowSize);
         S3ClientOptions s3ClientOptions =

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -71,7 +71,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
                                  .withPartSize(s3NativeClientConfiguration.partSizeBytes())
                                  .withComputeContentMd5(false)
                                  .withInitialReadWindowSize(initialWindowSize)
-                                 .withReadBackpressureEnabled(true)
+                                 .withReadBackpressureEnabled(s3NativeClientConfiguration.backpressureForDownloadEnabled())
                                  .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps());
         this.crtS3Client = new S3Client(s3ClientOptions);
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -60,8 +60,9 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
     private S3CrtAsyncHttpClient(Builder builder) {
         s3NativeClientConfiguration = builder.clientConfiguration;
-        long initialWindowSize = Math.min(MAX_WINDOW_SIZE, s3NativeClientConfiguration.partSizeBytes() * 10);
+        long initialWindowSize = s3NativeClientConfiguration.partSizeBytes() * 16; // 128
 
+        log.info(() -> "initial window size " + initialWindowSize);
         S3ClientOptions s3ClientOptions =
             new S3ClientOptions().withRegion(s3NativeClientConfiguration.signingRegion())
                                  .withEndpoint(s3NativeClientConfiguration.endpointOverride() == null ? null :

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -60,7 +60,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
     private S3CrtAsyncHttpClient(Builder builder) {
         s3NativeClientConfiguration = builder.clientConfiguration;
-        long initialWindowSize = Runtime.getRuntime().maxMemory();
+        long initialWindowSize = (Runtime.getRuntime().freeMemory()/2);
 
         log.info(() -> "initial window size " + initialWindowSize);
         S3ClientOptions s3ClientOptions =

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtDataPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtDataPublisher.java
@@ -25,6 +25,7 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.crt.s3.S3MetaRequest;
 import software.amazon.awssdk.utils.Logger;
 
 /**
@@ -44,6 +45,8 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
     private final AtomicReference<Subscriber<? super ByteBuffer>> subscriberRef = new AtomicReference<>(null);
 
     private volatile boolean isDone;
+
+    private volatile S3MetaRequest metaRequest;
 
     @Override
     public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
@@ -81,6 +84,7 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
     }
 
     public void deliverData(ByteBuffer byteBuffer) {
+        log.trace(() -> "received data of size: " + byteBuffer.remaining());
         // If the subscription is cancelled, no op
         if (isDone) {
             return;
@@ -122,6 +126,7 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
     }
 
     private void flushBuffer() {
+
         if (buffer.isEmpty()) {
             return;
         }
@@ -153,11 +158,26 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
                 }
 
                 DataEvent dataEvent = (DataEvent) event;
-                outstandingDemand.decrementAndGet();
-                subscriberRef.get().onNext(dataEvent.data());
+
+                int size = dataEvent.data().remaining();
+
+                // TODO: CRT may send empty byte buffer
+                //  we should remove size check once it's fixed on CRT side
+                // https://github.com/awslabs/aws-c-s3/pull/220
+                if (size > 0) {
+                    outstandingDemand.decrementAndGet();
+                    log.debug(() -> "incrementing read window by " + size);
+                    metaRequest.incrementReadWindow(size);
+                    subscriberRef.get().onNext(dataEvent.data());
+                }
+
             }
             isDelivering.set(false);
         }
+    }
+
+    public void metaRequest(S3MetaRequest s3MetaRequest) {
+        this.metaRequest = s3MetaRequest;
     }
 
     private final class DataSubscription implements Subscription {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtDataPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtDataPublisher.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.utils.Logger;
 /**
  * Publisher of the response data from crt. Tracks outstanding demand and delivers the data to the subscriber
  */
+//TODO: use SimplePublisher
 @SdkInternalApi
 public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
     private static final Logger log = Logger.loggerFor(S3CrtDataPublisher.class);
@@ -161,16 +162,10 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
 
                 int size = dataEvent.data().remaining();
 
-                // TODO: CRT may send empty byte buffer
-                //  we should remove size check once it's fixed on CRT side
-                // https://github.com/awslabs/aws-c-s3/pull/220
-                if (size > 0) {
-                    outstandingDemand.decrementAndGet();
-                    log.debug(() -> "incrementing read window by " + size);
-                    metaRequest.incrementReadWindow(size);
-                    subscriberRef.get().onNext(dataEvent.data());
-                }
-
+                outstandingDemand.decrementAndGet();
+                log.debug(() -> "incrementing read window by " + size);
+                metaRequest.incrementReadWindow(size);
+                subscriberRef.get().onNext(dataEvent.data());
             }
             isDelivering.set(false);
         }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtDataPublisher.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtDataPublisher.java
@@ -85,7 +85,7 @@ public class S3CrtDataPublisher implements SdkPublisher<ByteBuffer> {
     }
 
     public void deliverData(ByteBuffer byteBuffer) {
-        log.trace(() -> "received data of size: " + byteBuffer.remaining());
+        log.trace(() -> "Received data: " + byteBuffer);
         // If the subscription is cancelled, no op
         if (isDone) {
             return;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
@@ -66,6 +66,9 @@ public class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseHandler
 
     @Override
     public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+        if (bodyBytesIn == null) {
+            notifyError(new IllegalStateException("ByteBuffer delivered is null"));
+        }
         publisher.deliverData(bodyBytesIn);
         // Returning 0 to disable flow control because it is enforced in publisher
         return 0;

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
@@ -68,6 +68,7 @@ public class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseHandler
     public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
         if (bodyBytesIn == null) {
             notifyError(new IllegalStateException("ByteBuffer delivered is null"));
+            metaRequest.close();
         }
         publisher.deliverData(bodyBytesIn);
         // Returning 0 to disable flow control because it is enforced in publisher

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -41,7 +41,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final int maxConcurrency;
     private final URI endpointOverride;
     private final boolean checksumValidationEnabled;
-    private final boolean backpressureForDownloadEnabled;
+    private final Long readBufferSizeInBytes;
 
     public S3NativeClientConfiguration(Builder builder) {
         this.signingRegion = builder.signingRegion == null ? DefaultAwsRegionProviderChain.builder().build().getRegion().id() :
@@ -66,9 +66,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         this.endpointOverride = builder.endpointOverride;
 
         this.checksumValidationEnabled = builder.checksumValidationEnabled == null || builder.checksumValidationEnabled;
-        this.backpressureForDownloadEnabled = builder.backpressureForDownloadEnabled != null ?
-                                              builder.backpressureForDownloadEnabled :
-                                              true;
+        this.readBufferSizeInBytes = builder.readBufferSizeInBytes;
     }
 
     public static Builder builder() {
@@ -107,8 +105,12 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         return checksumValidationEnabled;
     }
 
+    public Long readBufferSizeInBytes() {
+        return readBufferSizeInBytes;
+    }
+
     public boolean backpressureForDownloadEnabled() {
-        return backpressureForDownloadEnabled;
+        return readBufferSizeInBytes != null;
     }
 
     @Override
@@ -118,6 +120,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     }
 
     public static final class Builder {
+        public Long readBufferSizeInBytes;
         private String signingRegion;
         private AwsCredentialsProvider credentialsProvider;
         private Long partSizeInBytes;
@@ -126,8 +129,6 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private URI endpointOverride;
         private ClientAsyncConfiguration asynConfiguration;
         private Boolean checksumValidationEnabled;
-
-        private Boolean backpressureForDownloadEnabled;
 
         private Builder() {
         }
@@ -174,8 +175,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
             return new S3NativeClientConfiguration(this);
         }
 
-        public Builder backpressureForDownload(Boolean backpressureForDownloadEnabled) {
-            this.backpressureForDownloadEnabled = backpressureForDownloadEnabled;
+        public Builder readBufferSizeInBytes(Long readBufferSizeInBytes) {
+            this.readBufferSizeInBytes = readBufferSizeInBytes;
             return this;
         }
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -41,6 +41,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private final int maxConcurrency;
     private final URI endpointOverride;
     private final boolean checksumValidationEnabled;
+    private final boolean backpressureForDownloadEnabled;
 
     public S3NativeClientConfiguration(Builder builder) {
         this.signingRegion = builder.signingRegion == null ? DefaultAwsRegionProviderChain.builder().build().getRegion().id() :
@@ -65,6 +66,9 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         this.endpointOverride = builder.endpointOverride;
 
         this.checksumValidationEnabled = builder.checksumValidationEnabled == null || builder.checksumValidationEnabled;
+        this.backpressureForDownloadEnabled = builder.backpressureForDownloadEnabled != null ?
+                                              builder.backpressureForDownloadEnabled :
+                                              true;
     }
 
     public static Builder builder() {
@@ -103,6 +107,10 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         return checksumValidationEnabled;
     }
 
+    public boolean backpressureForDownloadEnabled() {
+        return backpressureForDownloadEnabled;
+    }
+
     @Override
     public void close() {
         clientBootstrap.close();
@@ -118,6 +126,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private URI endpointOverride;
         private ClientAsyncConfiguration asynConfiguration;
         private Boolean checksumValidationEnabled;
+
+        private Boolean backpressureForDownloadEnabled;
 
         private Builder() {
         }
@@ -162,6 +172,11 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
         public S3NativeClientConfiguration build() {
             return new S3NativeClientConfiguration(this);
+        }
+
+        public Builder backpressureForDownload(Boolean backpressureForDownloadEnabled) {
+            this.backpressureForDownloadEnabled = backpressureForDownloadEnabled;
+            return this;
         }
     }
 }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 public class S3NativeClientConfiguration implements SdkAutoCloseable {
     private static final long DEFAULT_PART_SIZE_IN_BYTES = 8L * 1024 * 1024;
     private static final long DEFAULT_TARGET_THROUGHPUT_IN_GBPS = 5;
+
     private final String signingRegion;
     private final ClientBootstrap clientBootstrap;
     private final CrtCredentialsProviderAdapter credentialProviderAdapter;
@@ -66,7 +67,8 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         this.endpointOverride = builder.endpointOverride;
 
         this.checksumValidationEnabled = builder.checksumValidationEnabled == null || builder.checksumValidationEnabled;
-        this.readBufferSizeInBytes = builder.readBufferSizeInBytes;
+        this.readBufferSizeInBytes = builder.readBufferSizeInBytes == null ?
+                                     partSizeInBytes * 10 : builder.readBufferSizeInBytes;
     }
 
     public static Builder builder() {
@@ -107,10 +109,6 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
 
     public Long readBufferSizeInBytes() {
         return readBufferSizeInBytes;
-    }
-
-    public boolean backpressureForDownloadEnabled() {
-        return readBufferSizeInBytes != null;
     }
 
     @Override

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/CompleteMultipartUploadFunctionalTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/functionaltests/CompleteMultipartUploadFunctionalTest.java
@@ -38,16 +38,16 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 public class CompleteMultipartUploadFunctionalTest {
-    private static final URI HTTP_LOCALHOST_URI = URI.create("http://localhost:8080/");
 
     @Rule
-    public WireMockRule wireMock = new WireMockRule();
+    public WireMockRule wireMock = new WireMockRule(0);
+
 
     private S3ClientBuilder getSyncClientBuilder() {
 
         return S3Client.builder()
                        .region(Region.US_EAST_1)
-                       .endpointOverride(HTTP_LOCALHOST_URI)
+                       .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                        .credentialsProvider(
                            StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")));
     }
@@ -55,7 +55,7 @@ public class CompleteMultipartUploadFunctionalTest {
     private S3AsyncClientBuilder getAsyncClientBuilder() {
         return S3AsyncClient.builder()
                             .region(Region.US_EAST_1)
-                            .endpointOverride(HTTP_LOCALHOST_URI)
+                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                             .credentialsProvider(
                                 StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")));
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.s3.S3FinishedResponseContext;
+import software.amazon.awssdk.crt.s3.S3MetaRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
 
@@ -48,6 +49,9 @@ public class S3CrtResponseHandlerAdapterTest {
 
     @Mock
     private S3FinishedResponseContext context;
+
+    @Mock
+    private S3MetaRequest s3MetaRequest;
     private CompletableFuture<Void> future;
 
     @Before
@@ -56,6 +60,8 @@ public class S3CrtResponseHandlerAdapterTest {
         responseHandlerAdapter = new S3CrtResponseHandlerAdapter(future,
                                                                  sdkResponseHandler,
                                                                  crtDataPublisher);
+
+        responseHandlerAdapter.metaRequest(s3MetaRequest);
     }
 
     @Test
@@ -79,6 +85,7 @@ public class S3CrtResponseHandlerAdapterTest {
 
         responseHandlerAdapter.onFinished(stubResponseContext(0, 0, null));
         assertThat(future).isCompleted();
+        verify(s3MetaRequest).close();
     }
 
     @Test
@@ -107,6 +114,7 @@ public class S3CrtResponseHandlerAdapterTest {
         assertThat(actualByteBuffer).isEqualTo(ByteBuffer.wrap(errorPayload));
 
         assertThat(future).isCompleted();
+        verify(s3MetaRequest).close();
     }
 
     @Test
@@ -121,6 +129,7 @@ public class S3CrtResponseHandlerAdapterTest {
         Exception actualException = exceptionArgumentCaptor.getValue();
         assertThat(actualException).isInstanceOf(SdkClientException.class);
         assertThat(future).isCompletedExceptionally();
+        verify(s3MetaRequest).close();
     }
 
     private S3FinishedResponseContext stubResponseContext(int errorCode, int responseStatus, byte[] errorPayload) {

--- a/test/s3-benchmarks/pom.xml
+++ b/test/s3-benchmarks/pom.xml
@@ -30,6 +30,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <awsjavasdk.version>${project.version}</awsjavasdk.version>
+        <sdk-v1.version>1.12.1</sdk-v1.version>
     </properties>
     <name>AWS Java SDK :: Test :: S3 Benchmarks</name>
     <description>Contains benchmark code for S3 and TransferManager</description>
@@ -54,6 +55,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-transfer-manager</artifactId>
             <version>${awsjavasdk.version}-PREVIEW</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${sdk-v1.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -59,7 +59,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
     BaseTransferManagerBenchmark(TransferManagerBenchmarkConfig config) {
         logger.info(() -> "Benchmark config: " + config);
         Long partSizeInMb = config.partSizeInMb() == null ? null : config.partSizeInMb() * MB;
-        Long readBufferSizeInMb = config.readBufferSizeInMb() == null ? null : config.partSizeInMb() * MB;
+        Long readBufferSizeInMb = config.readBufferSizeInMb() == null ? null : config.readBufferSizeInMb() * MB;
         s3 = S3CrtAsyncClient.builder()
                              .targetThroughputInGbps(config.targetThroughput())
                              .minimumPartSizeInBytes(partSizeInMb)

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -59,10 +59,11 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
     BaseTransferManagerBenchmark(TransferManagerBenchmarkConfig config) {
         logger.info(() -> "Benchmark config: " + config);
         Long partSizeInMb = config.partSizeInMb() == null ? null : config.partSizeInMb() * MB;
+        Long readBufferSizeInMb = config.readBufferSizeInMb() == null ? null : config.partSizeInMb() * MB;
         s3 = S3CrtAsyncClient.builder()
                              .targetThroughputInGbps(config.targetThroughput())
                              .minimumPartSizeInBytes(partSizeInMb)
-                             .backpressureForDownloadEnabled(config.backpressureForDownloadEnabled())
+                             .readBufferSizeInBytes(readBufferSizeInMb)
                              .build();
         s3Sync = S3Client.builder()
                          .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -60,7 +60,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
         s3 = S3CrtAsyncClient.builder()
                              .targetThroughputInGbps(config.targetThroughput())
                              .minimumPartSizeInBytes(partSizeInMb)
-                             .readBufferSizeInBytes(readBufferSizeInMb)
+                             .initialReadBufferSizeInBytes(readBufferSizeInMb)
                              .targetThroughputInGbps(config.targetThroughput() == null ?
                                                      100.0 : config.targetThroughput())
                              .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -39,8 +39,9 @@ import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.utils.Logger;
 
 public abstract class BaseTransferManagerBenchmark implements TransferManagerBenchmark {
+    private static final int BENCHMARK_ITERATIONS = 10;
+
     protected static final int WARMUP_ITERATIONS = 10;
-    protected static final int BENCHMARK_ITERATIONS = 10;
 
     private static final Logger logger = Logger.loggerFor("TransferManagerBenchmark");
     private static final String WARMUP_KEY = "warmupobject";
@@ -51,6 +52,8 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
     protected final String bucket;
     protected final String key;
     protected final String path;
+
+    protected final int iteration;
     private final File file;
 
     BaseTransferManagerBenchmark(TransferManagerBenchmarkConfig config) {
@@ -68,6 +71,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
         bucket = config.bucket();
         key = config.key();
         path = config.filePath();
+        iteration = config.iteration() == null ? BENCHMARK_ITERATIONS : config.iteration();
         try {
             file = new RandomTempFile(1024 * 1000L);
             file.deleteOnExit();
@@ -92,7 +96,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
     /**
      * Hook method to allow subclasses to add additional warm up
      */
-    protected void additionalWarmup() {
+    protected void additionalWarmup() throws Exception {
         // default to no-op
     }
 
@@ -126,7 +130,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
         transferManager.close();
     }
 
-    private void warmUp() throws InterruptedException {
+    private void warmUp() throws Exception {
         logger.info(() -> "Starting to warm up");
 
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -62,6 +62,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
         s3 = S3CrtAsyncClient.builder()
                              .targetThroughputInGbps(config.targetThroughput())
                              .minimumPartSizeInBytes(partSizeInMb)
+                             .backpressureForDownloadEnabled(config.backpressureForDownloadEnabled())
                              .build();
         s3Sync = S3Client.builder()
                          .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -126,7 +126,12 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
     }
 
     private void cleanup() {
-        s3Sync.deleteObject(b -> b.bucket(bucket).key(WARMUP_KEY));
+        try {
+            s3Sync.deleteObject(b -> b.bucket(bucket).key(WARMUP_KEY));
+        } catch (Exception exception) {
+            logger.error(() -> "Failed to delete object: " + WARMUP_KEY);
+        }
+
         s3.close();
         s3Sync.close();
         transferManager.close();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -61,6 +61,8 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
                              .targetThroughputInGbps(config.targetThroughput())
                              .minimumPartSizeInBytes(partSizeInMb)
                              .readBufferSizeInBytes(readBufferSizeInMb)
+                             .targetThroughputInGbps(config.targetThroughput() == null ?
+                                                     100.0 : config.targetThroughput())
                              .build();
         s3Sync = S3Client.builder()
                          .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BaseTransferManagerBenchmark.java
@@ -62,7 +62,7 @@ public abstract class BaseTransferManagerBenchmark implements TransferManagerBen
                              .minimumPartSizeInBytes(partSizeInMb)
                              .initialReadBufferSizeInBytes(readBufferSizeInMb)
                              .targetThroughputInGbps(config.targetThroughput() == null ?
-                                                     100.0 : config.targetThroughput())
+                                                     Double.valueOf(100.0) : config.targetThroughput())
                              .build();
         s3Sync = S3Client.builder()
                          .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
@@ -31,6 +31,7 @@ public class BenchmarkRunner {
     private static final String KEY = "key";
     private static final String OPERATION = "operation";
     private static final String CHECKSUM_ALGORITHM = "checksumAlgo";
+    private static final String ITERATION = "iteration";
 
     private BenchmarkRunner() {
     }
@@ -48,6 +49,7 @@ public class BenchmarkRunner {
         options.addOption(null, PART_SIZE_IN_MB, true, "Part size in MB");
         options.addOption(null, MAX_THROUGHPUT, true, "The max throughput");
         options.addOption(null, CHECKSUM_ALGORITHM, true, "The checksum algorithm to use");
+        options.addOption(null, ITERATION, true, "The number of iterations");
 
         CommandLine cmd = parser.parse(options, args);
         TransferManagerBenchmarkConfig config = parseConfig(cmd);
@@ -74,11 +76,16 @@ public class BenchmarkRunner {
 
         Double maxThroughput = cmd.getOptionValue(MAX_THROUGHPUT) == null ? null :
                                Double.parseDouble(cmd.getOptionValue(MAX_THROUGHPUT));
+
         ChecksumAlgorithm checksumAlgorithm = null;
         if (cmd.getOptionValue(CHECKSUM_ALGORITHM) != null) {
             checksumAlgorithm = ChecksumAlgorithm.fromValue(cmd.getOptionValue(CHECKSUM_ALGORITHM)
                                                                                .toUpperCase(Locale.ENGLISH));
         }
+
+        Integer iteration = cmd.getOptionValue(ITERATION) == null ? null :
+                          Integer.parseInt(cmd.getOptionValue(ITERATION));
+
         return TransferManagerBenchmarkConfig.builder()
                                              .key(key)
                                              .bucket(bucket)
@@ -86,6 +93,7 @@ public class BenchmarkRunner {
                                              .checksumAlgorithm(checksumAlgorithm)
                                              .targetThroughput(maxThroughput)
                                              .filePath(filePath)
+                                             .iteration(iteration)
                                              .build();
     }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
@@ -33,6 +33,8 @@ public class BenchmarkRunner {
     private static final String CHECKSUM_ALGORITHM = "checksumAlgo";
     private static final String ITERATION = "iteration";
 
+    private static final String BACKPRESSURE_ENABLED = "backpressure";
+
     private BenchmarkRunner() {
     }
 
@@ -50,6 +52,7 @@ public class BenchmarkRunner {
         options.addOption(null, MAX_THROUGHPUT, true, "The max throughput");
         options.addOption(null, CHECKSUM_ALGORITHM, true, "The checksum algorithm to use");
         options.addOption(null, ITERATION, true, "The number of iterations");
+        options.addOption(null, BACKPRESSURE_ENABLED, true, "Whether backpressure is enabled");
 
         CommandLine cmd = parser.parse(options, args);
         TransferManagerBenchmarkConfig config = parseConfig(cmd);
@@ -80,11 +83,14 @@ public class BenchmarkRunner {
         ChecksumAlgorithm checksumAlgorithm = null;
         if (cmd.getOptionValue(CHECKSUM_ALGORITHM) != null) {
             checksumAlgorithm = ChecksumAlgorithm.fromValue(cmd.getOptionValue(CHECKSUM_ALGORITHM)
-                                                                               .toUpperCase(Locale.ENGLISH));
+                                                               .toUpperCase(Locale.ENGLISH));
         }
 
         Integer iteration = cmd.getOptionValue(ITERATION) == null ? null :
-                          Integer.parseInt(cmd.getOptionValue(ITERATION));
+                            Integer.parseInt(cmd.getOptionValue(ITERATION));
+
+        Boolean backpressureEnabled = cmd.getOptionValue(BACKPRESSURE_ENABLED) == null ? null :
+                                      Boolean.parseBoolean(cmd.getOptionValue(BACKPRESSURE_ENABLED));
 
         return TransferManagerBenchmarkConfig.builder()
                                              .key(key)
@@ -92,6 +98,7 @@ public class BenchmarkRunner {
                                              .partSizeInMb(partSize)
                                              .checksumAlgorithm(checksumAlgorithm)
                                              .targetThroughput(maxThroughput)
+                                             .backpressureForDownloadEnabled(backpressureEnabled)
                                              .filePath(filePath)
                                              .iteration(iteration)
                                              .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
@@ -45,11 +45,11 @@ public class BenchmarkRunner {
 
         Options options = new Options();
 
-        options.addRequiredOption(null, FILE, true, "Destination file path to be written or source file path to be "
-                                                    + "uploaded");
         options.addRequiredOption(null, BUCKET, true, "The s3 bucket");
         options.addRequiredOption(null, KEY, true, "The s3 key");
         options.addRequiredOption(null, OPERATION, true, "The operation to run tests: download | upload");
+        options.addOption(null, FILE, true, "Destination file path to be written to or source file path to be "
+                                            + "uploaded");
         options.addOption(null, PART_SIZE_IN_MB, true, "Part size in MB");
         options.addOption(null, MAX_THROUGHPUT, true, "The max throughput");
         options.addOption(null, CHECKSUM_ALGORITHM, true, "The checksum algorithm to use");

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkRunner.java
@@ -33,7 +33,7 @@ public class BenchmarkRunner {
     private static final String CHECKSUM_ALGORITHM = "checksumAlgo";
     private static final String ITERATION = "iteration";
 
-    private static final String BACKPRESSURE_ENABLED = "backpressure";
+    private static final String READ_BUFFER_IN_MB = "readBufferInMB";
 
     private BenchmarkRunner() {
     }
@@ -52,7 +52,7 @@ public class BenchmarkRunner {
         options.addOption(null, MAX_THROUGHPUT, true, "The max throughput");
         options.addOption(null, CHECKSUM_ALGORITHM, true, "The checksum algorithm to use");
         options.addOption(null, ITERATION, true, "The number of iterations");
-        options.addOption(null, BACKPRESSURE_ENABLED, true, "Whether backpressure is enabled");
+        options.addOption(null, READ_BUFFER_IN_MB, true, "Read buffer size in MB");
 
         CommandLine cmd = parser.parse(options, args);
         TransferManagerBenchmarkConfig config = parseConfig(cmd);
@@ -89,8 +89,8 @@ public class BenchmarkRunner {
         Integer iteration = cmd.getOptionValue(ITERATION) == null ? null :
                             Integer.parseInt(cmd.getOptionValue(ITERATION));
 
-        Boolean backpressureEnabled = cmd.getOptionValue(BACKPRESSURE_ENABLED) == null ? null :
-                                      Boolean.parseBoolean(cmd.getOptionValue(BACKPRESSURE_ENABLED));
+        Long readBufferInMB = cmd.getOptionValue(READ_BUFFER_IN_MB) == null ? null :
+                                      Long.parseLong(cmd.getOptionValue(READ_BUFFER_IN_MB));
 
         return TransferManagerBenchmarkConfig.builder()
                                              .key(key)
@@ -98,7 +98,7 @@ public class BenchmarkRunner {
                                              .partSizeInMb(partSize)
                                              .checksumAlgorithm(checksumAlgorithm)
                                              .targetThroughput(maxThroughput)
-                                             .backpressureForDownloadEnabled(backpressureEnabled)
+                                             .readBufferSizeInMb(readBufferInMB)
                                              .filePath(filePath)
                                              .iteration(iteration)
                                              .build();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkUtils.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/BenchmarkUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.s3benchmarks;
+
+import static software.amazon.awssdk.transfer.s3.SizeConstant.GB;
+
+import java.util.List;
+import software.amazon.awssdk.utils.Logger;
+
+public final class BenchmarkUtils {
+    static final int PRE_WARMUP_ITERATIONS = 10;
+    static final int PRE_WARMUP_RUNS = 20;
+    static final int BENCHMARK_ITERATIONS = 10;
+    static final String WARMUP_KEY = "warmupobject";
+
+    private static final Logger logger = Logger.loggerFor("TransferManagerBenchmark");
+
+    private BenchmarkUtils() {
+    }
+
+    public static void printOutResult(List<Double> metrics, String name, long contentLengthInByte) {
+        logger.info(() -> String.format("===============  %s Result ================", name));
+        logger.info(() -> String.valueOf(metrics));
+        double averageLatency = metrics.stream()
+                                       .mapToDouble(a -> a)
+                                       .average()
+                                       .orElse(0.0);
+
+        double lowestLatency = metrics.stream()
+                                      .mapToDouble(a -> a)
+                                      .min().orElse(0.0);
+
+        double contentLengthInGigabit = (contentLengthInByte / (double) GB) * 8.0;
+        logger.info(() -> "Average latency (s): " + averageLatency);
+        logger.info(() -> "Object size (Gigabit): " + contentLengthInGigabit);
+        logger.info(() -> "Average throughput (Gbps): " + contentLengthInGigabit / averageLatency);
+        logger.info(() -> "Highest average throughput (Gbps): " + contentLengthInGigabit / lowestLatency);
+        logger.info(() -> "==========================================================");
+    }
+}

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/CrtS3ClientBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/CrtS3ClientBenchmark.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.s3benchmarks;
+
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.BENCHMARK_ITERATIONS;
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.printOutResult;
+import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.s3.CrtS3RuntimeException;
+import software.amazon.awssdk.crt.s3.S3Client;
+import software.amazon.awssdk.crt.s3.S3ClientOptions;
+import software.amazon.awssdk.crt.s3.S3FinishedResponseContext;
+import software.amazon.awssdk.crt.s3.S3MetaRequest;
+import software.amazon.awssdk.crt.s3.S3MetaRequestOptions;
+import software.amazon.awssdk.crt.s3.S3MetaRequestResponseHandler;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.s3.internal.crt.S3NativeClientConfiguration;
+import software.amazon.awssdk.utils.Logger;
+
+public class CrtS3ClientBenchmark implements TransferManagerBenchmark {
+    private final String bucket;
+    private final String key;
+    private final String path;
+    private final int iteration;
+    private final S3NativeClientConfiguration s3NativeClientConfiguration;
+    private final S3Client crtS3Client;
+    private final software.amazon.awssdk.services.s3.S3Client s3Sync;
+    private final Region region;
+
+    private final long contentLength;
+
+    private static final Logger logger = Logger.loggerFor("CrtS3ClientBenchmark");
+
+    public CrtS3ClientBenchmark(TransferManagerBenchmarkConfig config) {
+
+        logger.info(() -> "Benchmark config: " + config);
+
+        Long readBufferSizeInMb = config.readBufferSizeInMb() == null ? null : config.readBufferSizeInMb() * MB;
+
+        Long partSizeInBytes = config.partSizeInMb() == null ? null : config.partSizeInMb() * MB;
+        s3NativeClientConfiguration = S3NativeClientConfiguration.builder()
+                                                                 .partSizeInBytes(partSizeInBytes)
+                                                                 .targetThroughputInGbps(config.targetThroughput())
+                                                                 .build();
+
+
+        S3ClientOptions s3ClientOptions =
+            new S3ClientOptions().withRegion(s3NativeClientConfiguration.signingRegion())
+                                 .withEndpoint(s3NativeClientConfiguration.endpointOverride() == null ? null :
+                                               s3NativeClientConfiguration.endpointOverride().toString())
+                                 .withCredentialsProvider(s3NativeClientConfiguration.credentialsProvider())
+                                 .withClientBootstrap(s3NativeClientConfiguration.clientBootstrap())
+                                 .withPartSize(s3NativeClientConfiguration.partSizeBytes())
+                                 .withComputeContentMd5(false)
+                                 .withThroughputTargetGbps(s3NativeClientConfiguration.targetThroughputInGbps());
+
+        bucket = config.bucket();
+        key = config.key();
+        path = config.filePath();
+        iteration = config.iteration() == null ? BENCHMARK_ITERATIONS : config.iteration();
+
+        if (readBufferSizeInMb != null) {
+            s3ClientOptions.withInitialReadWindowSize(readBufferSizeInMb);
+            s3ClientOptions.withReadBackpressureEnabled(true);
+        }
+
+        crtS3Client = new S3Client(s3ClientOptions);
+        s3Sync = software.amazon.awssdk.services.s3.S3Client.builder()
+                                                            .build();
+        this.contentLength = s3Sync.headObject(b -> b.bucket(bucket).key(key)).contentLength();
+
+        DefaultAwsRegionProviderChain instanceProfileRegionProvider = new DefaultAwsRegionProviderChain();
+        region = instanceProfileRegionProvider.getRegion();
+    }
+
+    @Override
+    public void run() {
+
+        try {
+            warmUp();
+            doRunBenchmark();
+        } catch (Exception e) {
+            logger.error(() -> "Exception occurred", e);
+        } finally {
+            cleanup();
+        }
+    }
+
+    private void cleanup() {
+        s3Sync.close();
+        s3NativeClientConfiguration.close();
+        crtS3Client.close();
+    }
+
+    private void warmUp() throws Exception {
+        logger.info(() -> "Starting to warm up");
+
+        for (int i = 0; i < 3; i++) {
+            sendOneRequest(new ArrayList<>());
+            Thread.sleep(500);
+        }
+        logger.info(() -> "Ending warm up");
+    }
+
+    private void doRunBenchmark() {
+        List<Double> metrics = new ArrayList<>();
+        for (int i = 0; i < iteration; i++) {
+            sendOneRequest(metrics);
+        }
+
+        printOutResult(metrics, "Download to File", contentLength);
+    }
+
+    private void sendOneRequest(List<Double> latencies) {
+
+        CompletableFuture<Void> resultFuture = new CompletableFuture<>();
+
+        S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
+            @Override
+            public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                return 0;
+            }
+
+            @Override
+            public void onFinished(S3FinishedResponseContext context) {
+                if (context.getErrorCode() != 0) {
+                    resultFuture.completeExceptionally(
+                        new CrtS3RuntimeException(context.getErrorCode(), context.getResponseStatus(),
+                                                  context.getErrorPayload()));
+                    return;
+                }
+                resultFuture.complete(null);
+            }
+        };
+
+        String endpoint = bucket + ".s3." + region + ".amazonaws.com";
+
+        HttpHeader[] headers = {new HttpHeader("Host", endpoint)};
+        HttpRequest httpRequest = new HttpRequest("GET", "/" + key, headers, null);
+
+        S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
+            .withEndpoint(URI.create("https://" + endpoint))
+            .withMetaRequestType(S3MetaRequestOptions.MetaRequestType.GET_OBJECT).withHttpRequest(httpRequest)
+            .withResponseHandler(responseHandler);
+
+        long start = System.currentTimeMillis();
+        try (S3MetaRequest metaRequest = crtS3Client.makeMetaRequest(metaRequestOptions)) {
+            resultFuture.get(10, TimeUnit.MINUTES);
+        } catch (ExecutionException | TimeoutException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        long end = System.currentTimeMillis();
+        latencies.add((end - start) / 1000.0);
+    }
+}

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.s3benchmarks;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -41,7 +40,7 @@ public class NoOpResponseTransformer implements AsyncResponseTransformer<GetObje
 
     @Override
     public void onStream(SdkPublisher<ByteBuffer> publisher) {
-        publisher.subscribe(new SimpleSubscriber(Buffer::clear) {
+        publisher.subscribe(new SimpleSubscriber(ignore -> {}) {
             @Override
             public void onComplete() {
                 super.onComplete();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
@@ -44,8 +44,8 @@ public class NoOpResponseTransformer implements AsyncResponseTransformer<GetObje
         }) {
             @Override
             public void onComplete() {
-                super.onComplete();
                 future.complete(null);
+                super.onComplete();
             }
         });
     }

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/NoOpResponseTransformer.java
@@ -40,7 +40,8 @@ public class NoOpResponseTransformer implements AsyncResponseTransformer<GetObje
 
     @Override
     public void onStream(SdkPublisher<ByteBuffer> publisher) {
-        publisher.subscribe(new SimpleSubscriber(ignore -> {}) {
+        publisher.subscribe(new SimpleSubscriber(ignore -> {
+        }) {
             @Override
             public void onComplete() {
                 super.onComplete();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmark.java
@@ -34,4 +34,12 @@ public interface TransferManagerBenchmark {
         return new TransferManagerUploadBenchmark(config);
     }
 
+    static TransferManagerBenchmark v1Download(TransferManagerBenchmarkConfig config) {
+        return new V1TransferManagerDownloadBenchmark(config);
+    }
+
+    static TransferManagerBenchmark v1Upload(TransferManagerBenchmarkConfig config) {
+        return new V1TransferManagerUploadBenchmark(config);
+    }
+
 }

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
@@ -26,6 +26,8 @@ public final class TransferManagerBenchmarkConfig {
     private final ChecksumAlgorithm checksumAlgorithm;
     private final Integer iteration;
 
+    private final Boolean backpressureForDownloadEnabled;
+
     private TransferManagerBenchmarkConfig(Builder builder) {
         this.filePath = builder.filePath;
         this.bucket = builder.bucket;
@@ -34,6 +36,7 @@ public final class TransferManagerBenchmarkConfig {
         this.partSizeInMb = builder.partSizeInMb;
         this.checksumAlgorithm = builder.checksumAlgorithm;
         this.iteration = builder.iteration;
+        this.backpressureForDownloadEnabled = builder.backpressureForDownloadEnabled;
     }
 
     public String filePath() {
@@ -64,6 +67,10 @@ public final class TransferManagerBenchmarkConfig {
         return iteration;
     }
 
+    public Boolean backpressureForDownloadEnabled() {
+        return backpressureForDownloadEnabled;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -75,12 +82,16 @@ public final class TransferManagerBenchmarkConfig {
                ", bucket: '" + bucket + '\'' +
                ", key: '" + key + '\'' +
                ", targetThroughput: " + targetThroughput +
-               ", partSizeInMB: " + partSizeInMb + '\'' +
+               ", partSizeInMb: " + partSizeInMb +
                ", checksumAlgorithm: " + checksumAlgorithm +
+               ", iteration: " + iteration +
+               ", backpressureForDownloadEnabled: " + backpressureForDownloadEnabled +
                '}';
     }
 
+
     static final class Builder {
+        private Boolean backpressureForDownloadEnabled;
         private ChecksumAlgorithm checksumAlgorithm;
         private String filePath;
         private String bucket;
@@ -122,6 +133,11 @@ public final class TransferManagerBenchmarkConfig {
 
         public Builder iteration(Integer iteration) {
             this.iteration = iteration;
+            return this;
+        }
+
+        public Builder backpressureForDownloadEnabled(Boolean backpressureForDownloadEnabled) {
+            this.backpressureForDownloadEnabled = backpressureForDownloadEnabled;
             return this;
         }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
@@ -24,6 +24,7 @@ public final class TransferManagerBenchmarkConfig {
     private final Double targetThroughput;
     private final Long partSizeInMb;
     private final ChecksumAlgorithm checksumAlgorithm;
+    private final Integer iteration;
 
     private TransferManagerBenchmarkConfig(Builder builder) {
         this.filePath = builder.filePath;
@@ -32,6 +33,7 @@ public final class TransferManagerBenchmarkConfig {
         this.targetThroughput = builder.targetThroughput;
         this.partSizeInMb = builder.partSizeInMb;
         this.checksumAlgorithm = builder.checksumAlgorithm;
+        this.iteration = builder.iteration;
     }
 
     public String filePath() {
@@ -58,6 +60,10 @@ public final class TransferManagerBenchmarkConfig {
         return checksumAlgorithm;
     }
 
+    public Integer iteration() {
+        return iteration;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -81,6 +87,8 @@ public final class TransferManagerBenchmarkConfig {
         private String key;
         private Double targetThroughput;
         private Long partSizeInMb;
+
+        private Integer iteration;
 
         public Builder filePath(String filePath) {
             this.filePath = filePath;
@@ -109,6 +117,11 @@ public final class TransferManagerBenchmarkConfig {
 
         public Builder checksumAlgorithm(ChecksumAlgorithm checksumAlgorithm) {
             this.checksumAlgorithm = checksumAlgorithm;
+            return this;
+        }
+
+        public Builder iteration(Integer iteration) {
+            this.iteration = iteration;
             return this;
         }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
@@ -89,7 +89,6 @@ public final class TransferManagerBenchmarkConfig {
                '}';
     }
 
-
     static final class Builder {
         private Long readBufferSizeInMb;
         private ChecksumAlgorithm checksumAlgorithm;

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerBenchmarkConfig.java
@@ -26,7 +26,7 @@ public final class TransferManagerBenchmarkConfig {
     private final ChecksumAlgorithm checksumAlgorithm;
     private final Integer iteration;
 
-    private final Boolean backpressureForDownloadEnabled;
+    private final Long readBufferSizeInMb;
 
     private TransferManagerBenchmarkConfig(Builder builder) {
         this.filePath = builder.filePath;
@@ -36,7 +36,7 @@ public final class TransferManagerBenchmarkConfig {
         this.partSizeInMb = builder.partSizeInMb;
         this.checksumAlgorithm = builder.checksumAlgorithm;
         this.iteration = builder.iteration;
-        this.backpressureForDownloadEnabled = builder.backpressureForDownloadEnabled;
+        this.readBufferSizeInMb = builder.readBufferSizeInMb;
     }
 
     public String filePath() {
@@ -67,8 +67,8 @@ public final class TransferManagerBenchmarkConfig {
         return iteration;
     }
 
-    public Boolean backpressureForDownloadEnabled() {
-        return backpressureForDownloadEnabled;
+    public Long readBufferSizeInMb() {
+        return readBufferSizeInMb;
     }
 
     public static Builder builder() {
@@ -85,13 +85,13 @@ public final class TransferManagerBenchmarkConfig {
                ", partSizeInMb: " + partSizeInMb +
                ", checksumAlgorithm: " + checksumAlgorithm +
                ", iteration: " + iteration +
-               ", backpressureForDownloadEnabled: " + backpressureForDownloadEnabled +
+               ", readBufferSizeInMb: " + readBufferSizeInMb +
                '}';
     }
 
 
     static final class Builder {
-        private Boolean backpressureForDownloadEnabled;
+        private Long readBufferSizeInMb;
         private ChecksumAlgorithm checksumAlgorithm;
         private String filePath;
         private String bucket;
@@ -136,8 +136,8 @@ public final class TransferManagerBenchmarkConfig {
             return this;
         }
 
-        public Builder backpressureForDownloadEnabled(Boolean backpressureForDownloadEnabled) {
-            this.backpressureForDownloadEnabled = backpressureForDownloadEnabled;
+        public Builder readBufferSizeInMb(Long readBufferSizeInMb) {
+            this.readBufferSizeInMb = readBufferSizeInMb;
             return this;
         }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -44,12 +44,6 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
         }
     }
 
-    @Override
-    protected void additionalWarmup() throws Exception {
-        //downloadToMemory(2, false);
-        //downloadToFile(2, false);
-    }
-
     private void downloadToMemory(int count, boolean printoutResult) throws Exception {
         List<Double> metrics = new ArrayList<>();
         logger.info(() -> "Starting to download to memory");

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -38,10 +38,13 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
 
     @Override
     protected void doRunBenchmark() {
-        try {
-            downloadToMemory(iteration, true);
-        } catch (Exception exception) {
-            logger.error(() -> "Request failed: ", exception);
+        if (path == null) {
+            try {
+                downloadToMemory(iteration, true);
+            } catch (Exception exception) {
+                logger.error(() -> "Request failed: ", exception);
+            }
+            return;
         }
 
         try {

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -46,8 +46,8 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
 
     @Override
     protected void additionalWarmup() throws Exception {
-        downloadToMemory(1, true);
-        downloadToFile(1, true);
+        downloadToMemory(2, false);
+        downloadToFile(2, false);
     }
 
     private void downloadToMemory(int count, boolean printoutResult) throws Exception {

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.s3benchmarks;
 
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.printOutResult;
 import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
 import java.io.File;
@@ -29,16 +30,22 @@ import software.amazon.awssdk.utils.Logger;
 
 public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchmark {
     private static final Logger logger = Logger.loggerFor("TransferManagerDownloadBenchmark");
-
+    private final long contentLength;
     public TransferManagerDownloadBenchmark(TransferManagerBenchmarkConfig config) {
         super(config);
+        this.contentLength = s3Sync.headObject(b -> b.bucket(bucket).key(key)).contentLength();
     }
 
     @Override
     protected void doRunBenchmark() {
         try {
-            downloadToFile(iteration, true);
             downloadToMemory(iteration, true);
+        } catch (Exception exception) {
+            logger.error(() -> "Request failed: ", exception);
+        }
+
+        try {
+            downloadToFile(iteration, true);
         } catch (Exception exception) {
             logger.error(() -> "Request failed: ", exception);
         }
@@ -52,7 +59,7 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
         }
 
         if (printoutResult) {
-            printOutResult(metrics, "Download to Memory");
+            printOutResult(metrics, "Download to Memory", contentLength);
         }
     }
 
@@ -63,7 +70,7 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
             downloadOnceToFile(metrics);
         }
         if (printoutResult) {
-            printOutResult(metrics, "Download to File");
+            printOutResult(metrics, "Download to File", contentLength);
         }
     }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -46,8 +46,8 @@ public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchma
 
     @Override
     protected void additionalWarmup() throws Exception {
-        downloadToMemory(2, false);
-        downloadToFile(2, false);
+        //downloadToMemory(2, false);
+        //downloadToFile(2, false);
     }
 
     private void downloadToMemory(int count, boolean printoutResult) throws Exception {

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerDownloadBenchmark.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.utils.Logger;
 public class TransferManagerDownloadBenchmark extends BaseTransferManagerBenchmark {
     private static final Logger logger = Logger.loggerFor("TransferManagerDownloadBenchmark");
     private final long contentLength;
+
     public TransferManagerDownloadBenchmark(TransferManagerBenchmarkConfig config) {
         super(config);
         this.contentLength = s3Sync.headObject(b -> b.bucket(bucket).key(key)).contentLength();

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerUploadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerUploadBenchmark.java
@@ -15,7 +15,12 @@
 
 package software.amazon.awssdk.s3benchmarks;
 
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.printOutResult;
+
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import software.amazon.awssdk.utils.Logger;
@@ -40,17 +45,21 @@ public class TransferManagerUploadBenchmark extends BaseTransferManagerBenchmark
 
     @Override
     protected void additionalWarmup() {
-        uploadFromFile(3, false);
+        try {
+            uploadFromFile(3, false);
+        } catch (Exception exception) {
+            logger.error(() -> "Warmup failed: ", exception);
+        }
     }
 
-    private void uploadFromFile(int count, boolean printOutResult) {
+    private void uploadFromFile(int count, boolean printOutResult) throws IOException {
         List<Double> metrics = new ArrayList<>();
         logger.info(() -> "Starting to upload from file");
         for (int i = 0; i < count; i++) {
             uploadOnceFromFile(metrics);
         }
         if (printOutResult) {
-            printOutResult(metrics, "Upload from File");
+            printOutResult(metrics, "Upload from File", Files.size(Paths.get(path)));
         }
     }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerUploadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerUploadBenchmark.java
@@ -32,7 +32,7 @@ public class TransferManagerUploadBenchmark extends BaseTransferManagerBenchmark
     @Override
     protected void doRunBenchmark() {
         try {
-            uploadFromFile(BENCHMARK_ITERATIONS, true);
+            uploadFromFile(iteration, true);
         } catch (Exception exception) {
             logger.error(() -> "Request failed: ", exception);
         }

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerUploadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/TransferManagerUploadBenchmark.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
 
 public class TransferManagerUploadBenchmark extends BaseTransferManagerBenchmark {
     private static final Logger logger = Logger.loggerFor("TransferManagerUploadBenchmark");
@@ -31,6 +32,7 @@ public class TransferManagerUploadBenchmark extends BaseTransferManagerBenchmark
 
     public TransferManagerUploadBenchmark(TransferManagerBenchmarkConfig config) {
         super(config);
+        Validate.notNull(config.filePath(), "File path must not be null");
         this.config = config;
     }
 

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1BaseTransferManagerBenchmark.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Validate;
 
 abstract class V1BaseTransferManagerBenchmark implements TransferManagerBenchmark {
     private static final int MAX_CONCURRENCY = 100;
@@ -54,6 +55,7 @@ abstract class V1BaseTransferManagerBenchmark implements TransferManagerBenchmar
 
     V1BaseTransferManagerBenchmark(TransferManagerBenchmarkConfig config) {
         logger.info(() -> "Benchmark config: " + config);
+        Validate.notNull(config.filePath(), "File path must not be null");
         Long partSizeInMb = config.partSizeInMb() == null ? null : config.partSizeInMb() * MB;
         s3Client = AmazonS3Client.builder()
                                  .withClientConfiguration(new ClientConfiguration().withMaxConnections(MAX_CONCURRENCY))

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1BaseTransferManagerBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1BaseTransferManagerBenchmark.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.s3benchmarks;
+
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.BENCHMARK_ITERATIONS;
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.PRE_WARMUP_ITERATIONS;
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.PRE_WARMUP_RUNS;
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.WARMUP_KEY;
+import static software.amazon.awssdk.transfer.s3.SizeConstant.MB;
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.transfer.Download;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.amazonaws.services.s3.transfer.Upload;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import software.amazon.awssdk.testutils.RandomTempFile;
+import software.amazon.awssdk.utils.Logger;
+
+abstract class V1BaseTransferManagerBenchmark implements TransferManagerBenchmark {
+    private static final int MAX_CONCURRENCY = 100;
+    private static final Logger logger = Logger.loggerFor("TransferManagerBenchmark");
+
+    protected final TransferManager transferManager;
+    protected final AmazonS3 s3Client;
+    protected final String bucket;
+    protected final String key;
+    protected final int iteration;
+    protected final String sourcePath;
+    private final File tmpFile;
+    private final ExecutorService executorService;
+
+    V1BaseTransferManagerBenchmark(TransferManagerBenchmarkConfig config) {
+        logger.info(() -> "Benchmark config: " + config);
+        Long partSizeInMb = config.partSizeInMb() == null ? null : config.partSizeInMb() * MB;
+        s3Client = AmazonS3Client.builder()
+                                 .withClientConfiguration(new ClientConfiguration().withMaxConnections(MAX_CONCURRENCY))
+                                 .build();
+        executorService = Executors.newFixedThreadPool(MAX_CONCURRENCY);
+        transferManager = TransferManagerBuilder.standard()
+                                                .withMinimumUploadPartSize(partSizeInMb)
+                                                .withS3Client(s3Client)
+                                                .withExecutorFactory(() -> executorService)
+                                                .build();
+        bucket = config.bucket();
+        key = config.key();
+        sourcePath = config.filePath();
+        iteration = config.iteration() == null ? BENCHMARK_ITERATIONS : config.iteration();
+        try {
+            tmpFile = new RandomTempFile(20 * MB);
+        } catch (IOException e) {
+            logger.error(() -> "Failed to create the file");
+            throw new RuntimeException("Failed to create the temp file", e);
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            warmUp();
+            doRunBenchmark();
+        } catch (Exception e) {
+            logger.error(() -> "Exception occurred", e);
+        } finally {
+            cleanup();
+        }
+    }
+
+    protected abstract void doRunBenchmark();
+
+    private void cleanup() {
+        executorService.shutdown();
+        transferManager.shutdownNow();
+        s3Client.shutdown();
+    }
+
+    private void warmUp() {
+        logger.info(() -> "Starting to warm up");
+
+        for (int i = 0; i < PRE_WARMUP_ITERATIONS; i++) {
+            warmUpUploadBatch();
+            warmUpDownloadBatch();
+
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warn(() -> "Thread interrupted when waiting for completion", e);
+            }
+        }
+        logger.info(() -> "Ending warm up");
+    }
+
+    private void warmUpDownloadBatch() {
+        List<Download> downloads = new ArrayList<>();
+        List<File> tmpFiles = new ArrayList<>();
+        for (int i = 0; i < PRE_WARMUP_RUNS; i++) {
+            File tmpFile = RandomTempFile.randomUncreatedFile();
+            tmpFiles.add(tmpFile);
+            downloads.add(transferManager.download(bucket, WARMUP_KEY, tmpFile));
+        }
+
+        downloads.forEach(u -> {
+            try {
+                u.waitForCompletion();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.error(() -> "Thread interrupted ", e);
+            }
+        });
+
+        tmpFiles.forEach(f -> runAndLogError(logger.logger(), "Deleting file failed", () -> Files.delete(f.toPath())));
+    }
+
+    private void warmUpUploadBatch() {
+        List<Upload> uploads = new ArrayList<>();
+        for (int i = 0; i < PRE_WARMUP_RUNS; i++) {
+            uploads.add(transferManager.upload(bucket, WARMUP_KEY, tmpFile));
+        }
+
+        uploads.forEach(u -> {
+            try {
+                u.waitForUploadResult();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.error(() -> "Thread interrupted ", e);
+            }
+        });
+    }
+}

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1TransferManagerDownloadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1TransferManagerDownloadBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.s3benchmarks;
+
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.printOutResult;
+import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.utils.Logger;
+
+public class V1TransferManagerDownloadBenchmark extends V1BaseTransferManagerBenchmark {
+    private static final Logger logger = Logger.loggerFor("V1TransferManagerDownloadBenchmark");
+
+    V1TransferManagerDownloadBenchmark(TransferManagerBenchmarkConfig config) {
+        super(config);
+    }
+
+    @Override
+    protected void doRunBenchmark() {
+        downloadToFile();
+    }
+
+    private void downloadToFile() {
+        List<Double> metrics = new ArrayList<>();
+        logger.info(() -> "Starting to download to file");
+        for (int i = 0; i < iteration; i++) {
+            downloadOnceToFile(metrics);
+        }
+        long contentLength = s3Client.getObjectMetadata(bucket, key).getContentLength();
+        printOutResult(metrics, "V1 Download to File", contentLength);
+    }
+
+    private void downloadOnceToFile(List<Double> latencies) {
+        Path downloadPath = new File(this.sourcePath).toPath();
+        long start = System.currentTimeMillis();
+
+        try {
+            transferManager.download(bucket, key, new File(this.sourcePath)).waitForCompletion();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn(() -> "Thread interrupted when waiting for completion", e);
+        }
+        long end = System.currentTimeMillis();
+        latencies.add((end - start) / 1000.0);
+        runAndLogError(logger.logger(),
+                       "Deleting file failed",
+                       () -> Files.delete(downloadPath));
+    }
+}

--- a/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1TransferManagerUploadBenchmark.java
+++ b/test/s3-benchmarks/src/main/java/software/amazon/awssdk/s3benchmarks/V1TransferManagerUploadBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.s3benchmarks;
+
+import static software.amazon.awssdk.s3benchmarks.BenchmarkUtils.printOutResult;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.utils.Logger;
+
+public class V1TransferManagerUploadBenchmark extends V1BaseTransferManagerBenchmark {
+    private static final Logger logger = Logger.loggerFor("V1TransferManagerUploadBenchmark");
+    private final File sourceFile;
+
+    V1TransferManagerUploadBenchmark(TransferManagerBenchmarkConfig config) {
+        super(config);
+        sourceFile = new File(sourcePath);
+    }
+
+    @Override
+    protected void doRunBenchmark() {
+        uploadFile();
+    }
+
+    private void uploadFile() {
+        List<Double> metrics = new ArrayList<>();
+        logger.info(() -> "Starting to upload");
+        for (int i = 0; i < iteration; i++) {
+            uploadOnce(metrics);
+        }
+        long contentLength = sourceFile.length();
+        printOutResult(metrics, "V1 Upload File", contentLength);
+    }
+
+    private void uploadOnce(List<Double> latencies) {
+        long start = System.currentTimeMillis();
+
+        try {
+            transferManager.upload(bucket, key, sourceFile).waitForCompletion();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn(() -> "Thread interrupted when waiting for completion", e);
+        }
+        long end = System.currentTimeMillis();
+        latencies.add((end - start) / 1000.0);
+    }
+}

--- a/test/s3-benchmarks/src/main/resources/log4j2.properties
+++ b/test/s3-benchmarks/src/main/resources/log4j2.properties
@@ -20,8 +20,15 @@ appender.console.name = ConsoleAppender
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n%throwable
 
+appender.file.type = File
+appender.file.name = FileAppender
+appender.file.fileName = s3-benchmark-result.txt
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n%throwable
+
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = ConsoleAppender
+rootLogger.appenderRef.file.ref = FileAppender
 
 # Uncomment below to enable more specific logging
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- Enable backpressure for read in TM to fix the issue where OOM was thrown if the consumer could not keep up with the speed of download. #3394 
 
## Modifications
- Enable backpressure for read in TM
- Expose initialReadBufferSize config. The default `initialReadBufferSize` is 10 * partSize
- Add more perf tests

## Testing
Tested in an EC2 instance

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
