### PR TITLE
Add TrustAllCertificates in CRT S3 Client options

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-e102314.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-e102314.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "API to Add TrustAllCertificates in CRT S3 Client options for test purposes"
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtHttpConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtHttpConfiguration.java
@@ -38,13 +38,13 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
     private final Duration connectionTimeout;
     private final S3CrtProxyConfiguration proxyConfiguration;
     private final S3CrtConnectionHealthConfiguration healthConfiguration;
-    private final Boolean shouldTrustAllCertificates;
+    private final Boolean trustAllCertificatesEnabled;
 
     private S3CrtHttpConfiguration(DefaultBuilder builder) {
         this.connectionTimeout = builder.connectionTimeout;
         this.proxyConfiguration = builder.proxyConfiguration;
         this.healthConfiguration = builder.healthConfiguration;
-        this.shouldTrustAllCertificates = builder.shouldTrustAllCertificates;
+        this.trustAllCertificatesEnabled = builder.trustAllCertificatesEnabled;
     }
 
     /**
@@ -76,10 +76,10 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
     }
 
     /**
-     * Return the configured {@link Builder#shouldTrustAllCertificates}.
+     * Return the configured {@link Builder#trustAllCertificatesEnabled}.
      */
-    public Boolean shouldTrustAllCertificates() {
-        return shouldTrustAllCertificates;
+    public Boolean trustAllCertificatesEnabled() {
+        return trustAllCertificatesEnabled;
     }
 
     @Override
@@ -102,7 +102,7 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
         if (!Objects.equals(healthConfiguration, that.healthConfiguration)) {
             return false;
         }
-        return Objects.equals(shouldTrustAllCertificates, that.shouldTrustAllCertificates);
+        return Objects.equals(trustAllCertificatesEnabled, that.trustAllCertificatesEnabled);
     }
 
     @Override
@@ -110,7 +110,7 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
         int result = connectionTimeout != null ? connectionTimeout.hashCode() : 0;
         result = 31 * result + (proxyConfiguration != null ? proxyConfiguration.hashCode() : 0);
         result = 31 * result + (healthConfiguration != null ? healthConfiguration.hashCode() : 0);
-        result = 31 * result + (shouldTrustAllCertificates != null ? shouldTrustAllCertificates.hashCode() : 0);
+        result = 31 * result + (trustAllCertificatesEnabled != null ? trustAllCertificatesEnabled.hashCode() : 0);
         return result;
     }
 
@@ -135,11 +135,10 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
          *     This turns off x.509 validation.
          *     By default, this option is off.
          *     Only enable this option for testing purposes.
-         * </p>
-         * @param shouldTrustAllCertificates True if SSL cert validation is disabled.
+         * @param trustAllCertificatesEnabled True if SSL cert validation is disabled.
          * @return The builder of the method chaining.
          */
-        Builder shouldTrustAllCertificates(Boolean shouldTrustAllCertificates);
+        Builder trustAllCertificatesEnabled(Boolean trustAllCertificatesEnabled);
 
         /**
          * Sets the http proxy configuration to use for this client.
@@ -191,7 +190,7 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
     private static final class DefaultBuilder implements Builder {
         private S3CrtConnectionHealthConfiguration healthConfiguration;
         private Duration connectionTimeout;
-        private Boolean shouldTrustAllCertificates;
+        private Boolean trustAllCertificatesEnabled;
         private S3CrtProxyConfiguration proxyConfiguration;
 
         private DefaultBuilder() {
@@ -201,7 +200,7 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
             this.healthConfiguration = httpConfiguration.healthConfiguration;
             this.connectionTimeout = httpConfiguration.connectionTimeout;
             this.proxyConfiguration = httpConfiguration.proxyConfiguration;
-            this.shouldTrustAllCertificates = httpConfiguration.shouldTrustAllCertificates;
+            this.trustAllCertificatesEnabled = httpConfiguration.trustAllCertificatesEnabled;
         }
 
         @Override
@@ -211,8 +210,8 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
         }
 
         @Override
-        public Builder shouldTrustAllCertificates(Boolean shouldTrustAllCertificates) {
-            this.shouldTrustAllCertificates = shouldTrustAllCertificates;
+        public Builder trustAllCertificatesEnabled(Boolean trustAllCertificatesEnabled) {
+            this.trustAllCertificatesEnabled = trustAllCertificatesEnabled;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtHttpConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/crt/S3CrtHttpConfiguration.java
@@ -38,11 +38,13 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
     private final Duration connectionTimeout;
     private final S3CrtProxyConfiguration proxyConfiguration;
     private final S3CrtConnectionHealthConfiguration healthConfiguration;
+    private final Boolean shouldTrustAllCertificates;
 
     private S3CrtHttpConfiguration(DefaultBuilder builder) {
         this.connectionTimeout = builder.connectionTimeout;
         this.proxyConfiguration = builder.proxyConfiguration;
         this.healthConfiguration = builder.healthConfiguration;
+        this.shouldTrustAllCertificates = builder.shouldTrustAllCertificates;
     }
 
     /**
@@ -73,6 +75,13 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
         return healthConfiguration;
     }
 
+    /**
+     * Return the configured {@link Builder#shouldTrustAllCertificates}.
+     */
+    public Boolean shouldTrustAllCertificates() {
+        return shouldTrustAllCertificates;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -90,7 +99,10 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
         if (!Objects.equals(proxyConfiguration, that.proxyConfiguration)) {
             return false;
         }
-        return Objects.equals(healthConfiguration, that.healthConfiguration);
+        if (!Objects.equals(healthConfiguration, that.healthConfiguration)) {
+            return false;
+        }
+        return Objects.equals(shouldTrustAllCertificates, that.shouldTrustAllCertificates);
     }
 
     @Override
