### PR TITLE
Added AsyncResponseBody.fromInputStream and AsyncRequestBody.forBlockingInputStream.

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-303765f.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-303765f.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Added AsyncResponseBody.fromInputStream and AsyncRequestBody.forBlockingInputStream, allowing streaming operation requests to be written to like an input stream."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
@@ -16,17 +16,20 @@
 package software.amazon.awssdk.core.async;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.internal.async.ByteArrayAsyncRequestBody;
 import software.amazon.awssdk.core.internal.async.FileAsyncRequestBody;
+import software.amazon.awssdk.core.internal.async.InputStreamWithExecutorAsyncRequestBody;
 import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.utils.BinaryUtils;
 
@@ -159,6 +162,44 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
      */
     static AsyncRequestBody fromByteBuffer(ByteBuffer byteBuffer) {
         return fromBytes(BinaryUtils.copyAllBytesFrom(byteBuffer));
+    }
+
+    /**
+     * Creates a {@link AsyncRequestBody} from a {@link InputStream}.
+     *
+     * <p>An {@link ExecutorService} is required in order to perform the blocking data reads, to prevent blocking the
+     * non-blocking event loop threads owned by the SDK.
+     */
+    static AsyncRequestBody fromInputStream(InputStream inputStream, Long contentLength, ExecutorService executor) {
+        return new InputStreamWithExecutorAsyncRequestBody(inputStream, contentLength, executor);
+    }
+
+    /**
+     * Creates a {@link BlockingInputStreamAsyncRequestBody} to use for writing an input stream to the downstream service.
+     *
+     * <p><b>Example Usage</b>
+     *
+     * <pre>
+     *     S3Client s3 = ...;
+     *
+     *     InputStream streamToWrite = ...;
+     *     long streamToWriteLength = ...;
+     *
+     *     // Start the operation
+     *     BlockingInputStreamAsyncRequestBody body =
+     *         AsyncRequestBody.forBlockingInputStream(streamToWriteLength);
+     *     CompletableFuture<PutObjectResponse> responseFuture =
+     *         s3.putObject(r -> r.bucket("bucketName").key("key"), body);
+     *
+     *     // Write the input stream to the running operation
+     *     body.writeInputStream(streamToWrite);
+     *
+     *     // Wait for the service to respond.
+     *     PutObjectResponse response = responseFuture.join();
+     * </pre>
+     */
+    static BlockingInputStreamAsyncRequestBody forBlockingInputStream(Long contentLength) {
+        return new BlockingInputStreamAsyncRequestBody(contentLength);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.io.SdkLengthAwareInputStream;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.async.InputStreamConsumingPublisher;
+
+/**
+ * An implementation of {@link AsyncRequestBody} that allows performing a blocking write of an input stream to a downstream
+ * service.
+ *
+ * <p>See {@link AsyncRequestBody#forBlockingInputStream(Long)}.
+ */
+@SdkPublicApi
+public class BlockingInputStreamAsyncRequestBody implements AsyncRequestBody {
+    private final InputStreamConsumingPublisher delegate = new InputStreamConsumingPublisher();
+    private final CountDownLatch subscribedLatch = new CountDownLatch(0);
+    private final AtomicBoolean subscribeCalled = new AtomicBoolean(false);
+    private final Long contentLength;
+
+    BlockingInputStreamAsyncRequestBody(Long contentLength) {
+        this.contentLength = contentLength;
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.ofNullable(contentLength);
+    }
+
+    /**
+     * Block the calling thread and write the provided input stream to the downstream service.
+     *
+     * <p>This method will block the calling thread immediately. This means that this request body should usually be passed to
+     * the SDK before this method is called.
+     *
+     * <p>This method will return the amount of data written when the entire input stream has been written. This will throw an
+     * exception if writing the input stream has failed.
+     *
+     * <p>You can invoke {@link #cancel()} to cancel any blocked write calls to the downstream service (and mark the stream as
+     * failed).
+     */
+    public long writeInputStream(InputStream inputStream) {
+        try {
+            waitForSubscriptionIfNeeded();
+            if (contentLength != null) {
+                return delegate.doBlockingWrite(new SdkLengthAwareInputStream(inputStream, contentLength));
+            }
+
+            return delegate.doBlockingWrite(inputStream);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            delegate.cancel();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Cancel any running write (and mark the stream as failed).
+     */
+    public void cancel() {
+        delegate.cancel();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        if (subscribeCalled.compareAndSet(false, true)) {
+            delegate.subscribe(s);
+            subscribedLatch.countDown();
+        } else {
+            s.onSubscribe(new NoopSubscription(s));
+            s.onError(NonRetryableException.create("A retry was attempted, but AsyncRequestBody.forBlockingInputStream does not "
+                                                   + "support retries. Consider using AsyncRequestBody.fromInputStream with an "
+                                                   + "input stream that supports mark/reset to get retry support."));
+        }
+    }
+
+    private void waitForSubscriptionIfNeeded() throws InterruptedException {
+        if (!subscribedLatch.await(10, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("The service request was not made within 10 seconds of doBlockingWrite being "
+                                            + "invoked. Make sure to invoke the service request BEFORE invoking doBlockingWrite "
+                                            + "if your caller is single-threaded.");
+        }
+    }
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBody.java
@@ -36,7 +36,7 @@ import software.amazon.awssdk.utils.async.InputStreamConsumingPublisher;
  * <p>See {@link AsyncRequestBody#forBlockingInputStream(Long)}.
  */
 @SdkPublicApi
-public class BlockingInputStreamAsyncRequestBody implements AsyncRequestBody {
+public final class BlockingInputStreamAsyncRequestBody implements AsyncRequestBody {
     private final InputStreamConsumingPublisher delegate = new InputStreamConsumingPublisher();
     private final CountDownLatch subscribedLatch = new CountDownLatch(1);
     private final AtomicBoolean subscribeCalled = new AtomicBoolean(false);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/NonRetryableException.java
@@ -45,6 +45,14 @@ public final class NonRetryableException extends SdkClientException {
         return new BuilderImpl();
     }
 
+    public static NonRetryableException create(String message) {
+        return builder().message(message).build();
+    }
+
+    public static NonRetryableException create(String message, Throwable cause) {
+        return builder().message(message).cause(cause).build();
+    }
+
     public interface Builder extends SdkClientException.Builder {
         @Override
         Builder message(String message);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBody.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.Logger;
+
+/**
+ * A {@link AsyncRequestBody} that allows reading data off of an {@link InputStream} using a background
+ * {@link ExecutorService}.
+ * <p>
+ * Created via {@link AsyncRequestBody#fromInputStream(InputStream, Long, ExecutorService)}.
+ */
+@SdkInternalApi
+public class InputStreamWithExecutorAsyncRequestBody implements AsyncRequestBody {
+    private static final Logger log = Logger.loggerFor(InputStreamWithExecutorAsyncRequestBody.class);
+
+    private final Object subscribeLock = new Object();
+    private final InputStream inputStream;
+    private final Long contentLength;
+    private final ExecutorService executor;
+
+    private Future<?> writeFuture;
+
+    public InputStreamWithExecutorAsyncRequestBody(InputStream inputStream,
+                                                   Long contentLength,
+                                                   ExecutorService executor) {
+        this.inputStream = inputStream;
+        this.contentLength = contentLength;
+        this.executor = executor;
+        IoUtils.markStreamWithMaxReadLimit(inputStream);
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.ofNullable(contentLength);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        // Each subscribe cancels the previous subscribe.
+        synchronized (subscribeLock) {
+            try {
+                if (writeFuture != null) {
+                    writeFuture.cancel(true);
+                    waitForCancellation(writeFuture); // Wait for the cancellation
+                    tryReset(inputStream);
+                }
+
+                BlockingInputStreamAsyncRequestBody delegate = AsyncRequestBody.forBlockingInputStream(contentLength);
+                writeFuture = executor.submit(() -> doBlockingWrite(delegate));
+                delegate.subscribe(s);
+            } catch (Throwable t) {
+                s.onSubscribe(new NoopSubscription(s));
+                s.onError(t);
+            }
+        }
+    }
+
+    private void tryReset(InputStream inputStream) {
+        try {
+            inputStream.reset();
+        } catch (IOException e) {
+            String message = "Request cannot be retried, because the request stream could not be reset.";
+            throw NonRetryableException.create(message, e);
+        }
+    }
+
+    @SdkTestInternalApi
+    public Future<?> activeWriteFuture() {
+        synchronized (subscribeLock) {
+            return writeFuture;
+        }
+    }
+
+    private void doBlockingWrite(BlockingInputStreamAsyncRequestBody asyncRequestBody) {
+        try {
+            asyncRequestBody.writeInputStream(inputStream);
+        } catch (Throwable t) {
+            log.debug(() -> "Encountered error while writing input stream to service.", t);
+            throw t;
+        }
+    }
+
+    private void waitForCancellation(Future<?> writeFuture) {
+        try {
+            writeFuture.get(10, TimeUnit.SECONDS);
+        } catch (ExecutionException | CancellationException e) {
+            // Expected - we cancelled.
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            throw new IllegalStateException("Timed out waiting to reset the input stream.", e);
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBodyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult.END_OF_STREAM;
+
+import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber;
+import software.amazon.awssdk.utils.async.StoringSubscriber;
+
+class BlockingInputStreamAsyncRequestBodyTest {
+    @Test
+    public void doBlockingWrite_waitsForSubscription() {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        try {
+            BlockingInputStreamAsyncRequestBody requestBody =
+                AsyncRequestBody.forBlockingInputStream(0L);
+            executor.schedule(() -> requestBody.subscribe(new StoringSubscriber<>(1)), 10, MILLISECONDS);
+            requestBody.writeInputStream(new StringInputStream(""));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void doBlockingWrite_writesToSubscriber() {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        try {
+            BlockingInputStreamAsyncRequestBody requestBody =
+                AsyncRequestBody.forBlockingInputStream(2L);
+            ByteBufferStoringSubscriber subscriber = new ByteBufferStoringSubscriber(4);
+            requestBody.subscribe(subscriber);
+            requestBody.writeInputStream(new ByteArrayInputStream(new byte[] { 0, 1 }));
+
+            ByteBuffer out = ByteBuffer.allocate(4);
+            assertThat(subscriber.transferTo(out)).isEqualTo(END_OF_STREAM);
+            out.flip();
+
+            assertThat(out.remaining()).isEqualTo(2);
+            assertThat(out.get()).isEqualTo((byte) 0);
+            assertThat(out.get()).isEqualTo((byte) 1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingInputStreamAsyncRequestBodyTest.java
@@ -17,13 +17,16 @@ package software.amazon.awssdk.core.async;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult.END_OF_STREAM;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber;
 import software.amazon.awssdk.utils.async.StoringSubscriber;
@@ -40,6 +43,15 @@ class BlockingInputStreamAsyncRequestBodyTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    @Timeout(10)
+    public void doBlockingWrite_failsIfSubscriptionNeverComes()  {
+        BlockingInputStreamAsyncRequestBody requestBody =
+            new BlockingInputStreamAsyncRequestBody(0L, Duration.ofSeconds(1));
+        assertThatThrownBy(() -> requestBody.writeInputStream(new StringInputStream("")))
+            .hasMessageContaining("The service request was not made");
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/InputStreamWithExecutorAsyncRequestBodyTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber;
+import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult;
+
+class InputStreamWithExecutorAsyncRequestBodyTest {
+    @Test
+    @Timeout(10)
+    public void dataFromInputStreamIsCopied() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            PipedOutputStream os = new PipedOutputStream();
+            PipedInputStream is = new PipedInputStream(os);
+
+            InputStreamWithExecutorAsyncRequestBody asyncRequestBody =
+                new InputStreamWithExecutorAsyncRequestBody(is, 4L, executor);
+
+            ByteBufferStoringSubscriber subscriber = new ByteBufferStoringSubscriber(8);
+            asyncRequestBody.subscribe(subscriber);
+
+            os.write(0);
+            os.write(1);
+            os.write(2);
+            os.write(3);
+            os.close();
+
+            asyncRequestBody.activeWriteFuture().get();
+
+            ByteBuffer output = ByteBuffer.allocate(8);
+            assertThat(subscriber.transferTo(output)).isEqualTo(TransferResult.END_OF_STREAM);
+            output.flip();
+
+            assertThat(output.remaining()).isEqualTo(4);
+            assertThat(output.get()).isEqualTo((byte) 0);
+            assertThat(output.get()).isEqualTo((byte) 1);
+            assertThat(output.get()).isEqualTo((byte) 2);
+            assertThat(output.get()).isEqualTo((byte) 3);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void errorsReadingInputStreamAreForwardedToSubscriber() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            PipedOutputStream os = new PipedOutputStream();
+            PipedInputStream is = new PipedInputStream(os);
+
+            is.close();
+            InputStreamWithExecutorAsyncRequestBody asyncRequestBody =
+                new InputStreamWithExecutorAsyncRequestBody(is, 4L, executor);
+
+            ByteBufferStoringSubscriber subscriber = new ByteBufferStoringSubscriber(8);
+            asyncRequestBody.subscribe(subscriber);
+            assertThatThrownBy(() -> asyncRequestBody.activeWriteFuture().get()).hasRootCauseInstanceOf(IOException.class);
+            assertThatThrownBy(() -> subscriber.transferTo(ByteBuffer.allocate(8))).hasRootCauseInstanceOf(IOException.class);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,7 @@
                             <exclude>software.amazon.awssdk.regions.*</exclude>
                             <exclude>software.amazon.awssdk.core.signer.NoOpSigner</exclude>
                             <exclude>software.amazon.awssdk.auth.credentials.ProfileCredentialsProviderFactory</exclude>
+                            <exclude>software.amazon.awssdk.utils.async.InputStreamSubscriber</exclude>
                         </excludes>
 
                         <ignoreMissingOldVersion>true</ignoreMissingOldVersion>

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BlockingAsyncRequestResponseBodyTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BlockingAsyncRequestResponseBodyTest.java
@@ -25,12 +25,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -38,6 +42,9 @@ import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.async.BlockingOutputStreamAsyncRequestBody;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -47,6 +54,8 @@ import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOper
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
+import software.amazon.awssdk.utils.StringInputStream;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 @Timeout(5)
 public class BlockingAsyncRequestResponseBodyTest {
@@ -61,6 +70,202 @@ public class BlockingAsyncRequestResponseBodyTest {
                                             .credentialsProvider(AnonymousCredentialsProvider.create())
                                             .endpointOverride(URI.create("http://localhost:" + wireMock.port()))
                                             .build();
+    }
+
+    @Test
+    public void blockingWithExecutor_sendsRightValues() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(),
+                                           AsyncRequestBody.fromInputStream(new StringInputStream("Hello"),
+                                                                            5L,
+                                                                            executorService))
+                  .join();
+            List<LoggedRequest> requests = wireMock.findAll(allRequests());
+            assertThat(requests).singleElement()
+                                .extracting(LoggedRequest::getBody)
+                                .extracting(String::new)
+                                .isEqualTo("Hello");
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void blockingWithExecutor_canUnderUpload() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(),
+                                           AsyncRequestBody.fromInputStream(new StringInputStream("Hello"),
+                                                                            4L,
+                                                                            executorService))
+                  .join();
+            List<LoggedRequest> requests = wireMock.findAll(allRequests());
+            assertThat(requests).singleElement()
+                                .extracting(LoggedRequest::getBody)
+                                .extracting(String::new)
+                                .isEqualTo("Hell");
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void blockingWithExecutor_canUnderUploadOneByteAtATime() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(),
+                                           AsyncRequestBody.fromInputStream(new TrickleInputStream(new StringInputStream("Hello")),
+                                                                            4L,
+                                                                            executorService))
+                  .join();
+            List<LoggedRequest> requests = wireMock.findAll(allRequests());
+            assertThat(requests).singleElement()
+                                .extracting(LoggedRequest::getBody)
+                                .extracting(String::new)
+                                .isEqualTo("Hell");
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void blockingWithExecutor_propagatesReadFailures() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+            CompletableFuture<StreamingInputOperationResponse> responseFuture =
+                client.streamingInputOperation(StreamingInputOperationRequest.builder().build(),
+                                               AsyncRequestBody.fromInputStream(new FailOnReadInputStream(),
+                                                                                5L,
+                                                                                executorService));
+            assertThatThrownBy(responseFuture::join).hasRootCauseInstanceOf(IOException.class);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void blockingWithExecutor_propagates400Failures() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(404).withBody("{}")));
+            CompletableFuture<?> responseFuture =
+                client.streamingInputOperation(StreamingInputOperationRequest.builder().build(),
+                                               AsyncRequestBody.fromInputStream(new StringInputStream("Hello"),
+                                                                                5L,
+                                                                                executorService));
+            assertThatThrownBy(responseFuture::join).hasCauseInstanceOf(SdkServiceException.class);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void blockingWithExecutor_propagates500Failures() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().daemonThreads(true).build());
+        try {
+            wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(500).withBody("{}")));
+            CompletableFuture<?> responseFuture =
+                client.streamingInputOperation(StreamingInputOperationRequest.builder().build(),
+                                               AsyncRequestBody.fromInputStream(new StringInputStream("Hello"),
+                                                                                5L,
+                                                                                executorService));
+            assertThatThrownBy(responseFuture::join).hasCauseInstanceOf(SdkServiceException.class);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void blockingInputStreamWithoutExecutor_sendsRightValues() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(5L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        body.writeInputStream(new StringInputStream("Hello"));
+        responseFuture.join();
+
+        List<LoggedRequest> requests = wireMock.findAll(allRequests());
+        assertThat(requests).singleElement()
+                            .extracting(LoggedRequest::getBody)
+                            .extracting(String::new)
+                            .isEqualTo("Hello");
+    }
+
+    @Test
+    public void blockingInputStreamWithoutExecutor_canUnderUpload() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(4L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        body.writeInputStream(new StringInputStream("Hello"));
+        responseFuture.join();
+
+        List<LoggedRequest> requests = wireMock.findAll(allRequests());
+        assertThat(requests).singleElement()
+                            .extracting(LoggedRequest::getBody)
+                            .extracting(String::new)
+                            .isEqualTo("Hell");
+    }
+
+    @Test
+    public void blockingInputStreamWithoutExecutor_canUnderUploadOneByteAtATime() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(4L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        body.writeInputStream(new TrickleInputStream(new StringInputStream("Hello")));
+        responseFuture.join();
+
+        List<LoggedRequest> requests = wireMock.findAll(allRequests());
+        assertThat(requests).singleElement()
+                            .extracting(LoggedRequest::getBody)
+                            .extracting(String::new)
+                            .isEqualTo("Hell");
+    }
+
+    @Test
+    public void blockingInputStreamWithoutExecutor_propagatesReadFailures() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(5L);
+        CompletableFuture<StreamingInputOperationResponse> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        assertThatThrownBy(() -> body.writeInputStream(new FailOnReadInputStream())).hasRootCauseInstanceOf(IOException.class);
+        assertThatThrownBy(responseFuture::get)
+            .hasCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("AsyncRequestBody.forBlockingInputStream does not support retries");
+    }
+
+    @Test
+    public void blockingInputStreamWithoutExecutor_propagates400Failures() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(404).withBody("{}")));
+        BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(5L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        body.writeInputStream(new StringInputStream("Hello"));
+        assertThatThrownBy(responseFuture::join).hasCauseInstanceOf(SdkServiceException.class);
+    }
+
+    @Test
+    public void blockingInputStreamWithoutExecutor_propagates500Failures() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(500).withBody("{}")));
+
+        BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(5L);
+        CompletableFuture<StreamingInputOperationResponse> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        body.writeInputStream(new StringInputStream("Hello"));
+        assertThatThrownBy(responseFuture::get)
+            .hasCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("AsyncRequestBody.forBlockingInputStream does not support retries");
     }
 
     @Test
@@ -201,5 +406,41 @@ public class BlockingAsyncRequestResponseBodyTest {
         assertThatThrownBy(responseFuture::get)
             .hasCauseInstanceOf(SdkClientException.class)
             .hasMessageContaining("AsyncRequestBody.forBlockingOutputStream does not support retries");
+    }
+
+    private static class FailOnReadInputStream extends InputStream {
+        @Override
+        public int read() throws IOException {
+            throw new IOException("Intentionally failed to read.");
+        }
+    }
+
+    private static class TrickleInputStream extends InputStream {
+        private final InputStream delegate;
+
+        private TrickleInputStream(InputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            if (b.length == 0) {
+                return 0;
+            }
+            return delegate.read(b, 0, 1);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (len == 0) {
+                return 0;
+            }
+            return delegate.read(b, off, 1);
+        }
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamConsumingPublisher.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamConsumingPublisher.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import static software.amazon.awssdk.utils.CompletableFutureUtils.joinInterruptibly;
+import static software.amazon.awssdk.utils.CompletableFutureUtils.joinInterruptiblyIgnoringFailures;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+
+/**
+ * A publisher to which an {@link InputStream} can be written.
+ * <p>
+ * See {@link #doBlockingWrite(InputStream)}.
+ */
+@SdkProtectedApi
+public class InputStreamConsumingPublisher implements Publisher<ByteBuffer> {
+    private static final int BUFFER_SIZE = 16 * 1024; // 16 KB
+
+    private final SimplePublisher<ByteBuffer> delegate = new SimplePublisher<>();
+
+    /**
+     * Write the provided input stream to the stream subscribed to this publisher.
+     * <p>
+     * This method will block the calling thread to write until: (1) the provided input stream is fully consumed,
+     * (2) the subscription is cancelled, (3) reading from the input stream fails, or (4) {@link #cancel()} is called.
+     *
+     * @return The amount of data written to the downstream subscriber.
+     */
+    public long doBlockingWrite(InputStream inputStream) {
+        try {
+            long dataWritten = 0;
+            while (true) {
+                byte[] data = new byte[BUFFER_SIZE];
+                int dataLength = inputStream.read(data);
+                if (dataLength > 0) {
+                    dataWritten += dataLength;
+                    joinInterruptibly(delegate.send(ByteBuffer.wrap(data, 0, dataLength)));
+                } else if (dataLength < 0) {
+                    // We ignore cancel failure on completion, because as long as our onNext calls have succeeded, the
+                    // subscriber got everything we wanted to send.
+                    joinInterruptiblyIgnoringCancellation(delegate.complete());
+                    break;
+                }
+            }
+            return dataWritten;
+        } catch (IOException e) {
+            joinInterruptiblyIgnoringFailures(delegate.error(e));
+            throw new UncheckedIOException(e);
+        } catch (RuntimeException | Error e) {
+            joinInterruptiblyIgnoringFailures(delegate.error(e));
+            throw e;
+        }
+    }
+
+    /**
+     * Cancel an ongoing {@link #doBlockingWrite(InputStream)} call.
+     */
+    public void cancel() {
+        delegate.error(new CancellationException("Input stream has been cancelled."));
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        delegate.subscribe(s);
+    }
+
+    private void joinInterruptiblyIgnoringCancellation(CompletableFuture<Void> complete) {
+        try {
+            joinInterruptibly(complete);
+        } catch (CancellationException e) {
+            // Ignore
+        }
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/InputStreamSubscriber.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferRe
  * subscriber when the input stream is not being read is bounded.
  */
 @SdkProtectedApi
-public class InputStreamSubscriber extends InputStream implements Subscriber<ByteBuffer>, SdkAutoCloseable {
+public final class InputStreamSubscriber extends InputStream implements Subscriber<ByteBuffer>, SdkAutoCloseable {
     private static final int BUFFER_SIZE = 4 * 1024 * 1024; // 4 MB
 
     private final ByteBufferStoringSubscriber delegate;

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamConsumingPublisherTckTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamConsumingPublisherTckTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+public class InputStreamConsumingPublisherTckTest extends PublisherVerification<ByteBuffer> {
+    private final ExecutorService executor =
+        Executors.newCachedThreadPool(new ThreadFactoryBuilder().daemonThreads(true).build());
+
+    public InputStreamConsumingPublisherTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long elements) {
+        InputStreamConsumingPublisher publisher = new InputStreamConsumingPublisher();
+        executor.submit(() -> {
+            publisher.doBlockingWrite(new InputStream() {
+                int i = 0;
+
+                @Override
+                public int read() throws IOException {
+                    throw new IOException();
+                }
+
+                @Override
+                public int read(byte[] b) throws IOException {
+                    if (i >= elements) {
+                        return -1;
+                    }
+                    ++i;
+                    assert b.length > 0;
+                    return 1;
+                }
+            });
+        });
+        return publisher;
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        InputStreamConsumingPublisher publisher = new InputStreamConsumingPublisher();
+        executor.submit(publisher::cancel);
+        return publisher;
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamConsumingPublisherTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamConsumingPublisherTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult.END_OF_STREAM;
+import static software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult.SUCCESS;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+public class InputStreamConsumingPublisherTest {
+    private static final ExecutorService EXECUTOR =
+        Executors.newCachedThreadPool(new ThreadFactoryBuilder().daemonThreads(true).build());
+    private ByteBufferStoringSubscriber subscriber;
+    private InputStreamConsumingPublisher publisher;
+
+    @BeforeEach
+    public void setup() {
+        this.subscriber = new ByteBufferStoringSubscriber(Long.MAX_VALUE);
+        this.publisher = new InputStreamConsumingPublisher();
+    }
+
+    @Test
+    public void subscribeAfterWrite_completes() throws InterruptedException {
+        EXECUTOR.submit(() -> publisher.doBlockingWrite(streamOfLength(0)));
+        Thread.sleep(200);
+        publisher.subscribe(subscriber);
+
+        assertThat(subscriber.transferTo(ByteBuffer.allocate(0))).isEqualTo(END_OF_STREAM);
+    }
+
+    @Test
+    public void zeroKb_completes() {
+        publisher.subscribe(subscriber);
+
+        assertThat(publisher.doBlockingWrite(streamOfLength(0))).isEqualTo(0);
+        assertThat(subscriber.transferTo(ByteBuffer.allocate(0))).isEqualTo(END_OF_STREAM);
+    }
+
+    @Test
+    public void oneKb_writesAndCompletes() {
+        publisher.subscribe(subscriber);
+
+        assertThat(publisher.doBlockingWrite(streamOfLength(1024))).isEqualTo(1024);
+        assertThat(subscriber.transferTo(ByteBuffer.allocate(1023))).isEqualTo(SUCCESS);
+        assertThat(subscriber.transferTo(ByteBuffer.allocate(1))).isEqualTo(END_OF_STREAM);
+    }
+
+    @Test
+    public void bytesAreDeliveredInOrder() {
+        publisher.subscribe(subscriber);
+
+        assertThat(publisher.doBlockingWrite(streamWithAllBytesInOrder())).isEqualTo(256);
+
+        ByteBuffer output = ByteBuffer.allocate(256);
+        assertThat(subscriber.transferTo(output)).isEqualTo(END_OF_STREAM);
+        output.flip();
+
+        for (int i = 0; i < 256; i++) {
+            assertThat(output.get()).isEqualTo((byte) i);
+        }
+    }
+
+    @Test
+    public void failedRead_signalsOnError() {
+        publisher.subscribe(subscriber);
+
+        assertThatThrownBy(() -> publisher.doBlockingWrite(streamWithFailedReadAfterLength(1024)))
+            .isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    public void cancel_signalsOnError() {
+        publisher.subscribe(subscriber);
+        publisher.cancel();
+
+        assertThatThrownBy(() -> subscriber.transferTo(ByteBuffer.allocate(0))).isInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    public void cancel_stopsRunningWrites() {
+        publisher.subscribe(subscriber);
+        Future<?> write = EXECUTOR.submit(() -> publisher.doBlockingWrite(streamOfLength(Integer.MAX_VALUE)));
+        publisher.cancel();
+
+        assertThatThrownBy(write::get).hasRootCauseInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    public void cancel_beforeWrite_stopsWrite() {
+        publisher.subscribe(subscriber);
+        publisher.cancel();
+        assertThatThrownBy(() -> publisher.doBlockingWrite(streamOfLength(Integer.MAX_VALUE)))
+            .hasRootCauseInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    public void cancel_beforeSubscribe_stopsWrite() {
+        publisher.cancel();
+        publisher.subscribe(subscriber);
+        assertThatThrownBy(() -> publisher.doBlockingWrite(streamOfLength(Integer.MAX_VALUE)))
+            .hasRootCauseInstanceOf(CancellationException.class);
+    }
+
+    public InputStream streamOfLength(int length) {
+        return new InputStream() {
+            int i = 0;
+            @Override
+            public int read() throws IOException {
+                if (i >= length) {
+                    return -1;
+                }
+                ++i;
+                return 1;
+            }
+        };
+    }
+
+    public InputStream streamWithAllBytesInOrder() {
+        return new InputStream() {
+            int i = 0;
+            @Override
+            public int read() throws IOException {
+                if (i > 255) {
+                    return -1;
+                }
+                return i++;
+            }
+        };
+    }
+
+    public InputStream streamWithFailedReadAfterLength(int length) {
+        return new InputStream() {
+            int i = 0;
+            @Override
+            public int read() throws IOException {
+                if (i > length) {
+                    throw new IOException("Failed to read!");
+                }
+                ++i;
+                return 1;
+            }
+        };
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/InputStreamSubscriberTest.java
@@ -174,7 +174,7 @@ public class InputStreamSubscriberTest {
             List<Future<?>> futures = new ArrayList<>();
             for (int i = 0; i < numIterations; i++) {
                 CountDownLatch waitingAtStartLine = new CountDownLatch(2);
-                CountDownLatch startLine = new CountDownLatch(0);
+                CountDownLatch startLine = new CountDownLatch(1);
 
                 InputStreamSubscriber subscriber = new InputStreamSubscriber();
                 subscriber.onSubscribe(mockSubscription(subscriber));


### PR DESCRIPTION
This allows streaming operation requests to be written to like an input stream.

Example usage with retry support, without blocking calling thread:

```java
String data = "Hello, world!";
ExecutorService executor = Executors.newCachedThreadPool();
InputStream data = new StringInputStream("Hello, world!");

s3.putObject(r -> r.bucket("foo").key("bar"),
             AsyncRequestBody.fromInputStream(data, data.length(), executor))
  .join();
```

Example usage without retry support, with blocking calling thread:
```java
String data = "Hello, world!";
BlockingInputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingInputStream(data.length());
CompletableFuture<?> responseFuture = s3.putObject(r -> r.bucket("foo").key("bar"), body);
body.writeInputStream(new StringInputStream(data));
responseFuture.join();
```

Other changes made to support this change:
1. Added `InputStreamConsumingPublisher`, a `Publisher<ByteBuffer>` that can read from an `InputStream`.

These supporting changes were also made, and are also being reviewed in https://github.com/aws/aws-sdk-java-v2/pull/3565:
1. Updated `SimplePublisher` to return more useful and predictable error messages when invoked after `onComplete`, `onError` or `cancel` has been called.
1. Added `CompletableFutureUtils.joinInterruptibly`, which behaves equivalent to executing `join()`, but allows the calling thread to still respond to interrupts.
1. Added `CompletableFutureUtils.joinInterruptiblyIgnoringFailures`, which behaves equivalent to executing `join()`, but allows the calling thread to still respond to interrupts, and ignores exceptions that are thrown.