### PR TITLE
Remove identity join in async client for ExecutionAttributes

### DIFF
--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsAsyncClientHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsAsyncClientHandler.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.core.client.handler.AsyncClientHandler;
 import software.amazon.awssdk.core.client.handler.ClientExecutionParams;
 import software.amazon.awssdk.core.client.handler.SdkAsyncClientHandler;
 import software.amazon.awssdk.core.http.ExecutionContext;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Async client handler for AWS SDK clients.
@@ -59,9 +60,19 @@ public final class AwsAsyncClientHandler extends SdkAsyncClientHandler implement
         return super.execute(executionParams, asyncResponseTransformer);
     }
 
+    // This method is not really used, but it is there for backwards compatibility, since this class is @SdkProtectedApi.
+    // The execute() methods in AwsAsyncClientHandler (inherited from BaseAsyncClientHandler) call the
+    // invokeInterceptorsAndCreateExecutionContextAsync below.
     @Override
     protected <InputT extends SdkRequest, OutputT extends SdkResponse> ExecutionContext
         invokeInterceptorsAndCreateExecutionContext(ClientExecutionParams<InputT, OutputT> executionParams) {
+        return CompletableFutureUtils.joinLikeSync(
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfiguration));
+    }
+
+    @Override
+    protected <InputT extends SdkRequest, OutputT extends SdkResponse> CompletableFuture<ExecutionContext>
+        invokeInterceptorsAndCreateExecutionContextAsync(ClientExecutionParams<InputT, OutputT> executionParams) {
         return AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfiguration);
     }
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsSyncClientHandler.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/handler/AwsSyncClientHandler.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.core.http.HttpResponseHandler;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.utils.CompletableFutureUtils;
 
 /**
  * Client handler for AWS SDK clients.
@@ -66,7 +67,8 @@ public final class AwsSyncClientHandler extends SdkSyncClientHandler implements 
     @Override
     protected <InputT extends SdkRequest, OutputT extends SdkResponse> ExecutionContext
         invokeInterceptorsAndCreateExecutionContext(ClientExecutionParams<InputT, OutputT> executionParams) {
-        return AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfiguration);
+        return CompletableFutureUtils.joinLikeSync(
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfiguration));
     }
 
     private <InputT extends SdkRequest, OutputT> ClientExecutionParams<InputT, OutputT> addCrc32Validation(

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AuthorizationStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AuthorizationStrategy.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.awscore.internal.authcontext;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.signer.Signer;
@@ -28,5 +29,5 @@ public interface AuthorizationStrategy {
 
     Signer resolveSigner();
 
-    void addCredentialsToExecutionAttributes(ExecutionAttributes executionAttributes);
+    CompletableFuture<Void> addCredentialsToExecutionAttributes(ExecutionAttributes executionAttributes);
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AwsCredentialsAuthorizationStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/AwsCredentialsAuthorizationStrategy.java
@@ -80,6 +80,7 @@ public final class AwsCredentialsAuthorizationStrategy implements AuthorizationS
         Validate.notNull(credentialsProvider, "No credentials provider exists to resolve credentials from.");
 
         long start = System.nanoTime();
+        // TODO: CompletableFutureUtils.forwardExceptionTo() here too?
         return credentialsProvider.resolveIdentity().thenAccept(credentialsIdentity -> {
             metricCollector.reportMetric(CoreMetric.CREDENTIALS_FETCH_DURATION, Duration.ofNanos(System.nanoTime() - start));
 

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/TokenAuthorizationStrategy.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/internal/authcontext/TokenAuthorizationStrategy.java
@@ -77,11 +77,11 @@ public final class TokenAuthorizationStrategy implements AuthorizationStrategy {
         Validate.notNull(defaultTokenProvider, "No token provider exists to resolve a token from.");
 
         long start = System.nanoTime();
+        // TODO: CompletableFutureUtils.forwardExceptionTo() here too?
         return defaultTokenProvider.resolveIdentity().thenAccept(token -> {
             metricCollector.reportMetric(CoreMetric.TOKEN_FETCH_DURATION, Duration.ofNanos(System.nanoTime() - start));
 
             Validate.validState(token != null, "Token providers must never return null.");
-            // TODO: Should the signer be changed to use AwsCredentialsIdentity? Maybe with Signer SRA work, not now.
             // TODO: Should the signer be changed to use TokenIdentity? Maybe with Signer SRA work, not now.
             executionAttributes.putAttribute(SdkTokenExecutionAttribute.SDK_TOKEN, TokenUtils.toSdkToken(token));
         });

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilderTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/internal/AwsExecutionContextBuilderTest.java
@@ -96,7 +96,8 @@ public class AwsExecutionContextBuilderTest {
             .build();
 
         ExecutionContext executionContext =
-            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(), testClientConfiguration);
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
+                                                                                   testClientConfiguration).join();
 
         assertThat(executionContext.executionAttributes().getAttribute(SdkExecutionAttribute.SERVICE_NAME)).isEqualTo("DoNotOverrideService");
     }
@@ -105,7 +106,7 @@ public class AwsExecutionContextBuilderTest {
     public void signing_ifNoOverrides_assignDefaultSigner() {
         ExecutionContext executionContext =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
-                                                                                   testClientConfiguration().build());
+                                                                                   testClientConfiguration().build()).join();
 
         assertThat(executionContext.signer()).isEqualTo(defaultSigner);
     }
@@ -119,7 +120,7 @@ public class AwsExecutionContextBuilderTest {
 
         ExecutionContext executionContext =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
-                                                                                   testClientConfiguration().build());
+                                                                                   testClientConfiguration().build()).join();
 
         assertThat(executionContext.signer()).isEqualTo(clientOverrideSigner);
     }
@@ -128,7 +129,7 @@ public class AwsExecutionContextBuilderTest {
     public void invokeInterceptorsAndCreateExecutionContext_noHttpChecksumTrait_resolvesChecksumSpecs() {
         ExecutionContext executionContext =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(clientExecutionParams(),
-                                                                                   testClientConfiguration().build());
+                                                                                   testClientConfiguration().build()).join();
 
         ExecutionAttributes executionAttributes = executionContext.executionAttributes();
         Optional<ChecksumSpecs> checksumSpecs1 = HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes);
@@ -148,7 +149,7 @@ public class AwsExecutionContextBuilderTest {
 
         ExecutionContext executionContext =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams,
-                                                                                   testClientConfiguration().build());
+                                                                                   testClientConfiguration().build()).join();
 
         ExecutionAttributes executionAttributes = executionContext.executionAttributes();
         ChecksumSpecs checksumSpecs1 = HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes).get();
@@ -166,13 +167,13 @@ public class AwsExecutionContextBuilderTest {
 
         ExecutionContext executionContext1 =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams,
-                                                                                   clientConfig);
+                                                                                   clientConfig).join();
         ExecutionAttributes executionAttributes1 = executionContext1.executionAttributes();
         ChecksumSpecs checksumSpecs1 = HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes1).get();
 
         ExecutionContext executionContext2 =
             AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams,
-                                                                                   clientConfig);
+                                                                                   clientConfig).join();
         ExecutionAttributes executionAttributes2 = executionContext2.executionAttributes();
         ChecksumSpecs checksumSpecs2 = HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes2).get();
         ChecksumSpecs checksumSpecs3 = HttpChecksumUtils.checksumSpecWithRequestAlgorithm(executionAttributes2).get();
@@ -190,7 +191,7 @@ public class AwsExecutionContextBuilderTest {
             .build();
 
         ExecutionContext executionContext =
-            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfig);
+            AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext(executionParams, clientConfig).join();
 
         ExecutionAttributes executionAttributes = executionContext.executionAttributes();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Identity resolution is async now. Inside async client we shouldn't join(). This removes earlier use of join() in endpoint discovery logic in async clients, addressing https://github.com/aws/aws-sdk-java-v2/pull/3829#discussion_r1140822300.

## Modifications
<!--- Describe your changes in detail -->
* Changed AuthorizationStrategy.addCredentialsToExecutionAttributes to return CompletableFuture.
* Changed AwsExecutionContextBuilder.invokeInterceptorsAndCreateExecutionContext to return CompletableFuture.
* AwsSyncClientHandler joins on the CompletableFuture.
* AwsAsyncClientHandler uses the CompletableFuture and the execute() methods in BaseAsyncClientHandler thenCompose on it for the remaining async logic.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
