### PR TITLE
Make 'a href' links bold in javadoc

### DIFF
--- a/javadoc-resources/aws-sdk-java-v2-javadoc.css
+++ b/javadoc-resources/aws-sdk-java-v2-javadoc.css
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+a:link {
+    font-weight: bold;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
 
         <skip.unit.tests>${skipTests}</skip.unit.tests>
         <integTestSourceDirectory>${project.basedir}/src/it/java</integTestSourceDirectory>
+        <javadoc.resourcesDir>${session.executionRootDirectory}</javadoc.resourcesDir>
     </properties>
 
     <dependencyManagement>
@@ -1016,6 +1017,11 @@
                             <doctitle>AWS SDK for Java API Reference - ${awsjavasdk.version}</doctitle>
                             <packagesheader>AWS SDK for Java</packagesheader>
                             <excludePackageNames>:*.codegen:software.amazon.awssdk.services.protocol*</excludePackageNames>
+                            <docfilessubdirs>true</docfilessubdirs>
+                            <javadocDirectory>${javadoc.resourcesDir}/javadoc-resources</javadocDirectory>
+                            <addStylesheets>
+                                <addStylesheet>aws-sdk-java-v2-javadoc.css</addStylesheet>
+                            </addStylesheets>
                             <groups>
                                 <group>
                                     <title>Greengrass</title>


### PR DESCRIPTION
# Description
Update the `maven-javadoc-plugin` to add a new custom css file to the generated javadoc. This custom css file will make **all** links in the javadoc website bold.

# Testing
Ran `mvn clean install javadoc:aggregate -B -Ppublic-javadoc -Dcheckstyle.skip -Dspotbugs.skip -DskipTests -Ddoclint=none -pl <module>` locally for a few modules and open the generated javadoc in chrome and firefox. That is the command ran by the release-javadoc build