### PR TITLE
Cleans spaces when constructing an expression name

### DIFF
--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 @SdkInternalApi
 public final class EnhancedClientUtils {
     private static final Set<Character> SPECIAL_CHARACTERS = Stream.of(
-        '*', '.', '-', '#', '+', ':', '/', '(', ')',
+        '*', '.', '-', '#', '+', ':', '/', '(', ')', ' ',
         '&', '<', '>', '?', '=', '!', '@', '%', '$', '|').collect(Collectors.toSet());
 
     private EnhancedClientUtils() {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicCrudTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BasicCrudTest.java
@@ -45,7 +45,7 @@ import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 
 public class BasicCrudTest extends LocalDynamoDbSyncTestBase {
-    private static final String ATTRIBUTE_NAME_WITH_SPECIAL_CHARACTERS = "a*t:t.r-i#bute+3/4(&?5=@)<6>!ch$ar%";
+    private static final String ATTRIBUTE_NAME_WITH_SPECIAL_CHARACTERS = "a*t:t.r-i#bute +3/4(&?5=@)<6>!ch$ar%";
 
     private static class Record {
         private String id;


### PR DESCRIPTION
## Motivation and Context
Attribute names containing spaces are legal in DDB (only '#' and ':' are reserved). When the enhanced client constructs an "expression attribute name", i.e. a label that is safe to be used in lieu of the actual attribute name, we do that by removing some special chars from the original attribute name and add it to a prefix. 

Example: `my/Strange.Attribute`  -> `#AMZN_MAPPED_my_Strange_Attribute`

At the moment, spaces are missing from the list of special chars.

## Modifications
This bug fix adds space to the list of special chars so that the following use case works as expected:

Example: `Spaced Attribute`  -> `#AMZN_MAPPED_Spaced_Attribute`

### Alternative solution
We could consider removing the attribute name from the expression name label altogether, favoring numbered names. 

Example:
`Spaced Attribute`  ->  `#AMZN_MAPPED_1`

We'd have to reconcile merging different sets of expression names in operations such as updateItem, which risks name collisions. Also, it's more difficult to know which attribute is which in some parts of the library. These downsides likely outweigh if we've missed another character that must be added in the future. 

## Testing
Unit tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
