### PR TITLE
Support HostPrefix in E2.0, enable E2.0 for all services

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-4ded69a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-4ded69a.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "This changes fixes the previously incorrect handling of `hostPrefix` in services, causing requests for some services to have the wrong URL. This change also undoes the suppression of rules-based endpoint generation for all services apart from EventBridge, S3, and S3 Control, which was implemented in [#3520](https://github.com/aws/aws-sdk-java-v2/issues/3520) because of the previously mentioned `hostPrefix` issue."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/EndpointProviderTasks.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/emitters/tasks/EndpointProviderTasks.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.codegen.emitters.tasks;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import software.amazon.awssdk.codegen.emitters.GeneratorTask;
@@ -46,10 +45,6 @@ public final class EndpointProviderTasks extends BaseGeneratorTasks {
 
     @Override
     protected List<GeneratorTask> createTasks() throws Exception {
-        if (!generatorTaskParams.getModel().getCustomizationConfig().useRuleBasedEndpoints()) {
-            return Collections.emptyList();
-        }
-
         List<GeneratorTask> tasks = new ArrayList<>();
         tasks.add(generateInterface());
         tasks.add(generateParams());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -213,11 +213,6 @@ public class CustomizationConfig {
 
     private boolean useGlobalEndpoint;
 
-    /**
-     * Whether Endpoints 2.0/rule based endpoints should be used for endpoint resolution.
-     */
-    private boolean useRuleBasedEndpoints = false;
-
     private List<String> interceptors = new ArrayList<>();
 
     private CustomizationConfig() {
@@ -555,14 +550,6 @@ public class CustomizationConfig {
 
     public void setSkipEndpointTests(Map<String, String> skipEndpointTests) {
         this.skipEndpointTests = skipEndpointTests;
-    }
-
-    public boolean useRuleBasedEndpoints() {
-        return useRuleBasedEndpoints;
-    }
-
-    public void setUseRuleBasedEndpoints(boolean useRuleBasedEndpoints) {
-        this.useRuleBasedEndpoints = useRuleBasedEndpoints;
     }
 
     public List<String> getInterceptors() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/AsyncClientBuilderClass.java
@@ -69,9 +69,7 @@ public class AsyncClientBuilderClass implements ClassSpec {
             }
         }
 
-        if (endpointRulesSpecUtils.isEndpointRulesEnabled()) {
-            builder.addMethod(endpointProviderMethod());
-        }
+        builder.addMethod(endpointProviderMethod());
 
         if (AuthUtils.usesBearerAuth(model)) {
             builder.addMethod(bearerTokenProviderMethod());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -111,11 +111,9 @@ public class BaseClientBuilderClass implements ClassSpec {
         builder.addMethod(finalizeServiceConfigurationMethod());
         defaultAwsAuthSignerMethod().ifPresent(builder::addMethod);
         builder.addMethod(signingNameMethod());
-        if (endpointRulesSpecUtils.isEndpointRulesEnabled()) {
-            builder.addMethod(defaultEndpointProviderMethod());
-        }
+        builder.addMethod(defaultEndpointProviderMethod());
 
-        if (hasClientContextParams() && endpointRulesSpecUtils.isEndpointRulesEnabled()) {
+        if (hasClientContextParams()) {
             model.getClientContextParams().forEach((n, m) -> {
                 builder.addMethod(clientContextParamSetter(n, m));
             });
@@ -191,9 +189,8 @@ public class BaseClientBuilderClass implements ClassSpec {
                                                .addParameter(SdkClientConfiguration.class, "config")
                                                .addCode("return config.merge(c -> c");
 
-        if (endpointRulesSpecUtils.isEndpointRulesEnabled()) {
-            builder.addCode(".option($T.ENDPOINT_PROVIDER, defaultEndpointProvider())", SdkClientOption.class);
-        }
+        builder.addCode(".option($T.ENDPOINT_PROVIDER, defaultEndpointProvider())", SdkClientOption.class);
+
 
         if (defaultAwsAuthSignerMethod().isPresent()) {
             builder.addCode(".option($T.SIGNER, defaultSigner())\n", SdkAdvancedClientOption.class);
@@ -261,11 +258,9 @@ public class BaseClientBuilderClass implements ClassSpec {
 
         List<ClassName> builtInInterceptors = new ArrayList<>();
 
-        if (endpointRulesSpecUtils.isEndpointRulesEnabled()) {
-            builtInInterceptors.add(endpointRulesSpecUtils.resolverInterceptorName());
-            builtInInterceptors.add(endpointRulesSpecUtils.authSchemesInterceptorName());
-            builtInInterceptors.add(endpointRulesSpecUtils.requestModifierInterceptorName());
-        }
+        builtInInterceptors.add(endpointRulesSpecUtils.resolverInterceptorName());
+        builtInInterceptors.add(endpointRulesSpecUtils.authSchemesInterceptorName());
+        builtInInterceptors.add(endpointRulesSpecUtils.requestModifierInterceptorName());
 
         for (String interceptor : model.getCustomizationConfig().getInterceptors()) {
             builtInInterceptors.add(ClassName.bestGuess(interceptor));

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderInterface.java
@@ -38,7 +38,6 @@ import software.amazon.awssdk.codegen.utils.AuthUtils;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.utils.internal.CodegenNamingUtils;
 
-
 public class BaseClientBuilderInterface implements ClassSpec {
     private final IntermediateModel model;
     private final String basePackage;
@@ -73,14 +72,12 @@ public class BaseClientBuilderInterface implements ClassSpec {
             builder.addMethod(serviceConfigurationConsumerBuilderMethod());
         }
 
-        if (endpointRulesSpecUtils.isEndpointRulesEnabled()) {
-            builder.addMethod(endpointProviderMethod());
+        builder.addMethod(endpointProviderMethod());
 
-            if (hasClientContextParams()) {
-                model.getClientContextParams().forEach((n, m) -> {
-                    builder.addMethod(clientContextParamSetter(n, m));
-                });
-            }
+        if (hasClientContextParams()) {
+            model.getClientContextParams().forEach((n, m) -> {
+                builder.addMethod(clientContextParamSetter(n, m));
+            });
         }
 
         if (generateTokenProviderMethod()) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/SyncClientBuilderClass.java
@@ -69,9 +69,7 @@ public class SyncClientBuilderClass implements ClassSpec {
             }
         }
 
-        if (endpointRulesSpecUtils.isEndpointRulesEnabled()) {
-            builder.addMethod(endpointProviderMethod());
-        }
+        builder.addMethod(endpointProviderMethod());
 
         if (AuthUtils.usesBearerAuth(model)) {
             builder.addMethod(tokenProviderMethodImpl());

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderTestSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointProviderTestSpec.java
@@ -88,7 +88,7 @@ public class EndpointProviderTestSpec implements ClassSpec {
             b.addStatement("testCases.add(new $T($L, $L))",
                            EndpointProviderTestCase.class,
                            createTestCase(test),
-                           TestGeneratorUtils.createExpect(test.getExpect()));
+                           TestGeneratorUtils.createExpect(test.getExpect(), null, null));
         });
 
         b.addStatement("return testCases");

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.jr.stree.JrsBoolean;
 import com.fasterxml.jackson.jr.stree.JrsString;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
@@ -32,6 +34,8 @@ import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.rules.endpoints.ParameterModel;
 import software.amazon.awssdk.codegen.model.service.ClientContextParam;
 import software.amazon.awssdk.codegen.model.service.ContextParam;
+import software.amazon.awssdk.codegen.model.service.EndpointTrait;
+import software.amazon.awssdk.codegen.model.service.HostPrefixProcessor;
 import software.amazon.awssdk.codegen.model.service.StaticContextParam;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
@@ -41,9 +45,12 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.HostnameValidator;
+import software.amazon.awssdk.utils.StringUtils;
 
 public class EndpointResolverInterceptorSpec implements ClassSpec {
     private final IntermediateModel model;
@@ -76,6 +83,8 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
             b.addMethod(setClientContextParamsMethod());
         }
 
+        b.addMethod(hostPrefixMethod());
+
         return b.build();
     }
 
@@ -106,6 +115,13 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         b.beginControlFlow("try");
         b.addStatement("$T result = $N.resolveEndpoint(ruleParams(context, executionAttributes)).join()", Endpoint.class,
                        providerVar);
+        b.addStatement("$T hostPrefix = hostPrefix(executionAttributes.getAttribute($T.OPERATION_NAME), context.request())",
+                       ParameterizedTypeName.get(Optional.class, String.class), SdkExecutionAttribute.class);
+        b.beginControlFlow("if (hostPrefix.isPresent() && !$T.disableHostPrefixInjection(executionAttributes))",
+                           endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
+        b.addStatement("result = $T.addHostPrefix(result, hostPrefix.get())",
+                       endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
+        b.endControlFlow();
         b.addStatement("executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, result)");
         b.addStatement("return context.request()");
         b.endControlFlow();
@@ -171,7 +187,7 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
                 case AWS_S3_FORCE_PATH_STYLE:
                 case AWS_S3_USE_ARN_REGION:
                 case AWS_S3_CONTROL_USE_ARN_REGION:
-                // end of S3 specific builtins
+                    // end of S3 specific builtins
                 case AWS_STS_USE_GLOBAL_ENDPOINT:
                     // V2 doesn't support this, only regional endpoints
                     return;
@@ -360,5 +376,67 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         });
 
         return b.build();
+    }
+
+
+    private MethodSpec hostPrefixMethod() {
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("hostPrefix")
+                                               .returns(ParameterizedTypeName.get(Optional.class, String.class))
+                                               .addParameter(String.class, "operationName")
+                                               .addParameter(SdkRequest.class, "request")
+                                               .addModifiers(Modifier.PRIVATE, Modifier.STATIC);
+
+        builder.beginControlFlow("switch (operationName)");
+
+        model.getOperations().forEach((name, opModel) -> {
+            String hostPrefix = getHostPrefix(opModel);
+            if (StringUtils.isBlank(hostPrefix)) {
+                return;
+            }
+
+            builder.beginControlFlow("case $S:", name);
+            HostPrefixProcessor processor = new HostPrefixProcessor(hostPrefix);
+
+            if (processor.c2jNames().isEmpty()) {
+                builder.addStatement("return $T.of($S)", Optional.class, processor.hostWithStringSpecifier());
+            } else {
+                String requestVar = opModel.getInput().getVariableName();
+                processor.c2jNames().forEach(c2jName -> {
+                    builder.addStatement("$1T.validateHostnameCompliant(request.getValueForField($2S, $3T.class).orElse(null), "
+                                         + "$2S, $4S)",
+                                         HostnameValidator.class,
+                                         c2jName,
+                                         String.class,
+                                         requestVar);
+                });
+
+                builder.addCode("return $T.of($T.format($S, ", Optional.class, String.class,
+                                processor.hostWithStringSpecifier());
+                Iterator<String> c2jNamesIter = processor.c2jNames().listIterator();
+                while (c2jNamesIter.hasNext()) {
+                    builder.addCode("request.getValueForField($S, $T.class).get()", c2jNamesIter.next(), String.class);
+                    if (c2jNamesIter.hasNext()) {
+                        builder.addCode(",");
+                    }
+                }
+                builder.addStatement("))");
+            }
+            builder.endControlFlow();
+        });
+
+        builder.addCode("default:");
+        builder.addStatement("return $T.empty()", Optional.class);
+        builder.endControlFlow();
+
+        return builder.build();
+    }
+
+    private String getHostPrefix(OperationModel opModel) {
+        EndpointTrait endpointTrait = opModel.getEndpointTrait();
+        if (endpointTrait == null) {
+            return null;
+        }
+
+        return endpointTrait.getHostPrefix();
     }
 }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointResolverInterceptorSpec.java
@@ -115,12 +115,14 @@ public class EndpointResolverInterceptorSpec implements ClassSpec {
         b.beginControlFlow("try");
         b.addStatement("$T result = $N.resolveEndpoint(ruleParams(context, executionAttributes)).join()", Endpoint.class,
                        providerVar);
+        b.beginControlFlow("if (!$T.disableHostPrefixInjection(executionAttributes))",
+                           endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
         b.addStatement("$T hostPrefix = hostPrefix(executionAttributes.getAttribute($T.OPERATION_NAME), context.request())",
                        ParameterizedTypeName.get(Optional.class, String.class), SdkExecutionAttribute.class);
-        b.beginControlFlow("if (hostPrefix.isPresent() && !$T.disableHostPrefixInjection(executionAttributes))",
-                           endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
+        b.beginControlFlow("if (hostPrefix.isPresent())");
         b.addStatement("result = $T.addHostPrefix(result, hostPrefix.get())",
                        endpointRulesSpecUtils.rulesRuntimeClassName("AwsEndpointProviderUtils"));
+        b.endControlFlow();
         b.endControlFlow();
         b.addStatement("executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, result)");
         b.addStatement("return context.request()");

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesClientTestSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesClientTestSpec.java
@@ -58,6 +58,7 @@ import software.amazon.awssdk.codegen.model.service.Location;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
 import software.amazon.awssdk.codegen.poet.PoetExtension;
 import software.amazon.awssdk.codegen.poet.PoetUtils;
+import software.amazon.awssdk.codegen.utils.AuthUtils;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.rules.testing.AsyncTestCase;
@@ -252,6 +253,9 @@ public class EndpointRulesClientTestSpec implements ClassSpec {
         b.beginControlFlow("() -> ");
         b.addStatement("$T builder = $T.builder()", syncClientBuilder(), syncClientClass());
         b.addStatement("builder.credentialsProvider($T.CREDENTIALS_PROVIDER)", BaseRuleSetClientTest.class);
+        if (AuthUtils.usesBearerAuth(model)) {
+            b.addStatement("builder.tokenProvider($T.TOKEN_PROVIDER)", BaseRuleSetClientTest.class);
+        }
         b.addStatement("builder.httpClient(getSyncHttpClient())");
 
         if (params != null) {
@@ -276,6 +280,9 @@ public class EndpointRulesClientTestSpec implements ClassSpec {
         b.beginControlFlow("() -> ");
         b.addStatement("$T builder = $T.builder()", asyncClientBuilder(), asyncClientClass());
         b.addStatement("builder.credentialsProvider($T.CREDENTIALS_PROVIDER)", BaseRuleSetClientTest.class);
+        if (AuthUtils.usesBearerAuth(model)) {
+            b.addStatement("builder.tokenProvider($T.TOKEN_PROVIDER)", BaseRuleSetClientTest.class);
+        }
         b.addStatement("builder.httpClient(getAsyncHttpClient())");
 
         if (params != null) {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesSpecUtils.java
@@ -182,8 +182,4 @@ public class EndpointRulesSpecUtils {
     public TypeName resolverReturnType() {
         return ParameterizedTypeName.get(CompletableFuture.class, Endpoint.class);
     }
-
-    public boolean isEndpointRulesEnabled() {
-        return intermediateModel.getCustomizationConfig().useRuleBasedEndpoints();
-    }
 }

--- a/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
+++ b/codegen/src/main/resources/software/amazon/awssdk/codegen/rules/AwsEndpointProviderUtils.java.resource
@@ -16,6 +16,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.HostnameValidator;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
@@ -72,6 +73,34 @@ public final class AwsEndpointProviderUtils {
      */
     public static boolean endpointIsDiscovered(ExecutionAttributes attrs) {
         return attrs.getOptionalAttribute(SdkInternalExecutionAttribute.IS_DISCOVERED_ENDPOINT).orElse(false);
+    }
+
+    /**
+     * True if the the {@link SdkInternalExecutionAttribute#DISABLE_HOST_PREFIX_INJECTION} attribute is present and its
+     * value is {@code true}, {@code false} otherwise.
+     */
+    public static boolean disableHostPrefixInjection(ExecutionAttributes attrs) {
+        return attrs.getOptionalAttribute(SdkInternalExecutionAttribute.DISABLE_HOST_PREFIX_INJECTION).orElse(false);
+    }
+
+    /**
+     * Apply the given endpoint prefix to the endpoint.
+     */
+    public static Endpoint addHostPrefix(Endpoint endpoint, String prefix) {
+        if (StringUtils.isBlank(prefix)) {
+            return endpoint;
+        }
+
+        validatePrefixIsHostNameCompliant(prefix);
+
+        URI originalUrl = endpoint.url();
+        String newHost = prefix + endpoint.url().getHost();
+        URI newUrl = invokeSafely(() -> new URI(originalUrl.getScheme(), null, newHost, originalUrl.getPort(),
+                             originalUrl.getPath(), originalUrl.getQuery(), originalUrl.getFragment()));
+
+        return endpoint.toBuilder()
+            .url(newUrl)
+            .build();
     }
 
     public static Endpoint valueAsEndpointOrThrow(Value value) {
@@ -169,5 +198,16 @@ public final class AwsEndpointProviderUtils {
                 break;
             }
         });
+    }
+
+    private static void validatePrefixIsHostNameCompliant(String prefix) {
+        String[] components = splitHostLabelOnDots(prefix);
+        for (String component : components) {
+            HostnameValidator.validateHostnameCompliant(component, component, "request");
+        }
+    }
+
+    private static String[] splitHostLabelOnDots(String label) {
+        return label.split("\\.");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
@@ -28,6 +29,8 @@ final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<J
 
     @Override
     protected final JsonAsyncClient buildClient() {
-        return new DefaultJsonAsyncClient(super.asyncClientConfiguration());
+        SdkClientConfiguration clientConfiguration = super.asyncClientConfiguration();
+        this.validateClientOptions(clientConfiguration);
+        return new DefaultJsonAsyncClient(clientConfiguration);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-async-client-builder-class.java
@@ -4,7 +4,8 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
  * Internal implementation of {@link JsonAsyncClientBuilder}.
@@ -14,6 +15,12 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<JsonAsyncClientBuilder, JsonAsyncClient> implements
                                                                                                                         JsonAsyncClientBuilder {
     @Override
+    public DefaultJsonAsyncClientBuilder endpointProvider(JsonEndpointProvider endpointProvider) {
+        clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER, endpointProvider);
+        return this;
+    }
+
+    @Override
     public DefaultJsonAsyncClientBuilder tokenProvider(SdkTokenProvider tokenProvider) {
         clientConfiguration.option(AwsClientOption.TOKEN_PROVIDER, tokenProvider);
         return this;
@@ -21,8 +28,6 @@ final class DefaultJsonAsyncClientBuilder extends DefaultJsonBaseClientBuilder<J
 
     @Override
     protected final JsonAsyncClient buildClient() {
-        SdkClientConfiguration clientConfiguration = super.asyncClientConfiguration();
-        this.validateClientOptions(clientConfiguration);
-        return new DefaultJsonAsyncClient(clientConfiguration);
+        return new DefaultJsonAsyncClient(super.asyncClientConfiguration());
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthS
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
@@ -76,5 +77,12 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
 
     private Signer defaultTokenSigner() {
         return BearerTokenSigner.create();
+    }
+
+    protected static void validateClientOptions(SdkClientConfiguration c) {
+        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
+                         "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
+        Validate.notNull(c.option(AwsClientOption.TOKEN_PROVIDER),
+                         "The 'overrideConfiguration.advancedOption[TOKEN_PROVIDER]' must be configured in the client builder.");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-class.java
@@ -15,8 +15,11 @@ import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.signer.Signer;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
+import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthSchemeInterceptor;
+import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.awssdk.utils.Validate;
 
 /**
  * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
@@ -36,7 +39,8 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
 
     @Override
     protected final SdkClientConfiguration mergeServiceDefaults(SdkClientConfiguration config) {
-        return config.merge(c -> c.option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
+        return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
+                                  .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
                                   .option(AwsClientOption.TOKEN_PROVIDER, defaultTokenProvider())
                                   .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
     }
@@ -44,6 +48,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     @Override
     protected final SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
         List<ExecutionInterceptor> endpointInterceptors = new ArrayList<>();
+        endpointInterceptors.add(new JsonResolveEndpointInterceptor());
+        endpointInterceptors.add(new JsonEndpointAuthSchemeInterceptor());
+        endpointInterceptors.add(new JsonRequestSetEndpointInterceptor());
         ClasspathInterceptorChainFactory interceptorFactory = new ClasspathInterceptorChainFactory();
         List<ExecutionInterceptor> interceptors = interceptorFactory
             .getInterceptors("software/amazon/awssdk/services/json/execution.interceptors");
@@ -59,18 +66,15 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
         return "json-service";
     }
 
+    private JsonEndpointProvider defaultEndpointProvider() {
+        return JsonEndpointProvider.defaultProvider();
+    }
+
     private SdkTokenProvider defaultTokenProvider() {
         return DefaultAwsTokenProvider.create();
     }
 
     private Signer defaultTokenSigner() {
         return BearerTokenSigner.create();
-    }
-
-    protected static void validateClientOptions(SdkClientConfiguration c) {
-        Validate.notNull(c.option(SdkAdvancedClientOption.TOKEN_SIGNER),
-                         "The 'overrideConfiguration.advancedOption[TOKEN_SIGNER]' must be configured in the client builder.");
-        Validate.notNull(c.option(AwsClientOption.TOKEN_PROVIDER),
-                         "The 'overrideConfiguration.advancedOption[TOKEN_PROVIDER]' must be configured in the client builder.");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-bearer-auth-client-builder-interface.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.json;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
  * This includes configuration specific to Json Service that is supported by both {@link JsonClientBuilder} and
@@ -10,6 +11,12 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
  */
 @Generated("software.amazon.awssdk:codegen")
 public interface JsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C>, C> extends AwsClientBuilder<B, C> {
+    /**
+     * Set the {@link JsonEndpointProvider} implementation that will be used by the client to determine the endpoint for
+     * each request. This is optional; if none is provided a default implementation will be used the SDK.
+     */
+    B endpointProvider(JsonEndpointProvider endpointProvider);
+
     /**
      * Set the token provider to use for bearer token authorization. This is optional, if none is provided, the SDK will
      * use {@link software.amazon.awssdk.auth.token.credentials.aws.DefaultAwsTokenProvider}.

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-class.java
@@ -19,6 +19,10 @@ import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.services.json.endpoints.JsonClientContextParams;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
+import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthSchemeInterceptor;
+import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
@@ -41,7 +45,8 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
 
     @Override
     protected final SdkClientConfiguration mergeServiceDefaults(SdkClientConfiguration config) {
-        return config.merge(c -> c.option(SdkAdvancedClientOption.SIGNER, defaultSigner())
+        return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
+                                  .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
                                   .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
                                   .option(SdkClientOption.SERVICE_CONFIGURATION, ServiceConfiguration.builder().build())
                                   .option(AwsClientOption.TOKEN_PROVIDER, defaultTokenProvider())
@@ -51,6 +56,9 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     @Override
     protected final SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
         List<ExecutionInterceptor> endpointInterceptors = new ArrayList<>();
+        endpointInterceptors.add(new JsonResolveEndpointInterceptor());
+        endpointInterceptors.add(new JsonEndpointAuthSchemeInterceptor());
+        endpointInterceptors.add(new JsonRequestSetEndpointInterceptor());
         ClasspathInterceptorChainFactory interceptorFactory = new ClasspathInterceptorChainFactory();
         List<ExecutionInterceptor> interceptors = interceptorFactory
             .getInterceptors("software/amazon/awssdk/services/json/execution.interceptors");
@@ -127,6 +135,10 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
     @Override
     protected final String signingName() {
         return "json-service";
+    }
+
+    private JsonEndpointProvider defaultEndpointProvider() {
+        return JsonEndpointProvider.defaultProvider();
     }
 
     public B serviceConfiguration(ServiceConfiguration serviceConfiguration) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-interface.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-interface.java
@@ -4,6 +4,7 @@ import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
  * This includes configuration specific to Json Service that is supported by both {@link JsonClientBuilder} and
@@ -16,6 +17,12 @@ public interface JsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C>, C>
     default B serviceConfiguration(Consumer<ServiceConfiguration.Builder> serviceConfiguration) {
         return serviceConfiguration(ServiceConfiguration.builder().applyMutation(serviceConfiguration).build());
     }
+
+    /**
+     * Set the {@link JsonEndpointProvider} implementation that will be used by the client to determine the endpoint for
+     * each request. This is optional; if none is provided a default implementation will be used the SDK.
+     */
+    B endpointProvider(JsonEndpointProvider endpointProvider);
 
     /**
      * Set the token provider to use for bearer token authorization. This is optional, if none is provided, the SDK will

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointAuthS
 import software.amazon.awssdk.services.json.endpoints.internal.JsonRequestSetEndpointInterceptor;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * Internal base class for {@link DefaultJsonClientBuilder} and {@link DefaultJsonAsyncClientBuilder}.
@@ -77,5 +78,10 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
 
     private JsonEndpointProvider defaultEndpointProvider() {
         return JsonEndpointProvider.defaultProvider();
+    }
+
+    protected static void validateClientOptions(SdkClientConfiguration c) {
+        Validate.notNull(c.option(SdkAdvancedClientOption.SIGNER),
+                         "The 'overrideConfiguration.advancedOption[SIGNER]' must be configured in the client builder.");
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-query-client-builder-class.java
@@ -18,6 +18,11 @@ import software.amazon.awssdk.core.interceptor.ClasspathInterceptorChainFactory;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.protocols.query.interceptor.QueryParametersToBodyInterceptor;
+import software.amazon.awssdk.services.query.endpoints.QueryClientContextParams;
+import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
+import software.amazon.awssdk.services.query.endpoints.internal.QueryEndpointAuthSchemeInterceptor;
+import software.amazon.awssdk.services.query.endpoints.internal.QueryRequestSetEndpointInterceptor;
+import software.amazon.awssdk.services.query.endpoints.internal.QueryResolveEndpointInterceptor;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Validate;
 
@@ -39,7 +44,8 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
 
     @Override
     protected final SdkClientConfiguration mergeServiceDefaults(SdkClientConfiguration config) {
-        return config.merge(c -> c.option(SdkAdvancedClientOption.SIGNER, defaultSigner())
+        return config.merge(c -> c.option(SdkClientOption.ENDPOINT_PROVIDER, defaultEndpointProvider())
+                                  .option(SdkAdvancedClientOption.SIGNER, defaultSigner())
                                   .option(SdkClientOption.CRC32_FROM_COMPRESSED_DATA_ENABLED, false)
                                   .option(AwsClientOption.TOKEN_PROVIDER, defaultTokenProvider())
                                   .option(SdkAdvancedClientOption.TOKEN_SIGNER, defaultTokenSigner()));
@@ -48,6 +54,9 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
     @Override
     protected final SdkClientConfiguration finalizeServiceConfiguration(SdkClientConfiguration config) {
         List<ExecutionInterceptor> endpointInterceptors = new ArrayList<>();
+        endpointInterceptors.add(new QueryResolveEndpointInterceptor());
+        endpointInterceptors.add(new QueryEndpointAuthSchemeInterceptor());
+        endpointInterceptors.add(new QueryRequestSetEndpointInterceptor());
         ClasspathInterceptorChainFactory interceptorFactory = new ClasspathInterceptorChainFactory();
         List<ExecutionInterceptor> interceptors = interceptorFactory
             .getInterceptors("software/amazon/awssdk/services/query/execution.interceptors");
@@ -68,6 +77,20 @@ abstract class DefaultQueryBaseClientBuilder<B extends QueryBaseClientBuilder<B,
     @Override
     protected final String signingName() {
         return "query-service";
+    }
+
+    private QueryEndpointProvider defaultEndpointProvider() {
+        return QueryEndpointProvider.defaultProvider();
+    }
+
+    public B booleanContextParam(Boolean booleanContextParam) {
+        clientContextParams.put(QueryClientContextParams.BOOLEAN_CONTEXT_PARAM, booleanContextParam);
+        return thisBuilder();
+    }
+
+    public B stringContextParam(String stringContextParam) {
+        clientContextParams.put(QueryClientContextParams.STRING_CONTEXT_PARAM, stringContextParam);
+        return thisBuilder();
     }
 
     private SdkTokenProvider defaultTokenProvider() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
@@ -4,7 +4,8 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
-import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
+import software.amazon.awssdk.core.client.config.SdkClientOption;
+import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
 /**
  * Internal implementation of {@link JsonClientBuilder}.
@@ -14,6 +15,12 @@ import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonClientBuilder, JsonClient> implements
                                                                                                          JsonClientBuilder {
     @Override
+    public DefaultJsonClientBuilder endpointProvider(JsonEndpointProvider endpointProvider) {
+        clientConfiguration.option(SdkClientOption.ENDPOINT_PROVIDER, endpointProvider);
+        return this;
+    }
+
+    @Override
     public DefaultJsonClientBuilder tokenProvider(SdkTokenProvider tokenProvider) {
         clientConfiguration.option(AwsClientOption.TOKEN_PROVIDER, tokenProvider);
         return this;
@@ -21,8 +28,6 @@ final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonCl
 
     @Override
     protected final JsonClient buildClient() {
-        SdkClientConfiguration clientConfiguration = super.syncClientConfiguration();
-        this.validateClientOptions(clientConfiguration);
-        return new DefaultJsonClient(clientConfiguration);
+        return new DefaultJsonClient(super.syncClientConfiguration());
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-sync-client-builder-class.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
+import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 
@@ -28,6 +29,8 @@ final class DefaultJsonClientBuilder extends DefaultJsonBaseClientBuilder<JsonCl
 
     @Override
     protected final JsonClient buildClient() {
-        return new DefaultJsonClient(super.syncClientConfiguration());
+        SdkClientConfiguration clientConfiguration = super.syncClientConfiguration();
+        this.validateClientOptions(clientConfiguration);
+        return new DefaultJsonClient(clientConfiguration);
     }
 }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-resolve-interceptor.java
@@ -31,10 +31,12 @@ public final class QueryResolveEndpointInterceptor implements ExecutionIntercept
             .getAttribute(SdkInternalExecutionAttribute.ENDPOINT_PROVIDER);
         try {
             Endpoint result = provider.resolveEndpoint(ruleParams(context, executionAttributes)).join();
-            Optional<String> hostPrefix = hostPrefix(executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME),
-                                                     context.request());
-            if (hostPrefix.isPresent() && !AwsEndpointProviderUtils.disableHostPrefixInjection(executionAttributes)) {
-                result = AwsEndpointProviderUtils.addHostPrefix(result, hostPrefix.get());
+            if (!AwsEndpointProviderUtils.disableHostPrefixInjection(executionAttributes)) {
+                Optional<String> hostPrefix = hostPrefix(executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME),
+                                                         context.request());
+                if (hostPrefix.isPresent()) {
+                    result = AwsEndpointProviderUtils.addHostPrefix(result, hostPrefix.get());
+                }
             }
             executionAttributes.putAttribute(SdkInternalExecutionAttribute.RESOLVED_ENDPOINT, result);
             return context.request();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
@@ -54,7 +54,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 builder.region(Region.of("us-east-1"));
                 APostOperationRequest request = APostOperationRequest.builder().build();
                 builder.build().aPostOperation(request);
-            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()),
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://foo-myservice.aws")).build()).build()),
             new SyncTestCase("test case 2", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
@@ -64,7 +64,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 builder.stringContextParam("this is a test");
                 APostOperationRequest request = APostOperationRequest.builder().build();
                 builder.build().aPostOperation(request);
-            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()),
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://foo-myservice.aws")).build()).build()),
             new SyncTestCase("test case 3", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
@@ -110,7 +110,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 builder.region(Region.of("us-east-1"));
                 APostOperationRequest request = APostOperationRequest.builder().build();
                 return builder.build().aPostOperation(request);
-            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()),
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://foo-myservice.aws")).build()).build()),
             new AsyncTestCase("test case 2", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
@@ -120,7 +120,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
                 builder.stringContextParam("this is a test");
                 APostOperationRequest request = APostOperationRequest.builder().build();
                 return builder.build().aPostOperation(request);
-            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://myservice.aws")).build()).build()),
+            }, Expect.builder().endpoint(Endpoint.builder().url(URI.create("https://foo-myservice.aws")).build()).build()),
             new AsyncTestCase("test case 3", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-rules-test-class.java
@@ -50,6 +50,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new SyncTestCase("test case 1", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getSyncHttpClient());
                 builder.region(Region.of("us-east-1"));
                 APostOperationRequest request = APostOperationRequest.builder().build();
@@ -58,6 +59,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new SyncTestCase("test case 2", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getSyncHttpClient());
                 builder.region(Region.of("us-east-1"));
                 builder.booleanContextParam(true);
@@ -68,6 +70,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new SyncTestCase("test case 3", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getSyncHttpClient());
                 builder.region(Region.of("us-east-1"));
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
@@ -77,6 +80,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new SyncTestCase("test case 4", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getSyncHttpClient());
                 builder.region(Region.of("us-east-6"));
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
@@ -87,6 +91,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new SyncTestCase("For region us-iso-west-1 with FIPS enabled and DualStack enabled", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getSyncHttpClient());
                 APostOperationRequest request = APostOperationRequest.builder().build();
                 builder.build().aPostOperation(request);
@@ -94,6 +99,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new SyncTestCase("Has complex operation input", () -> {
                 QueryClientBuilder builder = QueryClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getSyncHttpClient());
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
                                                                                            .nestedMember(ChecksumStructure.builder().checksumMode("foo").build()).build();
@@ -106,6 +112,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new AsyncTestCase("test case 1", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getAsyncHttpClient());
                 builder.region(Region.of("us-east-1"));
                 APostOperationRequest request = APostOperationRequest.builder().build();
@@ -114,6 +121,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new AsyncTestCase("test case 2", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getAsyncHttpClient());
                 builder.region(Region.of("us-east-1"));
                 builder.booleanContextParam(true);
@@ -124,6 +132,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new AsyncTestCase("test case 3", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getAsyncHttpClient());
                 builder.region(Region.of("us-east-1"));
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
@@ -133,6 +142,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new AsyncTestCase("test case 4", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getAsyncHttpClient());
                 builder.region(Region.of("us-east-6"));
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
@@ -143,6 +153,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new AsyncTestCase("For region us-iso-west-1 with FIPS enabled and DualStack enabled", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getAsyncHttpClient());
                 APostOperationRequest request = APostOperationRequest.builder().build();
                 return builder.build().aPostOperation(request);
@@ -150,6 +161,7 @@ public class QueryClientEndpointTests extends BaseRuleSetClientTest {
             new AsyncTestCase("Has complex operation input", () -> {
                 QueryAsyncClientBuilder builder = QueryAsyncClient.builder();
                 builder.credentialsProvider(BaseRuleSetClientTest.CREDENTIALS_PROVIDER);
+                builder.tokenProvider(BaseRuleSetClientTest.TOKEN_PROVIDER);
                 builder.httpClient(getAsyncHttpClient());
                 OperationWithContextParamRequest request = OperationWithContextParamRequest.builder()
                                                                                            .nestedMember(ChecksumStructure.builder().checksumMode("foo").build()).build();

--- a/core/endpoints-spi/pom.xml
+++ b/core/endpoints-spi/pom.xml
@@ -48,5 +48,20 @@
             <artifactId>annotations</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/endpoints-spi/src/main/java/software/amazon/awssdk/endpoints/Endpoint.java
+++ b/core/endpoints-spi/src/main/java/software/amazon/awssdk/endpoints/Endpoint.java
@@ -46,9 +46,41 @@ public final class Endpoint {
         return headers;
     }
 
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
     @SuppressWarnings("unchecked")
     public <T> T attribute(EndpointAttributeKey<T> key) {
         return (T) attributes.get(key);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Endpoint endpoint = (Endpoint) o;
+
+        if (url != null ? !url.equals(endpoint.url) : endpoint.url != null) {
+            return false;
+        }
+        if (headers != null ? !headers.equals(endpoint.headers) : endpoint.headers != null) {
+            return false;
+        }
+        return attributes != null ? attributes.equals(endpoint.attributes) : endpoint.attributes == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + (headers != null ? headers.hashCode() : 0);
+        result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
+        return result;
     }
 
     public static Builder builder() {
@@ -69,6 +101,19 @@ public final class Endpoint {
         private URI url;
         private final Map<String, List<String>> headers = new HashMap<>();
         private final Map<EndpointAttributeKey<?>, Object> attributes = new HashMap<>();
+
+        private BuilderImpl() {
+        }
+
+        private BuilderImpl(Endpoint e) {
+            this.url = e.url;
+            if (e.headers != null) {
+                e.headers.forEach((n, v) -> {
+                    this.headers.put(n, new ArrayList<>(v));
+                });
+            }
+            this.attributes.putAll(e.attributes);
+        }
 
         @Override
         public Builder url(URI url) {

--- a/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointTest.java
+++ b/core/endpoints-spi/src/test/java/software/amazon/awssdk/endpoints/EndpointTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class EndpointTest {
+    private static final EndpointAttributeKey<String> TEST_STRING_ATTR =
+        new EndpointAttributeKey<>("StringAttr", String.class);
+
+    @Test
+    public void testEqualsHashCode() {
+        EqualsVerifier.forClass(Endpoint.class)
+            .verify();
+    }
+
+    @Test
+    public void build_maximal() {
+        Endpoint endpoint = Endpoint.builder()
+                                    .url(URI.create("https://myservice.aws"))
+                                    .putHeader("foo", "bar")
+                                    .putHeader("foo", "baz")
+                                    .putAttribute(TEST_STRING_ATTR, "baz")
+                                    .build();
+
+        Map<String, List<String>> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("foo", Arrays.asList("bar", "baz"));
+
+        assertThat(endpoint.url()).isEqualTo(URI.create("https://myservice.aws"));
+        assertThat(endpoint.headers()).isEqualTo(expectedHeaders);
+        assertThat(endpoint.attribute(TEST_STRING_ATTR)).isEqualTo("baz");
+    }
+
+    @Test
+    public void toBuilder_unmodified_equalToOriginal() {
+        Endpoint original = Endpoint.builder()
+            .url(URI.create("https://myservice.aws"))
+            .putHeader("foo", "bar")
+            .putAttribute(TEST_STRING_ATTR, "baz")
+            .build();
+
+        assertThat(original.toBuilder().build()).isEqualTo(original);
+    }
+
+    @Test
+    public void toBuilder_headersModified_notReflectedInOriginal() {
+        Endpoint original = Endpoint.builder()
+                                    .putHeader("foo", "bar")
+                                    .build();
+
+        original.toBuilder()
+            .putHeader("foo", "baz")
+            .build();
+
+        assertThat(original.headers().get("foo")).containsExactly("bar");
+    }
+
+    @Test
+    public void toBuilder_attrsModified_notReflectedInOriginal() {
+        Endpoint original = Endpoint.builder()
+                                    .putAttribute(TEST_STRING_ATTR, "foo")
+                                    .build();
+
+        original.toBuilder()
+                .putAttribute(TEST_STRING_ATTR, "bar")
+                .build();
+
+        assertThat(original.attribute(TEST_STRING_ATTR)).isEqualTo("foo");
+    }
+}

--- a/services/eventbridge/pom.xml
+++ b/services/eventbridge/pom.xml
@@ -56,16 +56,6 @@
             <artifactId>aws-json-protocol</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>json-utils</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>endpoints-spi</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/services/eventbridge/src/main/resources/codegen-resources/customization.config
+++ b/services/eventbridge/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
 		"Invalid EndpointId (empty)": "Need operationInputs for EndpointId param",
 		"Valid endpointId with fips disabled and dualstack true": "Need operationInputs for EndpointId param",
 		"Valid endpointId with custom sdk endpoint": "Need operationInputs for EndpointId param"
-	},
-    "useRuleBasedEndpoints": true
+	}
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -409,6 +409,16 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>json-utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>endpoints-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>apache-client</artifactId>
             <groupId>software.amazon.awssdk</groupId>
             <version>${awsjavasdk.version}</version>

--- a/services/s3/pom.xml
+++ b/services/s3/pom.xml
@@ -76,16 +76,6 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>json-utils</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>endpoints-spi</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
             <version>${awscrt.version}</version>

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -236,7 +236,6 @@
   },
   "delegateAsyncClientClass": true,
   "useGlobalEndpoint": true,
-  "useRuleBasedEndpoints": true,
   "interceptors": [
     "software.amazon.awssdk.services.s3.internal.handlers.PutObjectInterceptor",
     "software.amazon.awssdk.services.s3.internal.handlers.CreateBucketInterceptor",

--- a/services/s3control/pom.xml
+++ b/services/s3control/pom.xml
@@ -71,16 +71,6 @@
             <artifactId>profiles</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>json-utils</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>endpoints-spi</artifactId>
-            <version>${awsjavasdk.version}</version>
-        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <artifactId>commons-io</artifactId>

--- a/services/s3control/src/main/resources/codegen-resources/customization.config
+++ b/services/s3control/src/main/resources/codegen-resources/customization.config
@@ -54,7 +54,6 @@
         "Bucket ARN with region mismatch and UseArnRegion unset": "SDK defaults to useArnRegion = false",
         "Accesspoint ARN with region mismatch, UseArnRegion=false and custom endpoint": "Does not work for client tests because operationInputs needed (so an operation that doesn't required AccountId is used)"
     },
-    "useRuleBasedEndpoints": true,
     "interceptors": [
         "software.amazon.awssdk.services.s3control.internal.interceptors.ConfigureSignerInterceptor",
         "software.amazon.awssdk.services.s3control.internal.interceptors.PayloadSigningInterceptor"

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
@@ -1,4 +1,3 @@
 {
-    "skipEndpointTestGeneration": true,
-    "useRuleBasedEndpoints": true
+    "skipEndpointTestGeneration": true
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/service-2.json
@@ -23,6 +23,16 @@
     }
   },
   "operations":{
+    "OperationWithHostPrefix": {
+      "name": "OperationWithStaticContextParamA",
+      "http": {
+        "method": "POST",
+        "requestUri": "/"
+      },
+      "endpoint": {
+        "hostPrefix": "foo."
+      }
+    },
     "OperationWithStaticContextParamA": {
       "name": "OperationWithStaticContextParamA",
       "http": {

--- a/test/protocol-tests/pom.xml
+++ b/test/protocol-tests/pom.xml
@@ -108,6 +108,16 @@
             <artifactId>utils</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>json-utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>endpoints-spi</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>

--- a/test/ruleset-testing-core/src/main/java/software/amazon/awssdk/core/rules/testing/BaseRuleSetClientTest.java
+++ b/test/ruleset-testing-core/src/main/java/software/amazon/awssdk/core/rules/testing/BaseRuleSetClientTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Assumptions;
@@ -33,6 +35,9 @@ import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.token.credentials.SdkToken;
+import software.amazon.awssdk.auth.token.credentials.SdkTokenProvider;
+import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.core.rules.testing.model.Expect;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.http.HttpExecuteRequest;
@@ -45,6 +50,7 @@ import software.amazon.awssdk.utils.CompletableFutureUtils;
 public abstract class BaseRuleSetClientTest {
     protected static final AwsCredentialsProvider CREDENTIALS_PROVIDER =
         StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+    protected static final SdkTokenProvider TOKEN_PROVIDER = StaticTokenProvider.create(new TestSdkToken());
 
     private static SdkHttpClient syncHttpClient;
     private static SdkAsyncHttpClient asyncHttpClient;
@@ -121,5 +127,18 @@ public abstract class BaseRuleSetClientTest {
 
     protected static SdkAsyncHttpClient getAsyncHttpClient() {
         return asyncHttpClient;
+    }
+
+    private static class TestSdkToken implements SdkToken {
+
+        @Override
+        public String token() {
+            return "TOKEN";
+        }
+
+        @Override
+        public Optional<Instant> expirationTime() {
+            return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This changes fixes the previously incorrect handling of `hostPrefix` in services, causing requests for some services to have the wrong URL. This change also undoes the suppression of rules-based endpoint generation for all services apart from EventBridge, S3, and S3 Control, which was implemented in #3520 because of the previously mentioned `hostPrefix` issue.

## Modifications
 - Remove `useRuleBasedEndpoints` customization, enabling rules based endpoints for all services again.
 - Update endpoint interceptors to correctly resolve and add the `hostPrefix` if necessary
 - Update generated client tests to support `hostPrefix`

## Testing
 - New unit tests
 - Client endpoint tests updated to correctly handle cases where the client adds a `hostPrefix` to the requests. i.e. if the operation being called has a `hostPrefix`, the expected URL is updated to also include that `hostPrefix`.
 - Manual verification of some services that use `hostPrefix` such as `location` and `evidently`.
 - ~~Running~~ Integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
