### PR TITLE
Added AsyncRequestBody.forBlockingOutputStream

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-2c6b2b3.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-2c6b2b3.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "feature", 
+    "description": "Added AsyncRequestBody.forBlockingOutputStream, allowing streaming operation requests to be written to like an output stream."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
@@ -169,9 +169,9 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
      * complete.
      *
      * <p><b>Example Usage</b>
-     *
-     * <pre>
-     *     S3Client s3 = ...;
+     * <p>
+     * {@snippet :
+     *     S3AsyncClient s3 = S3AsyncClient.create(); // Use one client for your whole application!
      *
      *     byte[] dataToSend = "Hello".getBytes(StandardCharsets.UTF_8);
      *     long lengthOfDataToSend = dataToSend.length();
@@ -189,7 +189,7 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
      *
      *     // Wait for the service to respond.
      *     PutObjectResponse response = responseFuture.join();
-     * </pre>
+     * }
      */
     static BlockingOutputStreamAsyncRequestBody forBlockingOutputStream(Long contentLength) {
         return new BlockingOutputStreamAsyncRequestBody(contentLength);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.async;
 
 import java.io.File;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -158,6 +159,40 @@ public interface AsyncRequestBody extends SdkPublisher<ByteBuffer> {
      */
     static AsyncRequestBody fromByteBuffer(ByteBuffer byteBuffer) {
         return fromBytes(BinaryUtils.copyAllBytesFrom(byteBuffer));
+    }
+
+    /**
+     * Creates a {@link BlockingOutputStreamAsyncRequestBody} to use for writing to the downstream service as if it's an output
+     * stream. Retries are not supported for this request body.
+     *
+     * <p>The caller is responsible for calling {@link OutputStream#close()} on the {@link #outputStream()} when writing is
+     * complete.
+     *
+     * <p><b>Example Usage</b>
+     *
+     * <pre>
+     *     S3Client s3 = ...;
+     *
+     *     byte[] dataToSend = "Hello".getBytes(StandardCharsets.UTF_8);
+     *     long lengthOfDataToSend = dataToSend.length();
+     *
+     *     // Start the operation
+     *     BlockingInputStreamAsyncRequestBody body =
+     *         AsyncRequestBody.forBlockingOutputStream(lengthOfDataToSend);
+     *     CompletableFuture<PutObjectResponse> responseFuture =
+     *         s3.putObject(r -> r.bucket("bucketName").key("key"), body);
+     *
+     *     // Write the input stream to the running operation
+     *     try (CancellableOutputStream outputStream = body.outputStream()) {
+     *         outputStream.write(dataToSend);
+     *     }
+     *
+     *     // Wait for the service to respond.
+     *     PutObjectResponse response = responseFuture.join();
+     * </pre>
+     */
+    static BlockingOutputStreamAsyncRequestBody forBlockingOutputStream(Long contentLength) {
+        return new BlockingOutputStreamAsyncRequestBody(contentLength);
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingOutputStreamAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/BlockingOutputStreamAsyncRequestBody.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.util.NoopSubscription;
+import software.amazon.awssdk.utils.CancellableOutputStream;
+import software.amazon.awssdk.utils.async.OutputStreamPublisher;
+
+/**
+ * An implementation of {@link AsyncRequestBody} that allows performing a blocking write of an output stream to a downstream
+ * service.
+ *
+ * <p>The caller is responsible for calling {@link OutputStream#close()} on the {@link #outputStream()} when writing is
+ * complete.
+ *
+ * @see AsyncRequestBody#forBlockingOutputStream(Long)
+ */
+@SdkPublicApi
+public final class BlockingOutputStreamAsyncRequestBody implements AsyncRequestBody {
+    private final OutputStreamPublisher delegate = new OutputStreamPublisher();
+    private final CountDownLatch subscribedLatch = new CountDownLatch(1);
+    private final AtomicBoolean subscribeCalled = new AtomicBoolean(false);
+    private final Long contentLength;
+    private final Duration subscribeTimeout;
+
+    BlockingOutputStreamAsyncRequestBody(Long contentLength) {
+        this(contentLength, Duration.ofSeconds(10));
+    }
+
+    BlockingOutputStreamAsyncRequestBody(Long contentLength, Duration subscribeTimeout) {
+        this.contentLength = contentLength;
+        this.subscribeTimeout = subscribeTimeout;
+    }
+
+    /**
+     * Return an output stream to which blocking writes can be made to the downstream service.
+     *
+     * <p>This method will block the calling thread until the SDK is connected to the service. This means that this request body
+     * should usually be passed to the SDK before this method is called.
+     *
+     * <p>You can invoke {@link CancellableOutputStream#cancel()} to cancel any blocked write calls to the downstream service
+     * (and mark the stream as failed).
+     */
+    public CancellableOutputStream outputStream() {
+        waitForSubscriptionIfNeeded();
+        return delegate;
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.ofNullable(contentLength);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        if (subscribeCalled.compareAndSet(false, true)) {
+            delegate.subscribe(s);
+            subscribedLatch.countDown();
+        } else {
+            s.onSubscribe(new NoopSubscription(s));
+            s.onError(NonRetryableException.create("A retry was attempted, but AsyncRequestBody.forBlockingOutputStream does not "
+                                                   + "support retries."));
+        }
+    }
+
+    private void waitForSubscriptionIfNeeded() {
+        try {
+            long timeoutSeconds = subscribeTimeout.getSeconds();
+            if (!subscribedLatch.await(timeoutSeconds, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("The service request was not made within " + timeoutSeconds + " seconds of "
+                                                + "outputStream being invoked. Make sure to invoke the service request "
+                                                + "BEFORE invoking outputStream if your caller is single-threaded.");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for subscription.", e);
+        }
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingOutputStreamAsyncRequestBodyTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/async/BlockingOutputStreamAsyncRequestBodyTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.async;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult.END_OF_STREAM;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.utils.CancellableOutputStream;
+import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber;
+import software.amazon.awssdk.utils.async.StoringSubscriber;
+
+class BlockingOutputStreamAsyncRequestBodyTest {
+    @Test
+    public void outputStream_waitsForSubscription() throws IOException {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        try {
+            BlockingOutputStreamAsyncRequestBody requestBody =
+                AsyncRequestBody.forBlockingOutputStream(0L);
+            executor.schedule(() -> requestBody.subscribe(new StoringSubscriber<>(1)), 100, MILLISECONDS);
+            try (OutputStream stream = requestBody.outputStream()) {
+                stream.write('h');
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void outputStream_failsIfSubscriptionNeverComes()  {
+        BlockingOutputStreamAsyncRequestBody requestBody =
+            new BlockingOutputStreamAsyncRequestBody(0L, Duration.ofSeconds(1));
+        assertThatThrownBy(requestBody::outputStream).hasMessageContaining("The service request was not made");
+    }
+
+    @Test
+    public void outputStream_writesToSubscriber() throws IOException {
+        BlockingOutputStreamAsyncRequestBody requestBody =
+            AsyncRequestBody.forBlockingOutputStream(0L);
+        ByteBufferStoringSubscriber subscriber = new ByteBufferStoringSubscriber(4);
+        requestBody.subscribe(subscriber);
+
+        CancellableOutputStream outputStream = requestBody.outputStream();
+        outputStream.write(0);
+        outputStream.write(1);
+        outputStream.close();
+
+        ByteBuffer out = ByteBuffer.allocate(4);
+        assertThat(subscriber.transferTo(out)).isEqualTo(END_OF_STREAM);
+        out.flip();
+
+        assertThat(out.remaining()).isEqualTo(2);
+        assertThat(out.get()).isEqualTo((byte) 0);
+        assertThat(out.get()).isEqualTo((byte) 1);
+    }
+
+}

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncInOutStreamIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/AsyncInOutStreamIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.BlockingOutputStreamAsyncRequestBody;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.testutils.service.S3BucketUtils;
+
+/**
+ * Test InputStream and OutputStream operations on AsyncRequestBody and AsyncResponseTransformer against S3.
+ */
+public class AsyncInOutStreamIntegrationTest extends S3IntegrationTestBase {
+
+    private static final String BUCKET = S3BucketUtils.temporaryBucketName("async-in-out-stream");
+
+    /**
+     * Creates all the test resources for the tests.
+     */
+    @BeforeClass
+    public static void createResources() {
+        createBucket(BUCKET);
+    }
+
+    /**
+     * Releases all resources created in this test.
+     */
+    @AfterClass
+    public static void tearDown() {
+        deleteBucketAndAllContents(BUCKET);
+    }
+
+    @Test
+    public void largeFilePutGet() throws IOException {
+        long length = 4 * 1024 * 1024; // 4 MB
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(length);
+        CompletableFuture<?> response = s3Async.putObject(r -> r.bucket(BUCKET).key("foo"), body);
+
+        try (OutputStream os = body.outputStream()) {
+            for (int i = 0; i < length; i++) {
+                os.write(i % 255);
+            }
+        }
+
+        response.join();
+
+        try (ResponseInputStream<GetObjectResponse> is =
+                 s3Async.getObject(r -> r.bucket(BUCKET).key("foo"),
+                                   AsyncResponseTransformer.toBlockingInputStream())
+                        .join()) {
+
+            assertThat(is.response().contentLength()).isEqualTo(length);
+
+            for (int i = 0; i < length; i++) {
+                assertThat(is.read()).isEqualTo(i % 255);
+            }
+        }
+    }
+}

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BlockingAsyncRequestResponseBodyTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/BlockingAsyncRequestResponseBodyTest.java
@@ -18,21 +18,33 @@ package software.amazon.awssdk.services;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.allRequests;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.BlockingOutputStreamAsyncRequestBody;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationRequest;
+import software.amazon.awssdk.services.protocolrestjson.model.StreamingInputOperationResponse;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationRequest;
 import software.amazon.awssdk.services.protocolrestjson.model.StreamingOutputOperationResponse;
 
@@ -85,5 +97,109 @@ public class BlockingAsyncRequestResponseBodyTest {
                                             AsyncResponseTransformer.toBlockingInputStream());
         ResponseInputStream<StreamingOutputOperationResponse> responseStream = responseFuture.join();
         responseStream.close();
+    }
+
+    @Test
+    public void blockingOutputStreamWithoutExecutor_sendsRightValues() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(5L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+
+        try (OutputStream stream = body.outputStream()) {
+            stream.write("Hello".getBytes(StandardCharsets.UTF_8));
+        }
+        responseFuture.join();
+
+        List<LoggedRequest> requests = wireMock.findAll(allRequests());
+        assertThat(requests).singleElement()
+                            .extracting(LoggedRequest::getBody)
+                            .extracting(String::new)
+                            .isEqualTo("Hello");
+    }
+
+    @Test
+    public void blockingOutputStreamWithoutExecutor_canUnderUpload() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(4L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+
+        try (OutputStream stream = body.outputStream()) {
+            stream.write("Hello".getBytes(StandardCharsets.UTF_8));
+        }
+        responseFuture.join();
+
+        List<LoggedRequest> requests = wireMock.findAll(allRequests());
+        assertThat(requests).singleElement()
+                            .extracting(LoggedRequest::getBody)
+                            .extracting(String::new)
+                            .isEqualTo("Hell");
+    }
+
+    @Test
+    public void blockingOutputStreamWithoutExecutor_canUnderUploadOneByteAtATime() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(4L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+
+        try (OutputStream stream = body.outputStream()) {
+            stream.write('H');
+            stream.write('e');
+            stream.write('l');
+            stream.write('l');
+            stream.write('o');
+        }
+        responseFuture.join();
+
+        List<LoggedRequest> requests = wireMock.findAll(allRequests());
+        assertThat(requests).singleElement()
+                            .extracting(LoggedRequest::getBody)
+                            .extracting(String::new)
+                            .isEqualTo("Hell");
+    }
+
+    @Test
+    public void blockingOutputStreamWithoutExecutor_propagatesCancellations() {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody("{}")));
+
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(5L);
+        CompletableFuture<StreamingInputOperationResponse> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+        body.outputStream().cancel();
+        assertThatThrownBy(responseFuture::get).hasRootCauseInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    public void blockingOutputStreamWithoutExecutor_propagates400Failures() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(404).withBody("{}")));
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(5L);
+        CompletableFuture<?> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+
+        try (OutputStream stream = body.outputStream()) {
+            stream.write("Hello".getBytes(StandardCharsets.UTF_8));
+        }
+        assertThatThrownBy(responseFuture::join).hasCauseInstanceOf(SdkServiceException.class);
+    }
+
+    @Test
+    public void blockingOutputStreamWithoutExecutor_propagates500Failures() throws IOException {
+        wireMock.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(500).withBody("{}")));
+
+        BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(5L);
+        CompletableFuture<StreamingInputOperationResponse> responseFuture =
+            client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);
+
+        try (OutputStream stream = body.outputStream()) {
+            stream.write("Hello".getBytes(StandardCharsets.UTF_8));
+        }
+        assertThatThrownBy(responseFuture::get)
+            .hasCauseInstanceOf(SdkClientException.class)
+            .hasMessageContaining("AsyncRequestBody.forBlockingOutputStream does not support retries");
     }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/CancellableOutputStream.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CancellableOutputStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils;
+
+import java.io.OutputStream;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * An implementation of {@link OutputStream} to which writing can be {@link #cancel()}ed.
+ * <p>
+ * Cancelling tells the downstream receiver of the output that the stream will not be written to anymore, and that the
+ * data sent was incomplete. The stream must still be {@link #close()}d by the caller.
+ */
+@SdkPublicApi
+public abstract class CancellableOutputStream extends OutputStream {
+    /**
+     * Cancel writing to the stream. This is different than {@link #close()} in that it indicates the data written so
+     * far is truncated and incomplete. Callers must still invoke {@link #close()} even if the stream is
+     * cancelled.
+     */
+    public abstract void cancel();
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/OutputStreamPublisher.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/OutputStreamPublisher.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import static software.amazon.awssdk.utils.CompletableFutureUtils.joinInterruptibly;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.utils.CancellableOutputStream;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Adapts a {@link Publisher} to an {@link OutputStream}.
+ * <p>
+ * Writes to the stream will block until demand is available in the downstream subscriber.
+ */
+@SdkProtectedApi
+public final class OutputStreamPublisher extends CancellableOutputStream implements Publisher<ByteBuffer> {
+    private final SimplePublisher<ByteBuffer> delegate = new SimplePublisher<>();
+    private final AtomicBoolean done = new AtomicBoolean(false);
+
+    /**
+     * An in-memory buffer used to store "small" (single-byte) writes so that we're not fulfilling downstream demand using tiny
+     * one-byte buffers.
+     */
+    private ByteBuffer smallWriteBuffer;
+
+    @Override
+    public void write(int b) {
+        Validate.validState(!done.get(), "Output stream is cancelled or closed.");
+
+        if (smallWriteBuffer != null && !smallWriteBuffer.hasRemaining()) {
+            flush();
+        }
+
+        if (smallWriteBuffer == null) {
+            smallWriteBuffer = ByteBuffer.allocate(4 * 1024); // 4 KB
+        }
+
+        smallWriteBuffer.put((byte) b);
+    }
+
+    @Override
+    public void write(byte[] b) {
+        flush();
+        send(ByteBuffer.wrap(b));
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+        flush();
+        send(ByteBuffer.wrap(b, off, len));
+    }
+
+    @Override
+    public void flush() {
+        if (smallWriteBuffer != null && smallWriteBuffer.position() > 0) {
+            smallWriteBuffer.flip();
+            send(smallWriteBuffer);
+            smallWriteBuffer = null;
+        }
+    }
+
+    @Override
+    public void cancel() {
+        if (done.compareAndSet(false, true)) {
+            delegate.error(new CancellationException("Output stream has been cancelled."));
+        }
+    }
+
+    @Override
+    public void close() {
+        if (done.compareAndSet(false, true)) {
+            flush();
+
+            // We ignore cancel failure on completion, because as long as our onNext calls have succeeded, the
+            // subscriber got everything we wanted to send.
+            joinInterruptiblyIgnoringCancellation(delegate.complete());
+        }
+    }
+
+    private void send(ByteBuffer bytes) {
+        joinInterruptibly(delegate.send(bytes));
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        delegate.subscribe(s);
+    }
+
+    private void joinInterruptiblyIgnoringCancellation(CompletableFuture<Void> complete) {
+        try {
+            joinInterruptibly(complete);
+        } catch (CancellationException e) {
+            // Ignore
+        }
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/async/SimplePublisher.java
@@ -15,20 +15,17 @@
 
 package software.amazon.awssdk.utils.async;
 
-import static java.util.Arrays.asList;
 import static software.amazon.awssdk.utils.async.SimplePublisher.QueueEntry.Type.CANCEL;
 import static software.amazon.awssdk.utils.async.SimplePublisher.QueueEntry.Type.ON_COMPLETE;
 import static software.amazon.awssdk.utils.async.SimplePublisher.QueueEntry.Type.ON_ERROR;
 import static software.amazon.awssdk.utils.async.SimplePublisher.QueueEntry.Type.ON_NEXT;
 
 import java.util.Queue;
-import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -72,27 +69,19 @@ public final class SimplePublisher<T> implements Publisher<T> {
      * <p>All logic within this publisher is represented using events in this queue. This ensures proper ordering of events
      * processing and simplified reasoning about thread safety.
      */
-    private final Queue<QueueEntry<T>> eventQueue = new ConcurrentLinkedQueue<>();
+    private final Queue<QueueEntry<T>> standardPriorityQueue = new ConcurrentLinkedQueue<>();
+    private final Queue<QueueEntry<T>> highPriorityQueue = new ConcurrentLinkedQueue<>();
 
     /**
-     * When processing the {@link #eventQueue}, these are the entries that should be skipped (and failed). This is used to
-     * safely drain the queue when there are urgent events needing processing, like a {@link Subscription#cancel()}.
-     */
-    private final Set<QueueEntry.Type> entryTypesToFail = new CopyOnWriteArraySet<>();
-
-    /**
-     * Whether the {@link #eventQueue} is currently being processed. Only one thread may read events from the queue at a time.
+     * Whether the {@link #standardPriorityQueue} is currently being processed. Only one thread may read events from the
+     * queue at a time.
      */
     private final AtomicBoolean processingQueue = new AtomicBoolean(false);
 
     /**
-     * An exception that should be raised to any failed {@link #send(Object)}, {@link #complete()} or {@link #error(Throwable)}
-     * operations. This is used to stop accepting messages after the downstream subscription is cancelled or after the
-     * caller sends a {@code complete()} or {@code #error()}.
-     *
-     * <p>This is a supplier to avoid the cost of creating an exception in the successful code path.
+     * The failure message that should be sent to future events.
      */
-    private final AtomicReference<Supplier<RuntimeException>> rejectException = new AtomicReference<>();
+    private final FailureMessage failureMessage = new FailureMessage();
 
     /**
      * The subscriber provided via {@link #subscribe(Subscriber)}. This publisher only supports a single subscriber.
@@ -123,8 +112,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
         OnNextQueueEntry<T> entry = new OnNextQueueEntry<>(value);
         try {
             Validate.notNull(value, "Null cannot be written.");
-            validateRejectState();
-            eventQueue.add(entry);
+            standardPriorityQueue.add(entry);
             processEventQueue();
         } catch (RuntimeException t) {
             entry.resultFuture.completeExceptionally(t);
@@ -153,9 +141,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
         OnCompleteQueueEntry<T> entry = new OnCompleteQueueEntry<>();
 
         try {
-            validateRejectState();
-            setRejectExceptionOrThrow(() -> new IllegalStateException("complete() has been invoked"));
-            eventQueue.add(entry);
+            standardPriorityQueue.add(entry);
             processEventQueue();
         } catch (RuntimeException t) {
             entry.resultFuture.completeExceptionally(t);
@@ -185,9 +171,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
         OnErrorQueueEntry<T> entry = new OnErrorQueueEntry<>(error);
 
         try {
-            validateRejectState();
-            setRejectExceptionOrThrow(() -> new IllegalStateException("error() has been invoked"));
-            eventQueue.add(entry);
+            standardPriorityQueue.add(entry);
             processEventQueue();
         } catch (RuntimeException t) {
             entry.resultFuture.completeExceptionally(t);
@@ -235,7 +219,8 @@ public final class SimplePublisher<T> implements Publisher<T> {
 
             // Once releasing the processing-queue flag, we need to double-check that the queue still doesn't need to be
             // processed, because new messages might have come in since we decided to release the flag.
-        } while (shouldProcessQueueEntry(eventQueue.peek()));
+        } while (shouldProcessQueueEntry(standardPriorityQueue.peek()) ||
+                 shouldProcessQueueEntry(highPriorityQueue.peek()));
     }
 
     /**
@@ -246,16 +231,21 @@ public final class SimplePublisher<T> implements Publisher<T> {
      */
     private void doProcessQueue() {
         while (true) {
-            QueueEntry<T> entry = eventQueue.peek();
+            QueueEntry<T> entry = highPriorityQueue.peek();
+            Queue<?> sourceQueue = highPriorityQueue;
+
+            if (entry == null) {
+                entry = standardPriorityQueue.peek();
+                sourceQueue = standardPriorityQueue;
+            }
 
             if (!shouldProcessQueueEntry(entry)) {
                 // We're done processing entries.
                 return;
             }
 
-            if (entryTypesToFail.contains(entry.type())) {
-                // We're supposed to skip this entry type. Fail it and move on.
-                entry.resultFuture.completeExceptionally(rejectException.get().get());
+            if (failureMessage.isSet()) {
+                entry.resultFuture.completeExceptionally(failureMessage.get());
             } else {
                 switch (entry.type()) {
                     case ON_NEXT:
@@ -267,18 +257,22 @@ public final class SimplePublisher<T> implements Publisher<T> {
                         log.trace(() -> "Decreased demand to " + newDemand);
                         break;
                     case ON_COMPLETE:
-                        entryTypesToFail.addAll(asList(ON_NEXT, ON_COMPLETE, ON_ERROR));
+                        failureMessage.trySet(() -> new IllegalStateException("onComplete() was already invoked."));
+
                         log.trace(() -> "Calling onComplete()");
                         subscriber.onComplete();
                         break;
                     case ON_ERROR:
-                        OnErrorQueueEntry<T> onErrorEntry = (OnErrorQueueEntry<T>) entry;
 
-                        entryTypesToFail.addAll(asList(ON_NEXT, ON_COMPLETE, ON_ERROR));
+                        OnErrorQueueEntry<T> onErrorEntry = (OnErrorQueueEntry<T>) entry;
+                        failureMessage.trySet(() -> new IllegalStateException("onError() was already invoked.",
+                                                                             onErrorEntry.failure));
                         log.trace(() -> "Calling onError() with " + onErrorEntry.failure, onErrorEntry.failure);
                         subscriber.onError(onErrorEntry.failure);
                         break;
                     case CANCEL:
+                        failureMessage.trySet(() -> new CancellationException("subscription has been cancelled."));
+
                         subscriber = null; // Allow subscriber to be garbage collected after cancellation.
                         break;
                     default:
@@ -289,7 +283,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
                 entry.resultFuture.complete(null);
             }
 
-            eventQueue.remove();
+            sourceQueue.remove();
         }
     }
 
@@ -297,23 +291,22 @@ public final class SimplePublisher<T> implements Publisher<T> {
      * Return true if we should process the provided queue entry.
      */
     private boolean shouldProcessQueueEntry(QueueEntry<T> entry) {
-        if (subscriber == null) {
-            // We don't have a subscriber yet.
-            return false;
-        }
-
         if (entry == null) {
             // The queue is empty.
             return false;
         }
 
-        if (entry.type() != ON_NEXT) {
-            // This event isn't an on-next event, so we don't need subscriber demand in order to process it.
+        if (failureMessage.isSet()) {
             return true;
         }
 
-        if (entryTypesToFail.contains(ON_NEXT)) {
-            // This is an on-next call (decided above), but we're failing on-next calls. Go ahead and fail it.
+        if (subscriber == null) {
+            // We don't have a subscriber yet.
+            return false;
+        }
+
+        if (entry.type() != ON_NEXT) {
+            // This event isn't an on-next event, so we don't need subscriber demand in order to process it.
             return true;
         }
 
@@ -332,12 +325,11 @@ public final class SimplePublisher<T> implements Publisher<T> {
         try {
             // Create exception here instead of in supplier to preserve a more-useful stack trace.
             RuntimeException failure = new IllegalStateException("Encountered fatal error in publisher", cause);
-            rejectException.compareAndSet(null, () -> failure);
-            entryTypesToFail.addAll(asList(QueueEntry.Type.values()));
+            failureMessage.trySet(() -> failure);
             subscriber.onError(cause instanceof Error ? cause : failure);
 
             while (true) {
-                QueueEntry<T> entry = eventQueue.poll();
+                QueueEntry<T> entry = standardPriorityQueue.poll();
                 if (entry == null) {
                     break;
                 }
@@ -346,24 +338,6 @@ public final class SimplePublisher<T> implements Publisher<T> {
         } catch (Throwable t) {
             t.addSuppressed(cause);
             log.error(() -> "Failed while processing a failure. This could result in stuck futures.", t);
-        }
-    }
-
-    /**
-     * Ensure that {@link #rejectException} is null. If it is not, throw the exception.
-     */
-    private void validateRejectState() {
-        if (rejectException.get() != null) {
-            throw rejectException.get().get();
-        }
-    }
-
-    /**
-     * Set the {@link #rejectException}, if it is null. If it is not, throw the exception.
-     */
-    private void setRejectExceptionOrThrow(Supplier<RuntimeException> rejectedException) {
-        if (!rejectException.compareAndSet(null, rejectedException)) {
-            throw rejectException.get().get();
         }
     }
 
@@ -379,9 +353,7 @@ public final class SimplePublisher<T> implements Publisher<T> {
                 // Create exception here instead of in supplier to preserve a more-useful stack trace.
                 IllegalArgumentException failure = new IllegalArgumentException("A downstream publisher requested an invalid "
                                                                                 + "amount of data: " + n);
-                rejectException.compareAndSet(null, () -> failure);
-                eventQueue.add(new OnErrorQueueEntry<>(failure));
-                entryTypesToFail.addAll(asList(ON_NEXT, ON_COMPLETE));
+                highPriorityQueue.add(new OnErrorQueueEntry<>(failure));
                 processEventQueue();
             } else {
                 long newDemand = outstandingDemand.updateAndGet(current -> {
@@ -401,16 +373,39 @@ public final class SimplePublisher<T> implements Publisher<T> {
             log.trace(() -> "Received cancel()");
 
             // Create exception here instead of in supplier to preserve a more-useful stack trace.
-            IllegalStateException failure = new IllegalStateException("A downstream publisher has cancelled the subscription.");
-            rejectException.compareAndSet(null, () -> failure);
-            eventQueue.add(new CancelQueueEntry<>());
-            entryTypesToFail.addAll(asList(ON_NEXT, ON_COMPLETE, ON_ERROR));
+            highPriorityQueue.add(new CancelQueueEntry<>());
             processEventQueue();
         }
     }
 
     /**
-     * An entry in the {@link #eventQueue}.
+     * A lazily-initialized failure message for future events sent to this publisher after a terminal event has
+     * occurred.
+     */
+    private static final class FailureMessage {
+        private Supplier<Throwable> failureMessageSupplier;
+        private Throwable failureMessage;
+
+        private void trySet(Supplier<Throwable> supplier) {
+            if (failureMessageSupplier == null) {
+                failureMessageSupplier = supplier;
+            }
+        }
+
+        private boolean isSet() {
+            return failureMessageSupplier != null;
+        }
+
+        private Throwable get() {
+            if (failureMessage == null) {
+                failureMessage = failureMessageSupplier.get();
+            }
+            return failureMessage;
+        }
+    }
+
+    /**
+     * An entry in the {@link #standardPriorityQueue}.
      */
     abstract static class QueueEntry<T> {
         /**

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/OutputStreamPublisherTckTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/OutputStreamPublisherTckTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+public class OutputStreamPublisherTckTest extends PublisherVerification<ByteBuffer> {
+    private final ExecutorService executor =
+        Executors.newCachedThreadPool(new ThreadFactoryBuilder().daemonThreads(true).build());
+
+    public OutputStreamPublisherTckTest() {
+        super(new TestEnvironment());
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createPublisher(long elements) {
+        OutputStreamPublisher publisher = new OutputStreamPublisher();
+        executor.submit(() -> {
+            for (int i = 0; i < elements; i++) {
+                publisher.write(new byte[1]);
+            }
+            publisher.close();
+        });
+        return publisher;
+    }
+
+    @Override
+    public Publisher<ByteBuffer> createFailedPublisher() {
+        OutputStreamPublisher publisher = new OutputStreamPublisher();
+        executor.submit(publisher::cancel);
+        return publisher;
+    }
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/OutputStreamPublisherTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/OutputStreamPublisherTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferResult;
+
+public class OutputStreamPublisherTest {
+    private StoringSubscriber<ByteBuffer> storingSubscriber;
+    private ByteBufferStoringSubscriber byteStoringSubscriber;
+    private OutputStreamPublisher publisher;
+
+    @BeforeEach
+    public void setup() {
+        storingSubscriber = new StoringSubscriber<>(Integer.MAX_VALUE);
+        byteStoringSubscriber = new ByteBufferStoringSubscriber(Integer.MAX_VALUE);
+        publisher = new OutputStreamPublisher();
+    }
+
+    @Test
+    public void oneByteWritesAreBuffered() {
+        publisher.subscribe(storingSubscriber);
+        publisher.write(0);
+        assertThat(storingSubscriber.poll()).isNotPresent();
+    }
+
+    @Test
+    public void oneByteWritesAreFlushedEventually() {
+        publisher.subscribe(storingSubscriber);
+        for (int i = 0; i < 1024 * 1024; i++) {
+            publisher.write(0);
+        }
+        assertThat(storingSubscriber.poll()).hasValueSatisfying(e -> {
+            assertThat(e.value().get()).isEqualTo((byte) 0);
+        });
+    }
+
+    @Test
+    public void flushDrainsBufferedBytes() {
+        publisher.subscribe(storingSubscriber);
+        publisher.write(0);
+        publisher.flush();
+        assertThat(storingSubscriber.poll()).hasValueSatisfying(v -> {
+            assertThat(v.value().remaining()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    public void emptyFlushDoesNothing() {
+        publisher.subscribe(storingSubscriber);
+        publisher.flush();
+        assertThat(storingSubscriber.poll()).isNotPresent();
+    }
+
+    @Test
+    public void oneByteWritesAreSentInOrder() {
+        publisher.subscribe(storingSubscriber);
+        for (int i = 0; i < 256; i++) {
+            publisher.write(i);
+        }
+        publisher.flush();
+
+        assertThat(storingSubscriber.poll()).hasValueSatisfying(e -> {
+            assertThat(e.value().get()).isEqualTo((byte) 0);
+        });
+    }
+
+    @Test
+    @Timeout(30)
+    public void writesBeforeSubscribeBlockUntilSubscribe() throws InterruptedException, ExecutionException {
+        ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder().daemonThreads(true).build());
+        try {
+            Future<?> writes = executor.submit(() -> {
+                publisher.write(new byte[256]);
+                publisher.close();
+            });
+
+            Thread.sleep(200);
+
+            assertThat(storingSubscriber.poll()).isNotPresent();
+            assertThat(writes.isDone()).isFalse();
+            publisher.subscribe(storingSubscriber);
+            assertThat(storingSubscriber.poll()).isPresent();
+            writes.get();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void mixedWriteTypesAreSentInOrder() {
+        publisher.subscribe(byteStoringSubscriber);
+
+        AtomicInteger i = new AtomicInteger(0);
+        writeByte(i);
+        writeBytes(i);
+        writeOffsetBytes(i);
+
+        writeByte(i);
+        writeOffsetBytes(i);
+        writeBytes(i);
+
+        writeBytes(i);
+        writeByte(i);
+        writeOffsetBytes(i);
+
+        writeBytes(i);
+        writeOffsetBytes(i);
+        writeByte(i);
+
+        writeOffsetBytes(i);
+        writeByte(i);
+        writeBytes(i);
+
+        writeOffsetBytes(i);
+        writeByte(i);
+        writeBytes(i);
+
+        publisher.close();
+
+        ByteBuffer out = ByteBuffer.allocate(i.get() + 1);
+        assertThat(byteStoringSubscriber.blockingTransferTo(out)).isEqualTo(TransferResult.END_OF_STREAM);
+        out.flip();
+
+        for (int j = 0; j < i.get(); j++) {
+            assertThat(out.get()).isEqualTo((byte) j);
+        }
+    }
+
+    @Test
+    public void cancel_preventsSingleByteWrites() {
+        publisher.subscribe(byteStoringSubscriber);
+        publisher.cancel();
+
+        assertThatThrownBy(() -> publisher.write(1)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void cancel_preventsMultiByteWrites() {
+        publisher.subscribe(byteStoringSubscriber);
+        publisher.cancel();
+
+        assertThatThrownBy(() -> publisher.write(new byte[8])).hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void cancel_preventsOffsetByteWrites() {
+        publisher.subscribe(byteStoringSubscriber);
+        publisher.cancel();
+
+        assertThatThrownBy(() -> publisher.write(new byte[8], 0, 1)).hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void close_preventsSingleByteWrites() {
+        publisher.subscribe(byteStoringSubscriber);
+        publisher.close();
+
+        assertThatThrownBy(() -> publisher.write(1)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void close_preventsMultiByteWrites() {
+        publisher.subscribe(byteStoringSubscriber);
+        publisher.close();
+
+        assertThatThrownBy(() -> publisher.write(new byte[8])).hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void close_preventsOffsetByteWrites() {
+        publisher.subscribe(byteStoringSubscriber);
+        publisher.close();
+
+        assertThatThrownBy(() -> publisher.write(new byte[8], 0, 1)).hasRootCauseInstanceOf(IllegalStateException.class);
+    }
+
+
+    private void writeByte(AtomicInteger i) {
+        publisher.write(i.getAndIncrement());
+    }
+
+    private void writeBytes(AtomicInteger i) {
+        publisher.write(new byte[] { (byte) i.getAndIncrement(), (byte) i.getAndIncrement() });
+    }
+
+    private void writeOffsetBytes(AtomicInteger i) {
+        publisher.write(new byte[] {
+                            0,
+                            0,
+                            (byte) i.getAndIncrement(),
+                            (byte) i.getAndIncrement(),
+                            (byte) i.getAndIncrement()
+                        },
+                        2, 3);
+    }
+
+}

--- a/utils/src/test/java/software/amazon/awssdk/utils/async/SimplePublisherTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/async/SimplePublisherTest.java
@@ -79,6 +79,7 @@ public class SimplePublisherTest {
     @Test
     public void writeAfterCompleteFails() {
         SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        publisher.subscribe(new StoringSubscriber<>(1));
         publisher.complete();
         assertThat(publisher.send(5)).isCompletedExceptionally();
     }
@@ -86,6 +87,7 @@ public class SimplePublisherTest {
     @Test
     public void writeAfterErrorFails() {
         SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        publisher.subscribe(new StoringSubscriber<>(1));
         publisher.error(new Throwable());
         assertThat(publisher.send(5)).isCompletedExceptionally();
     }
@@ -93,6 +95,7 @@ public class SimplePublisherTest {
     @Test
     public void completeAfterCompleteFails() {
         SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        publisher.subscribe(new StoringSubscriber<>(1));
         publisher.complete();
         assertThat(publisher.complete()).isCompletedExceptionally();
     }
@@ -100,6 +103,7 @@ public class SimplePublisherTest {
     @Test
     public void completeAfterErrorFails() {
         SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        publisher.subscribe(new StoringSubscriber<>(1));
         publisher.error(new Throwable());
         assertThat(publisher.complete()).isCompletedExceptionally();
     }
@@ -107,6 +111,7 @@ public class SimplePublisherTest {
     @Test
     public void errorAfterCompleteFails() {
         SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        publisher.subscribe(new StoringSubscriber<>(1));
         publisher.complete();
         assertThat(publisher.error(new Throwable())).isCompletedExceptionally();
     }
@@ -114,6 +119,7 @@ public class SimplePublisherTest {
     @Test
     public void errorAfterErrorFails() {
         SimplePublisher<Integer> publisher = new SimplePublisher<>();
+        publisher.subscribe(new StoringSubscriber<>(1));
         publisher.error(new Throwable());
         assertThat(publisher.error(new Throwable())).isCompletedExceptionally();
     }


### PR DESCRIPTION
This allows streaming operation requests to be written to like an output stream.

Example usage:
```java
BlockingOutputStreamAsyncRequestBody body = AsyncRequestBody.forBlockingOutputStream(5L);
CompletableFuture<?> responseFuture =
    client.streamingInputOperation(StreamingInputOperationRequest.builder().build(), body);

try (OutputStream stream = body.outputStream()) { // TODO: Test writing too much data and too little data
    stream.write("Hello".getBytes(StandardCharsets.UTF_8));
}
responseFuture.join();
```

Other changes made to support this change:
1. Added `OutputStreamPublisher` to utils. This is a `Publisher<ByteBuffer>` that can be written to like it's an output stream. Writes will block when there is no available downstream demand.
1. Added `CancellableOutputStream` to utils. This is an output stream that can be cancelled. This is useful for cancelling the upload via the output stream.

The following changes appear in this PR as well as https://github.com/aws/aws-sdk-java-v2/pull/3563:
1. Updated `SimplePublisher` to return more useful and predictable error messages when invoked after `onComplete`, `onError` or `cancel` has been called.
1. Added `CompletableFutureUtils.joinInterruptibly`, which behaves equivalent to executing `join()`, but allows the calling thread to still respond to interrupts.
1. Added `CompletableFutureUtils.joinInterruptiblyIgnoringFailures`, which behaves equivalent to executing `join()`, but allows the calling thread to still respond to interrupts, and ignores exceptions that are thrown.