### PR TITLE
NettyUtils: added safe check for null pointers. Added regression tests.

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-b68759c.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-b68759c.json
@@ -1,0 +1,6 @@
+{
+    "category": "Netty NIO HTTP Client", 
+    "contributor": "martinKindall", 
+    "type": "bugfix", 
+    "description": "The fix involves implementing a null-pointer check in the NettyUtils#isConnectionResetException() method, in case the\n    throwable of the original cause has no message."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/NettyUtils.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/utils/NettyUtils.java
@@ -81,7 +81,10 @@ public final class NettyUtils {
     }
 
     private static boolean isConnectionResetException(Throwable originalCause) {
-        return originalCause instanceof IOException && originalCause.getMessage().contains("Connection reset by peer");
+        String message = originalCause.getMessage();
+        return originalCause instanceof IOException &&
+               message != null &&
+               message.contains("Connection reset by peer");
     }
 
     private static boolean isAcquireTimeoutException(Throwable originalCause) {
@@ -95,7 +98,7 @@ public final class NettyUtils {
         String message = originalCause.getMessage();
         return originalCause instanceof IllegalStateException &&
                message != null &&
-               originalCause.getMessage().contains("Too many outstanding acquire operations");
+               message.contains("Too many outstanding acquire operations");
     }
 
     private static String getMessageForAcquireTimeoutException() {


### PR DESCRIPTION
## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/3935

## Modifications
Added null-pointer check and regression tests to increase coverage.

## Testing
The included tests were tested running the unit tests of that module with `./mvnw package`
Testing environment

JDK: java-1.8.0-amazon-corretto-devel
OS: Amazon Linux 2 Kernel 5.10, 64 bits.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
