### PR TITLE
Skip missing region test

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesClientTestSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules/EndpointRulesClientTestSpec.java
@@ -86,6 +86,7 @@ public class EndpointRulesClientTestSpec implements ClassSpec {
         tests.put("For region us-isob-east-1 with FIPS disabled and DualStack enabled", "Client builder does the validation");
         tests.put("For region us-isob-west-1 with FIPS enabled and DualStack enabled", "Client builder does the validation");
         tests.put("For region us-isob-west-1 with FIPS disabled and DualStack enabled", "Client builder does the validation");
+        tests.put("Missing region", "Client does validation");
         GLOBAL_SKIP_ENDPOINT_TESTS = Collections.unmodifiableMap(tests);
 
     }


### PR DESCRIPTION
## Motivation and Context
This test asserts that we throw a specific error message when no region is provided, that message won't be thrown by client since it does its own validation.

## Modifications
Skip the `Missing region` test on the end-to-end client tests. Note this doesn't affect the generated test class that tests the provider directly, since no tests are ever skipped for them.

## Testing
Tested with an `endpoint-tests.json` file that contains a test with this description.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
