### PR TITLE
Add create() for new AwsCredentials Identity types

### DIFF
--- a/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/CredentialUtilsTest.java
+++ b/core/auth/src/test/java/software/amazon/awssdk/auth/credentials/CredentialUtilsTest.java
@@ -41,7 +41,7 @@ public class CredentialUtilsTest {
 
     @Test
     public void isAnonymous_AwsCredentialsIdentity_false() {
-        assertThat(CredentialUtils.isAnonymous((AwsCredentialsIdentity) AwsBasicCredentials.create("akid", "skid"))).isFalse();
+        assertThat(CredentialUtils.isAnonymous(AwsCredentialsIdentity.create("akid", "skid"))).isFalse();
     }
 
     @Test
@@ -59,22 +59,8 @@ public class CredentialUtilsTest {
 
     @Test
     public void toCredentials_AwsSessionCredentialsIdentity_returnsAwsSessionCredentials() {
-        AwsCredentials awsCredentials = CredentialUtils.toCredentials(new AwsSessionCredentialsIdentity() {
-            @Override
-            public String accessKeyId() {
-                return "akid";
-            }
-
-            @Override
-            public String secretAccessKey() {
-                return "skid";
-            }
-
-            @Override
-            public String sessionToken() {
-                return "session";
-            }
-        });
+        AwsCredentials awsCredentials = CredentialUtils.toCredentials(AwsSessionCredentialsIdentity.create(
+            "akid", "skid", "session"));
 
         assertThat(awsCredentials).isInstanceOf(AwsSessionCredentials.class);
         AwsSessionCredentials awsSessionCredentials = (AwsSessionCredentials) awsCredentials;
@@ -92,17 +78,7 @@ public class CredentialUtilsTest {
 
     @Test
     public void toCredentials_AwsCredentialsIdentity_returnsAwsCredentials() {
-        AwsCredentials awsCredentials = CredentialUtils.toCredentials(new AwsCredentialsIdentity() {
-            @Override
-            public String accessKeyId() {
-                return "akid";
-            }
-
-            @Override
-            public String secretAccessKey() {
-                return "skid";
-            }
-        });
+        AwsCredentials awsCredentials = CredentialUtils.toCredentials(AwsCredentialsIdentity.create("akid", "skid"));
 
         assertThat(awsCredentials.accessKeyId()).isEqualTo("akid");
         assertThat(awsCredentials.secretAccessKey()).isEqualTo("skid");

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsCredentialsIdentity.java
@@ -15,8 +15,11 @@
 
 package software.amazon.awssdk.identity.spi;
 
+import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * Provides access to the AWS credentials used for accessing services: AWS access key ID and secret access key. These
@@ -39,4 +42,55 @@ public interface AwsCredentialsIdentity extends Identity {
      * Retrieve the AWS secret access key, used to authenticate the user interacting with services.
      */
     String secretAccessKey();
+
+    /**
+     * Constructs a new credentials object, with the specified AWS access key and AWS secret key.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with services.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
+     * */
+    static AwsCredentialsIdentity create(String accessKeyId, String secretAccessKey) {
+        Validate.paramNotNull(accessKeyId, "accessKeyId");
+        Validate.paramNotNull(secretAccessKey, "secretAccessKey");
+
+        return new AwsCredentialsIdentity() {
+            @Override
+            public String accessKeyId() {
+                return accessKeyId;
+            }
+
+            @Override
+            public String secretAccessKey() {
+                return secretAccessKey;
+            }
+
+            @Override
+            public String toString() {
+                return ToString.builder("AwsCredentialsIdentity")
+                               .add("accessKeyId", accessKeyId)
+                               .build();
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                AwsCredentialsIdentity that = (AwsCredentialsIdentity) o;
+                return Objects.equals(accessKeyId, that.accessKeyId()) &&
+                       Objects.equals(secretAccessKey, that.secretAccessKey());
+            }
+
+            @Override
+            public int hashCode() {
+                int hashCode = 1;
+                hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
+                hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
+                return hashCode;
+            }
+        };
+    }
 }

--- a/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentity.java
+++ b/core/identity-spi/src/main/java/software/amazon/awssdk/identity/spi/AwsSessionCredentialsIdentity.java
@@ -15,8 +15,11 @@
 
 package software.amazon.awssdk.identity.spi;
 
+import java.util.Objects;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * A special type of {@link AwsCredentialsIdentity} that provides a session token to be used in service authentication. Session
@@ -32,4 +35,66 @@ public interface AwsSessionCredentialsIdentity extends AwsCredentialsIdentity {
      * user has received temporary permission to access some resource.
      */
     String sessionToken();
+
+    /**
+     * Constructs a new session credentials object, with the specified AWS access key, AWS secret key and AWS session token.
+     *
+     * @param accessKeyId The AWS access key, used to identify the user interacting with services.
+     * @param secretAccessKey The AWS secret access key, used to authenticate the user interacting with services.
+     * @param sessionToken The AWS session token, retrieved from an AWS token service, used for authenticating that this user has
+     * received temporary permission to access some resource.
+     */
+    static AwsSessionCredentialsIdentity create(String accessKeyId, String secretAccessKey, String sessionToken) {
+        Validate.paramNotNull(accessKeyId, "accessKeyId");
+        Validate.paramNotNull(secretAccessKey, "secretAccessKey");
+        Validate.paramNotNull(sessionToken, "sessionToken");
+
+        return new AwsSessionCredentialsIdentity() {
+            @Override
+            public String accessKeyId() {
+                return accessKeyId;
+            }
+
+            @Override
+            public String secretAccessKey() {
+                return secretAccessKey;
+            }
+
+            @Override
+            public String sessionToken() {
+                return sessionToken;
+            }
+
+            @Override
+            public String toString() {
+                return ToString.builder("AwsSessionCredentialsIdentity")
+                               .add("accessKeyId", accessKeyId())
+                               .build();
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                AwsSessionCredentialsIdentity that = (AwsSessionCredentialsIdentity) o;
+                return Objects.equals(accessKeyId, that.accessKeyId()) &&
+                       Objects.equals(secretAccessKey, that.secretAccessKey()) &&
+                       Objects.equals(sessionToken, that.sessionToken());
+            }
+
+            @Override
+            public int hashCode() {
+                int hashCode = 1;
+                hashCode = 31 * hashCode + Objects.hashCode(accessKeyId());
+                hashCode = 31 * hashCode + Objects.hashCode(secretAccessKey());
+                hashCode = 31 * hashCode + Objects.hashCode(sessionToken());
+                return hashCode;
+            }
+        };
+    }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialProviderAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialProviderAdapterTest.java
@@ -69,17 +69,7 @@ public class CrtCredentialProviderAdapterTest {
     @Test
     void crtCredentials_provideAwsCredentials_shouldInvokeResolveAndClose() {
         IdentityProvider<? extends AwsCredentialsIdentity> awsCredentialsProvider = Mockito.mock(HttpCredentialsProvider.class);
-        AwsCredentialsIdentity credentials = new AwsCredentialsIdentity() {
-            @Override
-            public String accessKeyId() {
-                return "foo";
-            }
-
-            @Override
-            public String secretAccessKey() {
-                return "bar";
-            }
-        };
+        AwsCredentialsIdentity credentials = AwsCredentialsIdentity.create("foo", "bar");
         when(awsCredentialsProvider.resolveIdentity()).thenAnswer(invocation -> CompletableFuture.completedFuture(credentials));
 
         CrtCredentialsProviderAdapter adapter = new CrtCredentialsProviderAdapter(awsCredentialsProvider);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
For the new AwsCredentials Identity types, provide a `create()` to easily instantiate objects of the new type.

## Modifications
<!--- Describe your changes in detail -->
Add `create()` to the interfaces. Updated other code to use these methods.

Note, added them to AwsCredentialsIdentity and AwsSessionCredentialsIdentity separately instead of both methods in AwsCredentialsIdentity as per design doc.

Note, does not allow anonymous credentials with new type. Should it?

Note, these anonymous classes have their equals/hashCode. And 
`assertThat(AwsBasicCredentials.create("a", "b")).isNotEqualTo(AwsCredentialsIdentity.create("a", "b"));`

Note, AwsBasicCredentials.create uses `trimToNull`, but AwsSessionCredentials.create doesn't. Didn't use trimToNull in the new types.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`./mvnw clean install -pl :identity-spi,:auth,:s3`

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
