### PR TITLE
ProfileFile: Corrects behaviour when config and credentials not found

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-540f927.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-540f927.json
@@ -1,0 +1,6 @@
+{
+    "category": "AWS SDK for Java v2", 
+    "contributor": "martinKindall", 
+    "type": "bugfix", 
+    "description": "Avoids NullPointerException when config and credentials files were not found for profiles. Now it returns an empty map, as it used to."
+}

--- a/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
+++ b/core/profiles/src/main/java/software/amazon/awssdk/profiles/ProfileFile.java
@@ -117,7 +117,7 @@ public final class ProfileFile {
      */
     public Map<String, Profile> profiles() {
         Map<String, Profile> profileMap = profilesAndSectionsMap.get(PROFILES_SECTION_TITLE);
-        return profileMap != null ? Collections.unmodifiableMap(profileMap) : profileMap;
+        return profileMap != null ? Collections.unmodifiableMap(profileMap) : Collections.emptyMap();
     }
 
     @Override

--- a/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
+++ b/core/profiles/src/test/java/software/amazon/awssdk/profiles/ProfileFileTest.java
@@ -554,6 +554,15 @@ public class ProfileFileTest {
         ProfileFile.defaultProfileFile();
     }
 
+    @Test
+    public void returnsEmptyMap_when_AwsFilesDoNotExist() {
+        ProfileFile missingProfile = ProfileFile.aggregator()
+                                                .build();
+
+        assertThat(missingProfile.profiles()).isEmpty();
+        assertThat(missingProfile.profiles()).isInstanceOf(Map.class);
+    }
+
     private ProfileFile configFile(String configFile) {
         return ProfileFile.builder()
                           .content(new StringInputStream(configFile))


### PR DESCRIPTION
Now it returns an empty map, as it used to in previous sdk versions.

## Motivation and Context
https://github.com/aws/aws-sdk-java-v2/issues/3869

## Modifications
Returning empty map instead of null. This prevents null-pointer exceptions when calling the profiles() method.

## Testing
The included tests were tested running the unit tests of that module with ./mvnw package
Testing environment

Java version: 1.8.0_361, vendor: Oracle Corporation
OS name: "windows 10", version: "10.0", arch: "amd64"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
