### PR TITLE
Exclude javadoc JARs for third-party libraries

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -36,12 +36,14 @@
         "third-party-jackson-core": {
             "packageName": "AwsJavaSdk-ThirdParty-JacksonCore",
             "artifactType": "JAR",
-            "includes": ["target/aws-sdk-java-third-party-jackson-core-*.jar"]
+            "includes": ["target/aws-sdk-java-third-party-jackson-core-*.jar"],
+            "excludes": ["target/aws-sdk-java-third-party-jackson-core-*-javadoc.jar"]
         },
         "third-party-jackson-dataformat-cbor": {
             "packageName": "AwsJavaSdk-ThirdParty-JacksonDataformatCbor",
             "artifactType": "JAR",
-            "includes": ["target/aws-sdk-java-third-party-jackson-dataformat-cbor-*.jar"]
+            "includes": ["target/aws-sdk-java-third-party-jackson-dataformat-cbor-*.jar"],
+            "excludes": ["target/aws-sdk-java-third-party-jackson-dataformat-cbor-*-javadoc.jar"]
         },
         "ruleset-testing-core": {
             "packageName": "AwsJavaSdk-Test-RuleSetTestingCore"

--- a/.brazil.json
+++ b/.brazil.json
@@ -37,13 +37,13 @@
             "packageName": "AwsJavaSdk-ThirdParty-JacksonCore",
             "artifactType": "JAR",
             "includes": ["target/aws-sdk-java-third-party-jackson-core-*.jar"],
-            "excludes": ["target/aws-sdk-java-third-party-jackson-core-*-javadoc.jar"]
+            "excludes": ["aws-sdk-java-third-party-jackson-core-*-javadoc.jar"]
         },
         "third-party-jackson-dataformat-cbor": {
             "packageName": "AwsJavaSdk-ThirdParty-JacksonDataformatCbor",
             "artifactType": "JAR",
             "includes": ["target/aws-sdk-java-third-party-jackson-dataformat-cbor-*.jar"],
-            "excludes": ["target/aws-sdk-java-third-party-jackson-dataformat-cbor-*-javadoc.jar"]
+            "excludes": ["aws-sdk-java-third-party-jackson-dataformat-cbor-*-javadoc.jar"]
         },
         "ruleset-testing-core": {
             "packageName": "AwsJavaSdk-Test-RuleSetTestingCore"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Exclude javadoc JARs for third-party libraries


## Testing
Verified the workflow 

