### PR TITLE
Pin versions-maven-plugin version to 2.13.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
         <japicmp-maven-plugin.version>0.15.6</japicmp-maven-plugin.version>
+        <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
         <!-- Whenever we update maven-wrapper-plugin version, we need to run mvn wrapper:wrapper to update the Maven Wrapper files(mvnw, .maven and mvnw.cmd) -->
         <maven-wrapper-plugin.version>3.1.0</maven-wrapper-plugin.version>
 
@@ -434,6 +435,12 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${versions-maven-plugin.version}</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
2.14.0 has a bug (https://github.com/mojohaus/versions/issues/848) that broke us. We should be pinning all build tool versions, anyway.