### PR TITLE
CRT window size API update

### DIFF
--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -272,8 +272,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
          * client before we stop reading from the underlying TCP socket and wait for the Subscriber
          * to read more data.
          *
-         * @param readBufferSize The number of bytes that can be buffered. The maximum buffering size value is
-         *                       capped at {@code Integer.MAX}.
+         * @param readBufferSize The number of bytes that can be buffered.
          * @return The builder of the method chaining.
          */
         Builder readBufferSizeInBytes(Long readBufferSize);

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -54,7 +54,6 @@ import software.amazon.awssdk.metrics.NoOpMetricCollector;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Logger;
-import software.amazon.awssdk.utils.NumericUtils;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -160,7 +159,7 @@ public final class AwsCrtAsyncHttpClient implements SdkAsyncHttpClient {
                 .withSocketOptions(socketOptions)
                 .withTlsContext(tlsContext)
                 .withUri(uri)
-                .withWindowSize(NumericUtils.saturatedCast(readBufferSize))
+                .withWindowSize(readBufferSize)
                 .withMaxConnections(maxConnectionsPerEndpoint)
                 .withManualWindowManagement(true)
                 .withProxyOptions(proxyOptions)

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <commons-codec.verion>1.10</commons-codec.verion>
         <jmh.version>1.29</jmh.version>
-        <awscrt.version>0.21.4</awscrt.version>
+        <awscrt.version>0.21.5</awscrt.version>
 
         <!--Test dependencies -->
         <junit5.version>5.8.1</junit5.version>


### PR DESCRIPTION
We cut a ticket to the CRT team so that `HttpClientConnectionManagerOptions.withWindowSize` accepted a long parameter. The CRT team made the change with v0.21.5.