### PR TITLE
Fix intermittent test failures in AsyncApiCallTimeoutTest

### DIFF
--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/async/AsyncApiCallTimeoutTest.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/timeout/async/AsyncApiCallTimeoutTest.java
@@ -15,10 +15,6 @@
 
 package software.amazon.awssdk.protocol.tests.timeout.async;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -36,7 +32,10 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.protocol.tests.timeout.BaseApiCallTimeoutTest;
+import software.amazon.awssdk.protocol.tests.util.MockAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
 import software.amazon.awssdk.services.protocolrestjson.model.AllTypesResponse;
@@ -104,13 +103,34 @@ public class AsyncApiCallTimeoutTest extends BaseApiCallTimeoutTest {
 
     @Test
     public void increaseTimeoutInRequestOverrideConfig_shouldTakePrecedence() {
-        stubFor(post(anyUrl())
-                    .willReturn(aResponse().withStatus(200).withBody("{}").withFixedDelay(DELAY_AFTER_TIMEOUT)));
+        MockAsyncHttpClient mockClient = new MockAsyncHttpClient();
+        ProtocolRestJsonAsyncClient asyncClient = createClientWithMockClient(mockClient);
+        mockClient.stubNextResponse(mockResponse(200));
+        mockClient.withFixedDelay(DELAY_AFTER_TIMEOUT);
+
         CompletableFuture<AllTypesResponse> allTypesResponseCompletableFuture =
-            client.allTypes(b -> b.overrideConfiguration(c -> c.apiCallTimeout(Duration.ofMillis(DELAY_AFTER_TIMEOUT + 1000))));
+            asyncClient.allTypes(b -> b.overrideConfiguration(c -> c.apiCallTimeout(Duration.ofMillis(DELAY_AFTER_TIMEOUT + 1000))));
 
         AllTypesResponse response = allTypesResponseCompletableFuture.join();
         assertThat(response).isNotNull();
+    }
+
+    public ProtocolRestJsonAsyncClient createClientWithMockClient(MockAsyncHttpClient mockClient) {
+        return ProtocolRestJsonAsyncClient.builder()
+                                          .region(Region.US_WEST_1)
+                                          .httpClient(mockClient)
+                                          .credentialsProvider(() -> AwsBasicCredentials.create("akid", "skid"))
+                                          .overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMillis(TIMEOUT))
+                                                                       .retryPolicy(RetryPolicy.none()))
+                                          .build();
+    }
+
+    private HttpExecuteResponse mockResponse(int statusCode) {
+        return HttpExecuteResponse.builder()
+                                  .response(SdkHttpResponse.builder()
+                                                           .statusCode(statusCode)
+                                                           .build())
+                                  .build();
     }
 
 }

--- a/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/MockAsyncHttpClient.java
+++ b/test/protocol-tests/src/test/java/software/amazon/awssdk/protocol/tests/util/MockAsyncHttpClient.java
@@ -1,0 +1,89 @@
+package software.amazon.awssdk.protocol.tests.util;
+
+import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+import software.amazon.awssdk.utils.IoUtils;
+
+/**
+ * Mock implementation of {@link SdkAsyncHttpClient}.
+ */
+public class MockAsyncHttpClient implements SdkAsyncHttpClient {
+    private HttpExecuteResponse nextResponse;
+    private long fixedDelay;
+
+    @Override
+    public CompletableFuture<Void> execute(AsyncExecuteRequest request) {
+
+        byte[] content = nextResponse.responseBody().map(p -> invokeSafely(() -> IoUtils.toByteArray(p)))
+                                     .orElseGet(() -> new byte[0]);
+
+        request.responseHandler().onHeaders(nextResponse.httpResponse());
+        request.responseHandler().onStream(new ResponsePublisher(content));
+
+        try {
+            Thread.sleep(fixedDelay);
+        } catch (InterruptedException e) {
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public void stubNextResponse(HttpExecuteResponse nextResponse) {
+        this.nextResponse = nextResponse;
+    }
+
+    public void withFixedDelay(long fixedDelay) {
+        this.fixedDelay = fixedDelay;
+    }
+
+    private static class ResponsePublisher implements SdkHttpContentPublisher {
+        private final byte[] content;
+
+        private ResponsePublisher(byte[] content) {
+            this.content = content;
+        }
+
+        @Override
+        public Optional<Long> contentLength() {
+            return Optional.of((long) content.length);
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super ByteBuffer> s) {
+            s.onSubscribe(new Subscription() {
+                private boolean running = true;
+
+                @Override
+                public void request(long n) {
+                    if (n <= 0) {
+                        running = false;
+                        s.onError(new IllegalArgumentException("Demand must be positive"));
+                    } else if (running) {
+                        running = false;
+                        s.onNext(ByteBuffer.wrap(content));
+                        s.onComplete();
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    running = false;
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Intermittent test failures in AsyncApiCallTimeoutTest
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
Use mock HTTP client instead of Wiremock

## Testing
<!--- Please describe in detail how you tested your changes -->
Updated tests and ran successfully
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
