### PR TITLE
Remove extra spaces in Json and make it same as Items as in V1

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/JsonStringFormatHelper.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/JsonStringFormatHelper.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.internal.document;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+
+@SdkInternalApi
+public final class JsonStringFormatHelper {
+
+    private JsonStringFormatHelper() {
+    }
+
+    /**
+     * Helper function to convert a JsonNode to Json String representation
+     *
+     * @param jsonNode The JsonNode that needs to be converted to Json String.
+     * @return Json String of Json Node.
+     */
+    public static String stringValue(JsonNode jsonNode) {
+        if (jsonNode.isArray()) {
+            return StreamSupport.stream(jsonNode.asArray().spliterator(), false)
+                                .map(JsonStringFormatHelper::stringValue)
+                                .collect(Collectors.joining(",", "[", "]"));
+        }
+        if (jsonNode.isObject()) {
+            return mapToString(jsonNode);
+        }
+        return jsonNode.isString() ? "\"" + addEscapeCharacters(jsonNode.text()) + "\"" : jsonNode.toString();
+    }
+
+    /**
+     * Escapes characters for a give given string
+     *
+     * @param input Input string
+     * @return String with escaped characters.
+     */
+    public static String addEscapeCharacters(String input) {
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            switch (ch) {
+                case '\\':
+                    output.append("\\\\"); // escape backslash with a backslash
+                    break;
+                case '\n':
+                    output.append("\\n"); // newline character
+                    break;
+                case '\r':
+                    output.append("\\r"); // carriage return character
+                    break;
+                case '\t':
+                    output.append("\\t"); // tab character
+                    break;
+                case '\f':
+                    output.append("\\f"); // form feed
+                    break;
+                case '\"':
+                    output.append("\\\""); // double-quote character
+                    break;
+                case '\'':
+                    output.append("\\'"); // single-quote character
+                    break;
+                default:
+                    output.append(ch);
+                    break;
+            }
+        }
+        return output.toString();
+    }
+
+    private static String mapToString(JsonNode jsonNode) {
+        Map<String, JsonNode> value = jsonNode.asObject();
+
+        if (value.isEmpty()) {
+            return "{}";
+        }
+
+        StringBuilder output = new StringBuilder();
+        output.append("{");
+        value.forEach((k, v) -> output.append("\"").append(k).append("\":")
+                                      .append(stringValue(v)).append(","));
+        output.setCharAt(output.length() - 1, '}');
+        return output.toString();
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/document/EnhancedDocumentTestData.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/document/EnhancedDocumentTestData.java
@@ -92,7 +92,7 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                       .enhancedDocument(defaultDocBuilder()
                                                             .putNull("nullKey")
                                                             .build())
-                                      .json("{\"nullKey\": null}")
+                                      .json("{\"nullKey\":null}")
                                       .attributeConverterProvider(defaultProvider())
                                       .build());
 
@@ -104,7 +104,7 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                               DefaultEnhancedDocument.builder()).putObject("stringKey", "stringValue")
                                                                  .addAttributeConverterProvider(defaultProvider()).build())
                                       .attributeConverterProvider(defaultProvider())
-                                      .json("{\"stringKey\": \"stringValue\"}")
+                                      .json("{\"stringKey\":\"stringValue\"}")
 
                                       .build());
 
@@ -127,8 +127,8 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
 
 
                                       .attributeConverterProvider(defaultProvider())
-                                      .json("{\"id\": \"id-value\", \"sort\": \"sort-value\", \"attribute\": "
-                                            + "\"one\", \"attribute2\": \"two\", \"attribute3\": \"three\"}")
+                                      .json("{\"id\":\"id-value\",\"sort\":\"sort-value\",\"attribute\":\"one\","
+                                            + "\"attribute2\":\"two\",\"attribute3\":\"three\"}")
 
                                       .build());
 
@@ -143,7 +143,7 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                               .putNumber("bigDecimalNumberKey", new BigDecimal(10))
                                               .build())
                                       .attributeConverterProvider(defaultProvider())
