### PR TITLE
Added AsyncResponseTransformer.toBlockingInputStream. 

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-a887c1c.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-a887c1c.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Added AsyncResponseTransformer.toBlockingInputStream, allowing streaming operation responses to be read as if they're an InputStream."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/ResponseInputStream.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core;
 
+import java.io.InputStream;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.io.SdkFilterInputStream;
 import software.amazon.awssdk.http.Abortable;
@@ -43,6 +44,12 @@ public final class ResponseInputStream<ResponseT> extends SdkFilterInputStream i
         this.abortable = Validate.paramNotNull(in, "abortableInputStream");
     }
 
+    public ResponseInputStream(ResponseT resp, InputStream in) {
+        super(in);
+        this.response = Validate.paramNotNull(resp, "response");
+        this.abortable = in instanceof Abortable ? (Abortable) in : null;
+    }
+
     /**
      * @return The unmarshalled POJO response associated with this content.
      */
@@ -52,6 +59,8 @@ public final class ResponseInputStream<ResponseT> extends SdkFilterInputStream i
 
     @Override
     public void abort() {
-        abortable.abort();
+        if (abortable != null) {
+            abortable.abort();
+        }
     }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamResponseTransformer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.utils.async.InputStreamSubscriber;
+
+/**
+ * A {@link AsyncResponseTransformer} that allows performing blocking reads on the response data.
+ * <p>
+ * Created with {@link AsyncResponseTransformer#toBlockingInputStream()}.
+ */
+@SdkInternalApi
+public class InputStreamResponseTransformer<ResponseT extends SdkResponse>
+    implements AsyncResponseTransformer<ResponseT, ResponseInputStream<ResponseT>> {
+
+    private volatile CompletableFuture<ResponseInputStream<ResponseT>> future;
+    private volatile ResponseT response;
+
+    @Override
+    public CompletableFuture<ResponseInputStream<ResponseT>> prepare() {
+        CompletableFuture<ResponseInputStream<ResponseT>> result = new CompletableFuture<>();
+        this.future = result;
+        return result;
+    }
+
+    @Override
+    public void onResponse(ResponseT response) {
+        this.response = response;
+    }
+
+    @Override
+    public void onStream(SdkPublisher<ByteBuffer> publisher) {
+        InputStreamSubscriber inputStreamSubscriber = new InputStreamSubscriber();
+        publisher.subscribe(inputStreamSubscriber);
+        future.complete(new ResponseInputStream<>(response, inputStreamSubscriber));
+    }
+
+    @Override
+    public void exceptionOccurred(Throwable error) {
+        future.completeExceptionally(error);
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/InputStreamResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/InputStreamResponseTransformerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.protocol.VoidSdkResponse;
+import software.amazon.awssdk.utils.async.SimplePublisher;
+
+class InputStreamResponseTransformerTest {
+    private SimplePublisher<ByteBuffer> publisher;
+    private InputStreamResponseTransformer<SdkResponse> transformer;
+    private SdkResponse response;
+    private CompletableFuture<ResponseInputStream<SdkResponse>> resultFuture;
+
+    @BeforeEach
+    public void setup() {
+        publisher = new SimplePublisher<>();
+        transformer = new InputStreamResponseTransformer<>();
+        resultFuture = transformer.prepare();
+        response = VoidSdkResponse.builder().build();
+
+        transformer.onResponse(response);
+
+        assertThat(resultFuture).isNotDone();
+
+        transformer.onStream(SdkPublisher.adapt(publisher));
+
+        assertThat(resultFuture).isCompleted();
+        assertThat(resultFuture.join().response()).isEqualTo(response);
+    }
+
+    @Test
+    public void inputStreamReadsAreFromPublisher() throws IOException {
+        InputStream stream = resultFuture.join();
+
+        publisher.send(ByteBuffer.wrap(new byte[] { 0, 1, 2 }));
+        publisher.complete();
+
+        assertThat(stream.read()).isEqualTo(0);
+        assertThat(stream.read()).isEqualTo(1);
+        assertThat(stream.read()).isEqualTo(2);
+        assertThat(stream.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void inputStreamArrayReadsAreFromPublisher() throws IOException {
+        InputStream stream = resultFuture.join();
+
+        publisher.send(ByteBuffer.wrap(new byte[] { 0, 1, 2 }));
+        publisher.complete();
+
+        byte[] data = new byte[3];
+        assertThat(stream.read(data)).isEqualTo(3);
+
+        assertThat(data[0]).isEqualTo((byte) 0);
+        assertThat(data[1]).isEqualTo((byte) 1);
+        assertThat(data[2]).isEqualTo((byte) 2);
+        assertThat(stream.read(data)).isEqualTo(-1);
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BlockingAsyncRequestResponseBodyTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BlockingAsyncRequestResponseBodyTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
+
+@Timeout(5)
+public class BlockingAsyncRequestResponseBodyTest {
+    private final WireMockServer wireMock = new WireMockServer(0);
+    private ProtocolRestJsonAsyncClient client;
+
+    @BeforeEach
+    public void setup() {
+        wireMock.start();
+        client = ProtocolRestJsonAsyncClient.builder()
+                                            .region(Region.US_WEST_2)
+                                            .credentialsProvider(AnonymousCredentialsProvider.create())
+                                            .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
+                                            .build();
+    }
+
+    @Test
+    public void blockingResponseTransformer_readsRightValue() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("hello")));
+
+        CompletableFuture<ResponseInputStream<StreamingOutputOperationResponse>> responseFuture =
+            client.streamingOutputOperation(StreamingOutputOperationRequest.builder().build(),
+                                            AsyncResponseTransformer.toBlockingInputStream());
+        ResponseInputStream<StreamingOutputOperationResponse> responseStream = responseFuture.join();
+
+        assertThat(responseStream).asString(StandardCharsets.UTF_8).isEqualTo("hello");
+        assertThat(responseStream.response().sdkHttpResponse().statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    public void blockingResponseTransformer_abortCloseDoesNotThrow() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("hello")));
+
+        CompletableFuture<ResponseInputStream<StreamingOutputOperationResponse>> responseFuture =
+            client.streamingOutputOperation(StreamingOutputOperationRequest.builder().build(),
+                                            AsyncResponseTransformer.toBlockingInputStream());
+        ResponseInputStream<StreamingOutputOperationResponse> responseStream = responseFuture.join();
+        responseStream.abort();
+        responseStream.close();
+    }
+
+    @Test
+    public void blockingResponseTransformer_closeDoesNotThrow() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("hello")));
+
+        CompletableFuture<ResponseInputStream<StreamingOutputOperationResponse>> responseFuture =
+            client.streamingOutputOperation(StreamingOutputOperationRequest.builder().build(),
+                                            AsyncResponseTransformer.toBlockingInputStream());
+        ResponseInputStream<StreamingOutputOperationResponse> responseStream = responseFuture.join();
+        responseStream.close();
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Queue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult;
+
+/**
+ * Adapts a {@link Subscriber} to a {@link InputStream}.
+ * <p>
+ * Reads from the stream will block until data is published to this subscriber. The amount of data stored in memory by this
+ * subscriber when the input stream is not being read is bounded.
+ */
+@SdkProtectedApi
+public class InputStreamSubscriber extends InputStream implements Subscriber<ByteBuffer>, SdkAutoCloseable {
+    private static final int BUFFER_SIZE = 4 * 1024 * 1024; // 4 MB
+
+    private final ByteBufferStoringSubscriber delegate;
+    private final ByteBuffer singleByte = ByteBuffer.allocate(1);
+
+    private final AtomicReference<State> inputStreamState = new AtomicReference<>(State.UNINITIALIZED);
+    private final AtomicBoolean drainingCallQueue = new AtomicBoolean(false);
+    private final Queue<QueueEntry> callQueue = new ConcurrentLinkedQueue<>();
+
+    private Subscription subscription;
+
+    private boolean done = false;
+
+    public InputStreamSubscriber() {
+        this.delegate = new ByteBufferStoringSubscriber(BUFFER_SIZE);
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        if (!inputStreamState.compareAndSet(State.UNINITIALIZED, State.READABLE)) {
+            close();
+            return;
+        }
+
+        this.subscription = new CancelWatcher(s);
+        delegate.onSubscribe(subscription);
+    }
+
+    @Override
+    public void onNext(ByteBuffer byteBuffer) {
+        callQueue.add(new QueueEntry(false, () -> delegate.onNext(byteBuffer)));
+        drainQueue();
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        callQueue.add(new QueueEntry(true, () -> delegate.onError(t)));
+        drainQueue();
+    }
+
+    @Override
+    public void onComplete() {
+        callQueue.add(new QueueEntry(true, delegate::onComplete));
+        drainQueue();
+    }
+
+    @Override
+    public int read() {
+        singleByte.clear();
+        TransferResult transferResult = delegate.blockingTransferTo(singleByte);
+
+        if (singleByte.hasRemaining()) {
+            assert transferResult == TransferResult.END_OF_STREAM;
+            return -1;
+        }
+
+        return singleByte.get(0);
+    }
+
+    @Override
+    public int read(byte[] b) {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len) {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes, off, len);
+        TransferResult transferResult = delegate.blockingTransferTo(byteBuffer);
+        int dataTransferred = byteBuffer.position() - off;
+
+        if (dataTransferred == 0) {
+            assert transferResult == TransferResult.END_OF_STREAM;
+            return -1;
+        }
+
+        return dataTransferred;
+    }
+
+    @Override
+    public void close() {
+        if (inputStreamState.compareAndSet(State.UNINITIALIZED, State.CLOSED)) {
+            delegate.onSubscribe(new NoOpSubscription());
+            delegate.onError(new CancellationException());
+        } else if (inputStreamState.compareAndSet(State.READABLE, State.CLOSED)) {
+            subscription.cancel();
+            onError(new CancellationException());
+        }
+    }
+
+    private void drainQueue() {
+        do {
+            if (!drainingCallQueue.compareAndSet(false, true)) {
+                break;
+            }
+
+            try {
+                doDrainQueue();
+            } finally {
+                drainingCallQueue.set(false);
+            }
+        } while (!callQueue.isEmpty());
+    }
+
+    private void doDrainQueue() {
+        while (true) {
+            QueueEntry entry = callQueue.poll();
+            if (done || entry == null) {
+                return;
+            }
+            done = entry.terminal;
+            entry.call.run();
+        }
+    }
+
+    private static final class QueueEntry {
+        private final boolean terminal;
+        private final Runnable call;
+
+        private QueueEntry(boolean terminal, Runnable call) {
+            this.terminal = terminal;
+            this.call = call;
+        }
+    }
+
+    private enum State {
+        UNINITIALIZED,
+        READABLE,
+        CLOSED
+    }
+
+    private final class CancelWatcher implements Subscription {
+        private final Subscription s;
+
+        private CancelWatcher(Subscription s) {
+            this.s = s;
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+            s.cancel();
+            close();
+        }
+    }
+
+    private static final class NoOpSubscription implements Subscription {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
@@ -92,7 +92,7 @@ public class InputStreamSubscriber extends InputStream implements Subscriber<Byt
             return -1;
         }
 
-        return singleByte.get(0);
+        return singleByte.get(0) & 0xFF;
     }
 
     @Override

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTckTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTckTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import java.nio.ByteBuffer;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+public class InputStreamSubscriberTckTest extends SubscriberWhiteboxVerification<ByteBuffer> {
+    protected InputStreamSubscriberTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Subscriber<ByteBuffer> createSubscriber(WhiteboxSubscriberProbe<ByteBuffer> probe) {
+        return new ByteBufferStoringSubscriber(16) {
+            @Override
+            public void onError(Throwable throwable) {
+                super.onError(throwable);
+                probe.registerOnError(throwable);
+            }
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                super.onSubscribe(subscription);
+                probe.registerOnSubscribe(new SubscriberPuppet() {
+                    @Override
+                    public void triggerRequest(long elements) {
+                        subscription.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        subscription.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(ByteBuffer next) {
+                super.onNext(next);
+                probe.registerOnNext(next);
+            }
+
+            @Override
+            public void onComplete() {
+                super.onComplete();
+                probe.registerOnComplete();
+            }
+        };
+    }
+
+    @Override
+    public ByteBuffer createElement(int element) {
+        return ByteBuffer.wrap(new byte[0]);
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+public class InputStreamSubscriberTest {
+    private SimplePublisher<ByteBuffer> publisher;
+    private InputStreamSubscriber subscriber;
+
+    @BeforeEach
+    public void setup() {
+        publisher = new SimplePublisher<>();
+        subscriber = new InputStreamSubscriber();
+    }
+
+    @Test
+    public void onComplete_returnsEndOfStream_onRead() {
+        publisher.subscribe(subscriber);
+        publisher.complete();
+        assertThat(subscriber.read()).isEqualTo(-1);
+        assertThat(subscriber.read(new byte[0])).isEqualTo(-1);
+        assertThat(subscriber.read(new byte[0], 0, 0)).isEqualTo(-1);
+    }
+
+    @Test
+    public void onError_throws_onRead() {
+        IllegalStateException exception = new IllegalStateException();
+
+        publisher.subscribe(subscriber);
+        publisher.error(exception);
+        assertThatThrownBy(() -> subscriber.read()).isEqualTo(exception);
+        assertThatThrownBy(() -> subscriber.read(new byte[0])).isEqualTo(exception);
+        assertThatThrownBy(() -> subscriber.read(new byte[0], 0, 0)).isEqualTo(exception);
+    }
+
+    @Test
+    public void onComplete_afterOnNext_returnsEndOfStream() {
+        publisher.subscribe(subscriber);
+        publisher.send(byteBufferOfLength(1));
+        publisher.complete();
+        assertThat(subscriber.read()).isEqualTo(0);
+        assertThat(subscriber.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void onComplete_afterEmptyOnNext_returnsEndOfStream() {
+        publisher.subscribe(subscriber);
+        publisher.send(byteBufferOfLength(0));
+        publisher.send(byteBufferOfLength(0));
+        publisher.send(byteBufferOfLength(0));
+        publisher.complete();
+        assertThat(subscriber.read()).isEqualTo(-1);
+    }
+
+    @Test
+    public void read_afterOnNext_returnsData() {
+        publisher.subscribe(subscriber);
+        publisher.send(byteBufferWithByte(10));
+        assertThat(subscriber.read()).isEqualTo(10);
+    }
+
+    @Test
+    public void readBytes_afterOnNext_returnsData() {
+        publisher.subscribe(subscriber);
+        publisher.send(byteBufferWithByte(10));
+        publisher.send(byteBufferWithByte(20));
+
+        byte[] bytes = new byte[2];
+        assertThat(subscriber.read(bytes)).isEqualTo(2);
+        assertThat(bytes[0]).isEqualTo((byte) 10);
+        assertThat(bytes[1]).isEqualTo((byte) 20);
+    }
+
+    @Test
+    public void readBytesWithOffset_afterOnNext_returnsData() {
+        publisher.subscribe(subscriber);
+        publisher.send(byteBufferWithByte(10));
+        publisher.send(byteBufferWithByte(20));
+
+        byte[] bytes = new byte[3];
+        assertThat(subscriber.read(bytes, 1, 2)).isEqualTo(2);
+        assertThat(bytes[1]).isEqualTo((byte) 10);
+        assertThat(bytes[2]).isEqualTo((byte) 20);
+    }
+
+    @Test
+    public void read_afterClose_fails() {
+        publisher.subscribe(subscriber);
+        subscriber.close();
+        assertThatThrownBy(() -> subscriber.read()).isInstanceOf(CancellationException.class);
+        assertThatThrownBy(() -> subscriber.read(new byte[0])).isInstanceOf(CancellationException.class);
+        assertThatThrownBy(() -> subscriber.read(new byte[0], 0, 0)).isInstanceOf(CancellationException.class);
+    }
+
+    public static List<Arguments> stochastic_methodCallsSeemThreadSafe_parameters() {
+        Object[][] inputStreamOperations = {
+            { "read();", subscriberRead1() },
+            { "read(); close();", subscriberRead1().andThen(subscriberClose()) },
+            { "read(byte[]); close();", subscriberReadArray().andThen(subscriberClose()) },
+            { "read(byte[]); read(byte[]);", subscriberReadArray().andThen(subscriberReadArray()) }
+        };
+
+        Object[][] publisherOperations = {
+            { "onNext(...);", subscriberOnNext() },
+            { "onNext(...); onComplete();", subscriberOnNext().andThen(subscriberOnComplete()) },
+            { "onNext(...); onError(...);", subscriberOnNext().andThen(subscriberOnError()) },
+            { "onComplete();", subscriberOnComplete() },
+            { "onError(...);", subscriberOnError() }
+        };
+
+        List<Arguments> result = new ArrayList<>();
+        for (Object[] iso : inputStreamOperations) {
+            for (Object[] po : publisherOperations) {
+                result.add(Arguments.of(iso[1], po[1], iso[0] + " and " + po[0] + " in parallel"));
+            }
+        }
+        return result;
+    }
+
+    @ParameterizedTest(name = "{2}")
+    @MethodSource("stochastic_methodCallsSeemThreadSafe_parameters")
+    @Timeout(10)
+    public void stochastic_methodCallsSeemThreadSafe(Consumer<InputStreamSubscriber> inputStreamOperation,
+                                                     Consumer<InputStreamSubscriber> publisherOperation,
+                                                     String testName)
+        throws InterruptedException, ExecutionException {
+        int numIterations = 100;
+
+        // Read/close aren't mutually thread safe, and onNext/onComplete/onError aren't mutually thread safe, but one
+        // group of functions might be executed in parallel with the others. We try to make sure that this is safe.
+
+        ExecutorService executor = Executors.newFixedThreadPool(10, new ThreadFactoryBuilder().daemonThreads(true).build());
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < numIterations; i++) {
+                CountDownLatch waitingAtStartLine = new CountDownLatch(2);
+                CountDownLatch startLine = new CountDownLatch(0);
+
+                InputStreamSubscriber subscriber = new InputStreamSubscriber();
+                subscriber.onSubscribe(mockSubscription(subscriber));
+
+                futures.add(executor.submit(() -> {
+                    waitingAtStartLine.countDown();
+                    startLine.await();
+                    inputStreamOperation.accept(subscriber);
+                    return null;
+                }));
+                futures.add(executor.submit(() -> {
+                    waitingAtStartLine.countDown();
+                    startLine.await();
+                    publisherOperation.accept(subscriber);
+                    return null;
+                }));
+
+                waitingAtStartLine.await();
+                startLine.countDown();
+            }
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public static Consumer<InputStreamSubscriber> subscriberOnNext() {
+        return s -> s.onNext(ByteBuffer.allocate(1));
+    }
+
+    public static Consumer<InputStreamSubscriber> subscriberOnComplete() {
+        return s -> s.onComplete();
+    }
+
+    public static Consumer<InputStreamSubscriber> subscriberOnError() {
+        return s -> s.onError(new Throwable());
+    }
+
+    public static Consumer<InputStreamSubscriber> subscriberRead1() {
+        return s -> s.read();
+    }
+
+    public static Consumer<InputStreamSubscriber> subscriberReadArray() {
+        return s -> s.read(new byte[4]);
+    }
+
+    public static Consumer<InputStreamSubscriber> subscriberClose() {
+        return s -> s.close();
+    }
+
+    private Subscription mockSubscription(Subscriber<ByteBuffer> subscriber) {
+        Subscription subscription = mock(Subscription.class);
+        doAnswer(new Answer<Void>() {
+            boolean done = false;
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                if (!done) {
+                    subscriber.onNext(ByteBuffer.wrap(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }));
+                    subscriber.onComplete();
+                    done = true;
+                }
+                return null;
+            }
+        }).when(subscription).request(anyLong());
+        return subscription;
+    }
+
+
+    private ByteBuffer byteBufferOfLength(int length) {
+        return ByteBuffer.allocate(length);
+    }
+
+    public ByteBuffer byteBufferWithByte(int b) {
+        ByteBuffer buffer = ByteBuffer.allocate(1);
+        buffer.put((byte) b);
+        buffer.flip();
+        return buffer;
+    }
+}


### PR DESCRIPTION
This allows streaming operation responses to be read as if they're an InputStream.

Example usage:
```java
CompletableFuture<ResponseInputStream<GetObjectResponse>> responseFuture =
    s3AsyncClient.getObject(getObjectRequest, AsyncResponseTransformer.toBlockingInputStream());
try (ResponseInputStream<GetObjectResponse> responseStream = responseFuture.join()) {
    responseStream.transferTo(System.out); // BLOCKS the calling thread
}
```

Other changes made to support this change:
1. Created `InputStreamSubscriber`, a `Subscriber<ByteBuffer>` that extends `InputStream`. It allows subscribing to a publisher and then performing blocking reads against it. This is used by `AsyncResponseTransformer`.
1. Updated `ByteBufferStoringSubscriber` to support `blockingTransferTo(ByteBuffer)`. It's like `transferTo(ByteBuffer)`, except that it will block the caller until at least one byte of data is available to be read. This is used by `InputStreamSubscriber`.
1. Allow `ResponseInputStream` to store non-abortable streams. This is used by `AsyncResponseTransformer`.