### PR TITLE
S3 query param validation

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-eeb4182.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-eeb4182.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "S3 query param validation; enforce required params"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/AddShapes.java
@@ -23,6 +23,7 @@ import static software.amazon.awssdk.codegen.internal.Utils.isScalar;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import software.amazon.awssdk.codegen.internal.TypeUtils;
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.EnumModel;
@@ -192,6 +193,7 @@ abstract class AddShapes {
         memberModel.setXmlAttribute(c2jMemberDefinition.isXmlAttribute());
         memberModel.setUnionEnumTypeName(namingStrategy.getUnionEnumTypeName(memberModel));
         memberModel.setContextParam(c2jMemberDefinition.getContextParam());
+        memberModel.setRequired(isRequiredMember(c2jMemberName, parentShape));
 
 
         // Pass the xmlNameSpace from the member reference
@@ -307,6 +309,12 @@ abstract class AddShapes {
     private boolean isFlattened(Member member, Shape memberShape) {
         return member.isFlattened()
                || memberShape.isFlattened();
+    }
+
+    private boolean isRequiredMember(String memberName, Shape memberShape) {
+        return Optional.ofNullable(memberShape.getRequired())
+                       .map(l -> l.contains(memberName))
+                       .orElse(false);
     }
 
     /**

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/intermediate/MemberModel.java
@@ -59,6 +59,8 @@ public class MemberModel extends DocumentationModel {
     
     private String deprecatedMessage;
 
+    private boolean required;
+
     private ListModel listModel;
 
     private MapModel mapModel;
@@ -314,6 +316,14 @@ public class MemberModel extends DocumentationModel {
 
     public void setDeprecatedMessage(String deprecatedMessage) {
         this.deprecatedMessage = deprecatedMessage;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
     }
 
     public boolean isEventPayload() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ShapeModelSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ShapeModelSpec.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.LocationTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
 import software.amazon.awssdk.core.traits.PayloadTrait;
+import software.amazon.awssdk.core.traits.RequiredTrait;
 import software.amazon.awssdk.core.traits.TimestampFormatTrait;
 import software.amazon.awssdk.core.traits.XmlAttributeTrait;
 import software.amazon.awssdk.core.traits.XmlAttributesTrait;
@@ -184,6 +185,9 @@ class ShapeModelSpec {
         if (m.isXmlAttribute()) {
             traits.add(createXmlAttributeTrait());
         }
+        if (m.isRequired()) {
+            traits.add(createRequiredTrait());
+        }
 
         if (!traits.isEmpty()) {
             return CodeBlock.builder()
@@ -268,6 +272,12 @@ class ShapeModelSpec {
                         .build();
     }
 
+    private CodeBlock createRequiredTrait() {
+        return CodeBlock.builder()
+                        .add("$T.create()", ClassName.get(RequiredTrait.class))
+                        .build();
+    }
+
     private CodeBlock createMapTrait(MemberModel m) {
         return CodeBlock.builder()
                         .add("$T.builder()\n"
@@ -306,7 +316,7 @@ class ShapeModelSpec {
         String uri = xmlNamespace.getUri();
         String prefix = xmlNamespace.getPrefix();
         CodeBlock.Builder codeBlockBuilder = CodeBlock.builder()
-                                         .add("$T.create(", ClassName.get(XmlAttributesTrait.class));
+                                                      .add("$T.create(", ClassName.get(XmlAttributesTrait.class));
 
         String namespacePrefix = "xmlns:" + prefix;
         codeBlockBuilder.add("$T.of($S, $T.builder().attributeGetter((ignore) -> $S).build())",

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/JsonProtocolMarshaller.java
@@ -132,7 +132,7 @@ public class JsonProtocolMarshaller implements ProtocolMarshaller<SdkHttpFullReq
             .queryParamMarshaller(MarshallingType.INSTANT, QueryParamMarshaller.INSTANT)
             .queryParamMarshaller(MarshallingType.LIST, QueryParamMarshaller.LIST)
             .queryParamMarshaller(MarshallingType.MAP, QueryParamMarshaller.MAP)
-            .queryParamMarshaller(MarshallingType.NULL, JsonMarshaller.NULL)
+            .queryParamMarshaller(MarshallingType.NULL, QueryParamMarshaller.NULL)
 
             .pathParamMarshaller(MarshallingType.STRING, SimpleTypePathMarshaller.STRING)
             .pathParamMarshaller(MarshallingType.INTEGER, SimpleTypePathMarshaller.INTEGER)

--- a/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/QueryParamMarshaller.java
+++ b/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/QueryParamMarshaller.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
+import software.amazon.awssdk.core.traits.RequiredTrait;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 
 @SdkInternalApi
@@ -30,20 +31,20 @@ public final class QueryParamMarshaller {
         ValueToStringConverter.FROM_STRING);
 
     public static final JsonMarshaller<Integer> INTEGER = new SimpleQueryParamMarshaller<>(
-            ValueToStringConverter.FROM_INTEGER);
+        ValueToStringConverter.FROM_INTEGER);
 
     public static final JsonMarshaller<Long> LONG = new SimpleQueryParamMarshaller<>(ValueToStringConverter.FROM_LONG);
 
     public static final JsonMarshaller<Short> SHORT = new SimpleQueryParamMarshaller<>(ValueToStringConverter.FROM_SHORT);
 
     public static final JsonMarshaller<Double> DOUBLE = new SimpleQueryParamMarshaller<>(
-            ValueToStringConverter.FROM_DOUBLE);
+        ValueToStringConverter.FROM_DOUBLE);
 
     public static final JsonMarshaller<Float> FLOAT = new SimpleQueryParamMarshaller<>(
-            ValueToStringConverter.FROM_FLOAT);
+        ValueToStringConverter.FROM_FLOAT);
 
     public static final JsonMarshaller<Boolean> BOOLEAN = new SimpleQueryParamMarshaller<>(
-            ValueToStringConverter.FROM_BOOLEAN);
+        ValueToStringConverter.FROM_BOOLEAN);
 
     public static final JsonMarshaller<Instant> INSTANT
         = new SimpleQueryParamMarshaller<>(JsonProtocolMarshaller.INSTANT_VALUE_TO_STRING);
@@ -57,6 +58,12 @@ public final class QueryParamMarshaller {
     public static final JsonMarshaller<Map<String, ?>> MAP = (val, context, paramName, sdkField) -> {
         for (Map.Entry<String, ?> mapEntry : val.entrySet()) {
             context.marshall(MarshallLocation.QUERY_PARAM, mapEntry.getValue(), mapEntry.getKey());
+        }
+    };
+
+    public static final JsonMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
+        if (sdkField.containsTrait(RequiredTrait.class)) {
+            throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };
 

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/QueryParamMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/QueryParamMarshaller.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.protocol.MarshallLocation;
 import software.amazon.awssdk.core.traits.ListTrait;
 import software.amazon.awssdk.core.traits.MapTrait;
+import software.amazon.awssdk.core.traits.RequiredTrait;
 import software.amazon.awssdk.protocols.core.ValueToStringConverter;
 
 @SdkInternalApi
@@ -75,6 +76,12 @@ public final class QueryParamMarshaller {
 
                 context.request().putRawQueryParameter(entry.getKey(), valueMarshaller.convert(entry.getValue(), null));
             }
+        }
+    };
+
+    public static final XmlMarshaller<Void> NULL = (val, context, paramName, sdkField) -> {
+        if (sdkField.containsTrait(RequiredTrait.class)) {
+            throw new IllegalArgumentException(String.format("Parameter '%s' must not be null", paramName));
         }
     };
 

--- a/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlProtocolMarshaller.java
+++ b/core/protocols/aws-xml-protocol/src/main/java/software/amazon/awssdk/protocols/xml/internal/marshall/XmlProtocolMarshaller.java
@@ -189,7 +189,7 @@ public final class XmlProtocolMarshaller implements ProtocolMarshaller<SdkHttpFu
             .queryParamMarshaller(MarshallingType.INSTANT, QueryParamMarshaller.INSTANT)
             .queryParamMarshaller(MarshallingType.LIST, QueryParamMarshaller.LIST)
             .queryParamMarshaller(MarshallingType.MAP, QueryParamMarshaller.MAP)
-            .queryParamMarshaller(MarshallingType.NULL, XmlMarshaller.NULL)
+            .queryParamMarshaller(MarshallingType.NULL, QueryParamMarshaller.NULL)
 
             .pathParamMarshaller(MarshallingType.STRING, SimpleTypePathMarshaller.STRING)
             .pathParamMarshaller(MarshallingType.INTEGER, SimpleTypePathMarshaller.INTEGER)

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/RequiredTrait.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/traits/RequiredTrait.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.traits;
+
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+@SdkProtectedApi
+public final class RequiredTrait implements Trait {
+
+    private RequiredTrait() {
+    }
+
+    public static RequiredTrait create() {
+        return new RequiredTrait();
+    }
+}

--- a/services/apigateway/src/test/java/software/amazon/awssdk/services/apigateway/model/GetUsageRequestTest.java
+++ b/services/apigateway/src/test/java/software/amazon/awssdk/services/apigateway/model/GetUsageRequestTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.apigateway.model;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.util.concurrent.CompletionException;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.apigateway.ApiGatewayAsyncClient;
+import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
+
+@WireMockTest
+class GetUsageRequestTest {
+
+    private int wireMockPort;
+
+    private ApiGatewayClient client;
+
+    private ApiGatewayAsyncClient asyncClient;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        wireMockPort = wmRuntimeInfo.getHttpPort();
+
+        client = ApiGatewayClient.builder()
+                                 .credentialsProvider(StaticCredentialsProvider
+                                                          .create(AwsBasicCredentials.create("akid", "skid")))
+                                 .region(Region.US_WEST_2)
+                                 .endpointOverride(URI.create("http://localhost:" + wireMockPort))
+                                 .build();
+
+        asyncClient = ApiGatewayAsyncClient.builder()
+                                           .credentialsProvider(StaticCredentialsProvider
+                                                                    .create(AwsBasicCredentials.create("akid", "skid")))
+                                           .region(Region.US_WEST_2)
+                                           .endpointOverride(URI.create("http://localhost:" + wireMockPort))
+                                           .build();
+    }
+
+    @Test
+    void marshall_syncMissingUploadId_ThrowsException() {
+        stubAndRespondWith(200, "");
+
+        GetUsageRequest request = getUsageRequestWithDates(null, "20221115");
+
+        assertThatThrownBy(() -> client.getUsage(request))
+            .isInstanceOf(SdkClientException.class)
+            .hasMessageContaining("Parameter 'startDate' must not be null");
+    }
+
+    @Test
+    void marshall_syncEmptyStartDate_encodesAsEmptyValue() {
+        stubAndRespondWith(200, "");
+
+        GetUsageRequest request = getUsageRequestWithDates("", "20221115");
+        client.getUsage(request);
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("startDate", equalTo("")));
+    }
+
+    @Test
+    void marshall_syncNonEmptyStartDate_encodesValue() {
+        stubAndRespondWith(200, "");
+
+        GetUsageRequest request = getUsageRequestWithDates("20221101", "20221115");
+        client.getUsage(request);
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("startDate", equalTo("20221101")));
+    }
+
+    @Test
+    void marshall_asyncMissingStartDate_ThrowsException() {
+        stubAndRespondWith(200, "");
+
+        GetUsageRequest request = getUsageRequestWithDates(null, "20221115");
+
+        ThrowableAssert.ThrowingCallable throwingCallable = () -> asyncClient.getUsage(request).join();
+        assertThatThrownBy(throwingCallable)
+            .isInstanceOf(CompletionException.class)
+            .hasMessageContaining("Parameter 'startDate' must not be null");
+    }
+
+    @Test
+    void marshall_asyncEmptyStartDate_encodesAsEmptyValue() {
+        stubAndRespondWith(200, "");
+
+        GetUsageRequest request = getUsageRequestWithDates("", "20221115");
+        asyncClient.getUsage(request).join();
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("startDate", equalTo("")));
+    }
+
+    @Test
+    void marshall_asyncNonEmptyStartDate_encodesValue() {
+        stubAndRespondWith(200, "");
+
+        GetUsageRequest request = getUsageRequestWithDates("20221101", "20221115");
+        asyncClient.getUsage(request).join();
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("startDate", equalTo("20221101")));
+    }
+
+    private static GetUsageRequest getUsageRequestWithDates(String startDate, String endDate) {
+        return GetUsageRequest.builder()
+                              .usagePlanId("myUsagePlanId")
+                              .startDate(startDate)
+                              .endDate(endDate)
+                              .build();
+    }
+
+    private static void stubAndRespondWith(int status, String body) {
+        stubFor(any(urlMatching(".*"))
+                    .willReturn(aResponse().withStatus(status).withBody(body)));
+    }
+
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/AbortMultipartUploadRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/AbortMultipartUploadRequestTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class AbortMultipartUploadRequestTest extends S3RequestTestBase<AbortMultipartUploadRequest> {
+
+    @Override
+    AbortMultipartUploadRequest s3RequestWithUploadId(String uploadId) {
+        return abortMultipartUploadRequestWithUploadId(uploadId);
+    }
+
+    @Override
+    AbortMultipartUploadResponse performRequest(S3Client client, AbortMultipartUploadRequest request) {
+        return client.abortMultipartUpload(request);
+    }
+
+    @Override
+    CompletableFuture<AbortMultipartUploadResponse> performRequestAsync(S3AsyncClient client, AbortMultipartUploadRequest request) {
+        return client.abortMultipartUpload(request);
+    }
+
+    private static AbortMultipartUploadRequest abortMultipartUploadRequestWithUploadId(String uploadId) {
+        return AbortMultipartUploadRequest.builder()
+                                          .bucket("mybucket")
+                                          .key("mykey")
+                                          .uploadId(uploadId)
+                                          .build();
+    }
+
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/CompleteMultipartUploadRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/CompleteMultipartUploadRequestTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class CompleteMultipartUploadRequestTest extends S3RequestTestBase<CompleteMultipartUploadRequest> {
+
+    @Override
+    CompleteMultipartUploadRequest s3RequestWithUploadId(String uploadId) {
+        return completeMultipartUploadRequestWithUploadId(uploadId);
+    }
+
+    @Override
+    CompleteMultipartUploadResponse performRequest(S3Client client, CompleteMultipartUploadRequest request) {
+        return client.completeMultipartUpload(request);
+    }
+
+    @Override
+    CompletableFuture<CompleteMultipartUploadResponse> performRequestAsync(S3AsyncClient client,
+                                                                           CompleteMultipartUploadRequest request) {
+        return client.completeMultipartUpload(request);
+    }
+
+    private static CompleteMultipartUploadRequest completeMultipartUploadRequestWithUploadId(String uploadId) {
+        return CompleteMultipartUploadRequest.builder()
+                                             .bucket("mybucket")
+                                             .key("mykey")
+                                             .uploadId(uploadId)
+                                             .build();
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/ListPartsRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/ListPartsRequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class ListPartsRequestTest extends S3RequestTestBase<ListPartsRequest> {
+
+    @Override
+    ListPartsRequest s3RequestWithUploadId(String uploadId) {
+        return listPartsRequestWithUploadId(uploadId);
+    }
+
+    @Override
+    ListPartsResponse performRequest(S3Client client, ListPartsRequest request) {
+        return client.listParts(request);
+    }
+
+    @Override
+    CompletableFuture<ListPartsResponse> performRequestAsync(S3AsyncClient client, ListPartsRequest request) {
+        return client.listParts(request);
+    }
+
+    private static ListPartsRequest listPartsRequestWithUploadId(String uploadId) {
+        return ListPartsRequest.builder()
+                               .bucket("mybucket")
+                               .key("mykey")
+                               .uploadId(uploadId)
+                               .build();
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/S3RequestTestBase.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/S3RequestTestBase.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@WireMockTest
+abstract class S3RequestTestBase <T extends S3Request> {
+
+    private int wireMockPort;
+
+    private S3Client s3Client;
+
+    private S3AsyncClient s3AsyncClient;
+
+    abstract T s3RequestWithUploadId(String uploadId);
+    abstract S3Response performRequest(S3Client client, T request);
+    abstract CompletableFuture<? extends S3Response> performRequestAsync(S3AsyncClient client, T request);
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        wireMockPort = wmRuntimeInfo.getHttpPort();
+
+        s3Client = S3Client.builder()
+                           .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                            "skid")))
+                           .region(Region.US_WEST_2)
+                           .endpointOverride(URI.create("http://localhost:" + wireMockPort))
+                           .serviceConfiguration(S3Configuration.builder()
+                                                                .checksumValidationEnabled(false)
+                                                                .pathStyleAccessEnabled(true)
+                                                                .build())
+                           .build();
+
+        s3AsyncClient = S3AsyncClient.builder()
+                                     .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                                      "skid")))
+                                     .region(Region.US_WEST_2)
+                                     .endpointOverride(URI.create("http://localhost:" + wireMockPort))
+                                     .serviceConfiguration(S3Configuration.builder()
+                                                                          .checksumValidationEnabled(false)
+                                                                          .pathStyleAccessEnabled(true)
+                                                                          .build())
+                                     .build();
+    }
+
+    @Test
+    void marshall_syncMissingUploadId_ThrowsException() {
+        stubAndRespondWith(200,"<xml></xml>");
+
+        T request = s3RequestWithUploadId(null);
+
+        assertThatThrownBy(() -> performRequest(s3Client, request))
+            .isInstanceOf(SdkClientException.class)
+            .hasMessageContaining("Parameter 'uploadId' must not be null");
+    }
+
+    @Test
+    void marshall_syncEmptyUploadId_encodesAsEmptyValue() {
+        stubAndRespondWith(200,"<xml></xml>");
+
+        T request = s3RequestWithUploadId("");
+        performRequest(s3Client, request);
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("uploadId", equalTo("")));
+    }
+
+    @Test
+    void marshall_syncNonEmptyUploadId_encodesValue() {
+        stubAndRespondWith(200,"<xml></xml>");
+
+        T request = s3RequestWithUploadId("123");
+        performRequest(s3Client, request);
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("uploadId", equalTo("123")));
+    }
+
+    @Test
+    void marshall_asyncMissingUploadId_ThrowsException() {
+        stubAndRespondWith(200,"<xml></xml>");
+
+        T request = s3RequestWithUploadId(null);
+
+        ThrowableAssert.ThrowingCallable throwingCallable = () -> performRequestAsync(s3AsyncClient, request).join();
+        assertThatThrownBy(throwingCallable)
+            .isInstanceOf(CompletionException.class)
+            .hasMessageContaining("Parameter 'uploadId' must not be null");
+    }
+
+    @Test
+    void marshall_asyncEmptyUploadId_encodesAsEmptyValue() {
+        stubAndRespondWith(200,"<xml></xml>");
+
+        T request = s3RequestWithUploadId("");
+        performRequestAsync(s3AsyncClient, request).join();
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("uploadId", equalTo("")));
+    }
+
+    @Test
+    void marshall_asyncNonEmptyUploadId_encodesValue() {
+        stubAndRespondWith(200,"<xml></xml>");
+
+        T request = s3RequestWithUploadId("123");
+        performRequestAsync(s3AsyncClient, request).join();
+
+        verify(anyRequestedFor(anyUrl()).withQueryParam("uploadId", equalTo("123")));
+    }
+
+    private static void stubAndRespondWith(int status, String body) {
+        stubFor(any(urlMatching(".*"))
+                    .willReturn(aResponse().withStatus(status).withBody(body)));
+    }
+
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/UploadPartRequestTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/model/UploadPartRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.model;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.RandomStringUtils;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class UploadPartRequestTest extends S3RequestTestBase<UploadPartRequest> {
+
+    static final RequestBody REQUEST_BODY = RequestBody.fromString(RandomStringUtils.randomAscii(1_000));
+    static final AsyncRequestBody ASYNC_REQUEST_BODY = AsyncRequestBody.fromString(RandomStringUtils.randomAscii(1_000));
+
+    @Override
+    UploadPartRequest s3RequestWithUploadId(String uploadId) {
+        return uploadPartRequestWithUploadId(uploadId);
+    }
+
+    @Override
+    UploadPartResponse performRequest(S3Client client, UploadPartRequest request) {
+        return client.uploadPart(request, REQUEST_BODY);
+    }
+
+    @Override
+    CompletableFuture<UploadPartResponse> performRequestAsync(S3AsyncClient client, UploadPartRequest request) {
+        return client.uploadPart(request, ASYNC_REQUEST_BODY);
+    }
+
+    private static UploadPartRequest uploadPartRequestWithUploadId(String uploadId) {
+        return UploadPartRequest.builder()
+                                .bucket("mybucket")
+                                .key("mykey")
+                                .uploadId(uploadId)
+                                .partNumber(1)
+                                .build();
+    }
+
+}


### PR DESCRIPTION
Update SDK marshallers to validate required query parameters are non-null.

## Motivation and Context
An invocation of several S3 commands without a query parameter  are translated into a different one. This updates the XML and JSON marshallers so that passing a null value for a required parameter results in a thrown exception.

## Modifications
There are two main modifications:

__Implement a `RequiredTrait`__
- `MemberModel` now has getter/setter for encapsulating if it's required.
- `AddShapes` sets the new property by looking at the service file.
- `ShapeModelSec` adds a code block to `traits` as necessary.

__Enforce validation__
- JSON and XML `QueryParamMarshaller`s define a new `NULL` marshaller.
- `JsonProtocolMarshaller` and `XmlProtocolMarshaller` register the `NULL` marshaller variants.


## Testing
Added new unit tests, mostly for S3 but also for ApiGateway to verify both XML and JSON marshallers. Did not add integration tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