-                                      .json("{" + "\"numberKey\": 10, " + "\"bigDecimalNumberKey\": 10" + "}")
+                                      .json("{" + "\"numberKey\":10," + "\"bigDecimalNumberKey\":10" + "}")
 
                                       .build());
 
@@ -172,8 +172,9 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                                                                               .collect(Collectors.toSet()))
                                                             .putStringSet("stringSet", Stream.of("a", "b", "c").collect(Collectors.toSet()))
                                                             .build())
-                                      .json("{\"stringKey\": \"stringValue\", \"numberKey\": 10, \"boolKey\": true, \"nullKey\": null, \"numberSet\": [1,"
-                                            + " 2, 3], \"sdkBytesSet\": [\"a\", \"b\", \"c\"], \"stringSet\": [\"a\", \"b\", \"c\"]}")
+                                      .json("{\"stringKey\":\"stringValue\",\"numberKey\":10,\"boolKey\":true,\"nullKey\":null,"
+                                            + "\"numberSet\":[1,2,3],\"sdkBytesSet\":[\"a\",\"b\",\"c\"],\"stringSet\":[\"a\","
+                                            + "\"b\",\"c\"]}")
                              .attributeConverterProvider(defaultProvider())
                                       .build());
 
@@ -191,7 +192,7 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                                             .putNumberSet("bigDecimal", Stream.of(BigDecimal.valueOf(1000.002), BigDecimal.valueOf(2000.003) ).collect(Collectors.toCollection(LinkedHashSet::new)))
                                                             .putNumberSet("sdkNumberSet", Stream.of(SdkNumber.fromInteger(1), SdkNumber.fromInteger(2), SdkNumber.fromInteger(3) ).collect(Collectors.toSet()))
                                                             .build())
-                                      .json("{\"floatSet\": [2.0, 3.0], \"integerSet\": [-1, 0, 1], \"bigDecimal\": [1000.002, 2000.003], \"sdkNumberSet\": [1, 2, 3]}")
+                                      .json("{\"floatSet\": [2.0, 3.0],\"integerSet\": [-1, 0, 1],\"bigDecimal\": [1000.002, 2000.003],\"sdkNumberSet\": [1,2, 3]}")
                              .attributeConverterProvider(defaultProvider())
                                       .build());
 
@@ -216,7 +217,7 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                           .addAttribute("numberList", EnhancedType.of(Integer.class))
                                           .addAttribute("stringList", EnhancedType.of(String.class)))
                                       .attributeConverterProvider(defaultProvider())
-                                      .json("{\"numberList\": [1, 2], \"stringList\": [\"one\", \"two\"]}")
+                                      .json("{\"numberList\":[1,2],\"stringList\":[\"one\",\"two\"]}")
                                       .build());
 
         testDataList.add(dataBuilder().scenario("customList")
@@ -241,19 +242,12 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                           .addAttribute("customClassForDocumentAPI", EnhancedType.of(CustomClassForDocumentAPI.class)))
                                       .attributeConverterProvider(ChainConverterProvider.create(CustomAttributeForDocumentConverterProvider.create(),
                                                                                                 defaultProvider()))
-                                      .json("{\"customClassForDocumentAPI\": [{"
-                                            + "\"instantList\": [\"2023-03-01T17:14:05.049Z\", \"2023-03-01T17:14:05.049Z\", \"2023-03-01T17:14:05.049Z\"],"
-                                            + "\"longNumber\": 11,"
-                                            + "\"string\": \"11\","
-                                            + "\"stringSet\": [\"12\", \"13\", \"14\"]"
-                                            + "}, "
-                                            + "{"
-                                            + "\"instantList\": [\"2023-03-01T17:14:05.240Z\", \"2023-03-01T17:14:05.240Z\", "
-                                            + "\"2023-03-01T17:14:05.240Z\"],"
-                                            + "\"longNumber\": 202,"
-                                            + "\"string\": \"202\","
-                                            + "\"stringSet\": [\"203\", \"204\", \"205\"]"
-                                            + "}]}")
+                                      .json("{\"customClassForDocumentAPI\":[{\"instantList\":[\"2023-03-01T17:14:05.049Z\","
+                                            + "\"2023-03-01T17:14:05.049Z\",\"2023-03-01T17:14:05.049Z\"],\"longNumber\":11,"
+                                            + "\"string\":\"11\",\"stringSet\":[\"12\",\"13\",\"14\"]},"
+                                            + "{\"instantList\":[\"2023-03-01T17:14:05.240Z\",\"2023-03-01T17:14:05.240Z\","
+                                            + "\"2023-03-01T17:14:05.240Z\"],\"longNumber\":202,\"string\":\"202\","
+                                            + "\"stringSet\":[\"203\",\"204\",\"205\"]}]}")
 
                                       .build());
 
