### PR TITLE
The builder for EnhancedDocument should not rely on the order in which attribute converters are added to it

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/DocumentUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/DocumentUtils.java
@@ -146,9 +146,11 @@ public final class DocumentUtils {
             return convertMapToAttributeValue((Map<?, ?>) sourceObject, attributeConverterProvider);
         }
         AttributeConverter attributeConverter = attributeConverterProvider.converterFor(EnhancedType.of(sourceObject.getClass()));
+        if (attributeConverter == null) {
+            throw new IllegalStateException("Converter not found for Class " + sourceObject.getClass().getSimpleName());
+        }
         return attributeConverter.transformFrom(sourceObject);
     }
-
 
     /**
      * Coverts AttributeValue to simple java objects like String, SdkNumber, Boolean, List, Set, SdkBytes or Maps.

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomAttributeForDocumentConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomAttributeForDocumentConverterProvider.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converters.document;
+
+import java.util.Map;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.IntegerStringConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+public class CustomAttributeForDocumentConverterProvider implements AttributeConverterProvider {
+    private final Map<EnhancedType<?>, AttributeConverter<?>> converterCache = ImmutableMap.of(
+        EnhancedType.of(CustomClassForDocumentAPI.class), new CustomClassForDocumentAttributeConverter(),
+        EnhancedType.of(Integer.class), new CustomIntegerAttributeConverter()
+    );
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+        return (AttributeConverter<T>) converterCache.get(enhancedType);
+    }
+
+    public static CustomAttributeForDocumentConverterProvider create(){
+        return new CustomAttributeForDocumentConverterProvider();
+    }
+
+
+    private static class CustomStringAttributeConverter implements AttributeConverter<String> {
+
+        final static String DEFAULT_SUFFIX = "-custom";
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return EnhancedAttributeValue.fromString(input + DEFAULT_SUFFIX).toAttributeValue();
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            return input.s();
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    private static class CustomIntegerAttributeCo implements AttributeConverter<Integer> {
+
+        final static Integer DEFAULT_INCREMENT = 10;
+
+        @Override
+        public AttributeValue transformFrom(Integer input) {
+            return EnhancedAttributeValue.fromNumber(IntegerStringConverter.create().toString(input + DEFAULT_INCREMENT))
+                                         .toAttributeValue();
+        }
+
+        @Override
+        public Integer transformTo(AttributeValue input) {
+            return Integer.valueOf(input.n());
+        }
+
+        @Override
+        public EnhancedType<Integer> type() {
+            return EnhancedType.of(Integer.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.N;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomClassForDocumentAPI.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomClassForDocumentAPI.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converters.document;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.core.SdkBytes;
+
+public class CustomClassForDocumentAPI {
+    public String string() {
+        return string;
+    }
+
+    public Set<String> stringSet() {
+        return stringSet;
+    }
+
+    public SdkBytes binary() {
+        return binary;
+    }
+
+    public Set<byte[]> binarySet() {
+        return binarySet;
+    }
+
+    public boolean aBoolean() {
+        return aBoolean;
+    }
+
+    public Set<Boolean> booleanSet() {
+        return booleanSet;
+    }
+
+    public Long longNumber() {
+        return longNumber;
+    }
+
+    public Set<Long> longSet() {
+        return longSet;
+    }
+
+    public BigDecimal bigDecimal() {
+        return bigDecimal;
+    }
+
+    public Set<BigDecimal> bigDecimalSet() {
+        return bigDecimalSet;
+    }
+
+    public List<CustomClassForDocumentAPI> customClassList() {
+        return customClassForDocumentAPIList;
+    }
+
+    public List<Instant> instantList() {
+        return instantList;
+    }
+
+    public Map<String, CustomClassForDocumentAPI> customClassMap() {
+        return customClassMap;
+    }
+
+    public CustomClassForDocumentAPI innerCustomClass() {
+        return innerCustomClassForDocumentAPI;
+    }
+
+    private final String string;
+    private final Set<String> stringSet;
+    private final SdkBytes binary;
+    private final Set<byte[]> binarySet;
+    private final boolean aBoolean;
+    private final Set<Boolean> booleanSet;
+    private final Long longNumber;
+    private final Set<Long> longSet;
+    private final BigDecimal bigDecimal;
+    private final Set<BigDecimal> bigDecimalSet;
+    private final List<CustomClassForDocumentAPI> customClassForDocumentAPIList;
+    private final List<Instant> instantList;
+    private final Map<String, CustomClassForDocumentAPI> customClassMap;
+    private final CustomClassForDocumentAPI innerCustomClassForDocumentAPI;
+
+    public static Builder builder(){
+        return new Builder();
+    }
+
+    public CustomClassForDocumentAPI(Builder builder) {
+        this.string = builder.string;
+        this.stringSet = builder.stringSet;
+        this.binary = builder.binary;
+        this.binarySet = builder.binarySet;
+        this.aBoolean = builder.aBoolean;
+        this.booleanSet = builder.booleanSet;
+        this.longNumber = builder.longNumber;
+        this.longSet = builder.longSet;
+        this.bigDecimal = builder.bigDecimal;
+        this.bigDecimalSet = builder.bigDecimalSet;
+        this.customClassForDocumentAPIList = builder.customClassForDocumentAPIList;
+        this.instantList = builder.instantList;
+        this.customClassMap = builder.customClassMap;
+        this.innerCustomClassForDocumentAPI = builder.innerCustomClassForDocumentAPI;
+    }
+
+    public static final class Builder {
+        private String string;
+        private Set<String> stringSet;
+        private SdkBytes binary;
+        private Set<byte []> binarySet;
+        private boolean aBoolean;
+        private Set<Boolean> booleanSet;
+        private Long longNumber;
+        private Set<Long> longSet;
+        private BigDecimal bigDecimal;
+        private Set<BigDecimal> bigDecimalSet;
+        private List<CustomClassForDocumentAPI> customClassForDocumentAPIList;
+        private List<Instant> instantList;
+        private Map<String, CustomClassForDocumentAPI> customClassMap;
+        private CustomClassForDocumentAPI innerCustomClassForDocumentAPI;
+
+        private Builder() {
+        }
+
+
+        public Builder string(String string) {
+            this.string = string;
+            return this;
+        }
+
+        public Builder stringSet(Set<String> stringSet) {
+            this.stringSet = stringSet;
+            return this;
+        }
+
+        public Builder binary(SdkBytes binary) {
+            this.binary = binary;
+            return this;
+        }
+
+        public Builder binarySet(Set<byte[]> binarySet) {
+            this.binarySet = binarySet;
+            return this;
+        }
+
+        public Builder aBoolean(boolean aBoolean) {
+            this.aBoolean = aBoolean;
+            return this;
+        }
+
+        public Builder booleanSet(Set<Boolean> booleanSet) {
+            this.booleanSet = booleanSet;
+            return this;
+        }
+
+        public Builder longNumber(Long longNumber) {
+            this.longNumber = longNumber;
+            return this;
+        }
+
+        public Builder longSet(Set<Long> longSet) {
+            this.longSet = longSet;
+            return this;
+        }
+
+        public Builder bigDecimal(BigDecimal bigDecimal) {
+            this.bigDecimal = bigDecimal;
+            return this;
+        }
+
+        public Builder bigDecimalSet(Set<BigDecimal> bigDecimalSet) {
+            this.bigDecimalSet = bigDecimalSet;
+            return this;
+        }
+
+        public Builder customClassList(List<CustomClassForDocumentAPI> customClassForDocumentAPIList) {
+            this.customClassForDocumentAPIList = customClassForDocumentAPIList;
+            return this;
+        }
+
+        public Builder instantList(List<Instant> instantList) {
+            this.instantList = instantList;
+            return this;
+        }
+
+        public Builder customClassMap(Map<String, CustomClassForDocumentAPI> customClassMap) {
+            this.customClassMap = customClassMap;
+            return this;
+        }
+
+        public Builder innerCustomClass(CustomClassForDocumentAPI innerCustomClassForDocumentAPI) {
+            this.innerCustomClassForDocumentAPI = innerCustomClassForDocumentAPI;
+            return this;
+        }
+
+        public CustomClassForDocumentAPI build() {
+            return new CustomClassForDocumentAPI(this);
+        }
+    }
+
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomClassForDocumentAPIBuilder.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomClassForDocumentAPIBuilder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converters.document;
+

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomClassForDocumentAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomClassForDocumentAttributeConverter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converters.document;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BigDecimalAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BooleanAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ByteArrayAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LongAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class CustomClassForDocumentAttributeConverter implements AttributeConverter<CustomClassForDocumentAPI> {
+
+    final static Integer DEFAULT_INCREMENT = 10;
+
+    @Override
+    public AttributeValue transformFrom(CustomClassForDocumentAPI input) {
+
+        if(input == null){
+            return null;
+        }
+        Map<String, AttributeValue> attributeValueMap = new HashMap<>();
+
+        if(input.string() != null){
+            attributeValueMap.put("foo", AttributeValue.fromS(input.string()));
+        }
+
+        if(input.stringSet() != null){
+            attributeValueMap.put("stringSet", AttributeValue.fromSs(input.stringSet().stream().collect(Collectors.toList())));
+        }
+
+        if(input.booleanSet() != null){
+            attributeValueMap.put("booleanSet",
+                                  AttributeValue.fromL(input.booleanSet().stream().map(b -> AttributeValue.fromBool(b)).collect(Collectors.toList())));
+        }
+
+        if(input.bigDecimalSet() != null){
+            attributeValueMap.put("stringSet",
+                                  AttributeValue.fromNs(input.bigDecimalSet().stream().map(b -> b.toString()).collect(Collectors.toList())));
+        }
+
+        if(input.customClassList() != null){
+            attributeValueMap.put("customClassList", convertCustomList(input.customClassList()));
+        }
+
+        if (input.innerCustomClass() != null){
+            attributeValueMap.put("innerCustomClass", transformFrom(input.innerCustomClass()));
+        }
+        return EnhancedAttributeValue.fromMap(attributeValueMap).toAttributeValue();
+    }
+
+
+    private static AttributeValue convertCustomList(List<CustomClassForDocumentAPI> customClassForDocumentAPIList){
+        List<AttributeValue> convertCustomList =
+            customClassForDocumentAPIList.stream().map(customClassForDocumentAPI -> create().transformFrom(customClassForDocumentAPI)).collect(Collectors.toList());
+        return AttributeValue.fromL(convertCustomList);
+
+    }
+
+    @Override
+    public CustomClassForDocumentAPI transformTo(AttributeValue input) {
+
+        Map<String, AttributeValue> customAttr = input.m();
+
+        CustomClassForDocumentAPI.Builder builder = CustomClassForDocumentAPI.builder();
+        builder.string(StringAttributeConverter.create().transformTo(customAttr.get("foo")));
+        builder.stringSet(SetAttributeConverter.setConverter(StringAttributeConverter.create()).transformTo(customAttr.get("stringSet")));
+        builder.binary(SdkBytes.fromByteArray(ByteArrayAttributeConverter.create().transformTo(customAttr.get("binary"))));
+
+        builder.binarySet(SetAttributeConverter.setConverter(ByteArrayAttributeConverter.create()).transformTo(customAttr.get("binarySet")));
+
+        builder.aBoolean(BooleanAttributeConverter.create().transformTo(customAttr.get("aBoolean")));
+        builder.booleanSet(SetAttributeConverter.setConverter(BooleanAttributeConverter.create()).transformTo(customAttr.get(
+            "booleanSet")));
+
+        builder.longNumber(LongAttributeConverter.create().transformTo(customAttr.get("longNumber")));
+        builder.longSet(SetAttributeConverter.setConverter(LongAttributeConverter.create()).transformTo(customAttr.get("longSet")));
+
+        builder.bigDecimal(BigDecimalAttributeConverter.create().transformTo(customAttr.get("bigDecimal")));
+        builder.bigDecimalSet(SetAttributeConverter.setConverter(BigDecimalAttributeConverter.create()).transformTo(customAttr.get("bigDecimalSet")));
+
+        builder.customClassList(ListAttributeConverter.create(create()).transformTo(customAttr.get("customClassList")));
+        builder.innerCustomClass(create().transformTo(customAttr.get("innerCustomClass")));
+
+        return builder.build();
+    }
+
+    public static CustomClassForDocumentAttributeConverter create() {
+        return new CustomClassForDocumentAttributeConverter();
+    }
+
+    @Override
+    public EnhancedType<CustomClassForDocumentAPI> type() {
+        return EnhancedType.of(CustomClassForDocumentAPI.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.M;
+    }
+
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomIntegerAttributeConverter.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/converters/document/CustomIntegerAttributeConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.converters.document;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.EnhancedAttributeValue;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.string.IntegerStringConverter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class CustomIntegerAttributeConverter implements AttributeConverter<Integer> {
+
+    final static Integer DEFAULT_INCREMENT = 10;
+
+    @Override
+    public AttributeValue transformFrom(Integer input) {
+        return EnhancedAttributeValue.fromNumber(IntegerStringConverter.create().toString(input + DEFAULT_INCREMENT))
+                                     .toAttributeValue();
+    }
+
+    @Override
+    public Integer transformTo(AttributeValue input) {
+        return Integer.valueOf(input.n());
+    }
+
+    @Override
+    public EnhancedType<Integer> type() {
+        return EnhancedType.of(Integer.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.N;
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/document/EnhancedDocumentTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/document/EnhancedDocumentTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.converters.document.CustomAttributeForDocumentConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.converters.document.CustomClassForDocumentAPI;
 
 public class EnhancedDocumentTest {
 
@@ -70,7 +72,7 @@ public class EnhancedDocumentTest {
 
         assertThat(enhancedDocument.getList("numberList")
                                    .stream()
-                                   .map( o ->Integer.parseInt(o.toString()) )
+                                   .map(o -> Integer.parseInt(o.toString()))
                                    .collect(Collectors.toList()))
             .isEqualTo(Arrays.stream(NUMBER_STRING_ARRAY)
                              .map(s -> Integer.parseInt(s))
@@ -89,13 +91,13 @@ public class EnhancedDocumentTest {
     }
 
     @Test
-    public void nullArgsInStaticConstructor(){
+    void nullArgsInStaticConstructor() {
         assertThat(EnhancedDocument.fromMap(null)).isNull();
         assertThat(EnhancedDocument.fromJson(null)).isNull();
     }
 
     @Test
-    void accessingStringSetFromBuilderMethods(){
+    void accessingStringSetFromBuilderMethods() {
 
         Set<String> stringSet = Stream.of(STRINGS_ARRAY).collect(Collectors.toSet());
         EnhancedDocument enhancedDocument = EnhancedDocument.builder()
@@ -114,44 +116,135 @@ public class EnhancedDocumentTest {
         assertThat(fromBuilder.toJson()).isEqualTo(INNER_JSON);
     }
 
-  @Test
-  void builder_with_NullKeys() {
-      assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() ->EnhancedDocument.builder().addString(null, "Sample"))
+    @Test
+    void builder_with_NullKeys() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addString(null, "Sample"))
             .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addNull(null))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addNull(null))
+            .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addNumber(null, 3))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addNumber(null, 3))
+            .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addList(null, Arrays.asList()))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addList(null, Arrays.asList()))
+            .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addSdkBytes(null, SdkBytes.fromUtf8String("a")))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addSdkBytes(null, SdkBytes.fromUtf8String("a")))
+            .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addMap(null, new HashMap<>()))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addMap(null, new HashMap<>()))
+            .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addStringSet(null, Stream.of("a").collect(Collectors.toSet())))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addStringSet(null, Stream.of("a").collect(Collectors.toSet())))
+            .withMessage(EMPTY_OR_NULL_ERROR);
 
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addNumberSet(null, Stream.of(1).collect(Collectors.toSet())))
-           .withMessage(EMPTY_OR_NULL_ERROR);
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addStringSet(null, Stream.of("a").collect(Collectors.toSet())))
-           .withMessage(EMPTY_OR_NULL_ERROR);
-       assertThatExceptionOfType(IllegalArgumentException.class)
-           .isThrownBy(() ->EnhancedDocument.builder().addSdkBytesSet(null, Stream.of(SdkBytes.fromUtf8String("a")).collect(Collectors.toSet())))
-           .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addNumberSet(null, Stream.of(1).collect(Collectors.toSet())))
+            .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addStringSet(null, Stream.of("a").collect(Collectors.toSet())))
+            .withMessage(EMPTY_OR_NULL_ERROR);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> EnhancedDocument.builder().addSdkBytesSet(null, Stream.of(SdkBytes.fromUtf8String("a")).collect(Collectors.toSet())))
+            .withMessage(EMPTY_OR_NULL_ERROR);
+    }
+
+    @Test
+    void errorWhen_NoAttributeConverter_IsProviderIsDefined() {
+        CustomClassForDocumentAPI customObject = CustomClassForDocumentAPI.builder().string("str_one").aBoolean(false).build();
+
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(
+            () -> EnhancedDocument.builder().add("customObject", customObject).build())
+                                                              .withMessage("Converter not found for EnhancedType(software.amazon.awssdk.enhanced.dynamodb.converters.document.CustomClassForDocumentAPI)");
+
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(
+            () -> EnhancedDocument.builder().addList("customObject", Arrays.asList(customObject)).build())
+                                                              .withMessage("Converter not found for EnhancedType(software.amazon.awssdk.enhanced.dynamodb.converters.document.CustomClassForDocumentAPI)");
+
+        Map<String, CustomClassForDocumentAPI> customClassMap = new LinkedHashMap<>();
+        customClassMap.put("one", customObject);
+
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(
+            () -> EnhancedDocument.builder().addMap("customObject", customClassMap).build())
+                                                              .withMessage("Converter not found for EnhancedType(software.amazon.awssdk.enhanced.dynamodb.converters.document.CustomClassForDocumentAPI)");
+    }
+
+    @Test
+    void attributeConverter_OrderInBuilder_Doesnot_Matter_forSimpleAdd() {
+        CustomClassForDocumentAPI customObject = CustomClassForDocumentAPI.builder().string("str_one")
+                                                                          .longNumber(26L)
+                                                                          .aBoolean(false).build();
+        EnhancedDocument afterCustomClass = EnhancedDocument.builder()
+                                                            .attributeConverterProviders(CustomAttributeForDocumentConverterProvider.create())
+                                                            .addString("direct_attr", "sample_value")
+                                                            .add("customObject", customObject).build();
+
+        EnhancedDocument beforeCustomClass = EnhancedDocument.builder()
+                                                             .addString("direct_attr", "sample_value")
+                                                             .add("customObject", customObject)
+                                                             .attributeConverterProviders(CustomAttributeForDocumentConverterProvider.create())
+                                                             .build();
+        assertThat(afterCustomClass.toJson()).isEqualTo("{\"direct_attr\": \"sample_value\",\"customObject\": {\"foo\": "
+                                                        + "\"str_one\"}}");
+        assertThat(beforeCustomClass.toJson()).isEqualTo(afterCustomClass.toJson());
+    }
+
+    @Test
+    void attributeConverter_OrderInBuilder_Doesnot_Matter_ForListAdd() {
+        CustomClassForDocumentAPI customObjectOne = CustomClassForDocumentAPI.builder().string("str_one")
+                                                                             .longNumber(26L)
+                                                                             .aBoolean(false).build();
+
+        CustomClassForDocumentAPI customObjectTwo = CustomClassForDocumentAPI.builder().string("str_two")
+                                                                             .longNumber(27L)
+                                                                             .aBoolean(true).build();
+        EnhancedDocument afterCustomClass = EnhancedDocument.builder()
+                                                            .attributeConverterProviders(CustomAttributeForDocumentConverterProvider.create())
+                                                            .addString("direct_attr", "sample_value")
+                                                            .addList("customObject", Arrays.asList(customObjectOne,
+                                                                                                   customObjectTwo)).build();
+        EnhancedDocument beforeCustomClass = EnhancedDocument.builder()
+                                                             .addString("direct_attr", "sample_value")
+                                                             .addList("customObject", Arrays.asList(customObjectOne,
+                                                                                                    customObjectTwo))
+                                                             .attributeConverterProviders(CustomAttributeForDocumentConverterProvider.create())
+                                                             .build();
+        assertThat(afterCustomClass.toJson()).isEqualTo("{\"direct_attr\": \"sample_value\",\"customObject\": [{\"foo\": "
+                                                        + "\"str_one\"}, {\"foo\": \"str_two\"}]}");
+        assertThat(beforeCustomClass.toJson()).isEqualTo(afterCustomClass.toJson());
+    }
+
+    @Test
+    void attributeConverter_OrderInBuilder_Doesnot_Matter_forMapAdd() {
+        CustomClassForDocumentAPI customObjectOne = CustomClassForDocumentAPI.builder().string("str_one")
+                                                                             .longNumber(26L)
+                                                                             .aBoolean(false).build();
+        CustomClassForDocumentAPI customObjectTwo = CustomClassForDocumentAPI.builder().string("str_two")
+                                                                             .longNumber(27L)
+                                                                             .aBoolean(true)
+                                                                             .build();
+        Map<String, CustomClassForDocumentAPI> map = new LinkedHashMap<>();
+        map.put("one", customObjectOne);
+        map.put("two", customObjectTwo);
+
+        EnhancedDocument afterCustomClass = EnhancedDocument.builder()
+                                                            .attributeConverterProviders(CustomAttributeForDocumentConverterProvider.create())
+                                                            .addString("direct_attr", "sample_value")
+                                                            .addMap("customObject", map)
+                                                            .build();
+        EnhancedDocument beforeCustomClass = EnhancedDocument.builder()
+                                                             .addString("direct_attr", "sample_value")
+                                                             .addMap("customObject", map)
+                                                             .attributeConverterProviders(CustomAttributeForDocumentConverterProvider.create())
+                                                             .build();
+
     }
 }


### PR DESCRIPTION
…h attribute converters are added to it

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
- The builder for EnhancedDocument should not rely on the order in which attribute converters are added to it

## Modifications
<!--- Describe your changes in detail -->
- The generic objects are converted to AttributeValue Object are Build time.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added Junits

#
## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
