### PR TITLE
Include retried failure messages as "suppressed" exceptions.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-05b771b.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-05b771b.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "When raising an exception as a result of a service response, if service does not return a error message, include the error code or HTTP status code in exception messages instead of the string \"null\"."
+}

--- a/.changes/next-release/feature-AWSSDKforJavav2-2636db0.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-2636db0.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "When a request fails after SDK retries, include the retried failure messages as \"suppressed\" exceptions. Stack traces for these suppressed exceptions are not preserved."
+}

--- a/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
+++ b/.idea/inspectionProfiles/AWS_Java_SDK_2_0.xml
@@ -65,7 +65,7 @@
     <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassNameSameAsAncestorName" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="ClassNewInstance" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ClassReferencesSubclass" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="ClassReferencesSubclass" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="ClassWithMultipleLoggers" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="loggerNamesString" value="java.util.logging.Logger,org.slf4j.Logger,org.apache.commons.logging.Log,org.apache.log4j.Logger,org.apache.logging.log4j.Logger,software.amazon.awssdk.utils.Logger,software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger" />
     </inspection_tool>
@@ -189,10 +189,6 @@
       <option name="checkForEmptyMethods" value="true" />
     </inspection_tool>
     <inspection_tool class="LiteralAsArgToStringEquals" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="LocalVariableHidingMemberVariable" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="m_ignoreInvisibleFields" value="true" />
-      <option name="m_ignoreStaticMethods" value="true" />
-    </inspection_tool>
     <inspection_tool class="LoggerInitializedWithForeignClass" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
     </inspection_tool>
@@ -238,7 +234,6 @@
     <inspection_tool class="NestedSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NestedSynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonExceptionNameEndsWithException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonFinalFieldInEnum" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonFinalFieldOfException" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonFinalStaticVariableUsedInClassInitialization" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -284,7 +279,7 @@
     <inspection_tool class="OverridableMethodCallDuringObjectConstruction" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="OverriddenMethodCallDuringObjectConstruction" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ParameterNameDiffersFromOverriddenParameter" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <inspection_tool class="ParameterNameDiffersFromOverriddenParameter" enabled="false" level="WEAK WARNING" enabled_by_default="false">
       <option name="m_ignoreSingleCharacterNames" value="true" />
       <option name="m_ignoreOverridesOfLibraryMethods" value="false" />
     </inspection_tool>
@@ -323,10 +318,7 @@
     <inspection_tool class="SameReturnValue" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreAnonymousInnerClasses" value="false" />
-      <option name="superClassString" value="java.awt.Component" />
-    </inspection_tool>
+    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableHasSerializationMethods" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
       <option name="superClassString" value="java.awt.Component" />
@@ -372,7 +364,6 @@
     </inspection_tool>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousLiteralUnderscore" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
@@ -392,7 +383,6 @@
     <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreSupers" value="true" />
     </inspection_tool>
-    <inspection_tool class="TestMethodWithoutAssertion" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThisEscapedInConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDumpStack" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -458,7 +448,7 @@
     <inspection_tool class="WaitNotifyNotInSynchronizedContext" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WaitOrAwaitWithoutTimeout" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WaitWithoutCorrespondingNotify" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" field="packageLocal" method="packageLocal" ignoreAccessors="true" isSelected="false">
