### PR TITLE
Use joinLikeSync when resolving identity in sync code

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.services.endpointdiscoverytest;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
@@ -19,6 +20,7 @@ import software.amazon.awssdk.core.endpointdiscovery.EndpointDiscoveryRequest;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.metrics.NoOpMetricCollector;
@@ -39,6 +41,7 @@ import software.amazon.awssdk.services.endpointdiscoverytest.transform.DescribeE
 import software.amazon.awssdk.services.endpointdiscoverytest.transform.TestDiscoveryIdentifiersRequiredRequestMarshaller;
 import software.amazon.awssdk.services.endpointdiscoverytest.transform.TestDiscoveryOptionalRequestMarshaller;
 import software.amazon.awssdk.services.endpointdiscoverytest.transform.TestDiscoveryRequiredRequestMarshaller;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.Logger;
 
 /**
@@ -154,10 +157,12 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
         }
         URI cachedEndpoint = null;
         if (endpointDiscoveryEnabled) {
-            String key = testDiscoveryIdentifiersRequiredRequest.overrideConfiguration()
-                                                                .flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)
-                                                                .orElseGet(() -> clientConfiguration.option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER))
-                                                                .resolveIdentity().join().accessKeyId();
+            CompletableFuture<? extends AwsCredentialsIdentity> identityFuture =
+                testDiscoveryIdentifiersRequiredRequest.overrideConfiguration()
+                                            .flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)
+                                            .orElseGet(() -> clientConfiguration.option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER))
+                                            .resolveIdentity();
+            String key = CompletableFutureUtils.joinLikeSync(identityFuture).accessKeyId();
             EndpointDiscoveryRequest endpointDiscoveryRequest = EndpointDiscoveryRequest.builder().required(true)
                                                                                         .defaultEndpoint(clientConfiguration.option(SdkClientOption.ENDPOINT))
                                                                                         .overrideConfiguration(testDiscoveryIdentifiersRequiredRequest.overrideConfiguration().orElse(null)).build();
@@ -211,10 +216,12 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
         boolean endpointOverridden = clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN) == Boolean.TRUE;
         URI cachedEndpoint = null;
         if (endpointDiscoveryEnabled) {
-            String key = testDiscoveryOptionalRequest.overrideConfiguration()
-                                                     .flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)
-                                                     .orElseGet(() -> clientConfiguration.option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER))
-                                                     .resolveIdentity().join().accessKeyId();
+            CompletableFuture<? extends AwsCredentialsIdentity> identityFuture =
+                testDiscoveryOptionalRequest.overrideConfiguration()
+                                            .flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)
+                                            .orElseGet(() -> clientConfiguration.option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER))
+                                            .resolveIdentity();
+            String key = CompletableFutureUtils.joinLikeSync(identityFuture).accessKeyId();
             EndpointDiscoveryRequest endpointDiscoveryRequest = EndpointDiscoveryRequest.builder().required(false)
                                                                                         .defaultEndpoint(clientConfiguration.option(SdkClientOption.ENDPOINT))
                                                                                         .overrideConfiguration(testDiscoveryOptionalRequest.overrideConfiguration().orElse(null)).build();
@@ -275,10 +282,12 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
         }
         URI cachedEndpoint = null;
         if (endpointDiscoveryEnabled) {
-            String key = testDiscoveryRequiredRequest.overrideConfiguration()
-                                                     .flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)
-                                                     .orElseGet(() -> clientConfiguration.option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER))
-                                                     .resolveIdentity().join().accessKeyId();
+            CompletableFuture<? extends AwsCredentialsIdentity> identityFuture =
+                testDiscoveryRequiredRequest.overrideConfiguration()
+                                            .flatMap(AwsRequestOverrideConfiguration::credentialsIdentityProvider)
+                                            .orElseGet(() -> clientConfiguration.option(AwsClientOption.CREDENTIALS_IDENTITY_PROVIDER))
+                                            .resolveIdentity();
+            String key = CompletableFutureUtils.joinLikeSync(identityFuture).accessKeyId();
             EndpointDiscoveryRequest endpointDiscoveryRequest = EndpointDiscoveryRequest.builder().required(true)
                                                                                         .defaultEndpoint(clientConfiguration.option(SdkClientOption.ENDPOINT))
                                                                                         .overrideConfiguration(testDiscoveryRequiredRequest.overrideConfiguration().orElse(null)).build();

--- a/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
+++ b/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/CredentialUtils.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 @SdkProtectedApi
 public final class CredentialUtils {
@@ -101,8 +102,8 @@ public final class CredentialUtils {
             return (AwsCredentialsProvider) identityProvider;
         }
         return () -> {
-            // TODO: Exception handling for CompletionException thrown from join?
-            AwsCredentialsIdentity awsCredentialsIdentity = identityProvider.resolveIdentity().join();
+            AwsCredentialsIdentity awsCredentialsIdentity =
+                CompletableFutureUtils.joinLikeSync(identityProvider.resolveIdentity());
             return toCredentials(awsCredentialsIdentity);
         };
     }

--- a/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
+++ b/services/polly/src/main/java/software/amazon/awssdk/services/polly/internal/presigner/DefaultPollyPresigner.java
@@ -59,6 +59,7 @@ import software.amazon.awssdk.services.polly.model.PollyRequest;
 import software.amazon.awssdk.services.polly.presigner.PollyPresigner;
 import software.amazon.awssdk.services.polly.presigner.model.PresignedSynthesizeSpeechRequest;
 import software.amazon.awssdk.services.polly.presigner.model.SynthesizeSpeechPresignRequest;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Validate;
 
@@ -212,7 +213,7 @@ public final class DefaultPollyPresigner implements PollyPresigner {
     }
 
     private AwsCredentialsIdentity resolveCredentials(IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider) {
-        return credentialsProvider.resolveIdentity().join();
+        return CompletableFutureUtils.joinLikeSync(credentialsProvider.resolveIdentity());
     }
 
     private Presigner resolvePresigner(PollyRequest request) {

--- a/services/rds/src/main/java/software/amazon/awssdk/services/rds/DefaultRdsUtilities.java
+++ b/services/rds/src/main/java/software/amazon/awssdk/services/rds/DefaultRdsUtilities.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.StringUtils;
 
 @Immutable
@@ -111,11 +112,12 @@ final class DefaultRdsUtilities implements RdsUtilities {
     // TODO: update this to use AwsCredentialsIdentity when we migrate Signers to accept the new type.
     private AwsCredentials resolveCredentials(GenerateAuthenticationTokenRequest request) {
         if (request.credentialsIdentityProvider() != null) {
-            return CredentialUtils.toCredentials(request.credentialsIdentityProvider().resolveIdentity().join());
+            return CredentialUtils.toCredentials(
+                CompletableFutureUtils.joinLikeSync(request.credentialsIdentityProvider().resolveIdentity()));
         }
 
         if (this.credentialsProvider != null) {
-            return CredentialUtils.toCredentials(this.credentialsProvider.resolveIdentity().join());
+            return CredentialUtils.toCredentials(CompletableFutureUtils.joinLikeSync(this.credentialsProvider.resolveIdentity()));
         }
 
         throw new IllegalArgumentException("CredentialProvider should be provided either in GenerateAuthenticationTokenRequest " +

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialsProviderAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/CrtCredentialsProviderAdapter.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.crt.auth.credentials.DelegateCredentialsProvider;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 /**
@@ -45,8 +46,8 @@ public final class CrtCredentialsProviderAdapter implements SdkAutoCloseable {
                     return Credentials.createAnonymousCredentials();
                 }
 
-                // TODO: Exception handling for join?
-                AwsCredentialsIdentity sdkCredentials = credentialsProvider.resolveIdentity().join();
+                AwsCredentialsIdentity sdkCredentials =
+                    CompletableFutureUtils.joinLikeSync(credentialsProvider.resolveIdentity());
                 byte[] accessKey = sdkCredentials.accessKeyId().getBytes(StandardCharsets.UTF_8);
                 byte[] secreteKey = sdkCredentials.secretAccessKey().getBytes(StandardCharsets.UTF_8);
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/CompletableFutureUtils.java
@@ -239,4 +239,22 @@ public final class CompletableFutureUtils {
             // Ignore
         }
     }
+
+    /**
+     * Joins (interruptibly) on the future, and re-throws any RuntimeExceptions or Errors just like the async task would have
+     * thrown if it was executed synchronously.
+     */
+    public static <T> T joinLikeSync(CompletableFuture<T> future) {
+        try {
+            return joinInterruptibly(future);
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                // Make sure we don't lose the context of where the join is in the stack...
+                cause.addSuppressed(new RuntimeException("Task failed."));
+                throw (RuntimeException) cause;
+            }
+            throw e;
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Identity resolution is async now. Inside sync client we have to "join", but we can handle the exceptions from async resolution to make it appear like sync.

## Modifications
<!--- Describe your changes in detail -->
Add a utility `joinLikeSync()` method to handle exceptions just like the async task would have thrown if it was executed synchronously.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
