### PR TITLE
Make crt dependency optional in transfer manager module

### DIFF
--- a/.changes/next-release/removal-S3TransferManager-2c2c795.json
+++ b/.changes/next-release/removal-S3TransferManager-2c2c795.json
@@ -1,0 +1,6 @@
+{
+    "type": "removal",
+    "category": "S3 Transfer Manager",
+    "contributor": "",
+    "description": "Make `aws-crt` an optional dependency in `s3-transfer-manager` module. Customers need to explicitly add `aws-crt` dependency if they want to use CRT-based Transfer Manager"
+}

--- a/services-custom/s3-transfer-manager/README.md
+++ b/services-custom/s3-transfer-manager/README.md
@@ -9,7 +9,7 @@ as well as pause the transfer for execution at a later time.
 
 ### Add a dependency for the S3 Transfer Manager 
 
-First, you need to include the dependency in your project.
+First, you need to include `s3-transfer-manager` and `aws-crt` in your project.
 
 ```xml
 <dependency>
@@ -17,10 +17,15 @@ First, you need to include the dependency in your project.
   <artifactId>s3-transfer-manager</artifactId>
   <version>${awsjavasdk.version}-PREVIEW</version>
 </dependency>
+<dependency>
+  <groupId>software.amazon.awssdk.crt</groupId>
+  <artifactId>aws-crt</artifactId>
+  <version>${awscrt.version}</version>
+</dependency>
 ```
 
-Note that you need to replace `${awsjavasdk.version}` with the latest
-SDK version.
+Note that you need to replace `${awsjavasdk.version}` and `${awscrt.version}` with the latest
+version.
 
 ### Instantiate the S3 Transfer Manager
 

--- a/services-custom/s3-transfer-manager/pom.xml
+++ b/services-custom/s3-transfer-manager/pom.xml
@@ -80,6 +80,8 @@
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
             <version>${awscrt.version}</version>
+            <!-- Only required for CRT-based TM -->
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/S3TransferManager.java
@@ -678,6 +678,11 @@ public interface S3TransferManager extends SdkAutoCloseable {
 
     /**
      * Create an {@code S3TransferManager} using the default values.
+     * <p>
+     * The type of {@link S3AsyncClient} used depends on if AWS Common Runtime (CRT) library
+     * {@code software.amazon.awssdk.crt:crt} is on the classpath. If CRT is available, a CRT-based S3 client will be created
+     * ({@link S3AsyncClient#crtCreate()}). Otherwise, a standard S3 client({@link S3AsyncClient#create()}) will be created. Note
+     * that only CRT-based S3 client supports parallel transfer for now, so it's recommended to add CRT as a dependency.
      */
     static S3TransferManager create() {
         return builder().build();

--- a/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerTest.java
+++ b/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/S3TransferManagerTest.java
@@ -58,9 +58,6 @@ class S3TransferManagerTest {
     private DownloadDirectoryHelper downloadDirectoryHelper;
     private TransferManagerConfiguration configuration;
 
-
-    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-
     @BeforeEach
     public void methodSetup() {
         mockS3Crt = mock(S3CrtAsyncClient.class);

--- a/test/s3-benchmarks/pom.xml
+++ b/test/s3-benchmarks/pom.xml
@@ -57,6 +57,11 @@
             <version>${awsjavasdk.version}-PREVIEW</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>${awscrt.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${sdk-v1.version}</version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Make crt dependency optional in transfer manager module so that once we have Java based TM, it'll be the default implementation. This means customers will need to explicitly add `aws-crt` dependency for now for parallel feature.

## Modifications
- Make crt dependency optional in transfer manager module
- Use Java based S3AsyncClient if CRT is not on the classpath in `S3TransferManager#create`

