### PR TITLE
Fixed an issue in S3 Transfer Manager where a thread could get stuck …

### DIFF
--- a/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
+++ b/services-custom/s3-transfer-manager/src/main/java/software/amazon/awssdk/transfer/s3/internal/AsyncBufferingSubscriber.java
@@ -116,6 +116,7 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
         log.debug(() -> "Delivering next item, numRequestInFlight=" + numberOfRequestInFlight);
 
         consumer.apply(item).whenComplete((r, t) -> {
+            log.trace(() -> "Finished delivering, decrementing numRequestsInFlight, numRequestsInFlight=" + numberOfRequestInFlight);
             numRequestsInFlight.decrementAndGet();
             if (!isStreamingDone) {
                 subscription.request(1);
@@ -145,9 +146,9 @@ public class AsyncBufferingSubscriber<T> implements Subscriber<T> {
 
     @Override
     public void onComplete() {
+        log.debug(() -> "Received onComplete");
         isStreamingDone = true;
         storingSubscriber.onComplete();
-        flushBufferIfNeeded();
     }
 
     /**


### PR DESCRIPTION
…waiting for all requests to finish in a downloadDirectory operation

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
#3850 

## Modifications
Removed the logic to flush buffer when onComplete is invoked. It's not needed because when a request is finished, it should trigger buffer flush automatically. The existing logic could cause the thread that invoked onComplete to starve when there are still requests in flight.

## Testing
Ran existing tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
