### PR TITLE
Close and release channel upon validation failure

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-7b511ce.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-7b511ce.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO HTTP Client",
+    "contributor": "",
+    "description": "Fix a bug where, if validation of of the amount of expected data to be received (HTTP `Content-Length`) fails, the connection would be left dangling, consuming a connection from the pool until the client is shut down."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ResponseHandler.java
@@ -376,6 +376,8 @@ public class ResponseHandler extends SimpleChannelInboundHandler<HttpObject> {
                         }
                     } catch (IOException e) {
                         notifyError(e);
+                        runAndLogError(channelContext.channel(), () -> "Could not release channel back to the pool",
+                                       () -> closeAndRelease(channelContext));
                     }
                 }
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/PublisherAdapterTest.java
@@ -235,6 +235,56 @@ public class PublisherAdapterTest {
         }
     }
 
+    @Test
+    public void contentLengthValidationFails_closesAndReleasesConnection() {
+        channel.attr(ChannelAttributeKey.RESPONSE_CONTENT_LENGTH).set(1L);
+        channel.attr(ChannelAttributeKey.RESPONSE_DATA_READ).set(0L);
+
+        Publisher<HttpContent> publisher = subscriber -> subscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(long l) {
+                subscriber.onComplete();
+            }
+
+            @Override
+            public void cancel() {
+            }
+        });
+
+        DefaultStreamedHttpResponse streamedResponse = new DefaultStreamedHttpResponse(HttpVersion.HTTP_1_1,
+                                                                                       HttpResponseStatus.OK, publisher);
+
+        Subscriber<ByteBuffer> subscriber = new Subscriber<ByteBuffer>() {
+            private Subscription subscription;
+
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                this.subscription = subscription;
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        };
+
+        ResponseHandler.PublisherAdapter publisherAdapter = new ResponseHandler.PublisherAdapter(streamedResponse, ctx,
+                                                                                                 requestContext, executeFuture);
+
+        publisherAdapter.subscribe(subscriber);
+
+        verify(ctx).close();
+        verify(channelPool).release(channel);
+    }
+
     static final class TestSubscriber implements Subscriber<ByteBuffer> {
 
         private Subscription subscription;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When content length validation fails when PublisherAdapter#onComplete is invoked, behave as on PublisherAdapter#onError and also close and release the channel; otherwise the channel would be left in the leased state forever.


## Modifications
Close and release the channel if validation fails in `PublisherAdapter#onComplete()`.

## Testing
- New unit test
- Ran integ tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
