### PR TITLE
Retry on UncheckedIOException.

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetrySetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetrySetting.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.internal.retry;
 import static java.util.Collections.unmodifiableSet;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
@@ -78,6 +79,7 @@ public final class SdkDefaultRetrySetting {
         Set<Class<? extends Exception>> retryableExceptions = new HashSet<>();
         retryableExceptions.add(RetryableException.class);
         retryableExceptions.add(IOException.class);
+        retryableExceptions.add(UncheckedIOException.class);
         retryableExceptions.add(ApiCallAttemptTimeoutException.class);
         RETRYABLE_EXCEPTIONS = unmodifiableSet(retryableExceptions);
     }


### PR DESCRIPTION
Retry on UncheckedIOException.

## Motivation and Context
In some cases IOException is converted to UncheckedIOException and that suppresses retry with default retry policy. 
For example: in UrlConnectionHttpClient
```
throw new UncheckedIOException(new IOException(message, e));
```

## Modifications
Added UncheckedIOException to retryable exception list.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
