### PR TITLE
Fixed crosslinking of operations.

### DIFF
--- a/scripts/doc_crosslinks/crosslink_redirect.html
+++ b/scripts/doc_crosslinks/crosslink_redirect.html
@@ -54,8 +54,14 @@
                 else
                 {
                     redirectServiceSuffixLink =  serviceFolderPath + serviceName + "/" + clientObjectName + ".html" ;
-                    if(typeName != null)
-                        redirectServiceSuffixLink  = redirectServiceSuffixLink + "#" + camelize(typeName) + "--";
+                    if(typeName != null) {
+                        methodName = camelize(typeName)
+                        requestObjectName = methodName.charAt(0).toUpperCase() + methodName.slice(1) + "Request"
+                        redirectServiceSuffixLink =
+                            redirectServiceSuffixLink +
+                            "#" + methodName +
+                            "(software.amazon.awssdk.services." + serviceName + ".model." + requestObjectName + ")";
+                    }
                     if(checkResourceExists( baseUri.replace(/crosslink_redirect.*/gi, redirectServiceSuffixLink) ))
                         redirectSuffixLink =  redirectServiceSuffixLink;
                 }


### PR DESCRIPTION
When we used Java 8 to generate javadocs, it generated method IDs without method parameters: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#createBucket--

Since moving to Java 17 for javadoc generation, it now requires the method parameter type in the ID: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#createBucket(software.amazon.awssdk.services.s3.model.CreateBucketRequest)

This change was tested manually.