### PR TITLE
Add default backoff strategies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,6 +47,7 @@
         <module>endpoints-spi</module>
         <module>imds</module>
         <module>retries-api</module>
+        <module>retries</module>
     </modules>
 
     <dependencyManagement>

--- a/core/retries/pom.xml
+++ b/core/retries/pom.xml
@@ -24,25 +24,30 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>retries-api</artifactId>
-    <name>AWS Java SDK :: Retries API</name>
+    <artifactId>retries</artifactId>
+    <name>AWS Java SDK :: Retries</name>
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>software.amazon.awssdk.retries.api</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>software.amazon.awssdk.retries</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-api</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>annotations</artifactId>

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/BackoffStrategiesConstants.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/BackoffStrategiesConstants.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Constants and utility functions shared by the BackoffStrategy implementations.
+ */
+@SdkInternalApi
+class BackoffStrategiesConstants {
+    static final Duration BASE_DELAY_CEILING = Duration.ofMillis(Integer.MAX_VALUE); // Around ~24.8 days
+    static final Duration MAX_BACKOFF_CEILING = Duration.ofMillis(Integer.MAX_VALUE); // Around ~24.8 days
+    /**
+     * Max permitted retry times. To prevent exponentialDelay from overflow, there must be 2 ^ retriesAttempted &lt;= 2 ^ 31 - 1,
+     * which means retriesAttempted &lt;= 30, so that is the ceil for retriesAttempted.
+     */
+    static final int RETRIES_ATTEMPTED_CEILING = (int) Math.floor(Math.log(Integer.MAX_VALUE) / Math.log(2));
+
+    private BackoffStrategiesConstants() {
+    }
+
+    /**
+     * Returns the computed exponential delay in milliseconds given the retries attempted, the base delay and the max backoff
+     * time.
+     *
+     * <p>Specifically it returns {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}. To prevent overflowing the attempts
+     * get capped to 30.
+     */
+    static int calculateExponentialDelay(int retriesAttempted, Duration baseDelay, Duration maxBackoffTime) {
+        int cappedRetries = Math.min(retriesAttempted, BackoffStrategiesConstants.RETRIES_ATTEMPTED_CEILING);
+        return (int) Math.min(baseDelay.multipliedBy(1L << (cappedRetries - 2)).toMillis(), maxBackoffTime.toMillis());
+    }
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/DefaultBackoffStrategies.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/DefaultBackoffStrategies.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import software.amazon.awssdk.annotations.SdkPublicApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+
+/**
+ * Determines how long to wait before each execution attempt.
+ */
+@SdkPublicApi
+public final class DefaultBackoffStrategies {
+
+    private DefaultBackoffStrategies() {
+    }
+
+    /**
+     * Do not back off: retry immediately.
+     */
+    public static BackoffStrategy retryImmediately() {
+        return new Immediately();
+    }
+
+    /**
+     * Wait for a random period of time between 0ms and the provided delay.
+     */
+    public static BackoffStrategy fixedDelay(Duration delay) {
+        return new FixedDelayWithJitter(ThreadLocalRandom::current, delay);
+    }
+
+    /**
+     * Wait for a period of time equal to the provided delay.
+     */
+    public static BackoffStrategy fixedDelayWithoutJitter(Duration delay) {
+        return new FixedDelayWithoutJitter(delay);
+    }
+
+    /**
+     * Wait for a random period of time between 0ms and an exponentially increasing amount of time between each subsequent attempt
+     * of the same call.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits between
+     * 0ms and {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+     */
+    public static BackoffStrategy exponentialDelay(Duration baseDelay, Duration maxDelay) {
+        return new ExponentialDelayWithJitter(ThreadLocalRandom::current, baseDelay, maxDelay);
+    }
+
+    /**
+     * Wait for an exponentially increasing amount of time between each subsequent attempt of the same call.
+     *
+     * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits for
+     * {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+     */
+    public static BackoffStrategy exponentialDelayWithoutJitter(Duration baseDelay, Duration maxDelay) {
+        return new ExponentialDelayWithoutJitter(baseDelay, maxDelay);
+    }
+
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/ExponentialDelayWithJitter.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/ExponentialDelayWithJitter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import static software.amazon.awssdk.retries.backoff.BackoffStrategiesConstants.calculateExponentialDelay;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.utils.NumericUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Strategy that waits for a random period of time between 0ms and an exponentially increasing amount of time between each
+ * subsequent attempt of the same call.
+ *
+ * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits between
+ * 0ms and {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+ */
+@SdkInternalApi
+final class ExponentialDelayWithJitter implements BackoffStrategy {
+    private final Supplier<Random> randomSupplier;
+    private final Duration baseDelay;
+    private final Duration maxDelay;
+
+    ExponentialDelayWithJitter(Supplier<Random> randomSupplier, Duration baseDelay, Duration maxDelay) {
+        this.randomSupplier = Validate.paramNotNull(randomSupplier, "random");
+        this.baseDelay = NumericUtils.min(Validate.isPositive(baseDelay, "baseDelay"),
+                                          BackoffStrategiesConstants.BASE_DELAY_CEILING);
+        this.maxDelay = NumericUtils.min(Validate.isPositive(maxDelay, "maxDelay"),
+                                         BackoffStrategiesConstants.MAX_BACKOFF_CEILING);
+    }
+
+    @Override
+    public Duration computeDelay(int attempt) {
+        Validate.isPositive(attempt, "attempt");
+        if (attempt == 1) {
+            return Duration.ZERO;
+        }
+        int delay = calculateExponentialDelay(attempt, baseDelay, maxDelay);
+        int randInt = randomSupplier.get().nextInt(delay);
+        return Duration.ofMillis(randInt);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("ExponentialDelayWithJitter")
+                       .add("baseDelay", baseDelay)
+                       .add("maxDelay", maxDelay)
+                       .build();
+    }
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/ExponentialDelayWithoutJitter.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/ExponentialDelayWithoutJitter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import static software.amazon.awssdk.retries.backoff.BackoffStrategiesConstants.calculateExponentialDelay;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.utils.NumericUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Strategy that waits for an exponentially increasing amount of time between each subsequent attempt of the same call.
+ *
+ * <p>Specifically, the first attempt waits 0ms, and each subsequent attempt waits for
+ * {@code min(maxDelay, baseDelay * (1 << (attempt - 2)))}.
+ */
+@SdkInternalApi
+final class ExponentialDelayWithoutJitter implements BackoffStrategy {
+    private final Duration baseDelay;
+    private final Duration maxDelay;
+
+    ExponentialDelayWithoutJitter(Duration baseDelay, Duration maxDelay) {
+        this.baseDelay = NumericUtils.min(Validate.isPositive(baseDelay, "baseDelay"),
+                                          BackoffStrategiesConstants.BASE_DELAY_CEILING);
+        this.maxDelay = NumericUtils.min(Validate.isPositive(maxDelay, "maxDelay"),
+                                         BackoffStrategiesConstants.MAX_BACKOFF_CEILING);
+    }
+
+    @Override
+    public Duration computeDelay(int attempt) {
+        Validate.isPositive(attempt, "attempt");
+        if (attempt == 1) {
+            return Duration.ZERO;
+        }
+        int delay = calculateExponentialDelay(attempt, baseDelay, maxDelay);
+        return Duration.ofMillis(delay);
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("ExponentialDelayWithoutJitter")
+                       .add("baseDelay", baseDelay)
+                       .add("maxDelay", maxDelay)
+                       .build();
+    }
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/FixedDelayWithJitter.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/FixedDelayWithJitter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import java.time.Duration;
+import java.util.Random;
+import java.util.function.Supplier;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.utils.NumericUtils;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Strategy that waits for a random period of time between 0ms and the provided delay.
+ */
+@SdkInternalApi
+final class FixedDelayWithJitter implements BackoffStrategy {
+    private final Supplier<Random> randomSupplier;
+    private final Duration delay;
+
+    FixedDelayWithJitter(Supplier<Random> randomSupplier, Duration delay) {
+        this.randomSupplier = Validate.paramNotNull(randomSupplier, "random");
+        this.delay = NumericUtils.min(Validate.isPositive(delay, "delay"), BackoffStrategiesConstants.BASE_DELAY_CEILING);
+    }
+
+    @Override
+    public Duration computeDelay(int attempt) {
+        Validate.isPositive(attempt, "attempt");
+        return Duration.ofMillis(randomSupplier.get().nextInt((int) delay.toMillis()));
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("FixedDelayWithJitter")
+                       .add("delay", delay)
+                       .build();
+    }
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/FixedDelayWithoutJitter.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/FixedDelayWithoutJitter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Strategy that waits for a period of time equal to the provided delay.
+ */
+@SdkInternalApi
+final class FixedDelayWithoutJitter implements BackoffStrategy {
+    private final Duration delay;
+
+    FixedDelayWithoutJitter(Duration delay) {
+        this.delay = Validate.isPositive(delay, "delay");
+    }
+
+    @Override
+    public Duration computeDelay(int attempt) {
+        Validate.isPositive(attempt, "attempt");
+        return delay;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.builder("FixedDelayWithoutJitter")
+                       .add("delay", delay)
+                       .build();
+    }
+}

--- a/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/Immediately.java
+++ b/core/retries/src/main/java/software/amazon/awssdk/retries/backoff/Immediately.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import java.time.Duration;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.utils.Validate;
+
+/**
+ * Strategy that do not back off: retry immediately.
+ */
+@SdkInternalApi
+final class Immediately implements BackoffStrategy {
+    @Override
+    public Duration computeDelay(int attempt) {
+        Validate.isPositive(attempt, "attempt");
+        return Duration.ZERO;
+    }
+
+    @Override
+    public String toString() {
+        return "(Immediately)";
+    }
+}

--- a/core/retries/src/test/java/software/amazon/awssdk/retries/backoff/ExponentialDelayWithJitterTest.java
+++ b/core/retries/src/test/java/software/amazon/awssdk/retries/backoff/ExponentialDelayWithJitterTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+import java.util.function.Function;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ExponentialDelayWithJitterTest {
+    static final ComputedNextInt MIN_VALUE_RND = new ComputedNextInt(bound -> 0);
+    static final ComputedNextInt MID_VALUE_RND = new ComputedNextInt(bound -> bound / 2);
+    static final ComputedNextInt MAX_VALUE_RND = new ComputedNextInt(bound -> bound - 1);
+    static final Duration BASE_DELAY = Duration.ofMillis(23);
+    static final Duration MAX_DELAY = Duration.ofSeconds(20);
+
+    public static Collection<TestCase> parameters() {
+        return Arrays.asList(
+            // --- Using random that returns: bound - 1
+            new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(45)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(183)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(735)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(11775)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(19999)
+            // --- Using random that returns: bound / 2
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(23)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(92)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(368)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(5888)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(10000)
+            // --- Using random that returns: 0
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testCase(TestCase testCase) {
+        assertThat(testCase.run(), equalTo(testCase.expected()));
+    }
+
+    static class TestCase {
+        Random random;
+        int attempt;
+        long expectedDelayMs;
+
+        TestCase configureRandom(Random random) {
+            this.random = random;
+            return this;
+        }
+
+        TestCase givenAttempt(int attempt) {
+            this.attempt = attempt;
+            return this;
+        }
+
+        TestCase expectDelayInMs(long expectedDelayMs) {
+            this.expectedDelayMs = expectedDelayMs;
+            return this;
+        }
+
+        Duration run() {
+            return
+                new ExponentialDelayWithJitter(() -> random, BASE_DELAY, MAX_DELAY)
+                    .computeDelay(this.attempt);
+        }
+
+        Duration expected() {
+            return Duration.ofMillis(expectedDelayMs);
+        }
+    }
+
+    static class ComputedNextInt extends Random {
+        final Function<Integer, Integer> compute;
+
+        ComputedNextInt(Function<Integer, Integer> compute) {
+            this.compute = compute;
+        }
+
+        @Override
+        public int nextInt(int bound) {
+            return compute.apply(bound);
+        }
+    }
+}

--- a/core/retries/src/test/java/software/amazon/awssdk/retries/backoff/FixedDelayWithJitterTest.java
+++ b/core/retries/src/test/java/software/amazon/awssdk/retries/backoff/FixedDelayWithJitterTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.retries.backoff;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+import java.util.function.Function;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FixedDelayWithJitterTest {
+    static final ComputedNextInt MIN_VALUE_RND = new ComputedNextInt(bound -> 0);
+    static final ComputedNextInt MID_VALUE_RND = new ComputedNextInt(bound -> bound / 2);
+    static final ComputedNextInt MAX_VALUE_RND = new ComputedNextInt(bound -> bound - 1);
+    static final Duration BASE_DELAY = Duration.ofMillis(23);
+
+    public static Collection<TestCase> parameters() {
+        return Arrays.asList(
+            // --- Using random that returns: bound - 1
+            new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(22)
+            , new TestCase()
+                .configureRandom(MAX_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(22)
+            // --- Using random that returns: bound / 2
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(11)
+            , new TestCase()
+                .configureRandom(MID_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(11)
+            // --- Using random that returns: 0
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(1)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(2)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(3)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(5)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(7)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(11)
+                .expectDelayInMs(0)
+            , new TestCase()
+                .configureRandom(MIN_VALUE_RND)
+                .givenAttempt(13)
+                .expectDelayInMs(0)
+        );
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testCase(TestCase testCase) {
+        assertThat(testCase.run(), equalTo(testCase.expected()));
+    }
+
+    static class TestCase {
+        Random random;
+        int attempt;
+        long expectedDelayMs;
+
+        TestCase configureRandom(Random random) {
+            this.random = random;
+            return this;
+        }
+
+        TestCase givenAttempt(int attempt) {
+            this.attempt = attempt;
+            return this;
+        }
+
+        TestCase expectDelayInMs(long expectedDelayMs) {
+            this.expectedDelayMs = expectedDelayMs;
+            return this;
+        }
+
+        Duration run() {
+            return
+                new FixedDelayWithJitter(() -> random, BASE_DELAY)
+                    .computeDelay(this.attempt);
+        }
+
+        Duration expected() {
+            return Duration.ofMillis(expectedDelayMs);
+        }
+    }
+
+    static class ComputedNextInt extends Random {
+        final Function<Integer, Integer> compute;
+
+        ComputedNextInt(Function<Integer, Integer> compute) {
+            this.compute = compute;
+        }
+
+        @Override
+        public int nextInt(int bound) {
+            return compute.apply(bound);
+        }
+    }
+}


### PR DESCRIPTION
This new module includes the interfaces and classes that will be used to implement the new retry logic within the SDK.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

As part of the Smithy Reference Architecture this change adds a new default backoff strategies.

## Modifications
No modifications to existing code were made. We will make those changes in follow up pull requests.
<!--- Describe your changes in detail -->

## Testing
* Added unit tests for al
* Added unit tests for `ExponentialDelayWithJitter` and `FixedDelayWithJitterTest` similar to the tests present for its equivalent class [here](https://github.com/aws/aws-sdk-java-v2/blob/03f2db714bf987b59e8e5b7f6ec2d9b46f3126dc/core/sdk-core/src/test/java/software/amazon/awssdk/core/retry/backoff/FullJitterBackoffStrategyTest.java#L41)

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ x] Local run of `mvn install` succeeds
- [ x] My code follows the code style of this project
- [ x] My change requires a change to the Javadoc documentation
- [ x] I have updated the Javadoc documentation accordingly
- [ x] I have added tests to cover my changes
- [ x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
