### PR TITLE
Prefer Supplier<ProfileFile> over ProfileFileSupplier in APIs

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.auth.credentials;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.internal.LazyAwsCredentialsProvider;
 import software.amazon.awssdk.profiles.ProfileFile;
@@ -53,7 +54,7 @@ public final class DefaultCredentialsProvider
 
     private final LazyAwsCredentialsProvider providerChain;
 
-    private final ProfileFileSupplier profileFileSupplier;
+    private final Supplier<ProfileFile> profileFile;
 
     private final String profileName;
 
@@ -65,7 +66,7 @@ public final class DefaultCredentialsProvider
      * @see #builder()
      */
     private DefaultCredentialsProvider(Builder builder) {
-        this.profileFileSupplier = builder.profileFileSupplier;
+        this.profileFile = builder.profileFile;
         this.profileName = builder.profileName;
         this.reuseLastProviderEnabled = builder.reuseLastProviderEnabled;
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
@@ -93,7 +94,7 @@ public final class DefaultCredentialsProvider
                 EnvironmentVariableCredentialsProvider.create(),
                 WebIdentityTokenFileCredentialsProvider.create(),
                 ProfileCredentialsProvider.builder()
-                                          .profileFile(builder.profileFileSupplier)
+                                          .profileFile(builder.profileFile)
                                           .profileName(builder.profileName)
                                           .build(),
                 ContainerCredentialsProvider.builder()
@@ -101,7 +102,7 @@ public final class DefaultCredentialsProvider
                                             .build(),
                 InstanceProfileCredentialsProvider.builder()
                                                   .asyncCredentialUpdateEnabled(asyncCredentialUpdateEnabled)
-                                                  .profileFile(builder.profileFileSupplier)
+                                                  .profileFile(builder.profileFile)
                                                   .profileName(builder.profileName)
                                                   .build()
             };
@@ -146,7 +147,7 @@ public final class DefaultCredentialsProvider
      * Configuration that defines the {@link DefaultCredentialsProvider}'s behavior.
      */
     public static final class Builder implements CopyableBuilder<Builder, DefaultCredentialsProvider> {
-        private ProfileFileSupplier profileFileSupplier;
+        private Supplier<ProfileFile> profileFile;
         private String profileName;
         private Boolean reuseLastProviderEnabled = true;
         private Boolean asyncCredentialUpdateEnabled = false;
@@ -158,7 +159,7 @@ public final class DefaultCredentialsProvider
         }
 
         private Builder(DefaultCredentialsProvider credentialsProvider) {
-            this.profileFileSupplier = credentialsProvider.profileFileSupplier;
+            this.profileFile = credentialsProvider.profileFile;
             this.profileName = credentialsProvider.profileName;
             this.reuseLastProviderEnabled = credentialsProvider.reuseLastProviderEnabled;
             this.asyncCredentialUpdateEnabled = credentialsProvider.asyncCredentialUpdateEnabled;
@@ -170,8 +171,8 @@ public final class DefaultCredentialsProvider
                                        .orElse(null));
         }
 
-        public Builder profileFile(ProfileFileSupplier profileFileSupplier) {
-            this.profileFileSupplier = profileFileSupplier;
+        public Builder profileFile(Supplier<ProfileFile> profileFileSupplier) {
+            this.profileFile = profileFileSupplier;
             return this;
         }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/InstanceProfileCredentialsProvider.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.auth.credentials.internal.Ec2MetadataConfigProvider;
@@ -79,7 +80,7 @@ public final class InstanceProfileCredentialsProvider
 
     private final String asyncThreadName;
 
-    private final ProfileFileSupplier profileFileSupplier;
+    private final Supplier<ProfileFile> profileFile;
 
     private final String profileName;
 
@@ -91,13 +92,13 @@ public final class InstanceProfileCredentialsProvider
         this.endpoint = builder.endpoint;
         this.asyncCredentialUpdateEnabled = builder.asyncCredentialUpdateEnabled;
         this.asyncThreadName = builder.asyncThreadName;
-        this.profileFileSupplier = builder.profileFileSupplier;
+        this.profileFile = builder.profileFile;
         this.profileName = builder.profileName;
 
         this.httpCredentialsLoader = HttpCredentialsLoader.create();
         this.configProvider =
             Ec2MetadataConfigProvider.builder()
-                                     .profileFile(builder.profileFileSupplier)
+                                     .profileFile(builder.profileFile)
                                      .profileName(builder.profileName)
                                      .build();
 
@@ -282,7 +283,7 @@ public final class InstanceProfileCredentialsProvider
          *
          * <p>By default, {@link ProfileFile#defaultProfileFile()} is used.
          * 
-         * @see #profileFile(ProfileFileSupplier) 
+         * @see #profileFile(Supplier)
          */
         Builder profileFile(ProfileFile profileFile);
 
@@ -292,7 +293,7 @@ public final class InstanceProfileCredentialsProvider
          * @param profileFileSupplier Supplier interface for generating a ProfileFile instance.
          * @see #profileFile(ProfileFile)
          */
-        Builder profileFile(ProfileFileSupplier profileFileSupplier);
+        Builder profileFile(Supplier<ProfileFile> profileFileSupplier);
 
         /**
          * Configure the profile name used for loading IMDS-related configuration, like the endpoint mode (IPv4 vs IPv6).
@@ -314,7 +315,7 @@ public final class InstanceProfileCredentialsProvider
         private String endpoint;
         private Boolean asyncCredentialUpdateEnabled;
         private String asyncThreadName;
-        private ProfileFileSupplier profileFileSupplier;
+        private Supplier<ProfileFile> profileFile;
         private String profileName;
 
         private BuilderImpl() {
@@ -326,7 +327,7 @@ public final class InstanceProfileCredentialsProvider
             this.endpoint = provider.endpoint;
             this.asyncCredentialUpdateEnabled = provider.asyncCredentialUpdateEnabled;
             this.asyncThreadName = provider.asyncThreadName;
-            this.profileFileSupplier = provider.profileFileSupplier;
+            this.profileFile = provider.profileFile;
             this.profileName = provider.profileName;
         }
 
@@ -377,12 +378,12 @@ public final class InstanceProfileCredentialsProvider
         }
 
         @Override
-        public Builder profileFile(ProfileFileSupplier profileFileSupplier) {
-            this.profileFileSupplier = profileFileSupplier;
+        public Builder profileFile(Supplier<ProfileFile> profileFileSupplier) {
+            this.profileFile = profileFileSupplier;
             return this;
         }
 
-        public void setProfileFile(ProfileFileSupplier profileFileSupplier) {
+        public void setProfileFile(Supplier<ProfileFile> profileFileSupplier) {
             profileFile(profileFileSupplier);
         }
 


### PR DESCRIPTION
## Motivation and Context
In order to keep the APIs consistent, current public methods taking `ProfileFileSupplier` as an argument will be switched over to `Supplier<ProfileFile>`. The former class is a subclass of the latter, so this is not a breaking change.

## Testing
Only existing test cases.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