@@ -293,8 +287,8 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                               .build()
                                       )
                                       .attributeConverterProvider(defaultProvider())
-                                      .json("{\"threeLevelList\": [[[\"l1_0\", \"l1_1\"], [\"l2_0\", \"l2_1\"]], [[\"l3_0\", "
-                                            + "\"l3_1\"], [\"l4_0\", \"l4_1\"]]]}")
+                                      .json("{\"threeLevelList\":[[[\"l1_0\",\"l1_1\"],[\"l2_0\",\"l2_1\"]],[[\"l3_0\","
+                                            + "\"l3_1\"],[\"l4_0\",\"l4_1\"]]]}")
                                       .typeMap(typeMap()
                                                    .addAttribute("threeLevelList", new EnhancedType<List<List<String>>>() {
                                                    }))
@@ -324,8 +318,7 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                               )
                                               .build()
                                       )
-                                      .json("{\"listOfListOfMaps\": [{\"key_a_1\": [1, 2],\"key_a_2\": [1, 2]}, {\"key_b_1\": "
-                                            + "[1]}]}")
+                                      .json("{\"listOfListOfMaps\":[{\"key_a_1\":[1,2],\"key_a_2\":[1,2]},{\"key_b_1\":[1]}]}")
                                       .attributeConverterProvider(defaultProvider())
                                       .typeMap(typeMap()
                                                    .addAttribute("listOfListOfMaps", new EnhancedType<Map<String, List<Integer>>>() {
@@ -348,9 +341,9 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                       .typeMap(typeMap()
                                                    .addAttribute("simpleMap", EnhancedType.of(CharSequence.class),
                                                                  EnhancedType.of(String.class)))
-                                      .json("{\"simpleMap\": {\"key_suffix_1\": \"1\",\"key_suffix_2\": \"2\",\"key_suffix_3\":"
-                                            + " \"3\",\"key_suffix_4\": "
-                                            + "\"4\",\"key_suffix_5\": \"5\",\"key_suffix_6\": \"6\",\"key_suffix_7\": \"7\"}}")
+                                      .json("{\"simpleMap\":{\"key_suffix_1\":\"1\",\"key_suffix_2\":\"2\","
+                                            + "\"key_suffix_3\":\"3\",\"key_suffix_4\":\"4\",\"key_suffix_5\":\"5\","
+                                            + "\"key_suffix_6\":\"6\",\"key_suffix_7\":\"7\"}}")
 
                                       .build());
 
@@ -376,12 +369,9 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                                             EnhancedType.of(CustomClassForDocumentAPI.class))
                                               .build()
                                       )
-                                      .json("{\"customMapValue\": {\"entryOne\": {"
-                                            + "\"instantList\": [\"2023-03-01T17:14:05.050Z\", \"2023-03-01T17:14:05.050Z\", \"2023-03-01T17:14:05.050Z\"],"
-                                            + "\"longNumber\": 12,"
-                                            + "\"string\": \"12\","
-                                            + "\"stringSet\": [\"13\", \"14\", \"15\"]"
-                                            + "}}}")
+                                      .json("{\"customMapValue\":{\"entryOne\":{\"instantList\":[\"2023-03-01T17:14:05.050Z\","
+                                            + "\"2023-03-01T17:14:05.050Z\",\"2023-03-01T17:14:05.050Z\"],\"longNumber\":12,"
+                                            + "\"string\":\"12\",\"stringSet\":[\"13\",\"14\",\"15\"]}}}")
                                       .typeMap(typeMap()
                                                    .addAttribute("customMapValue", EnhancedType.of(CharSequence.class),
                                                                  EnhancedType.of(CustomClassForDocumentAPI.class)))
