### PR TITLE
ProfileFileSupplier aggregate files in order

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-6d1d0aa.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-6d1d0aa.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "", 
+    "type": "bugfix", 
+    "description": "Keep precedence of options when passed to ProfileFileSupplier.aggregate"
+}

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileSupplier.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFileSupplier.java
@@ -16,8 +16,9 @@
 package software.amazon.awssdk.profiles;
 
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -120,7 +121,8 @@ public interface ProfileFileSupplier extends Supplier<ProfileFile> {
         return new ProfileFileSupplier() {
 
             final AtomicReference<ProfileFile> currentAggregateProfileFile = new AtomicReference<>();
-            final HashMap<Supplier<ProfileFile>, ProfileFile> currentValuesBySupplier = new LinkedHashMap<>();
+            final Map<Supplier<ProfileFile>, ProfileFile> currentValuesBySupplier
+                = Collections.synchronizedMap(new LinkedHashMap<>());
 
             @Override
             public ProfileFile get() {
@@ -138,7 +140,7 @@ public interface ProfileFileSupplier extends Supplier<ProfileFile> {
                 return  currentAggregateProfileFile.get();
             }
 
-            private synchronized boolean didSuppliedValueChange(Supplier<ProfileFile> supplier) {
+            private boolean didSuppliedValueChange(Supplier<ProfileFile> supplier) {
                 ProfileFile next = supplier.get();
                 ProfileFile current = currentValuesBySupplier.put(supplier, next);
 


### PR DESCRIPTION
## Motivation and Context
The implementation of `aggregate` does not guarantee the profile files were submitted to `ProfileFile.Aggregator.addFile()` in the order given by the suppliers.
The current implementation uses a `Map` to keep track of whether a supplier returns a different object. Unfortunately, the `values()` method does not guarantee an ordering.

## Modifications
In order to preserve ordering and thread-safety, a `List` scoped to the method will be used to store the supplied profile files. If these need to be aggregated, the list will be used to feed the aggregator.

## Testing
Added two unit tests.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
