### PR TITLE
DefaultCredentialsProvider reload profile

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -26,8 +26,8 @@ import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 /**
  * AWS credentials provider chain that looks for credentials in this order:
  * <ol>
- *   <li>Java System Properties - <code>aws.accessKeyId</code> and <code>aws.secretAccessKey</code></li>
- *   <li>Environment Variables - <code>AWS_ACCESS_KEY_ID</code> and <code>AWS_SECRET_ACCESS_KEY</code></li>
+ *   <li>Java System Properties - {@code aws.accessKeyId} and {@code aws.secretAccessKey}</li>
+ *   <li>Environment Variables - {@code AWS_ACCESS_KEY_ID} and {@code AWS_SECRET_ACCESS_KEY}</li>
  *   <li>Web Identity Token credentials from system properties or environment variables</li>
  *   <li>Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI</li>
  *   <li>Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment
@@ -87,21 +87,21 @@ public final class DefaultCredentialsProvider
 
         return LazyAwsCredentialsProvider.create(() -> {
             AwsCredentialsProvider[] credentialsProviders = new AwsCredentialsProvider[] {
-                    SystemPropertyCredentialsProvider.create(),
-                    EnvironmentVariableCredentialsProvider.create(),
-                    WebIdentityTokenFileCredentialsProvider.create(),
-                    ProfileCredentialsProvider.builder()
-                                              .profileFile(builder.profileFile)
-                                              .profileName(builder.profileName)
-                                              .build(),
-                    ContainerCredentialsProvider.builder()
-                                                .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
-                                                .build(),
-                    InstanceProfileCredentialsProvider.builder()
-                                                      .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
-                                                      .profileFile(builder.profileFile)
-                                                      .profileName(builder.profileName)
-                                                      .build()
+                SystemPropertyCredentialsProvider.create(),
+                EnvironmentVariableCredentialsProvider.create(),
+                WebIdentityTokenFileCredentialsProvider.create(),
+                ProfileCredentialsProvider.builder()
+                                          .profileFile(builder.profileFile)
+                                          .profileName(builder.profileName)
+                    .build(),
+                ContainerCredentialsProvider.builder()
+                                            .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
+                    .build(),
+                InstanceProfileCredentialsProvider.builder()
+                                                  .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
+                                                  .profileFile(builder.profileFile)
+                                                  .profileName(builder.profileName)
+                    .build()
             };
 
             return AwsCredentialsProviderChain.builder()
@@ -198,6 +198,7 @@ public final class DefaultCredentialsProvider
         /**
          * Create a {@link DefaultCredentialsProvider} using the configuration defined in this builder.
          */
+        @Override
         public DefaultCredentialsProvider build() {
             return new DefaultCredentialsProvider(this);
         }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -95,15 +95,15 @@ public final class DefaultCredentialsProvider
                 ProfileCredentialsProvider.builder()
                                           .profileFile(builder.profileFileSupplier)
                                           .profileName(builder.profileName)
-                    .build(),
+                                          .build(),
                 ContainerCredentialsProvider.builder()
                                             .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
-                    .build(),
+                                            .build(),
                 InstanceProfileCredentialsProvider.builder()
                                                   .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
                                                   .profileFile(builder.profileFileSupplier)
                                                   .profileName(builder.profileName)
-                    .build()
+                                                  .build()
             };
 
             return AwsCredentialsProviderChain.builder()

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -292,6 +292,7 @@ public final class InstanceProfileCredentialsProvider
         /**
          * Build a {@link InstanceProfileCredentialsProvider} from the provided configuration.
          */
+        @Override
         InstanceProfileCredentialsProvider build();
     }
 

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProviderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.credentials;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSupplier;
+import software.amazon.awssdk.utils.StringInputStream;
+
+class DefaultCredentialsProviderTest {
+
+    @Test
+    void resolveCredentials_requestFallsIntoProfileCredentialsProviderWithProfileFile_returnsCredentials() {
+        DefaultCredentialsProvider provider = DefaultCredentialsProvider
+            .builder()
+            .profileFile(credentialFile("test", "access", "secret"))
+            .profileName("test")
+            .build();
+
+        assertThat(provider.resolveCredentials()).satisfies(awsCredentials -> {
+            assertThat(awsCredentials.accessKeyId()).isEqualTo("access");
+            assertThat(awsCredentials.secretAccessKey()).isEqualTo("secret");
+        });
+    }
+
+    @Test
+    void resolveCredentials_requestFallsIntoProfileCredentialsProviderWithProfileFileSupplier_returnsCredentials() {
+        List<ProfileFile> profileFileList = Arrays.asList(credentialFile("test", "access", "secret"),
+                                                          credentialFile("test", "modified", "update"));
+        ProfileFileSupplier profileFileSupplier = supply(profileFileList);
+
+        DefaultCredentialsProvider provider = DefaultCredentialsProvider
+            .builder()
+            .profileFile(profileFileSupplier)
+            .profileName("test")
+            .build();
+
+        assertThat(provider.resolveCredentials()).satisfies(awsCredentials -> {
+            assertThat(awsCredentials.accessKeyId()).isEqualTo("access");
+            assertThat(awsCredentials.secretAccessKey()).isEqualTo("secret");
+        });
+
+        assertThat(provider.resolveCredentials()).satisfies(awsCredentials -> {
+            assertThat(awsCredentials.accessKeyId()).isEqualTo("modified");
+            assertThat(awsCredentials.secretAccessKey()).isEqualTo("update");
+        });
+    }
+
+    private ProfileFile credentialFile(String credentialFile) {
+        return ProfileFile.builder()
+                          .content(new StringInputStream(credentialFile))
+                          .type(ProfileFile.Type.CREDENTIALS)
+                          .build();
+    }
+
+    private ProfileFile credentialFile(String name, String accessKeyId, String secretAccessKey) {
+        String contents = String.format("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n",
+                                        name, accessKeyId, secretAccessKey);
+        return credentialFile(contents);
+    }
+
+    private static ProfileFileSupplier supply(Iterable<ProfileFile> iterable) {
+        return iterable.iterator()::next;
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`DefaultCredentialsProvider`  creates a chain of providers. Allow the default provider to take in a `ProfileFileSupplier` to enable profile reloading functionality.

## Testing
Unit tests added.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
