### PR TITLE
Add DynamoDB support for converting ARNs

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDB-e9516e8.json
+++ b/.changes/next-release/feature-AmazonDynamoDB-e9516e8.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB",
+    "contributor": "belugabehr",
+    "description": "Add support for converting ARNs"
+}

--- a/services-custom/dynamodb-enhanced/pom.xml
+++ b/services-custom/dynamodb-enhanced/pom.xml
@@ -133,6 +133,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>annotations</artifactId>
             <version>${awsjavasdk.version}</version>
         </dependency>

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProvider.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.PrimitiveConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ArnAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.AtomicBooleanAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.AtomicIntegerAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.AtomicLongAttributeConverter;
@@ -208,6 +209,7 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
 
     private static Builder getDefaultBuilder() {
         return DefaultAttributeConverterProvider.builder()
+                                                .addConverter(ArnAttributeConverter.create())
                                                 .addConverter(AtomicBooleanAttributeConverter.create())
                                                 .addConverter(AtomicIntegerAttributeConverter.create())
                                                 .addConverter(AtomicLongAttributeConverter.create())

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ArnAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/attribute/ArnAttributeConverter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.TypeConvertingVisitor;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.ArnStringConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * A converter between {@link Arn} and {@link AttributeValue}.
+ *
+ * <p>
+ * This supports storing and reading values in DynamoDB as a string.
+ */
+@SdkInternalApi
+@ThreadSafe
+@Immutable
+public final class ArnAttributeConverter implements AttributeConverter<Arn> {
+    public static final ArnStringConverter STRING_CONVERTER = ArnStringConverter.create();
+
+    public static ArnAttributeConverter create() {
+        return new ArnAttributeConverter();
+    }
+
+    @Override
+    public EnhancedType<Arn> type() {
+        return EnhancedType.of(Arn.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.S;
+    }
+
+    @Override
+    public AttributeValue transformFrom(Arn input) {
+        return AttributeValue.builder().s(STRING_CONVERTER.toString(input)).build();
+    }
+
+    @Override
+    public Arn transformTo(AttributeValue input) {
+        return EnhancedAttributeValue.fromAttributeValue(input).convert(Visitor.INSTANCE);
+    }
+
+    private static final class Visitor extends TypeConvertingVisitor<Arn> {
+        private static final Visitor INSTANCE = new Visitor();
+
+        private Visitor() {
+            super(Arn.class, ArnAttributeConverter.class);
+        }
+
+        @Override
+        public Arn convertString(String value) {
+            return STRING_CONVERTER.fromString(value);
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/ArnStringConverter.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/ArnStringConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.converter.string;
+
+import software.amazon.awssdk.annotations.Immutable;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.arns.Arn;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.StringConverter;
+
+/**
+ * A converter between {@link Arn} and {@link String}.
+ */
+@SdkInternalApi
+@ThreadSafe
+@Immutable
+public class ArnStringConverter implements StringConverter<Arn> {
+    private ArnStringConverter() {
+    }
+
+    public static ArnStringConverter create() {
+        return new ArnStringConverter();
+    }
+
+    @Override
+    public EnhancedType<Arn> type() {
+        return EnhancedType.of(Arn.class);
+    }
+
+    @Override
+    public Arn fromString(String string) {
+        return Arn.fromString(string);
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/DefaultStringConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/string/DefaultStringConverterProvider.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.utils.Validate;
  * <p>
  * Included converters:
  * <ul>
+ *     <li>{@link ArnStringConverter}</li>
  *     <li>{@link AtomicIntegerStringConverter}</li>
  *     <li>{@link AtomicLongStringConverter}</li>
  *     <li>{@link BigDecimalStringConverter}</li>
@@ -106,6 +107,7 @@ public class DefaultStringConverterProvider implements StringConverterProvider {
 
     public static DefaultStringConverterProvider create() {
         return DefaultStringConverterProvider.builder()
+                                             .addConverter(ArnStringConverter.create())
                                              .addConverter(ByteArrayStringConverter.create())
                                              .addConverter(CharacterArrayStringConverter.create())
                                              .addConverter(BooleanStringConverter.create())


### PR DESCRIPTION
## Motivation and Context
Fixes #3661

## Modifications
Added new converter class for AWS ARN.

## Testing
Use existing unit tests that dynamically load each converter.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