@@ -419,14 +409,14 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                               .build()
 
                                       )
-                                      .json("{\"nullKey\": null, \"numberKey\": 1, \"stringKey\": \"stringValue\", "
-                                            + "\"simpleDate\": \"-999999999-01-01\", \"stringSet\": "
-                                            + "[\"one\", \"two\"], \"sdkByteKey\": \"a\", \"sdkByteSet\": [\"a\", \"b\"], "
-                                            + "\"numberSetSet\": [1, 2], "
+                                      .json("{\"nullKey\": null, \"numberKey\": 1, \"stringKey\":\"stringValue\", "
+                                            + "\"simpleDate\":\"-999999999-01-01\",\"stringSet\": "
+                                            + "[\"one\",\"two\"],\"sdkByteKey\":\"a\",\"sdkByteSet\":[\"a\",\"b\"], "
+                                            + "\"numberSetSet\": [1,2], "
                                             + "\"numberList\": [4, 5, 6], "
                                             + "\"simpleMap\": {\"78b3522c-2ab3-4162-8c5d-f093fa76e68c\": 3,"
-                                            + "\"4ae1f694-52ce-4cf6-8211-232ccf780da8\": 9}, \"mapKey\": {\"1\": [\"a\", \"b\","
-                                            + " \"c\"],\"2\": [\"1\"]}}")
+                                            + "\"4ae1f694-52ce-4cf6-8211-232ccf780da8\": 9}, \"mapKey\": {\"1\":[\"a\",\"b\","
+                                            + " \"c\"],\"2\":[\"1\"]}}")
                                       .attributeConverterProvider(defaultProvider())
                              .isGeneric(false)
                                       .build());
@@ -455,12 +445,9 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                                        + "}")
                                               .build()
                                       )
-                                      .json("{\"customMapValue\": {\"entryOne\": {"
-                                            + "\"instantList\": [\"2023-03-01T17:14:05.050Z\", \"2023-03-01T17:14:05.050Z\", "
-                                            + "\"2023-03-01T17:14:05.050Z\"],"
-                                            + "\"longNumber\": 12,"
-                                            + "\"string\": \"12\""
-                                            + "}}}")
+                                      .json("{\"customMapValue\":{\"entryOne\":{\"instantList\":[\"2023-03-01T17:14:05.050Z\","
+                                            + "\"2023-03-01T17:14:05.050Z\",\"2023-03-01T17:14:05.050Z\"],\"longNumber\":12,"
+                                            + "\"string\":\"12\"}}}")
                                       .typeMap(typeMap()
                                                    .addAttribute("customMapValue", EnhancedType.of(CharSequence.class),
                                                                  EnhancedType.of(CustomClassForDocumentAPI.class)))
@@ -478,18 +465,18 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
                                       .enhancedDocument(
                                           defaultDocBuilder()
                                               .putJson("simpleMap",
-                                                       "{\"key_suffix_1\": \"1\",\"key_suffix_2\": \"2\",\"key_suffix_3\":"
+                                                       "{\"key_suffix_1\":\"1\",\"key_suffix_2\":\"2\",\"key_suffix_3\":"
                                                        + " \"3\",\"key_suffix_4\": "
-                                                       + "\"4\",\"key_suffix_5\": \"5\",\"key_suffix_6\": \"6\",\"key_suffix_7\": \"7\"}" )
+                                                       + "\"4\",\"key_suffix_5\":\"5\",\"key_suffix_6\":\"6\",\"key_suffix_7\":\"7\"}" )
                                               .build()
                                       )
                                       .attributeConverterProvider(defaultProvider())
                                       .typeMap(typeMap()
                                                    .addAttribute("simpleMap", EnhancedType.of(String.class),
                                                                  EnhancedType.of(String.class)))
