### PR TITLE
Validate that localhost resolves to loopback address

### DIFF
--- a/.changes/next-release/bugfix-AmazonElasticContainerServiceECS-09f6115.json
+++ b/.changes/next-release/bugfix-AmazonElasticContainerServiceECS-09f6115.json
@@ -1,6 +1,0 @@
-{
-    "category": "Amazon Elastic Container Service (ECS)", 
-    "contributor": "", 
-    "type": "bugfix", 
-    "description": "HTTP(S) credential provider requires the implementation to verify that the resolved addresses for the host are actually loopback addresses."
-}

--- a/.changes/next-release/bugfix-AmazonElasticContainerServiceECS-09f6115.json
+++ b/.changes/next-release/bugfix-AmazonElasticContainerServiceECS-09f6115.json
@@ -1,0 +1,6 @@
+{
+    "category": "Amazon Elastic Container Service (ECS)", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "HTTP(S) credential provider requires the implementation to verify that the resolved addresses for the host are actually loopback addresses."
+}

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -15,17 +15,18 @@
 
 package software.amazon.awssdk.auth.credentials;
 
-import static java.util.Collections.unmodifiableSet;
-
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
+import java.util.function.Predicate;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.internal.ContainerCredentialsRetryPolicy;
 import software.amazon.awssdk.auth.credentials.internal.HttpCredentialsLoader;
@@ -65,7 +66,9 @@ import software.amazon.awssdk.utils.cache.RefreshResult;
 public final class ContainerCredentialsProvider
     implements HttpCredentialsProvider,
                ToCopyableBuilder<ContainerCredentialsProvider.Builder, ContainerCredentialsProvider> {
-    private static final Set<String> ALLOWED_HOSTS = unmodifiableSet(new HashSet<>(Arrays.asList("localhost", "127.0.0.1")));
+    private static final Predicate<InetAddress> ALLOWED_HOSTS_IPv4_RULES = InetAddress::isLoopbackAddress;
+    private static final Predicate<InetAddress> ALLOWED_HOSTS_IPv6_RULES = InetAddress::isLoopbackAddress;
+    private static final String HTTPS = "https";
 
     private final String endpoint;
     private final HttpCredentialsLoader httpCredentialsLoader;
@@ -207,17 +210,43 @@ public final class ContainerCredentialsProvider
 
         private URI createGenericContainerUrl() {
             URI uri = URI.create(SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI.getStringValueOrThrow());
-            if (!ALLOWED_HOSTS.contains(uri.getHost())) {
+            if (!isHttps(uri) && !isAllowedHost(uri.getHost())) {
                 String envVarName = SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable();
                 throw SdkClientException.builder()
-                                        .message(String.format("The full URI (%s) contained within environment " +
-                                                               "variable %s has an invalid host. Host can only be one of [%s].",
-                                                               uri,
-                                                               envVarName,
-                                                               String.join(",", ALLOWED_HOSTS)))
+                                        .message(String.format("The full URI (%s) contained within environment variable " +
+                                                               "%s has an invalid host. Host should resolve to a loopback" +
+                                                               " address.",
+                                                               uri, envVarName))
                                         .build();
             }
             return uri;
+        }
+
+        private boolean isHttps(URI endpoint) {
+            return Objects.equals(HTTPS, endpoint.getScheme());
+        }
+
+        private boolean isAllowedHost(String host) {
+            try {
+                InetAddress[] addresses = InetAddress.getAllByName(host);
+
+                return addresses.length > 0 && Arrays.stream(addresses)
+                                                     .allMatch(this::matchesAllowedHostRules);
+
+            } catch (UnknownHostException e) {
+                throw SdkClientException.builder()
+                                        .cause(e)
+                                        .message(String.format("host (%s) could not be resolved to an IP address.", host))
+                                        .build();
+            }
+        }
+
+        private boolean matchesAllowedHostRules(InetAddress inetAddress) {
+            if (inetAddress instanceof Inet6Address) {
+                return ALLOWED_HOSTS_IPv6_RULES.test(inetAddress);
+            }
+
+            return ALLOWED_HOSTS_IPv4_RULES.test(inetAddress);
         }
     }
 

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsProvider.java
@@ -213,8 +213,8 @@ public final class ContainerCredentialsProvider
                 String envVarName = SdkSystemSetting.AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable();
                 throw SdkClientException.builder()
                                         .message(String.format("The full URI (%s) contained within environment variable " +
-                                                               "%s has an invalid host. Host should resolve to a loopback" +
-                                                               " address.",
+                                                               "%s has an invalid host. Host should resolve to a loopback " +
+                                                               "address or have the full URI be HTTPS.",
                                                                uri, envVarName))
                                         .build();
             }

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsEndpointProviderTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/ContainerCredentialsEndpointProviderTest.java
@@ -71,9 +71,49 @@ public class ContainerCredentialsEndpointProviderTest {
         assertThat(sut.endpoint().toString(), equalTo(fullUri));
     }
 
+    @Test
+    public void theLoopbackIpv6AddressIsAlsoAcceptable() throws IOException {
+        String fullUri = "http://[::1]:9851/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test
+    public void anyHttpsAddressIsAlsoAcceptable() throws IOException {
+        String fullUri = "https://192.168.10.120:9851/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test
+    public void anyHttpsIpv6AddressIsAlsoAcceptable() throws IOException {
+        String fullUri = "https://[::FFFF:152.16.24.123]/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test(expected = SdkClientException.class)
+    public void nonLoopbackAddressIsNotAcceptable() throws IOException {
+        String fullUri = "http://192.168.10.120:9851/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test(expected = SdkClientException.class)
+    public void nonLoopbackIpv6AddressIsNotAcceptable() throws IOException {
+        String fullUri = "http://[::FFFF:152.16.24.123]/endpoint";
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), fullUri);
+
+        assertThat(sut.endpoint().toString(), equalTo(fullUri));
+    }
+
     @Test(expected = SdkClientException.class)
     public void onlyLocalHostAddressesAreValid() throws IOException {
-        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), "https://google.com/endpoint");
+        helper.set(AWS_CONTAINER_CREDENTIALS_FULL_URI.environmentVariable(), "http://google.com/endpoint");
         sut.endpoint();
     }
 


### PR DESCRIPTION
## Motivation and Context
HTTP(S) credential provider requires the implementation to verify that the resolved addresses for the host are actually loopback addresses.
InetAddress is used to resolve DNS names.

## Testing
Added unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
