### PR TITLE
CRT HTTP/1 GA - Surface Area Updates - readBufferSizeInBytes takes long

### DIFF
--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -101,7 +101,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
             this.bootstrap = registerOwnedResource(clientBootstrap);
             this.socketOptions = registerOwnedResource(clientSocketOptions);
             this.tlsContext = registerOwnedResource(clientTlsContext);
-            this.readBufferSize = builder.readBufferSize == null ?  DEFAULT_STREAM_WINDOW_SIZE : builder.readBufferSize;
+            this.readBufferSize = builder.readBufferSize == null ? DEFAULT_STREAM_WINDOW_SIZE : builder.readBufferSize;
             this.maxConnectionsPerEndpoint = config.get(SdkHttpConfigurationOption.MAX_CONNECTIONS);
             this.monitoringOptions = revolveHttpMonitoringOptions(builder.connectionHealthConfiguration);
             this.maxConnectionIdleInMilliseconds = config.get(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT).toMillis();
@@ -207,7 +207,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
                 .withSocketOptions(socketOptions)
                 .withTlsContext(tlsContext)
                 .withUri(uri)
-                .withWindowSize((int) readBufferSize)
+                .withWindowSize(NumericUtils.saturatedCast(readBufferSize))
                 .withMaxConnections(maxConnectionsPerEndpoint)
                 .withManualWindowManagement(true)
                 .withProxyOptions(proxyOptions)
@@ -320,10 +320,9 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
          * client before we stop reading from the underlying TCP socket and wait for the Subscriber
          * to read more data.
          *
-         * @param readBufferSize The number of bytes that can be buffered
+         * @param readBufferSize The number of bytes that can be buffered. The maximum buffering size value is
+         *                       capped at {@code Integer.MAX}.
          * @return The builder of the method chaining.
-         *
-         * TODO: This is also used for the write buffer size. Should we rename it?
          */
         Builder readBufferSizeInBytes(Long readBufferSize);
 

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -74,7 +74,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
     private static final Logger log = Logger.loggerFor(AwsCrtAsyncHttpClient.class);
 
     private static final String AWS_COMMON_RUNTIME = "AwsCommonRuntime";
-    private static final int DEFAULT_STREAM_WINDOW_SIZE = 16 * 1024 * 1024; // 16 MB
+    private static final long DEFAULT_STREAM_WINDOW_SIZE = 16L * 1024L * 1024L; // 16 MB
 
     private final Map<URI, HttpClientConnectionManager> connectionPools = new ConcurrentHashMap<>();
     private final LinkedList<CrtResource> ownedSubResources = new LinkedList<>();
@@ -84,7 +84,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
     private final HttpProxyOptions proxyOptions;
     private final HttpMonitoringOptions monitoringOptions;
     private final long maxConnectionIdleInMilliseconds;
-    private final int readBufferSize;
+    private final long readBufferSize;
     private final int maxConnectionsPerEndpoint;
     private boolean isClosed = false;
 
@@ -207,7 +207,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
                 .withSocketOptions(socketOptions)
                 .withTlsContext(tlsContext)
                 .withUri(uri)
-                .withWindowSize(readBufferSize)
+                .withWindowSize((int) readBufferSize)
                 .withMaxConnections(maxConnectionsPerEndpoint)
                 .withManualWindowManagement(true)
                 .withProxyOptions(proxyOptions)
@@ -325,7 +325,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
          *
          * TODO: This is also used for the write buffer size. Should we rename it?
          */
-        Builder readBufferSizeInBytes(Integer readBufferSize);
+        Builder readBufferSizeInBytes(Long readBufferSize);
 
         /**
          * Sets the http proxy configuration to use for this client.
@@ -421,7 +421,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
      */
     private static final class DefaultBuilder implements Builder {
         private final AttributeMap.Builder standardOptions = AttributeMap.builder();
-        private Integer readBufferSize;
+        private Long readBufferSize;
         private ProxyConfiguration proxyConfiguration;
         private ConnectionHealthConfiguration connectionHealthConfiguration;
         private TcpKeepAliveConfiguration tcpKeepAliveConfiguration;
@@ -450,7 +450,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
         }
 
         @Override
-        public Builder readBufferSizeInBytes(Integer readBufferSize) {
+        public Builder readBufferSizeInBytes(Long readBufferSize) {
             Validate.isPositiveOrNull(readBufferSize, "readBufferSize");
             this.readBufferSize = readBufferSize;
             return this;

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestContext.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestContext.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.metrics.MetricCollector;
 @SdkInternalApi
 public final class CrtRequestContext {
     private final AsyncExecuteRequest request;
-    private final int readBufferSize;
+    private final long readBufferSize;
     private final HttpClientConnectionManager crtConnPool;
     private final MetricCollector metricCollector;
 
@@ -42,7 +42,7 @@ public final class CrtRequestContext {
         return request;
     }
 
-    public int readBufferSize() {
+    public long readBufferSize() {
         return readBufferSize;
     }
 
@@ -56,7 +56,7 @@ public final class CrtRequestContext {
 
     public static class Builder {
         private AsyncExecuteRequest request;
-        private int readBufferSize;
+        private long readBufferSize;
         private HttpClientConnectionManager crtConnPool;
 
         private Builder() {
@@ -67,7 +67,7 @@ public final class CrtRequestContext {
             return this;
         }
 
-        public Builder readBufferSize(int readBufferSize) {
+        public Builder readBufferSize(long readBufferSize) {
             this.readBufferSize = readBufferSize;
             return this;
         }

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapter.java
@@ -27,7 +27,7 @@ final class CrtRequestBodyAdapter implements HttpRequestBodyStream {
     private final SdkHttpContentPublisher requestPublisher;
     private final ByteBufferStoringSubscriber requestBodySubscriber;
 
-    CrtRequestBodyAdapter(SdkHttpContentPublisher requestPublisher, int readLimit) {
+    CrtRequestBodyAdapter(SdkHttpContentPublisher requestPublisher, long readLimit) {
         this.requestPublisher = requestPublisher;
         this.requestBodySubscriber = new ByteBufferStoringSubscriber(readLimit);
         requestPublisher.subscribe(requestBodySubscriber);


### PR DESCRIPTION
PR in support for CRT HTTP/1 GA - Surface Area Updates. This PR modifies the `readBufferSizeInBytes` to take a `long`, not `int` parameter.

## Modifications
Updated method and cascaded changes into `CrtRequestContext` and `CrtRequestBodyAdapter`.

## Testing
No new tests added.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
