### PR TITLE
Attempt to call close() on evicted cache values 

### DIFF
--- a/utils/src/main/java/software/amazon/awssdk/utils/cache/lru/LruCache.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/cache/lru/LruCache.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
 /**
@@ -39,6 +40,8 @@ import software.amazon.awssdk.utils.Validate;
 @SdkProtectedApi
 @ThreadSafe
 public final class LruCache<K, V>  {
+
+    private static final Logger log = Logger.loggerFor(LruCache.class);
 
     private static final int DEFAULT_SIZE = 100;
 
@@ -146,8 +149,19 @@ public final class LruCache<K, V>  {
      */
     private void evict() {
         leastRecentlyUsed.isEvicted(true);
+        closeEvictedResourcesIfPossible(leastRecentlyUsed.value);
         cache.remove(leastRecentlyUsed.key());
         removeFromQueue(leastRecentlyUsed);
+    }
+
+    private void closeEvictedResourcesIfPossible(V value) {
+        if (value instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) value).close();
+            } catch (Exception e) {
+                log.warn(() -> "Attempted to close instance that was evicted by cache, but got exception: " + e.getMessage());
+            }
+        }
     }
 
     public int size() {


### PR DESCRIPTION
## Motivation and Context
When cached values are evicted, they may own resources that should be closed and garbage collected. 

## Modifications
The cache will call `close()` on values that implement AutoCloseable when a value is evicted. Failures are logged, but not propagated. 

## Testing
Unit tested. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
