### PR TITLE
In CodeGenerator, default the resourceDirectory to the sourcesDirectory when one is not explicitly specified.

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/CodeGenerator.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/CodeGenerator.java
@@ -52,7 +52,8 @@ public class CodeGenerator {
         this.models = builder.models;
         this.sourcesDirectory = builder.sourcesDirectory;
         this.testsDirectory = builder.testsDirectory;
-        this.resourcesDirectory = builder.resourcesDirectory;
+        this.resourcesDirectory = builder.resourcesDirectory != null ? builder.resourcesDirectory
+                                                                     : builder.sourcesDirectory;
         this.fileNamePrefix = builder.fileNamePrefix;
     }
 


### PR DESCRIPTION
This fixes a backwards-incompatibility for customers we didn't know existed: those that use CodeGenerator directly.