+    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" field="packageLocal" method="packageLocal" ignoreAccessors="true" checkParameterExcludingHierarchy="false" isSelected="false">
       <option name="LOCAL_VARIABLE" value="true" />
       <option name="FIELD" value="true" />
       <option name="METHOD" value="true" />

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ExceptionProperties.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/model/ExceptionProperties.java
@@ -33,7 +33,8 @@ public class ExceptionProperties {
                 builderMethod(className, "message", String.class),
                 builderMethod(className, "requestId", String.class),
                 builderMethod(className, "statusCode", int.class),
-                builderMethod(className, "cause", Throwable.class));
+                builderMethod(className, "cause", Throwable.class),
+                builderMethod(className, "writableStackTrace", Boolean.class));
     }
 
     public static List<MethodSpec> builderImplMethods(ClassName className) {
@@ -42,7 +43,8 @@ public class ExceptionProperties {
                 builderImplMethods(className, "message", String.class),
                 builderImplMethods(className, "requestId", String.class),
                 builderImplMethods(className, "statusCode", int.class),
-                builderImplMethods(className, "cause", Throwable.class));
+                builderImplMethods(className, "cause", Throwable.class),
+                builderImplMethods(className, "writableStackTrace", Boolean.class));
     }
 
     private static MethodSpec builderMethod(ClassName className, String name, Class clazz) {

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/SourceException.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/SourceException.java.resource
@@ -16,6 +16,9 @@ public class SourceException extends SdkException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         Builder message(String message);
 
         @Override
@@ -32,6 +35,12 @@ public class SourceException extends SdkException {
         @Override
         public Builder message(String message) {
             super.message(message);
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            super.writableStackTrace(writableStackTrace);
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/baseserviceexception.java
@@ -37,6 +37,9 @@ public class JsonProtocolTestsException extends AwsServiceException {
 
         @Override
         Builder cause(Throwable cause);
+
+        @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
     }
 
     protected static class BuilderImpl extends AwsServiceException.BuilderImpl implements Builder {
@@ -74,6 +77,12 @@ public class JsonProtocolTestsException extends AwsServiceException {
         @Override
         public BuilderImpl cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/model/emptymodeledexception.java
@@ -56,6 +56,9 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
 
         @Override
         Builder cause(Throwable cause);
+
+        @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
     }
 
     static final class BuilderImpl extends JsonProtocolTestsException.BuilderImpl implements Builder {
@@ -93,6 +96,12 @@ public final class EmptyModeledException extends JsonProtocolTestsException impl
         @Override
         public BuilderImpl cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/exception/AwsServiceException.java
@@ -70,7 +70,11 @@ public class AwsServiceException extends SdkServiceException {
             if (extendedRequestId() != null) {
                 details.add("Extended Request ID: " + extendedRequestId());
             }
-            return awsErrorDetails().errorMessage() + " " + details;
+            String message = super.getMessage();
+            if (message == null) {
+                message = awsErrorDetails().errorMessage();
+            }
+            return message + " " + details;
         }
 
         return super.getMessage();
@@ -231,6 +235,12 @@ public class AwsServiceException extends SdkServiceException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryFailedException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryFailedException.java
@@ -56,6 +56,9 @@ public class EndpointDiscoveryFailedException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         EndpointDiscoveryFailedException build();
     }
 
@@ -77,6 +80,12 @@ public class EndpointDiscoveryFailedException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/AbortedException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/AbortedException.java
@@ -55,6 +55,9 @@ public final class AbortedException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         AbortedException build();
     }
 
@@ -76,6 +79,12 @@ public final class AbortedException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallAttemptTimeoutException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallAttemptTimeoutException.java
@@ -59,6 +59,9 @@ public final class ApiCallAttemptTimeoutException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         ApiCallAttemptTimeoutException build();
     }
 
@@ -80,6 +83,12 @@ public final class ApiCallAttemptTimeoutException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallTimeoutException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/ApiCallTimeoutException.java
@@ -59,6 +59,9 @@ public final class ApiCallTimeoutException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         ApiCallTimeoutException build();
     }
 
@@ -80,6 +83,12 @@ public final class ApiCallTimeoutException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/Crc32MismatchException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/Crc32MismatchException.java
@@ -59,6 +59,9 @@ public final class Crc32MismatchException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         Crc32MismatchException build();
     }
 
@@ -80,6 +83,12 @@ public final class Crc32MismatchException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
@@ -53,6 +53,9 @@ public final class NonRetryableException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         NonRetryableException build();
     }
 
@@ -84,6 +87,12 @@ public final class NonRetryableException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/RetryableException.java
@@ -61,6 +61,9 @@ public final class RetryableException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         RetryableException build();
     }
 
@@ -82,6 +85,12 @@ public final class RetryableException extends SdkClientException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkClientException.java
@@ -73,6 +73,9 @@ public class SdkClientException extends SdkException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         SdkClientException build();
     }
 
