### PR TITLE
Use the endpoint operation for client endpoin tests if exists

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesClientTestSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesClientTestSpec.java
@@ -134,6 +134,18 @@ public class EndpointRulesClientTestSpec implements ClassSpec {
     private String findDefaultRequest() {
         Map<String, OperationModel> operations = this.model.getOperations();
 
+        // If this is an endpoint discovery service, then use the endpoint
+        // operation since it goes to the service endpoint
+        Optional<String> endpointOperation = operations.entrySet()
+                                                       .stream()
+                                                       .filter(e -> e.getValue().isEndpointOperation())
+                                                       .map(Map.Entry::getKey)
+                                                       .findFirst();
+
+        if (endpointOperation.isPresent()) {
+            return endpointOperation.get();
+        }
+
         // Ideally look for something that we don't need to set any parameters
         // on. That means either a request with no members or one that does not
         // have any members bound to the URI path


### PR DESCRIPTION
## Motivation and Context
If the service uses endpoint discovery, default to the service's endpoint operation, otherwise we risk picking an operation that relies on endpoint discovery, in which case the client endpoint tests will be useless because we skip using the Endpoints 2.0 endpoint provider if we have an endpoint from Endpoint Discovery.

## Modifications
Use the endpoint operation by default for client endpoint tests if the service has one.

## Testing
`mvn clean install`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
