### PR TITLE
New API for the retries module

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-b456b1c.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-b456b1c.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "sugmanue", 
+    "type": "feature", 
+    "description": "As part of the Smithy Reference Architecture this change adds a new module for retries"
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,6 +46,7 @@
         <module>json-utils</module>
         <module>endpoints-spi</module>
         <module>imds</module>
+        <module>retries-api</module>
     </modules>
 
     <dependencyManagement>

--- a/core/retries-api/pom.xml
+++ b/core/retries-api/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/apache2.0
+  ~
+  ~ or in the "license" file accompanying this file. This file is distributed
+  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~ express or implied. See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>core</artifactId>
+        <groupId>software.amazon.awssdk</groupId>
+        <version>2.20.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>retries-api</artifactId>
+    <name>AWS Java SDK :: Retries API</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>software.amazon.awssdk.retriesapi</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/AcquireInitialTokenRequest.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/AcquireInitialTokenRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Encapsulates the abstract scope to start the attempts about to be executed using a retry strategy.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface AcquireInitialTokenRequest {
+    /**
+     * An abstract scope for the attempts about to be executed.
+     *
+     * <p>A scope should be a unique string describing the smallest possible scope of failure for the attempts about to be
+     * executed. In practical terms, this is a key for the token bucket used to throttle request attempts. All attempts with the
+     * same scope share the same token bucket within the same {@link RetryStrategy}, ensuring that token-bucket throttling for
+     * requests against one resource do not result in throttling for requests against other, unrelated resources.
+     */
+    String scope();
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/AcquireInitialTokenResponse.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/AcquireInitialTokenResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Encapsulates the response from the {@link RetryStrategy} to the request to start the attempts to be executed.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface AcquireInitialTokenResponse {
+    /**
+     * A {@link RetryToken} acquired by this invocation, used in subsequent {@link RetryStrategy#refreshRetryToken} or
+     * {@link RetryStrategy#recordSuccess} calls.
+     */
+    RetryToken token();
+
+    /**
+     * The amount of time to wait before performing the first attempt.
+     */
+    Duration delay();
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/BackoffStrategy.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/BackoffStrategy.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.utils.NumericUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Determines how long to wait before each execution attempt.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface BackoffStrategy {
+    Duration BASE_DELAY_CEILING = Duration.ofMillis(Integer.MAX_VALUE); // Around ~24.8 days
+    Duration MAX_BACKOFF_CEILING = Duration.ofMillis(Integer.MAX_VALUE); // Around ~24.8 days
+    /**
+     * Max permitted retry times. To prevent exponentialDelay from overflow, there must be 2 ^ retriesAttempted &lt;= 2 ^ 31 - 1,
+     * which means retriesAttempted &lt;= 30, so that is the ceil for retriesAttempted.
+     */
+    int RETRIES_ATTEMPTED_CEILING = (int) Math.floor(Math.log(Integer.MAX_VALUE) / Math.log(2));
+
+    /**
+     * Do not back off: retry immediately.
+     */
+    static BackoffStrategy retryImmediately() {
+        return new Immediately();
+    }
+
+    /**
+     * Wait for a random period of time between 0ms and the provided delay.
+     */
+    static BackoffStrategy fixedDelay(Duration delay) {
+        return new FixedDelayWithJitter(ThreadLocalRandom::current, delay);
+    }
+
+    /**
+     * Wait for a period of time equal to the provided delay.
+     */
+    static BackoffStrategy fixedDelayWithoutJitter(Duration delay) {
+        return new FixedDelayWithoutJitter(delay);
+    }
+
+    /**
+     * Wait for a random period of time between 0ms and an exponentially increasing amount of time between each subsequent attempt
+     * of the same call.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits between
+     * 0ms and {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+     */
+    static BackoffStrategy exponentialDelay(Duration baseDelay, Duration maxDelay) {
+        return new ExponentialDelayWithJitter(ThreadLocalRandom::current, baseDelay, maxDelay);
+    }
+
+    /**
+     * Wait for an exponentially increasing amount of time between each subsequent attempt of the same call.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits for
+     * {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+     */
+    static BackoffStrategy exponentialDelayWithoutJitter(Duration baseDelay, Duration maxDelay) {
+        return new ExponentialDelayWithoutJitter(baseDelay, maxDelay);
+    }
+
+    /**
+     * Returns the computed exponential delay in milliseconds given the retries attempted, the base delay and the max backoff
+     * time.
+     *
+     * <p>Specifically it returns {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}. To prevent overflowing the attempts
+     * get capped to 30.
+     */
+    default int calculateExponentialDelay(int retriesAttempted, Duration baseDelay, Duration maxBackoffTime) {
+        int cappedRetries = Math.min(retriesAttempted, RETRIES_ATTEMPTED_CEILING);
+        return (int) Math.min(baseDelay.multipliedBy(1L << (cappedRetries - 2)).toMillis(), maxBackoffTime.toMillis());
+    }
+
+    /**
+     * Compute the amount of time to wait before the provided attempt number is executed.
+     *
+     * @param attempt The attempt to compute the delay for, starting at one.
+     * @throws IllegalArgumentException If the given attempt is less or equal to zero.
+     */
+    Duration computeDelay(int attempt);
+
+    /**
+     * Strategy that do not back off: retry immediately.
+     */
+    final class Immediately implements BackoffStrategy {
+        @Override
+        public Duration computeDelay(int attempt) {
+            Validate.isPositive(attempt, "attempt");
+            return Duration.ZERO;
+        }
+
+        @Override
+        public String toString() {
+            return "(Immediately)";
+        }
+    }
+
+    /**
+     * Strategy that waits for a period of time equal to the provided delay.
+     */
+    final class FixedDelayWithoutJitter implements BackoffStrategy {
+        private final Duration delay;
+
+        FixedDelayWithoutJitter(Duration delay) {
+            this.delay = Validate.isPositive(delay, "delay");
+        }
+
+        @Override
+        public Duration computeDelay(int attempt) {
+            Validate.isPositive(attempt, "attempt");
+            return delay;
+        }
+
+        @Override
+        public String toString() {
+            return ToString.builder("FixedDelayWithoutJitter")
+                           .add("delay", delay)
+                           .build();
+        }
+    }
+
+    /**
+     * Strategy that waits for a random period of time between 0ms and the provided delay.
+     */
+    final class FixedDelayWithJitter implements BackoffStrategy {
+        private final Supplier<Random> randomSupplier;
+        private final Duration delay;
+
+        FixedDelayWithJitter(Supplier<Random> randomSupplier, Duration delay) {
+            this.randomSupplier = Validate.paramNotNull(randomSupplier, "random");
+            this.delay = NumericUtils.min(Validate.isPositive(delay, "delay"), BASE_DELAY_CEILING);
+        }
+
+        @Override
+        public Duration computeDelay(int attempt) {
+            Validate.isPositive(attempt, "attempt");
+            return Duration.ofMillis(randomSupplier.get().nextInt((int) delay.toMillis()));
+        }
+
+        @Override
+        public String toString() {
+            return ToString.builder("FixedDelayWithJitter")
+                           .add("delay", delay)
+                           .build();
+        }
+    }
+
+    /**
+     * Strategy that waits for a random period of time between 0ms and an exponentially increasing amount of time between each
+     * subsequent attempt of the same call.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits between
+     * 0ms and {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+     */
+    final class ExponentialDelayWithJitter implements BackoffStrategy {
+        private final Supplier<Random> randomSupplier;
+        private final Duration baseDelay;
+        private final Duration maxDelay;
+
+        ExponentialDelayWithJitter(Supplier<Random> randomSupplier, Duration baseDelay, Duration maxDelay) {
+            this.randomSupplier = Validate.paramNotNull(randomSupplier, "random");
+            this.baseDelay = NumericUtils.min(Validate.isPositive(baseDelay, "baseDelay"), BASE_DELAY_CEILING);
+            this.maxDelay = NumericUtils.min(Validate.isPositive(maxDelay, "maxDelay"), MAX_BACKOFF_CEILING);
+        }
+
+        @Override
+        public Duration computeDelay(int attempt) {
+            Validate.isPositive(attempt, "attempt");
+            if (attempt == 1) {
+                return Duration.ZERO;
+            }
+            int delay = calculateExponentialDelay(attempt, baseDelay, maxDelay);
+            int randInt = randomSupplier.get().nextInt(delay);
+            return Duration.ofMillis(randInt);
+        }
+
+        @Override
+        public String toString() {
+            return ToString.builder("ExponentialDelayWithJitter")
+                           .add("baseDelay", baseDelay)
+                           .add("maxDelay", maxDelay)
+                           .build();
+        }
+    }
+
+    /**
+     * Strategy that waits for an exponentially increasing amount of time between each subsequent attempt of the same call.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits for
+     * {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+     */
+    final class ExponentialDelayWithoutJitter implements BackoffStrategy {
+        private final Duration baseDelay;
+        private final Duration maxDelay;
+
+        public ExponentialDelayWithoutJitter(Duration baseDelay, Duration maxDelay) {
+            this.baseDelay = NumericUtils.min(Validate.isPositive(baseDelay, "baseDelay"), BASE_DELAY_CEILING);
+            this.maxDelay = NumericUtils.min(Validate.isPositive(maxDelay, "maxDelay"), MAX_BACKOFF_CEILING);
+        }
+
+        @Override
+        public Duration computeDelay(int attempt) {
+            Validate.isPositive(attempt, "attempt");
+            if (attempt == 1) {
+                return Duration.ZERO;
+            }
+            int delay = calculateExponentialDelay(attempt, baseDelay, maxDelay);
+            return Duration.ofMillis(delay);
+        }
+
+        @Override
+        public String toString() {
+            return ToString.builder("ExponentialDelayWithoutJitter")
+                           .add("baseDelay", baseDelay)
+                           .add("maxDelay", maxDelay)
+                           .build();
+        }
+    }
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RecordSuccessRequest.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RecordSuccessRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Request that the calling code makes to the {@link RetryStrategy} using
+ * {@link RetryStrategy#recordSuccess(RecordSuccessRequest)} to notify that the attempted execution succeeded.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface RecordSuccessRequest {
+    /**
+     * A {@link RetryToken} acquired a previous {@link RetryStrategy#acquireInitialToken} or
+     * {@link RetryStrategy#refreshRetryToken} call.
+     */
+    RetryToken token();
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RecordSuccessResponse.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RecordSuccessResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Response given to the calling code by the {@link RetryStrategy} after calling
+ * {@link RetryStrategy#recordSuccess(RecordSuccessRequest)}.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface RecordSuccessResponse {
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RefreshRetryTokenRequest.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RefreshRetryTokenRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import java.time.Duration;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Request that the calling code makes to the {@link RetryStrategy} using
+ * {@link RetryStrategy#refreshRetryToken(RefreshRetryTokenRequest)} to notify that the attempted execution failed and the
+ * {@link RetryToken} needs to be refreshed.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface RefreshRetryTokenRequest {
+    /**
+     * A {@link RetryToken} acquired a previous {@link RetryStrategy#acquireInitialToken} or
+     * {@link RetryStrategy#refreshRetryToken} call.
+     */
+    RetryToken token();
+
+    /**
+     * A suggestion of how long to wait from the last attempt failure. For HTTP calls, this is usually extracted from a "retry
+     * after" header from the downstream service.
+     */
+    Optional<Duration> suggestedDelay();
+
+    /**
+     * The cause of the last attempt failure.
+     */
+    Throwable failure();
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RefreshRetryTokenResponse.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RefreshRetryTokenResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * Response from the {@link RetryStrategy} after calling {@link RetryStrategy#refreshRetryToken(RefreshRetryTokenRequest)}.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface RefreshRetryTokenResponse {
+    /**
+     * A {@link RetryToken} acquired by this invocation, used in subsequent {@link RetryStrategy#refreshRetryToken} or
+     * {@link RetryStrategy#recordSuccess} calls.
+     */
+    RetryToken token();
+
+    /**
+     * The amount of time to wait before performing the next attempt.
+     */
+    Duration delay();
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RetryStrategy.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RetryStrategy.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import java.util.function.Predicate;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.utils.builder.CopyableBuilder;
+import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
+
+/**
+ * A strategy used by an SDK to determine when something should be retried.
+ *
+ * <p>We do not recommend SDK users create their own retry strategies. We recommend refining an
+ * existing strategy:
+ * <ol>
+ *     <li>If you are using the strategy with a service, you can get the existing strategy
+ *     from that service via {@code [ServiceName]Client.defaults().retryStrategy()}.
+ *     <li>{@code RetryStrategies} from the {@code software.amazon.awssdk:retries} module.
+ * </ol>
+ *
+ * <p>Terminology:
+ * <ol>
+ *     <li>An <b>attempt</b> is a single invocation of an action.
+ *     <li>The <b>attempt count</b> is which attempt (starting with 1) the SDK is attempting to
+ *     make.
+ * </ol>
+ */
+@ThreadSafe
+@SdkPublicApi
+public interface RetryStrategy extends ToCopyableBuilder<RetryStrategy.Builder, RetryStrategy> {
+    /**
+     * Invoked before the first request attempt.
+     *
+     * <p>Callers MUST wait for the {@code delay} returned by this call before making the first attempt. Callers that wish to
+     * retry a failed attempt MUST call {@link #refreshRetryToken} before doing so.
+     *
+     * <p>If the attempt was successful, callers MUST call {@link #recordSuccess}.
+     *
+     * @throws NullPointerException            if a required parameter is not specified
+     * @throws TokenAcquisitionFailedException if a token cannot be acquired
+     */
+    AcquireInitialTokenResponse acquireInitialToken(AcquireInitialTokenRequest request);
+
+    /**
+     * Invoked before each subsequent (non-first) request attempt.
+     *
+     * <p>Callers MUST wait for the {@code delay} returned by this call before making the next attempt. If the next attempt
+     * fails, callers MUST re-call {@link #refreshRetryToken} before attempting another retry. This call invalidates the provided
+     * token, and returns a new one. Callers MUST use the new token.
+     *
+     * <p>If the attempt was successful, callers MUST call {@link #recordSuccess}.
+     *
+     * @throws NullPointerException            if a required parameter is not specified
+     * @throws IllegalArgumentException        if the provided token was not issued by this strategy or the provided token was
+     *                                         already used for a previous refresh or success call.
+     * @throws TokenAcquisitionFailedException if a token cannot be acquired
+     */
+    RefreshRetryTokenResponse refreshRetryToken(RefreshRetryTokenRequest request);
+
+    /**
+     * Invoked after an attempt succeeds.
+     *
+     * @throws NullPointerException     if a required parameter is not specified
+     * @throws IllegalArgumentException if the provided token was not issued by this strategy or the provided token was already
+     *                                  used for a previous refresh or success call.
+     */
+    RecordSuccessResponse recordSuccess(RecordSuccessRequest request);
+
+    /**
+     * Create a new {@link Builder} with the current configuration.
+     *
+     * <p>This is useful for modifying the strategy's behavior, like conditions or max retries.
+     */
+    @Override
+    Builder toBuilder();
+
+    /**
+     * Builder to create immutable instances of {@link RetryStrategy}.
+     */
+    interface Builder extends CopyableBuilder<Builder, RetryStrategy> {
+        /**
+         * Configure the strategy to retry when the provided predicate returns true, given a failure exception.
+         */
+        Builder retryOnException(Predicate<Throwable> shouldRetry);
+
+        /**
+         * Configure the strategy to retry when a failure exception class is equal to the provided class.
+         */
+        default Builder retryOnException(Class<? extends Throwable> throwable) {
+            return retryOnException(t -> t.getClass() == throwable);
+        }
+
+        /**
+         * Configure the strategy to retry when a failure exception class is an instance of the provided class (includes
+         * subtypes).
+         */
+        default Builder retryOnExceptionInstanceOf(Class<? extends Throwable> throwable) {
+            return retryOnException(t -> throwable.isAssignableFrom(t.getClass()));
+        }
+
+        /**
+         * Configure the strategy to retry when a failure exception or one of its cause classes is equal to the provided class.
+         */
+        default Builder retryOnExceptionOrCause(Class<? extends Throwable> throwable) {
+            return retryOnException(t -> {
+                if (t.getClass() == throwable) {
+                    return true;
+                }
+                Throwable cause = t.getCause();
+                while (cause != null) {
+                    if (cause.getClass() == throwable) {
+                        return true;
+                    }
+                    cause = cause.getCause();
+                }
+                return false;
+            });
+        }
+
+        /**
+         * Configure the strategy to retry when a failure exception or one of its cause classes is an instance of the provided
+         * class (includes subtypes).
+         */
+        default Builder retryOnExceptionOrCauseInstanceOf(Class<? extends Throwable> throwable) {
+            return retryOnException(t -> {
+                if (throwable.isAssignableFrom(t.getClass())) {
+                    return true;
+                }
+                Throwable cause = t.getCause();
+                while (cause != null) {
+                    if (throwable.isAssignableFrom(cause.getClass())) {
+                        return true;
+                    }
+                    cause = cause.getCause();
+                }
+                return false;
+            });
+        }
+
+        /**
+         * Configure the strategy to retry the root cause of a failure (the final cause) a failure exception is equal to the
+         * provided class.
+         */
+        default Builder retryOnRootCause(Class<? extends Throwable> throwable) {
+            return retryOnException(t -> {
+                boolean shouldRetry = false;
+                Throwable cause = t.getCause();
+                while (cause != null) {
+                    shouldRetry = throwable == cause.getClass();
+                    cause = cause.getCause();
+                }
+                return shouldRetry;
+            });
+        }
+
+        /**
+         * Configure the strategy to retry the root cause of a failure (the final cause) a failure exception is an instance of to
+         * the provided class (includes subtypes).
+         */
+        default Builder retryOnRootCauseInstanceOf(Class<? extends Throwable> throwable) {
+            return retryOnException(t -> {
+                boolean shouldRetry = false;
+                Throwable cause = t.getCause();
+                while (cause != null) {
+                    shouldRetry = throwable.isAssignableFrom(cause.getClass());
+                    cause = cause.getCause();
+                }
+                return shouldRetry;
+            });
+        }
+
+        /**
+         * Configure the maximum number of attempts used by this executor.
+         *
+         * <p>The actual number of attempts made may be less, depending on the retry strategy implementation. For example, the
+         * standard and adaptive retry modes both employ short-circuiting which reduces the maximum attempts during outages.
+         *
+         * <p>The default value for the standard and adaptive retry strategies is 3.
+         */
+        Builder maxAttempts(int maxAttempts);
+
+        /**
+         * Configure the predicate to allow the strategy categorize a Throwable as throttling exception.
+         */
+        Builder treatAsThrottling(Predicate<Throwable> treatAsThrottling);
+
+        /**
+         * Build a new {@link RetryStrategy} with the current configuration on this builder.
+         */
+        @Override
+        RetryStrategy build();
+    }
+}
+

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RetryToken.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/RetryToken.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.annotations.ThreadSafe;
+
+/**
+ * An opaque token representing an in-progress execution.
+ *
+ * <p>Created via {@link RetryStrategy#acquireInitialToken} before a first attempt and refreshed
+ * after each attempt failure via {@link RetryStrategy#refreshRetryToken}.
+ *
+ * <p>Released via {@link RetryStrategy#recordSuccess} after a successful attempt.
+ */
+@SdkPublicApi
+@ThreadSafe
+public interface RetryToken {
+}

--- a/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/TokenAcquisitionFailedException.java
+++ b/core/retries-api/src/main/java/software/amazon/awssdk/retriesapi/TokenAcquisitionFailedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * Exception thrown by {@link RetryStrategy} when a new token cannot be acquired.
+ */
+@SdkPublicApi
+public final class TokenAcquisitionFailedException extends RuntimeException {
+    /**
+     * Exception construction accepting message with no root cause.
+     */
+    public TokenAcquisitionFailedException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Exception constructor accepting message and a root cause.
+     */
+    public TokenAcquisitionFailedException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/core/retries-api/src/test/java/software/amazon/awssdk/retriesapi/ExponentialDelayWithJitterTest.java
+++ b/core/retries-api/src/test/java/software/amazon/awssdk/retriesapi/ExponentialDelayWithJitterTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+import java.util.function.Function;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ExponentialDelayWithJitterTest {
+    static final ComputedNextInt MIN_VALUE_RND = new ComputedNextInt(bound -> 0);
+    static final ComputedNextInt MID_VALUE_RND = new ComputedNextInt(bound -> bound / 2);
+    static final ComputedNextInt MAX_VALUE_RND = new ComputedNextInt(bound -> bound - 1);
+    static final Duration BASE_DELAY = Duration.ofMillis(23);
+    static final Duration MAX_DELAY = Duration.ofSeconds(20);
+
+    @Parameterized.Parameters
+    public static Collection<TestCase> parameters() {
+        return Arrays.asList(
+            // --- Using random that returns: bound - 1
+            new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(45)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(183)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(735)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(11775)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(19999)
+            // --- Using random that returns: bound / 2
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(23)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(92)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(368)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(5888)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(10000)
+            // --- Using random that returns: 0
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(0)
+        );
+    }
+
+    @Parameterized.Parameter
+    public TestCase testCase;
+
+    @Test
+    public void testCase() {
+        assertThat(testCase.run()).isEqualTo(testCase.expected());
+    }
+
+    static class TestCase {
+        Random random;
+        int attempt;
+        long expectedDelayMs;
+
+        TestCase configureRandom(Random random) {
+            this.random = random;
+            return this;
+        }
+
+        TestCase givenAttempt(int attempt) {
+            this.attempt = attempt;
+            return this;
+        }
+
+        TestCase expectDelayInMs(long expectedDelayMs) {
+            this.expectedDelayMs = expectedDelayMs;
+            return this;
+        }
+
+        Duration run() {
+            return
+                new BackoffStrategy.ExponentialDelayWithJitter(() -> random, BASE_DELAY, MAX_DELAY)
+                    .computeDelay(this.attempt);
+        }
+
+        Duration expected() {
+            return Duration.ofMillis(expectedDelayMs);
+        }
+    }
+
+    static class ComputedNextInt extends Random {
+        final Function<Integer, Integer> compute;
+
+        ComputedNextInt(Function<Integer, Integer> compute) {
+            this.compute = compute;
+        }
+
+        @Override
+        public int nextInt(int bound) {
+            return compute.apply(bound);
+        }
+    }
+}

--- a/core/retries-api/src/test/java/software/amazon/awssdk/retriesapi/FixedDelayWithJitterTest.java
+++ b/core/retries-api/src/test/java/software/amazon/awssdk/retriesapi/FixedDelayWithJitterTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retriesapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+import java.util.function.Function;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class FixedDelayWithJitterTest {
+    static final ComputedNextInt MIN_VALUE_RND = new ComputedNextInt(bound -> 0);
+    static final ComputedNextInt MID_VALUE_RND = new ComputedNextInt(bound -> bound / 2);
+    static final ComputedNextInt MAX_VALUE_RND = new ComputedNextInt(bound -> bound - 1);
+    static final Duration BASE_DELAY = Duration.ofMillis(23);
+
+    @Parameterized.Parameters
+    public static Collection<TestCase> parameters() {
+        return Arrays.asList(
+            // --- Using random that returns: bound - 1
+            new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(22)
+            // --- Using random that returns: bound / 2
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(11)
+            // --- Using random that returns: 0
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(0)
+        );
+    }
+
+    @Parameterized.Parameter
+    public TestCase testCase;
+
+    @Test
+    public void testCase() {
+        assertThat(testCase.run()).isEqualTo(testCase.expected());
+    }
+
+    static class TestCase {
+        Random random;
+        int attempt;
+        long expectedDelayMs;
+
+        TestCase configureRandom(Random random) {
+            this.random = random;
+            return this;
+        }
+
+        TestCase givenAttempt(int attempt) {
+            this.attempt = attempt;
+            return this;
+        }
+
+        TestCase expectDelayInMs(long expectedDelayMs) {
+            this.expectedDelayMs = expectedDelayMs;
+            return this;
+        }
+
+        Duration run() {
+            return
+                new BackoffStrategy.FixedDelayWithJitter(() -> random, BASE_DELAY)
+                    .computeDelay(this.attempt);
+        }
+
+        Duration expected() {
+            return Duration.ofMillis(expectedDelayMs);
+        }
+    }
+
+    static class ComputedNextInt extends Random {
+        final Function<Integer, Integer> compute;
+
+        ComputedNextInt(Function<Integer, Integer> compute) {
+            this.compute = compute;
+        }
+
+        @Override
+        public int nextInt(int bound) {
+            return compute.apply(bound);
+        }
+    }
+}


### PR DESCRIPTION
This new module includes the interfaces and classes that will be used to implement the new retry logic within the SDK.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

As part of the Smithy Reference Architecture this change adds a new module for retries. This change adds only the API part.

## Modifications
No modifications to existing code were made. We will make those changes in follow up pull requests.
<!--- Describe your changes in detail -->

## Testing
* Added unit tests for all the default methods in the `RetryStrategy.Builder` interface that create lambdas to be used to decide if an exception should be retried.

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ x] Local run of `mvn install` succeeds
- [ x] My code follows the code style of this project
- [ x] My change requires a change to the Javadoc documentation
- [ x] I have updated the Javadoc documentation accordingly
- [ x] I have added tests to cover my changes
- [ x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
