### PR TITLE
Do not attempt to pad time string if current length is sufficient

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/converter/ConverterUtils.java
@@ -53,14 +53,19 @@ public class ConverterUtils {
     }
 
     public static String padLeft(int paddingAmount, int valueToPad) {
-        String value = Integer.toString(valueToPad);
-        int padding = paddingAmount - value.length();
-        StringBuilder result = new StringBuilder(paddingAmount);
-        for (int i = 0; i < padding; i++) {
-            result.append('0');
+        final String result;
+        final String value = Integer.toString(valueToPad);
+        if (value.length() == paddingAmount) {
+            result = value;
+        } else {
+            int padding = paddingAmount - value.length();
+            StringBuilder sb = new StringBuilder(paddingAmount);
+            for (int i = 0; i < padding; i++) {
+                sb.append('0');
+            }
+            result = sb.append(value).toString();
         }
-        result.append(value);
-        return result.toString();
+        return result;
     }
 
     public static String[] splitNumberOnDecimal(String valueToSplit) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This method is used exclusively to pad the results of `Duration#getNano` up to nine characters.

https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#getNano--

The range of possible values are: 0 to 999,999,999

Of the set of values with a length less than 9 are: [0,100000000)
Of the set of values with a length greater than 9 are: [100000000,999999999]

So, just by random dart-throwing, 90% of the values are going to have a length of 9 digits and require no padding.  Save on instantiation of `StringBuilder`, and copying data into them, by only padding when required.

## Modifications
Check for the size of the string, and if it is already the same size as the require padded value, simply return the value itself.

## Testing
This is a performance enhancement.  There are no functionality changes and the existing test suite validates.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
