### PR TITLE
keep default serviceClientConfiguration implementation for AwsClient interface

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsClient.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/AwsClient.java
@@ -26,6 +26,4 @@ import software.amazon.awssdk.core.SdkClient;
 @ThreadSafe
 public interface AwsClient extends SdkClient {
 
-    @Override
-    AwsServiceClientConfiguration serviceClientConfiguration();
 }


### PR DESCRIPTION
Prevent direct implementation of `AwsClient` to require to overriding `serviceClientConfiguration()`