### PR TITLE
Skip avoidable conversion in CredentialsUtils

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
@@ -97,6 +97,9 @@ public final class CredentialUtils {
         if (identityProvider == null) {
             return null;
         }
+        if (identityProvider instanceof AwsCredentialsProvider) {
+            return (AwsCredentialsProvider) identityProvider;
+        }
         return () -> {
             // TODO: Exception handling for CompletionException thrown from join?
             AwsCredentialsIdentity awsCredentialsIdentity = identityProvider.resolveIdentity().join();

--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/CredentialUtilsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/CredentialUtilsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
 
 public class CredentialUtilsTest {
 
@@ -83,7 +84,7 @@ public class CredentialUtilsTest {
     }
 
     @Test
-    public void toCredentials_AwsCredentials_doesNotCreateNewObject() {
+    public void toCredentials_AwsCredentials_returnsAsIs() {
         AwsCredentialsIdentity input = AwsBasicCredentials.create("ak", "sk");
         AwsCredentials output = CredentialUtils.toCredentials(input);
         assertThat(output).isSameAs(input);
@@ -128,6 +129,14 @@ public class CredentialUtilsTest {
     @Test
     public void toCredentialsProvider_null_returnsNull() {
         assertThat(CredentialUtils.toCredentialsProvider(null)).isNull();
+    }
+
+    @Test
+    public void toCredentialsProvider_AwsCredentialsProvider_returnsAsIs() {
+        IdentityProvider<AwsCredentialsIdentity> input =
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+        AwsCredentialsProvider output = CredentialUtils.toCredentialsProvider(input);
+        assertThat(output).isSameAs(input);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
In CredentialUtils.toCredentialsProvider, avoid creating another object if the input is already the right type. Made similar change in recent [PR](https://github.com/aws/aws-sdk-java-v2/pull/3829/files#diff-928b4009e4b9df4c8822e946fe1512c7b38f05dbc88ed67f69cf4dd1d690a8a5), to only for toCredentials. Did not want to add more to that PR as it was already big.

## Modifications
<!--- Describe your changes in detail -->
In CredentialUtils.toCredentialsProvider, avoid creating another object if the input is already the right type.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test and
```
 ./mvnw clean install -pl :auth
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
