### PR TITLE
Resetting wiremock manually

### DIFF
--- a/core/imds/src/test/java/software/amazon/awssdk/imds/internal/CachedTokenClientTest.java
+++ b/core/imds/src/test/java/software/amazon/awssdk/imds/internal/CachedTokenClientTest.java
@@ -34,6 +34,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.net.URI;
 import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -49,6 +50,11 @@ class CachedTokenClientTest {
     void init(WireMockRuntimeInfo wmRuntimeInfo) {
         this.clientBuilder = Ec2MetadataClient.builder()
                                               .endpoint(URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort()));
+    }
+
+    @AfterEach
+    void tearDown(WireMockRuntimeInfo wmRuntimeInfo) {
+        wmRuntimeInfo.getWireMock().resetMappings();
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Trying to fix the flaky test
```
getToken_responseTtlHeadersNotANumber_shouldFailAndNotRetry
com.github.tomakehurst.wiremock.client.VerificationException: 
Expected exactly 1 requests matching the following pattern but received 2:
{
  "urlPath" : "/latest/api/token",
  "method" : "PUT",
  "headers" : {
    "x-aws-ec2-metadata-token-ttl-seconds" : {
      "equalTo" : "21600"
    }
  }
}
    at software.amazon.awssdk.imds.internal.Ec2MetadataClientTest.failureAssertions(Ec2MetadataClientTest.java:80)
```

## Modifications
Resetting wiremock mappings manually

