### PR TITLE
S3 support classes take Supplier<ProfileFile>

### DIFF
--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -335,7 +335,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         /**
          * The supplier of profile file instances that should be consulted to determine the default value of
          * {@link #useArnRegionEnabled(Boolean)} or {@link #multiRegionEnabled(Boolean)}.
-         * This is not used, if those parameters are configured.
+         * This is not used, if those parameters are configured on the builder.
          *
          * <p>
          * By default, the {@link ProfileFile#defaultProfileFile()} is used.

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/S3Configuration.java
@@ -15,12 +15,15 @@
 
 package software.amazon.awssdk.services.s3;
 
+import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.ServiceConfiguration;
 import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
 import software.amazon.awssdk.services.s3.internal.FieldWithDefault;
 import software.amazon.awssdk.services.s3.internal.settingproviders.DisableMultiRegionProviderChain;
@@ -66,9 +69,9 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
     private final FieldWithDefault<Boolean> dualstackEnabled;
     private final FieldWithDefault<Boolean> checksumValidationEnabled;
     private final FieldWithDefault<Boolean> chunkedEncodingEnabled;
-    private final FieldWithDefault<Boolean> useArnRegionEnabled;
-    private final FieldWithDefault<Boolean> multiRegionEnabled;
-    private final FieldWithDefault<ProfileFile> profileFile;
+    private final Boolean useArnRegionEnabled;
+    private final Boolean multiRegionEnabled;
+    private final FieldWithDefault<Supplier<ProfileFile>> profileFile;
     private final FieldWithDefault<String> profileName;
 
     private S3Configuration(DefaultS3ServiceConfigurationBuilder builder) {
@@ -78,11 +81,11 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         this.checksumValidationEnabled =  FieldWithDefault.create(builder.checksumValidationEnabled,
                                                                  DEFAULT_CHECKSUM_VALIDATION_ENABLED);
         this.chunkedEncodingEnabled = FieldWithDefault.create(builder.chunkedEncodingEnabled, DEFAULT_CHUNKED_ENCODING_ENABLED);
-        this.profileFile = FieldWithDefault.createLazy(builder.profileFile, ProfileFile::defaultProfileFile);
+        this.profileFile = FieldWithDefault.create(builder.profileFile, ProfileFile::defaultProfileFile);
         this.profileName = FieldWithDefault.create(builder.profileName,
                                                    ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow());
-        this.useArnRegionEnabled = FieldWithDefault.createLazy(builder.useArnRegionEnabled, this::resolveUseArnRegionEnabled);
-        this.multiRegionEnabled = FieldWithDefault.createLazy(builder.multiRegionEnabled, this::resolveMultiRegionEnabled);
+        this.useArnRegionEnabled = builder.useArnRegionEnabled;
+        this.multiRegionEnabled = builder.multiRegionEnabled;
 
         if (accelerateModeEnabled() && pathStyleAccessEnabled()) {
             throw new IllegalArgumentException("Accelerate mode cannot be used with path style addressing");
@@ -189,7 +192,8 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
      * @return True if a different region in the ARN can be used.
      */
     public boolean useArnRegionEnabled() {
-        return useArnRegionEnabled.value();
+        return Optional.ofNullable(useArnRegionEnabled)
+                       .orElseGet(this::resolveUseArnRegionEnabled);
     }
 
     /**
@@ -198,19 +202,20 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
      * @return True if multi-region ARNs is enabled.
      */
     public boolean multiRegionEnabled() {
-        return multiRegionEnabled.value();
+        return Optional.ofNullable(multiRegionEnabled)
+                       .orElseGet(this::resolveMultiRegionEnabled);
     }
 
     @Override
     public Builder toBuilder() {
         return builder()
                 .dualstackEnabled(dualstackEnabled.valueOrNullIfDefault())
-                .multiRegionEnabled(multiRegionEnabled.valueOrNullIfDefault())
+                .multiRegionEnabled(multiRegionEnabled)
                 .accelerateModeEnabled(accelerateModeEnabled.valueOrNullIfDefault())
                 .pathStyleAccessEnabled(pathStyleAccessEnabled.valueOrNullIfDefault())
                 .checksumValidationEnabled(checksumValidationEnabled.valueOrNullIfDefault())
                 .chunkedEncodingEnabled(chunkedEncodingEnabled.valueOrNullIfDefault())
-                .useArnRegionEnabled(useArnRegionEnabled.valueOrNullIfDefault())
+                .useArnRegionEnabled(useArnRegionEnabled)
                 .profileFile(profileFile.valueOrNullIfDefault())
                 .profileName(profileName.valueOrNullIfDefault());
     }
