### PR TITLE
Fix for Issue #3569 where the user set Content-Encoding was over writ…

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-16b5911.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-16b5911.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Append Content-encoding header instead of over writing the header when Checksum algorithm is selected along with user set Content-encoding"
+}

--- a/core/auth-crt/src/main/java/software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtS3V4aSigner.java
+++ b/core/auth-crt/src/main/java/software/amazon/awssdk/authcrt/signer/internal/DefaultAwsCrtS3V4aSigner.java
@@ -224,6 +224,6 @@ public final class DefaultAwsCrtS3V4aSigner implements AwsCrtS3V4aSigner {
     private static void updateRequestWithTrailer(SignerChecksumParams signerChecksumParams,
                                                  SdkHttpFullRequest.Builder mutableRequest) {
         mutableRequest.putHeader("x-amz-trailer", signerChecksumParams.checksumHeaderName());
-        mutableRequest.putHeader("Content-Encoding", "aws-chunked");
+        mutableRequest.appendHeader("Content-Encoding", "aws-chunked");
     }
 }

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsS3V4Signer.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/signer/internal/AbstractAwsS3V4Signer.java
@@ -236,7 +236,7 @@ public abstract class AbstractAwsS3V4Signer extends AbstractAws4Signer<AwsS3V4Si
                             ChecksumSpecs.builder().headerName(signerParams.checksumParams().checksumHeaderName()).build())) {
                         isTrailingChecksum = true;
                         mutableRequest.putHeader("x-amz-trailer", headerForTrailerChecksumLocation);
-                        mutableRequest.putHeader("Content-Encoding", "aws-chunked");
+                        mutableRequest.appendHeader("Content-Encoding", "aws-chunked");
                     }
                 }
                 // Make sure "Content-Length" header is not empty so that HttpClient

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/AsyncRequestBodyHttpChecksumTrailerInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/AsyncRequestBodyHttpChecksumTrailerInterceptor.java
@@ -105,7 +105,7 @@ public final class AsyncRequestBodyHttpChecksumTrailerInterceptor implements Exe
 
         return context.httpRequest().copy(r ->
                 r.putHeader(HttpChecksumConstant.HEADER_FOR_TRAILER_REFERENCE, checksum.headerName())
-                        .putHeader("Content-encoding", HttpChecksumConstant.AWS_CHUNKED_HEADER)
+                        .appendHeader("Content-encoding", HttpChecksumConstant.AWS_CHUNKED_HEADER)
                         .putHeader("x-amz-content-sha256", HttpChecksumConstant.CONTENT_SHA_256_FOR_UNSIGNED_TRAILER)
                         .putHeader("x-amz-decoded-content-length", Long.toString(originalContentLength))
                         .putHeader(Header.CONTENT_LENGTH,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/SyncHttpChecksumInTrailerInterceptor.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/interceptor/SyncHttpChecksumInTrailerInterceptor.java
@@ -108,7 +108,7 @@ public final class SyncHttpChecksumInTrailerInterceptor implements ExecutionInte
         long originalContentLength = context.requestBody().get().optionalContentLength().orElse(0L);
         return context.httpRequest().copy(
             r -> r.putHeader(HttpChecksumConstant.HEADER_FOR_TRAILER_REFERENCE, checksum.headerName())
-                  .putHeader("Content-encoding", AWS_CHUNKED_HEADER)
+                  .appendHeader("Content-encoding", AWS_CHUNKED_HEADER)
                   .putHeader("x-amz-content-sha256", CONTENT_SHA_256_FOR_UNSIGNED_TRAILER)
                   .putHeader("x-amz-decoded-content-length", Long.toString(originalContentLength))
                   .putHeader(CONTENT_LENGTH,

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/CaptureChecksumValidationInterceptor.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/utils/CaptureChecksumValidationInterceptor.java
@@ -27,6 +27,11 @@ public class CaptureChecksumValidationInterceptor implements ExecutionIntercepto
     private  ChecksumValidation responseValidation;
     private  String requestChecksumInTrailer;
     private  String requestChecksumInHeader;
+    private  String contentEncoding;
+
+    public String contentEncoding() {
+        return contentEncoding;
+    }
 
     public Algorithm validationAlgorithm() {
         return validationAlgorithm;
@@ -64,6 +69,7 @@ public class CaptureChecksumValidationInterceptor implements ExecutionIntercepto
             executionAttributes.getOptionalAttribute(SdkExecutionAttribute.HTTP_CHECKSUM_VALIDATION_ALGORITHM).orElse(null);
         responseValidation =
             executionAttributes.getOptionalAttribute(SdkExecutionAttribute.HTTP_RESPONSE_CHECKSUM_VALIDATION).orElse(null);
+        contentEncoding = String.join(",", context.httpRequest().matchingHeaders("content-encoding"));
     }
 
     @Override

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/customresponsemetadata/service-2.json
@@ -907,6 +907,11 @@
           "location":"header",
           "locationName":"x-amz-checksum-mode"
         },
+        "ContentEncoding":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"Content-Encoding"
+        },
         "ChecksumAlgorithm":{
           "shape":"ChecksumAlgorithm",
           "location":"header",
@@ -924,6 +929,11 @@
           "shape":"ChecksumMode",
           "location":"header",
           "locationName":"x-amz-checksum-mode"
+        },
+        "ContentEncoding":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"Content-Encoding"
         },
         "ChecksumAlgorithm":{
           "shape":"ChecksumAlgorithm",

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/xml/service-2.json
@@ -765,6 +765,11 @@
           "documentation":"<p>Object data.</p>",
           "streaming":true
         },
+        "ContentEncoding":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"Content-Encoding"
+        },
         "ChecksumMode":{
           "shape":"ChecksumMode",
           "location":"header",
@@ -787,6 +792,11 @@
           "shape":"ChecksumMode",
           "location":"header",
           "locationName":"x-amz-checksum-mode"
+        },
+        "ContentEncoding":{
+          "shape":"String",
+          "location":"header",
+          "locationName":"Content-Encoding"
         },
         "ChecksumAlgorithm":{
           "shape":"ChecksumAlgorithm",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Fix for [Issue 3569](https://github.com/aws/aws-sdk-java-v2/issues/3569)

## Modifications
<!--- Describe your changes in detail -->
Checksum related interceptors and signers did a putHeader which over wrote the content-encoding header instead of overwriting it, Thus appendHeader is used in these places.     

-DefaultAwsCrtS3V4aSigner
- AbstractAwsS3V4Signer
- AsyncRequestBodyHttpChecksumTrailerInterceptor
- SyncHttpChecksumInTrailerInterceptor

### Fix
- The sdk will append the aws-chunked content-header value. Thus if user has set the content header as gzip then sdk will send this header as multiple header as mentioned in https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
 ```
Amazon S3 supports multiple content encodings. For example:
Content-Encoding : aws-chunked,gzip
That is, you can specify your custom content-encoding when using Signature Version 4 streaming API.
 ```


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits
- Aded integ test

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