-                                      .json("{\"simpleMap\": {\"key_suffix_1\": \"1\",\"key_suffix_2\": \"2\",\"key_suffix_3\":"
-                                            + " \"3\",\"key_suffix_4\": "
-                                            + "\"4\",\"key_suffix_5\": \"5\",\"key_suffix_6\": \"6\",\"key_suffix_7\": \"7\"}}")
+                                      .json("{\"simpleMap\":{\"key_suffix_1\":\"1\",\"key_suffix_2\":\"2\","
+                                            + "\"key_suffix_3\":\"3\",\"key_suffix_4\":\"4\",\"key_suffix_5\":\"5\","
+                                            + "\"key_suffix_6\":\"6\",\"key_suffix_7\":\"7\"}}")
 
                                       .build());
 
@@ -545,9 +532,9 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
 
                                               .build()
                                       )
-                                      .json("{\"bytes\": \"HelloWorld\", \"setOfBytes\": [\"one\", \"two\", \"three\"], "
-                                            + "\"listOfBytes\": [\"i1\", \"i2\", \"i3\"], \"mapOfBytes\": {\"k1\": \"v1\","
-                                            + "\"k2\": \"v2\"}}")
+                                      .json("{\"bytes\":\"HelloWorld\",\"setOfBytes\":[\"one\",\"two\",\"three\"], "
+                                            + "\"listOfBytes\":[\"i1\",\"i2\",\"i3\"],\"mapOfBytes\": {\"k1\":\"v1\","
+                                            + "\"k2\":\"v2\"}}")
                              .attributeConverterProvider(defaultProvider())
                              .typeMap(typeMap()
                                           .addAttribute("listOfBytes", EnhancedType.of(SdkBytes.class))
@@ -653,9 +640,9 @@ public final class EnhancedDocumentTestData implements ArgumentsProvider {
     /**
      * getStringListObjectMap("lvl_1", 3, 2)
      * {
-     *  key_lvl_1_1=[1, 2],
-     *  key_lvl_1_2=[1, 2],
-     *  key_lvl_1_3=[1, 2]
+     *  key_lvl_1_1=[1,2],
+     *  key_lvl_1_2=[1,2],
+     *  key_lvl_1_3=[1,2]
      * }
      */
     private static Map<String, List<Integer>> getStringListObjectMap(String suffixKey, int numberOfKeys ,

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/document/ParameterizedDocumentTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/document/ParameterizedDocumentTest.java
@@ -125,10 +125,11 @@ class ParameterizedDocumentTest {
                         break;
                     case L:
                         EnhancedType enhancedType = enhancedTypeMap.get(key).get(0);
-                        ListAttributeConverter converter = ListAttributeConverter.create(
-                            Optional.ofNullable(chainConverterProvider.converterFor(enhancedType))
-                                    .orElseThrow(() -> new IllegalStateException("Converter not found for " + enhancedType))
-                        );
+                        ListAttributeConverter converter = ListAttributeConverter
+                            .create(chainConverterProvider.converterFor(enhancedType));
+                        if(converter == null){
+                            throw new IllegalStateException("Converter not found for " + enhancedType);
+                        }
                         assertThat(converter.transformTo(value)).isEqualTo(enhancedDocument.getList(key, enhancedType));
                         assertThat(enhancedDocument.getUnknownTypeList(key)).isEqualTo(value.l());
                         break;
@@ -148,7 +149,4 @@ class ParameterizedDocumentTest {
                 }
             });
         }
-
-
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- The present implementation of toJson representations in ArrayJsonNode and ObjectJsonNode includes additional spaces. This, however, contrasts with the V1 to Json, which does not incorporate any spaces between array elements or between key and values in a map. 
- Additionally, character escaping has not been executed, and hence, it is imperative to add the same.

## Modifications
<!--- Describe your changes in detail -->
- Not using toString of JsonNode
- Added new code to generate to String for Arrays and Map without the commas.



## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added temporary parmeterized test and verified both V1 and v2 matches
```java
    @ParameterizedTest
    @ArgumentsSource(EnhancedDocumentTestData.class)
    void testV1VsV2(TestData testData){

        Assertions.assertThat(EnhancedDocument.fromJson(testData.getJson()).toJson())
            .isEqualTo(Item.fromJSON(testData.getJson()).toJSON());

    }
``` 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