@@ -325,6 +330,19 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
          */
         Builder profileFile(ProfileFile profileFile);
 
+        Supplier<ProfileFile> profileFileSupplier();
+
+        /**
+         * The supplier of profile file instances that should be consulted to determine the default value of
+         * {@link #useArnRegionEnabled(Boolean)} or {@link #multiRegionEnabled(Boolean)}.
+         * This is not used, if those parameters are configured.
+         *
+         * <p>
+         * By default, the {@link ProfileFile#defaultProfileFile()} is used.
+         * </p>
+         */
+        Builder profileFile(Supplier<ProfileFile> profileFile);
+
         String profileName();
 
         /**
@@ -347,7 +365,7 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
         private Boolean chunkedEncodingEnabled;
         private Boolean useArnRegionEnabled;
         private Boolean multiRegionEnabled;
-        private ProfileFile profileFile;
+        private Supplier<ProfileFile> profileFile;
         private String profileName;
 
         @Override
@@ -449,11 +467,25 @@ public final class S3Configuration implements ServiceConfiguration, ToCopyableBu
 
         @Override
         public ProfileFile profileFile() {
-            return profileFile;
+            return Optional.ofNullable(profileFile)
+                .map(Supplier::get)
+                .orElse(null);
         }
 
         @Override
         public Builder profileFile(ProfileFile profileFile) {
+            return profileFile(Optional.ofNullable(profileFile)
+                                       .map(ProfileFileSupplier::fixedProfileFile)
+                                       .orElse(null));
+        }
+
+        @Override
+        public Supplier<ProfileFile> profileFileSupplier() {
+            return profileFile;
+        }
+
+        @Override
+        public Builder profileFile(Supplier<ProfileFile> profileFile) {
             this.profileFile = profileFile;
             return this;
         }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/DisableMultiRegionProviderChain.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/DisableMultiRegionProviderChain.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.s3.internal.settingproviders;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
@@ -50,11 +51,17 @@ public final class DisableMultiRegionProviderChain implements DisableMultiRegion
      * </ol>
      */
     public static DisableMultiRegionProviderChain create() {
-        return create(ProfileFile.defaultProfileFile(),
+        return create(ProfileFile::defaultProfileFile,
                       ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow());
     }
 
     public static DisableMultiRegionProviderChain create(ProfileFile profileFile, String profileName) {
+        return new DisableMultiRegionProviderChain(Arrays.asList(
+            SystemsSettingsDisableMultiRegionProvider.create(),
+            ProfileDisableMultiRegionProvider.create(profileFile, profileName)));
+    }
+
+    public static DisableMultiRegionProviderChain create(Supplier<ProfileFile> profileFile, String profileName) {
         return new DisableMultiRegionProviderChain(Arrays.asList(
             SystemsSettingsDisableMultiRegionProvider.create(),
             ProfileDisableMultiRegionProvider.create(profileFile, profileName)));

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileDisableMultiRegionProvider.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileDisableMultiRegionProvider.java
@@ -49,6 +49,10 @@ public final class ProfileDisableMultiRegionProvider implements DisableMultiRegi
         return new ProfileDisableMultiRegionProvider(() -> profileFile, profileName);
     }
 
+    public static ProfileDisableMultiRegionProvider create(Supplier<ProfileFile> profileFile, String profileName) {
+        return new ProfileDisableMultiRegionProvider(profileFile, profileName);
+    }
+
     @Override
     public Optional<Boolean> resolve() {
         return profileFile.get()

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileUseArnRegionProvider.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileUseArnRegionProvider.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.utils.StringUtils;
 @SdkInternalApi
 public final class ProfileUseArnRegionProvider implements UseArnRegionProvider {
     /**
-     * Property name for specifying whether or not use arn region should be enabled.
+     * Property name for specifying whether or not to use arn region should be enabled.
      */
     private static final String AWS_USE_ARN_REGION = "s3_use_arn_region";
 
@@ -47,6 +47,10 @@ public final class ProfileUseArnRegionProvider implements UseArnRegionProvider {
 
     public static ProfileUseArnRegionProvider create(ProfileFile profileFile, String profileName) {
         return new ProfileUseArnRegionProvider(() -> profileFile, profileName);
+    }
+
+    public static ProfileUseArnRegionProvider create(Supplier<ProfileFile> profileFile, String profileName) {
+        return new ProfileUseArnRegionProvider(profileFile, profileName);
     }
 
     @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/UseArnRegionProviderChain.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/settingproviders/UseArnRegionProviderChain.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.services.s3.internal.settingproviders;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
@@ -49,11 +50,16 @@ public final class UseArnRegionProviderChain implements UseArnRegionProvider {
      * </ol>
      */
     public static UseArnRegionProviderChain create() {
-        return create(ProfileFile.defaultProfileFile(),
+        return create(ProfileFile::defaultProfileFile,
                       ProfileFileSystemSetting.AWS_PROFILE.getStringValueOrThrow());
     }
 
     public static UseArnRegionProviderChain create(ProfileFile profileFile, String profileName) {
+        return new UseArnRegionProviderChain(Arrays.asList(SystemsSettingsUseArnRegionProvider.create(),
+                                                           ProfileUseArnRegionProvider.create(profileFile, profileName)));
+    }
+
+    public static UseArnRegionProviderChain create(Supplier<ProfileFile> profileFile, String profileName) {
         return new UseArnRegionProviderChain(Arrays.asList(SystemsSettingsUseArnRegionProvider.create(),
                                                            ProfileUseArnRegionProvider.create(profileFile, profileName)));
     }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3ConfigurationTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/S3ConfigurationTest.java
@@ -87,4 +87,32 @@ public class S3ConfigurationTest {
         assertThat(config.multiRegionEnabled()).isEqualTo(true);
     }
 
+    @Test
+    public void multiRegionEnabled_enabledInCProfile_shouldResolveToConfigCorrectlyOncePerCall() {
+        S3Configuration config = S3Configuration.builder().build();
+
+        String trueProfileConfig = getClass().getResource("internal/settingproviders/ProfileFile_true").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), trueProfileConfig);
+        assertThat(config.multiRegionEnabled()).isEqualTo(false);
+
+        System.clearProperty(AWS_CONFIG_FILE.property());
+        String falseProfileConfig = getClass().getResource("internal/settingproviders/ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseProfileConfig);
+        assertThat(config.multiRegionEnabled()).isEqualTo(true);
+    }
+
+    @Test
+    public void useArnRegionEnabled_enabledInCProfile_shouldResolveToConfigCorrectlyOncePerCall() {
+        S3Configuration config = S3Configuration.builder().build();
+
+        String trueProfileConfig = getClass().getResource("internal/settingproviders/ProfileFile_true").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), trueProfileConfig);
+        assertThat(config.useArnRegionEnabled()).isEqualTo(true);
+
+        System.clearProperty(AWS_CONFIG_FILE.property());
+        String falseProfileConfig = getClass().getResource("internal/settingproviders/ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseProfileConfig);
+        assertThat(config.useArnRegionEnabled()).isEqualTo(false);
+    }
+
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/DisableMultiRegionProviderChainTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/DisableMultiRegionProviderChainTest.java
@@ -24,23 +24,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
-public class DisableMultiRegionProviderChainTest {
+class DisableMultiRegionProviderChainTest {
     private final EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
 
     @AfterEach
-    public void clearSystemProperty() {
+    void clearSystemProperty() {
         System.clearProperty(AWS_S3_DISABLE_MULTIREGION_ACCESS_POINTS.property());
         System.clearProperty(AWS_CONFIG_FILE.property());
         helper.reset();
     }
 
     @Test
-    public void notSpecified_shouldReturnEmptyOptional() {
+    void notSpecified_shouldReturnEmptyOptional() {
         assertThat(DisableMultiRegionProviderChain.create().resolve()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void specifiedInBothProviders_systemPropertiesShouldTakePrecedence() {
+    void specifiedInBothProviders_systemPropertiesShouldTakePrecedence() {
         System.setProperty(AWS_S3_DISABLE_MULTIREGION_ACCESS_POINTS.property(), "false");
         String configFile = getClass().getResource("ProfileFile_true").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);
@@ -49,7 +49,7 @@ public class DisableMultiRegionProviderChainTest {
     }
 
     @Test
-    public void systemPropertiesThrowException_shouldUseConfigFile() {
+    void systemPropertiesThrowException_shouldUseConfigFile() {
         System.setProperty(AWS_S3_DISABLE_MULTIREGION_ACCESS_POINTS.property(), "foobar");
         String configFile = getClass().getResource("ProfileFile_true").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);
@@ -58,7 +58,7 @@ public class DisableMultiRegionProviderChainTest {
     }
 
     @Test
-    public void systemPropertiesNotSpecified_shouldUseConfigFile() {
+    void systemPropertiesNotSpecified_shouldUseConfigFile() {
         String configFile = getClass().getResource("ProfileFile_true").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);
 
@@ -66,7 +66,21 @@ public class DisableMultiRegionProviderChainTest {
     }
 
     @Test
-    public void bothProvidersThrowException_shouldReturnEmpty() {
+    void resolve_systemPropertiesNotSpecified_shouldResolveOncePerCall() {
+        String trueConfigFile = getClass().getResource("ProfileFile_true").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), trueConfigFile);
+
+        assertThat(DisableMultiRegionProviderChain.create().resolve()).isEqualTo(Optional.of(Boolean.TRUE));
+
+        System.clearProperty(AWS_CONFIG_FILE.property());
+        String falseConfigFile = getClass().getResource("ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseConfigFile);
+
+        assertThat(DisableMultiRegionProviderChain.create().resolve()).isEqualTo(Optional.of(Boolean.FALSE));
+    }
+
+    @Test
+    void bothProvidersThrowException_shouldReturnEmpty() {
         System.setProperty(AWS_S3_DISABLE_MULTIREGION_ACCESS_POINTS.property(), "foobar");
         String configFile = getClass().getResource("ProfileFile_unsupportedValue").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileDisableMultiRegionProviderTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileDisableMultiRegionProviderTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.services.s3.internal.settingproviders;
 
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -70,6 +71,20 @@ public class ProfileDisableMultiRegionProviderTest {
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);
 
         assertThatThrownBy(() -> provider.resolve()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void resolve_specifiedMultipleValuesInConfigFile_shouldResolveOncePerCall() {
+        String trueConfigFile = getClass().getResource("ProfileFile_true").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), trueConfigFile);
+
+        assertThat(provider.resolve()).isEqualTo(Optional.of(TRUE));
+
+        System.clearProperty(AWS_CONFIG_FILE.property());
+        String falseConfigFile = getClass().getResource("ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseConfigFile);
+
+        assertThat(provider.resolve()).isEqualTo(Optional.of(FALSE));
     }
 
     @Test

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileUseArnRegionProviderTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/ProfileUseArnRegionProviderTest.java
@@ -82,6 +82,20 @@ public class ProfileUseArnRegionProviderTest {
     }
 
     @Test
+    public void resolveUseArnRegion_specifiedMultipleValuesInConfigFile_shouldResolveOncePerCall() {
+        String trueConfigFile = getClass().getResource("ProfileFile_true").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), trueConfigFile);
+
+        assertThat(provider.resolveUseArnRegion()).isEqualTo(Optional.of(TRUE));
+
+        System.clearProperty(AWS_CONFIG_FILE.property());
+        String falseConfigFile = getClass().getResource("ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseConfigFile);
+
+        assertThat(provider.resolveUseArnRegion()).isEqualTo(Optional.of(FALSE));
+    }
+
+    @Test
     public void specifiedInOverrideConfig_shouldUse() {
         ExecutionInterceptor interceptor = Mockito.spy(AbstractExecutionInterceptor.class);
 

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/UseArnRegionProviderChainTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/UseArnRegionProviderChainTest.java
@@ -24,23 +24,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
-public class UseArnRegionProviderChainTest {
+class UseArnRegionProviderChainTest {
     private final EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
 
     @AfterEach
-    public void clearSystemProperty() {
+    void clearSystemProperty() {
         System.clearProperty(AWS_S3_USE_ARN_REGION.property());
         System.clearProperty(AWS_CONFIG_FILE.property());
         helper.reset();
     }
 
     @Test
-    public void notSpecified_shouldReturnEmptyOptional() {
+    void notSpecified_shouldReturnEmptyOptional() {
         assertThat(UseArnRegionProviderChain.create().resolveUseArnRegion()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void specifiedInBothProviders_systemPropertiesShouldTakePrecedence() {
+    void specifiedInBothProviders_systemPropertiesShouldTakePrecedence() {
         System.setProperty(AWS_S3_USE_ARN_REGION.property(), "false");
         String configFile = getClass().getResource("ProfileFile_true").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);
@@ -49,7 +49,7 @@ public class UseArnRegionProviderChainTest {
     }
 
     @Test
-    public void systemPropertiesThrowException_shouldUseConfigFile() {
+    void systemPropertiesThrowException_shouldUseConfigFile() {
         System.setProperty(AWS_S3_USE_ARN_REGION.property(), "foobar");
         String configFile = getClass().getResource("ProfileFile_true").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);
@@ -58,21 +58,25 @@ public class UseArnRegionProviderChainTest {
     }
 
     @Test
-    void resolveUseArnRegion_systemPropertiesNotSpecified_shouldResolveOncePerCall() {
+    void resolveUseArnRegion_systemPropertiesNotSpecifiedConfigFileValueTrue_resolvesOncePerCall() {
         String trueConfigFile = getClass().getResource("ProfileFile_true").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), trueConfigFile);
 
-        assertThat(UseArnRegionProviderChain.create().resolveUseArnRegion()).isEqualTo(Optional.of(Boolean.TRUE));
-
-        System.clearProperty(AWS_CONFIG_FILE.property());
-        String falseConfigFile = getClass().getResource("ProfileFile_false").getFile();
-        System.setProperty(AWS_CONFIG_FILE.property(), falseConfigFile);
-
-        assertThat(UseArnRegionProviderChain.create().resolveUseArnRegion()).isEqualTo(Optional.of(Boolean.FALSE));
+        UseArnRegionProviderChain providerChain = UseArnRegionProviderChain.create();
+        assertThat(providerChain.resolveUseArnRegion()).isEqualTo(Optional.of(Boolean.TRUE));
     }
 
     @Test
-    public void bothProvidersThrowException_shouldReturnEmpty() {
+    void resolveUseArnRegion_systemPropertiesNotSpecifiedConfigFileValueFalse_resolvesOncePerCall() {
+        String falseConfigFile = getClass().getResource("ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseConfigFile);
+
+        UseArnRegionProviderChain providerChain = UseArnRegionProviderChain.create();
+        assertThat(providerChain.resolveUseArnRegion()).isEqualTo(Optional.of(Boolean.FALSE));
+    }
+
+    @Test
+    void bothProvidersThrowException_shouldReturnEmpty() {
         System.setProperty(AWS_S3_USE_ARN_REGION.property(), "foobar");
         String configFile = getClass().getResource("ProfileFile_unsupportedValue").getFile();
         System.setProperty(AWS_CONFIG_FILE.property(), configFile);

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/UseArnRegionProviderChainTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/settingproviders/UseArnRegionProviderChainTest.java
@@ -58,6 +58,20 @@ public class UseArnRegionProviderChainTest {
     }
 
     @Test
+    void resolveUseArnRegion_systemPropertiesNotSpecified_shouldResolveOncePerCall() {
+        String trueConfigFile = getClass().getResource("ProfileFile_true").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), trueConfigFile);
+
+        assertThat(UseArnRegionProviderChain.create().resolveUseArnRegion()).isEqualTo(Optional.of(Boolean.TRUE));
+
+        System.clearProperty(AWS_CONFIG_FILE.property());
+        String falseConfigFile = getClass().getResource("ProfileFile_false").getFile();
+        System.setProperty(AWS_CONFIG_FILE.property(), falseConfigFile);
+
+        assertThat(UseArnRegionProviderChain.create().resolveUseArnRegion()).isEqualTo(Optional.of(Boolean.FALSE));
+    }
+
+    @Test
     public void bothProvidersThrowException_shouldReturnEmpty() {
         System.setProperty(AWS_S3_USE_ARN_REGION.property(), "foobar");
         String configFile = getClass().getResource("ProfileFile_unsupportedValue").getFile();


### PR DESCRIPTION
## Motivation and Context
Continue updating the API to pass `Supplier<ProfileFile>` to classes.

## Modifications
Updated services/s3 classes using `ProfileFile` internally.

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