@@ -98,6 +110,7 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
         int result = connectionTimeout != null ? connectionTimeout.hashCode() : 0;
         result = 31 * result + (proxyConfiguration != null ? proxyConfiguration.hashCode() : 0);
         result = 31 * result + (healthConfiguration != null ? healthConfiguration.hashCode() : 0);
+        result = 31 * result + (shouldTrustAllCertificates != null ? shouldTrustAllCertificates.hashCode() : 0);
         return result;
     }
 
@@ -114,6 +127,19 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
          * @return The builder of the method chaining.
          */
         Builder connectionTimeout(Duration connectionTimeout);
+
+
+        /**
+         * <p>
+         *     Option to disable SSL cert validation and SSL host name verification.
+         *     This turns off x.509 validation.
+         *     By default, this option is off.
+         *     Only enable this option for testing purposes.
+         * </p>
+         * @param shouldTrustAllCertificates True if SSL cert validation is disabled.
+         * @return The builder of the method chaining.
+         */
+        Builder shouldTrustAllCertificates(Boolean shouldTrustAllCertificates);
 
         /**
          * Sets the http proxy configuration to use for this client.
@@ -165,6 +191,7 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
     private static final class DefaultBuilder implements Builder {
         private S3CrtConnectionHealthConfiguration healthConfiguration;
         private Duration connectionTimeout;
+        private Boolean shouldTrustAllCertificates;
         private S3CrtProxyConfiguration proxyConfiguration;
 
         private DefaultBuilder() {
@@ -174,11 +201,18 @@ public final class S3CrtHttpConfiguration implements ToCopyableBuilder<S3CrtHttp
             this.healthConfiguration = httpConfiguration.healthConfiguration;
             this.connectionTimeout = httpConfiguration.connectionTimeout;
             this.proxyConfiguration = httpConfiguration.proxyConfiguration;
+            this.shouldTrustAllCertificates = httpConfiguration.shouldTrustAllCertificates;
         }
 
         @Override
         public Builder connectionTimeout(Duration connectionTimeout) {
             this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        @Override
+        public Builder shouldTrustAllCertificates(Boolean shouldTrustAllCertificates) {
+            this.shouldTrustAllCertificates = shouldTrustAllCertificates;
             return this;
         }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
+import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
@@ -41,6 +42,7 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
 @SdkInternalApi
 public class S3NativeClientConfiguration implements SdkAutoCloseable {
     static final long DEFAULT_PART_SIZE_IN_BYTES = 8L * 1024 * 1024;
+    private static final Logger log = Logger.loggerFor(S3NativeClientConfiguration.class);
     private static final long DEFAULT_TARGET_THROUGHPUT_IN_GBPS = 10;
 
     private final String signingRegion;
@@ -69,8 +71,10 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
                              .withCipherPreference(TlsCipherPreference.TLS_CIPHER_SYSTEM_DEFAULT);
 
         if (builder.httpConfiguration != null
-            && builder.httpConfiguration.shouldTrustAllCertificates() != null) {
-            clientTlsContextOptions.withVerifyPeer(!builder.httpConfiguration.shouldTrustAllCertificates());
+            && builder.httpConfiguration.trustAllCertificatesEnabled() != null) {
+            log.warn(() -> "SSL Certificate verification is disabled. "
+                           + "This is not a safe setting and should only be used for testing.");
+            clientTlsContextOptions.withVerifyPeer(!builder.httpConfiguration.trustAllCertificatesEnabled());
         }
         this.tlsContext = new TlsContext(clientTlsContextOptions);
         this.credentialProviderAdapter =

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3NativeClientConfiguration.java
@@ -67,6 +67,11 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         TlsContextOptions clientTlsContextOptions =
             TlsContextOptions.createDefaultClient()
                              .withCipherPreference(TlsCipherPreference.TLS_CIPHER_SYSTEM_DEFAULT);
+
+        if (builder.httpConfiguration != null
+            && builder.httpConfiguration.shouldTrustAllCertificates() != null) {
+            clientTlsContextOptions.withVerifyPeer(!builder.httpConfiguration.shouldTrustAllCertificates());
+        }
         this.tlsContext = new TlsContext(clientTlsContextOptions);
         this.credentialProviderAdapter =
             builder.credentialsProvider == null ?
@@ -175,6 +180,7 @@ public class S3NativeClientConfiguration implements SdkAutoCloseable {
         private Integer maxConcurrency;
         private URI endpointOverride;
         private Boolean checksumValidationEnabled;
+
         private S3CrtHttpConfiguration httpConfiguration;
         private StandardRetryOptions standardRetryOptions;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
- S3 Crtclient did not have a way to disable TrustCertificates in its in-built http client
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->
Based on https://github.com/aws/aws-sdk-java-v2/blob/master/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java#L103 added a option in S3CrtHttpConfiguration class to disable TrustAllCertificates options
- Reference [tls_context_options](https://awslabs.github.io/aws-crt-cpp/class_aws_1_1_crt_1_1_io_1_1_tls_context_options.html#a94e652e626b9b6f5b6fcde274244fcb7)

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
