### PR TITLE
Update AwsCredentialsProviderChain for new Identity type

### DIFF
--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/AwsCredentialsProviderChain.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
@@ -52,11 +54,11 @@ public final class AwsCredentialsProviderChain
                ToCopyableBuilder<AwsCredentialsProviderChain.Builder, AwsCredentialsProviderChain> {
     private static final Logger log = Logger.loggerFor(AwsCredentialsProviderChain.class);
 
-    private final List<AwsCredentialsProvider> credentialsProviders;
+    private final List<IdentityProvider<? extends AwsCredentialsIdentity>> credentialsProviders;
 
     private final boolean reuseLastProviderEnabled;
 
-    private volatile AwsCredentialsProvider lastUsedProvider;
+    private volatile IdentityProvider<? extends AwsCredentialsIdentity> lastUsedProvider;
 
     /**
      * @see #builder()
@@ -84,21 +86,33 @@ public final class AwsCredentialsProviderChain
         return builder().credentialsProviders(awsCredentialsProviders).build();
     }
 
+    /**
+     * Create an AWS credentials provider chain with default configuration that checks the given credential providers.
+     * @param awsCredentialsProviders The credentials providers that should be checked for credentials, in the order they should
+     *                                be checked.
+     * @return A credential provider chain that checks the provided credential providers in order.
+     */
+    public static AwsCredentialsProviderChain of(IdentityProvider<? extends AwsCredentialsIdentity>... awsCredentialsProviders) {
+        return builder().credentialsProviders(awsCredentialsProviders).build();
+    }
+
     @Override
     public AwsCredentials resolveCredentials() {
         if (reuseLastProviderEnabled && lastUsedProvider != null) {
-            return lastUsedProvider.resolveCredentials();
+            // TODO: Exception handling for join?
+            return CredentialUtils.toCredentials(lastUsedProvider.resolveIdentity().join());
         }
 
         List<String> exceptionMessages = null;
-        for (AwsCredentialsProvider provider : credentialsProviders) {
+        for (IdentityProvider<? extends AwsCredentialsIdentity> provider : credentialsProviders) {
             try {
-                AwsCredentials credentials = provider.resolveCredentials();
+                // TODO: Exception handling for join?
+                AwsCredentialsIdentity credentials = provider.resolveIdentity().join();
 
                 log.debug(() -> "Loading credentials from " + provider);
 
                 lastUsedProvider = provider;
-                return credentials;
+                return CredentialUtils.toCredentials(credentials);
             } catch (RuntimeException e) {
                 // Ignore any exceptions and move onto the next provider
                 String message = provider + ": " + e.getMessage();
@@ -156,19 +170,43 @@ public final class AwsCredentialsProviderChain
         /**
          * Configure the credentials providers that should be checked for credentials, in the order they should be checked.
          */
-        Builder credentialsProviders(AwsCredentialsProvider... credentialsProviders);
+        Builder credentialsIdentityProviders(
+            Collection<? extends IdentityProvider<? extends AwsCredentialsIdentity>> credentialsProviders);
+
+        /**
+         * Configure the credentials providers that should be checked for credentials, in the order they should be checked.
+         */
+        default Builder credentialsProviders(AwsCredentialsProvider... credentialsProviders) {
+            return credentialsProviders((IdentityProvider<? extends AwsCredentialsIdentity>[]) credentialsProviders);
+        }
+
+        /**
+         * Configure the credentials providers that should be checked for credentials, in the order they should be checked.
+         */
+        default Builder credentialsProviders(IdentityProvider<? extends AwsCredentialsIdentity>... credentialsProviders) {
+            throw new UnsupportedOperationException();
+        }
 
         /**
          * Add a credential provider to the chain, after the credential providers that have already been configured.
          */
-        Builder addCredentialsProvider(AwsCredentialsProvider credentialsProviders);
+        default Builder addCredentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            return addCredentialsProvider((IdentityProvider<? extends AwsCredentialsIdentity>) credentialsProvider);
+        }
+
+        /**
+         * Add a credential provider to the chain, after the credential providers that have already been configured.
+         */
+        default Builder addCredentialsProvider(IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider) {
+            throw new UnsupportedOperationException();
+        }
 
         AwsCredentialsProviderChain build();
     }
 
     private static final class BuilderImpl implements Builder {
         private Boolean reuseLastProviderEnabled = true;
-        private List<AwsCredentialsProvider> credentialsProviders = new ArrayList<>();
+        private List<IdentityProvider<? extends AwsCredentialsIdentity>> credentialsProviders = new ArrayList<>();
 
         private BuilderImpl() {
         }
@@ -199,13 +237,25 @@ public final class AwsCredentialsProviderChain
         }
 
         @Override
-        public Builder credentialsProviders(AwsCredentialsProvider... credentialsProviders) {
-            return credentialsProviders(Arrays.asList(credentialsProviders));
+        public Builder credentialsIdentityProviders(
+                Collection<? extends IdentityProvider<? extends AwsCredentialsIdentity>> credentialsProviders) {
+            this.credentialsProviders = new ArrayList<>(credentialsProviders);
+            return this;
+        }
+
+        public void setCredentialsIdentityProviders(
+                Collection<? extends IdentityProvider<? extends AwsCredentialsIdentity>> credentialsProviders) {
+            credentialsIdentityProviders(credentialsProviders);
         }
 
         @Override
-        public Builder addCredentialsProvider(AwsCredentialsProvider credentialsProviders) {
-            this.credentialsProviders.add(credentialsProviders);
+        public Builder credentialsProviders(IdentityProvider<? extends AwsCredentialsIdentity>... credentialsProviders) {
+            return credentialsIdentityProviders(Arrays.asList(credentialsProviders));
+        }
+
+        @Override
+        public Builder addCredentialsProvider(IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider) {
+            this.credentialsProviders.add(credentialsProvider);
             return this;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
As part of SRA changes, update AwsCredentialsProviderChain for new Identity type.

## Modifications
<!--- Describe your changes in detail -->
Added overloaded methods that accept the new Identity type. For Collection input, cannot use the same method name because it results in compile error: `both methods have same erasure`, so created method with different name.

Confirmed that adding overloaded varargs for the 2 types is fine and not ambiguous when when called with zero args, because of https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2.5 - it chooses the more specific method (old type, which is sub-type of the new type). In any case these methods with varargs when called with zero args, throws RuntimeException because we require at least 1 provider in the chain.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests and `./mvnw clean install -pl :auth`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
