### PR TITLE
Fixed an issue that could cause exception to be thrown from CombinedR…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-6f2699a.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-6f2699a.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fixed an issue that could cause exception to be thrown from `CombinedResponseAsyncHttpResponseHandler#onStream` when `onError` got invoked first"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/CombinedResponseAsyncHttpResponseHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/async/CombinedResponseAsyncHttpResponseHandler.java
@@ -75,6 +75,11 @@ public final class CombinedResponseAsyncHttpResponseHandler<OutputT>
         Validate.isTrue(headersFuture != null, "onStream() invoked without prepare().");
         Validate.isTrue(headersFuture.isDone(), "headersFuture is still not completed when onStream() is "
                                                 + "invoked.");
+
+        if (headersFuture.isCompletedExceptionally()) {
+            return;
+        }
+
         SdkHttpResponse sdkHttpResponse = headersFuture.join();
         if (sdkHttpResponse.isSuccessful()) {
             successResponseHandler.onStream(publisher);

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/async/CombinedResponseAsyncHttpResponseHandlerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/async/CombinedResponseAsyncHttpResponseHandlerTest.java
@@ -17,7 +17,10 @@ package software.amazon.awssdk.core.internal.http.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.reactivex.Flowable;
@@ -70,6 +73,18 @@ class CombinedResponseAsyncHttpResponseHandlerTest {
                                responseHandler.onStream(publisher()))
             .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("headersFuture is still not completed when onStream()");
 
+    }
+
+    @Test
+    void onStream_HeadersFutureCompleteSuccessfully_shouldNotThrowException() {
+        when(successResponseHandler.prepare()).thenReturn(CompletableFuture.completedFuture(null));
+
+        responseHandler.prepare();
+        responseHandler.onError(new RuntimeException("error"));
+        Flowable<ByteBuffer> publisher = publisher();
+        responseHandler.onStream(publisher);
+        verify(successResponseHandler, times(0)).onStream(publisher);
+        verify(errorResponseHandler, times(0)).onStream(publisher);
     }
 
     @Test


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context


When `CombinedResponseAsyncHttpResponseHandler#onError` gets invoked, `headersFuture` gets completed exceptionally. We currently wait for the future to complete in `CombinedResponseAsyncHttpResponseHandler#onStream`, so if `onError` gets invoked first, `CombinedResponseAsyncHttpResponseHandler#onStream` will throw exception from `headersFuture.join()`

## Modifications
Check if `headersFuture` completed exceptionally before calling `headersFuture.join()`.

## Testing
Added unit test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