@@ -94,6 +97,12 @@ public class SdkClientException extends SdkException {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkException.java
@@ -30,7 +30,7 @@ public class SdkException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     protected SdkException(Builder builder) {
-        super(messageFromBuilder(builder), builder.cause());
+        super(messageFromBuilder(builder), builder.cause(), true, writableStackTraceFromBuilder(builder));
     }
 
     /**
@@ -46,6 +46,10 @@ public class SdkException extends RuntimeException {
         }
 
         return null;
+    }
+
+    private static boolean writableStackTraceFromBuilder(Builder builder) {
+        return builder.writableStackTrace() == null || builder.writableStackTrace();
     }
 
     public static SdkException create(String message, Throwable cause) {
@@ -107,6 +111,19 @@ public class SdkException extends RuntimeException {
         String message();
 
         /**
+         * Specifies whether the stack trace in this exception can be written.
+         *
+         * @param writableStackTrace Whether the stack trace can be written.
+         * @return This method for object chaining
+         */
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        /**
+         * Whether the stack trace in this exception can be written.
+         */
+        Boolean writableStackTrace();
+
+        /**
          * Creates a new {@link SdkException} with the specified properties.
          *
          * @return The new {@link SdkException}.
@@ -119,6 +136,7 @@ public class SdkException extends RuntimeException {
 
         protected Throwable cause;
         protected String message;
+        protected Boolean writableStackTrace;
 
         protected BuilderImpl() {
         }
@@ -165,6 +183,25 @@ public class SdkException extends RuntimeException {
         @Override
         public String message() {
             return message;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
+            return this;
+        }
+
+        public void setWritableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
+        }
+
+        @Override
+        public Boolean writableStackTrace() {
+            return writableStackTrace;
+        }
+
+        public Boolean getWritableStackTrace() {
+            return writableStackTrace;
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java
@@ -124,6 +124,9 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         @Override
         Builder cause(Throwable cause);
 
+        @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
         /**
          * Specifies the requestId returned by the called service.
          *
@@ -202,6 +205,12 @@ public class SdkServiceException extends SdkException implements SdkPojo {
         @Override
         public Builder cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Builder writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
@@ -154,7 +154,6 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
             }
 
             responseFuture.whenComplete((response, exception) -> {
-
                 if (exception != null) {
                     if (exception instanceof Exception) {
                         maybeRetryExecute(future, (Exception) exception);

--- a/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/ExpiredTokenException.java
+++ b/services/sso/src/main/java/software/amazon/awssdk/services/sso/auth/ExpiredTokenException.java
@@ -54,6 +54,9 @@ public final class ExpiredTokenException extends SdkClientException {
         Builder cause(Throwable cause);
 
         @Override
+        Builder writableStackTrace(Boolean writableStackTrace);
+
+        @Override
         ExpiredTokenException build();
     }
 
@@ -74,6 +77,12 @@ public final class ExpiredTokenException extends SdkClientException {
         @Override
         public BuilderImpl cause(Throwable cause) {
             this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public BuilderImpl writableStackTrace(Boolean writableStackTrace) {
+            this.writableStackTrace = writableStackTrace;
             return this;
         }
 

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/AsyncRetryFailureTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/AsyncRetryFailureTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+
+public class AsyncRetryFailureTest extends RetryFailureTestSuite<MockAsyncHttpClient> {
+    private final ProtocolRestJsonAsyncClient client;
+
+    public AsyncRetryFailureTest() {
+        super(new MockAsyncHttpClient());
+        client = ProtocolRestJsonAsyncClient.builder()
+                                            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                                            .region(Region.US_EAST_1)
+                                            .endpointOverride(URI.create("http://localhost"))
+                                            .httpClient(mockHttpClient)
+                                            .build();
+    }
+
+    @Override
+    protected void callAllTypesOperation() {
+        client.allTypes().join();
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/RetryFailureTestSuite.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/RetryFailureTestSuite.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.testutils.service.http.MockHttpClient;
+
+/**
+ * A set of tests that verify the behavior of the SDK when retries are exhausted.
+ */
+public abstract class RetryFailureTestSuite<T extends MockHttpClient> {
+    protected final T mockHttpClient;
+
+    protected RetryFailureTestSuite(T mockHttpClient) {
+        this.mockHttpClient = mockHttpClient;
+    }
+
+    @BeforeEach
+    public void setupClient() {
+        mockHttpClient.reset();
+    }
+
+    protected abstract void callAllTypesOperation();
+
+    @Test
+    public void clientSideErrorsIncludeSuppressedExceptions() {
+        mockHttpClient.stubResponses(retryableFailure(),
+                                     retryableFailure(),
+                                     nonRetryableFailure());
+
+        try {
+            callAllTypesOperation();
+        } catch (Throwable e) {
+            if (e instanceof CompletionException) {
+                e = e.getCause();
+            }
+            e.printStackTrace();
+
+            assertThat(e.getSuppressed()).hasSize(2)
+                                         .allSatisfy(t -> assertThat(t.getMessage()).contains("500"));
+        }
+    }
+
+    private HttpExecuteResponse retryableFailure() {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder()
+                                                           .statusCode(500)
+                                                           .putHeader("content-length", "0")
+                                                           .build())
+                                  .build();
+    }
+
+    private HttpExecuteResponse nonRetryableFailure() {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder()
+                                                           .statusCode(400)
+                                                           .putHeader("content-length", "0")
+                                                           .build())
+                                  .build();
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/SyncRetryFailureTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/retry/SyncRetryFailureTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.retry;
+
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+public class SyncRetryFailureTest extends RetryFailureTestSuite<MockSyncHttpClient> {
+    private final ProtocolRestJsonClient client;
+
+    public SyncRetryFailureTest() {
+        super(new MockSyncHttpClient());
+        client = ProtocolRestJsonClient.builder()
+                                       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid",
+                                                                                                                        "skid")))
+                                       .region(Region.US_EAST_1)
+                                       .endpointOverride(URI.create("http://localhost"))
+                                       .httpClient(mockHttpClient)
+                                       .build();
+    }
+
+    @Override
+    protected void callAllTypesOperation() {
+        client.allTypes();
+    }
+}


### PR DESCRIPTION
Additionally, always include a useful exception message even when the service returns no error message.

Stack trace example before this change:
```
software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException: null (Service: ProtocolRestJson, Status Code: 400, Request ID: null)
	at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleErrorResponse(CombinedResponseHandler.java:125)
    ...
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
```

Stack trace example after this change:

```
software.amazon.awssdk.services.protocolrestjson.model.ProtocolRestJsonException: Service returned HTTP status code 400 (Service: ProtocolRestJson, Status Code: 400, Request ID: null)
	at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleErrorResponse(CombinedResponseHandler.java:125)
    ...
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
	Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 1 failure: Service returned HTTP status code 500 (Service: ProtocolRestJson, Status Code: 500, Request ID: null)
	Suppressed: software.amazon.awssdk.core.exception.SdkClientException: Request attempt 2 failure: Service returned HTTP status code 500 (Service: ProtocolRestJson, Status Code: 500, Request ID: null)
```

I also deleted some IntelliJ checks that we frequently have to violate.