### PR TITLE
For copy operation, always forward multipart copy exception from one …

### DIFF
--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -161,8 +161,10 @@ class CopyObjectHelperTest {
         when(s3AsyncClient.uploadPartCopy(any(UploadPartCopyRequest.class)))
             .thenReturn(uploadPartCopyFuture1, uploadPartCopyFuture2, uploadPartCopyFuture3, uploadPartCopyFuture4);
 
-        CompletableFuture<CopyObjectResponse> future =
-            copyHelper.copyObject(copyObjectRequest);
+        when(s3AsyncClient.abortMultipartUpload(any(AbortMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(AbortMultipartUploadResponse.builder().build()));
+
+        CompletableFuture<CopyObjectResponse> future = copyHelper.copyObject(copyObjectRequest);
 
         assertThatThrownBy(future::join).hasMessageContaining("Failed to send multipart copy requests").hasRootCause(exception);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -34,6 +34,7 @@ import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -80,7 +81,9 @@ class CopyObjectHelperTest {
         CompletableFuture<CopyObjectResponse> future =
             copyHelper.copyObject(copyObjectRequest());
 
-        assertThatThrownBy(future::join).hasCause(exception);
+        assertThatThrownBy(future::join).hasCauseInstanceOf(SdkClientException.class)
+                                        .hasMessageContaining("Failed to retrieve metadata")
+                                        .hasRootCause(exception);
     }
 
     @Test
@@ -140,7 +143,7 @@ class CopyObjectHelperTest {
      * Four parts, after the first part failed, the remaining four futures should be cancelled
      */
     @Test
-    void multiPartCopy_onePartFailed_shouldCancelFailAndAbort() {
+    void multiPartCopy_onePartFailed_shouldFailOtherPartsAndAbort() {
         CopyObjectRequest copyObjectRequest = copyObjectRequest();
 
         stubSuccessfulHeadObjectCall(4000L);
@@ -161,7 +164,7 @@ class CopyObjectHelperTest {
         CompletableFuture<CopyObjectResponse> future =
             copyHelper.copyObject(copyObjectRequest);
 
-        assertThatThrownBy(future::join).hasCause(exception);
+        assertThatThrownBy(future::join).hasMessageContaining("Failed to send multipart copy requests").hasRootCause(exception);
 
         verify(s3AsyncClient, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
 
@@ -170,9 +173,9 @@ class CopyObjectHelperTest {
         AbortMultipartUploadRequest actualRequest = argumentCaptor.getValue();
         assertThat(actualRequest.uploadId()).isEqualTo(MULTIPART_ID);
 
-        assertThat(uploadPartCopyFuture2).isCancelled();
-        assertThat(uploadPartCopyFuture3).isCancelled();
-        assertThat(uploadPartCopyFuture4).isCancelled();
+        assertThat(uploadPartCopyFuture2).isCompletedExceptionally();
+        assertThat(uploadPartCopyFuture3).isCompletedExceptionally();
+        assertThat(uploadPartCopyFuture4).isCompletedExceptionally();
     }
 
     @Test
@@ -185,7 +188,7 @@ class CopyObjectHelperTest {
 
         stubSuccessfulUploadPartCopyCalls();
 
-        SdkClientException exception = SdkClientException.create("failed");
+        SdkClientException exception = SdkClientException.create("CompleteMultipartUpload failed");
 
         CompletableFuture<CompleteMultipartUploadResponse> completeMultipartUploadFuture =
             CompletableFutureUtils.failedFuture(exception);
@@ -193,10 +196,13 @@ class CopyObjectHelperTest {
         when(s3AsyncClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
             .thenReturn(completeMultipartUploadFuture);
 
+        when(s3AsyncClient.abortMultipartUpload(any(AbortMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(AbortMultipartUploadResponse.builder().build()));
+
         CompletableFuture<CopyObjectResponse> future =
             copyHelper.copyObject(copyObjectRequest);
 
-        assertThatThrownBy(future::join).hasCause(exception);
+        assertThatThrownBy(future::join).hasMessageContaining("Failed to send multipart copy requests").hasRootCause(exception);
 
         ArgumentCaptor<AbortMultipartUploadRequest> argumentCaptor = ArgumentCaptor.forClass(AbortMultipartUploadRequest.class);
         verify(s3AsyncClient).abortMultipartUpload(argumentCaptor.capture());

--- a/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
@@ -169,19 +169,21 @@ public final class CompletableFutureUtils {
     /**
      * Similar to {@link CompletableFuture#allOf(CompletableFuture[])}, but
      * when any future is completed exceptionally, forwards the
-     * cancel to other futures.
+     * exception to other futures.
      *
      * @param futures The futures.
      * @return The new future that is completed when all the futures in {@code
      * futures} are.
      */
-    public static CompletableFuture<Void> allOfCancelForwarded(CompletableFuture<?>[] futures) {
+    public static CompletableFuture<Void> allOfExceptionForwarded(CompletableFuture<?>[] futures) {
 
         CompletableFuture<Void> anyFail = anyFail(futures);
 
         anyFail.whenComplete((r, t) -> {
-            for (CompletableFuture<?> cf : futures) {
-                cf.cancel(true);
+            if (t != null) {
+                for (CompletableFuture<?> cf : futures) {
+                    cf.completeExceptionally(t);
+                }
             }
         });
 
@@ -196,13 +198,13 @@ public final class CompletableFutureUtils {
      * @return a new CompletableFuture that is completed if any provided
      * future completed exceptionally.
      */
-    public static CompletableFuture<Void> anyFail(CompletableFuture<?>[] futures) {
+    static CompletableFuture<Void> anyFail(CompletableFuture<?>[] futures) {
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
 
         for (CompletableFuture<?> future : futures) {
             future.whenComplete((r, t) -> {
                 if (t != null) {
-                    completableFuture.complete(null);
+                    completableFuture.completeExceptionally(t);
                 }
             });
         }

--- a/utils/src/test/java/software/amazon/awssdk/utils/CompletableFutureUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/CompletableFutureUtilsTest.java
@@ -116,7 +116,7 @@ public class CompletableFutureUtilsTest {
         CompletableFuture<Void> anyFail = CompletableFutureUtils.anyFail(completableFutures);
         completableFutures[0] = CompletableFuture.completedFuture("test");
         completableFutures[1].completeExceptionally(exception);
-        assertThat(anyFail.isDone()).isTrue();
+        assertThatThrownBy(anyFail::join).hasCause(exception);
     }
 
     @Test(timeout = 1000)
@@ -132,28 +132,27 @@ public class CompletableFutureUtilsTest {
     }
 
     @Test(timeout = 1000)
-    public void allOfCancelForwarded_anyFutureFails_shouldCancelOthers() {
+    public void allOfExceptionForwarded_anyFutureFails_shouldForwardExceptionToOthers() {
         RuntimeException exception = new RuntimeException("blah");
         CompletableFuture[] completableFutures = new CompletableFuture[2];
         completableFutures[0] = new CompletableFuture();
         completableFutures[1] = new CompletableFuture();
 
-        CompletableFuture<Void> resultFuture = CompletableFutureUtils.allOfCancelForwarded(completableFutures);
+        CompletableFuture<Void> resultFuture = CompletableFutureUtils.allOfExceptionForwarded(completableFutures);
         completableFutures[0].completeExceptionally(exception);
 
         assertThatThrownBy(resultFuture::join).hasCause(exception);
-
-        assertThat(completableFutures[1].isCancelled()).isTrue();
+        assertThatThrownBy(completableFutures[1]::join).hasCause(exception);
     }
 
     @Test(timeout = 1000)
-    public void allOfCancelForwarded_allFutureSucceed_shouldComplete() {
+    public void allOfExceptionForwarded_allFutureSucceed_shouldComplete() {
         RuntimeException exception = new RuntimeException("blah");
         CompletableFuture[] completableFutures = new CompletableFuture[2];
         completableFutures[0] = new CompletableFuture();
         completableFutures[1] = new CompletableFuture();
 
-        CompletableFuture<Void> resultFuture = CompletableFutureUtils.allOfCancelForwarded(completableFutures);
+        CompletableFuture<Void> resultFuture = CompletableFutureUtils.allOfExceptionForwarded(completableFutures);
         completableFutures[0].complete("test");
         completableFutures[1].complete("test");
 


### PR DESCRIPTION
…request to other multipart copy requests

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
In the existing code, if one of the multipart copy request fails, all other futures will be cancelled. There could be a race condition that `CancellationException` is returned from `CompletableFuture.allOf` instead of the actual root cause, making it very hard to troubleshoot issues.

```
java.util.concurrent.ExecutionException: software.amazon.awssdk.core.exception.SdkClientException: Failed to send multipart copy requests.
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
        at software.amazon.awssdk.s3benchmarks.TransferManagerCopyBenchmark.copyOnce(TransferManagerCopyBenchmark.java:67)
        at software.amazon.awssdk.s3benchmarks.TransferManagerCopyBenchmark.copy(TransferManagerCopyBenchmark.java:55)
        at software.amazon.awssdk.s3benchmarks.TransferManagerCopyBenchmark.additionalWarmup(TransferManagerCopyBenchmark.java:47)
        at software.amazon.awssdk.s3benchmarks.BaseTransferManagerBenchmark.warmUp(BaseTransferManagerBenchmark.java:136)
        at software.amazon.awssdk.s3benchmarks.BaseTransferManagerBenchmark.run(BaseTransferManagerBenchmark.java:89)
        at software.amazon.awssdk.s3benchmarks.BenchmarkRunner.main(BenchmarkRunner.java:104)
Caused by: java.util.concurrent.CancellationException
        at java.base/java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2396)
        ... 49 more
```

## Modifications
Instead of cancelling other futures, this change will forward exceptions to other futures to preserve the stacktrace.
```
java.util.concurrent.ExecutionException: software.amazon.awssdk.core.exception.SdkClientException: Failed to send multipart copy requests.
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
	at software.amazon.awssdk.s3benchmarks.TransferManagerCopyBenchmark.copyOnce(TransferManagerCopyBenchmark.java:67)
	at software.amazon.awssdk.s3benchmarks.TransferManagerCopyBenchmark.copy(TransferManagerCopyBenchmark.java:55)
	at software.amazon.awssdk.s3benchmarks.TransferManagerCopyBenchmark.additionalWarmup(TransferManagerCopyBenchmark.java:47)
	at software.amazon.awssdk.s3benchmarks.BaseTransferManagerBenchmark.warmUp(BaseTransferManagerBenchmark.java:136)
	at software.amazon.awssdk.s3benchmarks.BaseTransferManagerBenchmark.run(BaseTransferManagerBenchmark.java:89)
	at software.amazon.awssdk.s3benchmarks.BenchmarkRunner.main(BenchmarkRunner.java:104)
Caused by: software.amazon.awssdk.core.exception.SdkClientException: Failed to send multipart copy requests.
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:102)
	at software.amazon.awssdk.core.exception.SdkClientException.create(SdkClientException.java:47)
	at software.amazon.awssdk.services.s3.internal.crt.CopyObjectHelper.handleException(CopyObjectHelper.java:197)
	at software.amazon.awssdk.services.s3.internal.crt.CopyObjectHelper.lambda$doCopyInParts$12(CopyObjectHe
Caused by: software.amazon.awssdk.services.s3.model.S3Exception: Part number must be an integer between 1 and 10000, inclusive (Service: S3, Status Code: 400, Request ID:xxx)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:108)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:85)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:43)

```

## Testing
Tested manually with error cases and updated existing tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
